### PR TITLE
Relax VB Type Restrictions for If(a, b)

### DIFF
--- a/docs/Language Feature Status.md
+++ b/docs/Language Feature Status.md
@@ -30,6 +30,7 @@ efforts behind them.
 | Feature | Branch | State | Developers | Reviewer | LDM Champ |
 | ------- | ------ | ----- | ---------- | -------- | --------- |
 | [Line continuation comments](https://github.com/dotnet/vblang/issues/65) | [continuation-comments](https://github.com/dotnet/roslyn/tree/features/continuation-comments) | Prototype | [paul1956](https://github.com/paul1956) | [AlekseyTs](https://github.com/AlekseyTs) | [gafter](https://github.com/gafter) |
+| [Relax null coalesing operator requirements](https://github.com/dotnet/vblang/issues/339) | [null-operator-enhancements](https://github.com/dotnet/roslyn/tree/features/null-operator-enhancements) | In Progress | [333fred](https://github.com/333fred) | [cston](https://github.com/cston) | [gafter](https://github.com/gafter) |
 
 # C# 7.3
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3387,12 +3387,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Prior to C# 8.0, the spec said that the left type must be either a reference type or a nullable value type. This was relaxed
                 // with C# 8.0, so if the feature is not enabled then issue a diagnostic and return
-                if (!optLeftType.IsValueType && !isLeftNullable)
+                if (!optLeftType.IsValueType)
                 {
-                    if (!CheckFeatureAvailability(node, MessageID.IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator, diagnostics))
-                    {
-                        return new BoundNullCoalescingOperator(node, leftOperand, rightOperand, Conversion.NoConversion, CreateErrorType());
-                    }
+                    CheckFeatureAvailability(node, MessageID.IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator, diagnostics);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -9737,6 +9737,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater..
+        /// </summary>
+        internal static string ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable {
+            get {
+                return ResourceManager.GetString("ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A &apos;{0}&apos; character must be escaped (by doubling) in an interpolated string..
         /// </summary>
         internal static string ERR_UnescapedCurly {
@@ -11066,6 +11075,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string IDS_FeatureTypeVariance {
             get {
                 return ResourceManager.GetString("IDS_FeatureTypeVariance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unconstrained type parameters in null coalescing operator.
+        /// </summary>
+        internal static string IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator {
+            get {
+                return ResourceManager.GetString("IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -9737,15 +9737,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater..
-        /// </summary>
-        internal static string ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable {
-            get {
-                return ResourceManager.GetString("ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to A &apos;{0}&apos; character must be escaped (by doubling) in an interpolated string..
         /// </summary>
         internal static string ERR_UnescapedCurly {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5366,4 +5366,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_DefaultLiteralConvertedToNullIsNotIntended_Title" xml:space="preserve">
     <value>'default' is converted to 'null'</value>
   </data>
+  <data name="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable" xml:space="preserve">
+    <value>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</value>
+  </data>
+  <data name="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator" xml:space="preserve">
+    <value>unconstrained type parameters in null coalescing operator</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5366,9 +5366,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_DefaultLiteralConvertedToNullIsNotIntended_Title" xml:space="preserve">
     <value>'default' is converted to 'null'</value>
   </data>
-  <data name="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable" xml:space="preserve">
-    <value>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</value>
-  </data>
   <data name="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator" xml:space="preserve">
     <value>unconstrained type parameters in null coalescing operator</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1583,7 +1583,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_FeatureNotAvailableInVersion8 = 8400,
         ERR_AltInterpolatedVerbatimStringsNotAvailable = 8401,
         WRN_DefaultLiteralConvertedToNullIsNotIntended = 8402,
-        ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable = 8403,
         #endregion diagnostics introduced for C# 8.0
     }
     // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1583,6 +1583,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_FeatureNotAvailableInVersion8 = 8400,
         ERR_AltInterpolatedVerbatimStringsNotAvailable = 8401,
         WRN_DefaultLiteralConvertedToNullIsNotIntended = 8402,
+        ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable = 8403,
         #endregion diagnostics introduced for C# 8.0
     }
     // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -163,6 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         IDS_FeatureAltInterpolatedVerbatimStrings = MessageBase + 12745,
         IDS_FeatureCoalesceAssignmentExpression = MessageBase + 12746,
+        IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator = MessageBase + 12747,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -221,6 +222,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // C# 8.0 features.
                 case MessageID.IDS_FeatureAltInterpolatedVerbatimStrings:
                 case MessageID.IDS_FeatureCoalesceAssignmentExpression:
+                case MessageID.IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator:
                     return LanguageVersion.CSharp8;
 
                 // C# 7.3 features.

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
+        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
+        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>
@@ -40,6 +45,11 @@
       <trans-unit id="IDS_FeatureCoalesceAssignmentExpression">
         <source>coalescing assignment</source>
         <target state="new">coalescing assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator">
+        <source>unconstrained type parameters in null coalescing operator</source>
+        <target state="new">unconstrained type parameters in null coalescing operator</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_NULL">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -32,11 +32,6 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_UnconstrainedTypeParameterInNullCoalescingNotAvailable">
-        <source>To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</source>
-        <target state="new">To use a variable of an unconstrained type parameter in a null-coalescing assignment, please use language version {0} or greater.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="IDS_FeatureAltInterpolatedVerbatimStrings">
         <source>alternative interpolated verbatim strings</source>
         <target state="new">alternative interpolated verbatim strings</target>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
@@ -51,7 +51,23 @@ public class C
 }
 ";
 
-            var verifier = CompileAndVerify(source, expectedOutput: @"
+            CompileAndVerify(@"
+using System;
+class C
+{
+    static void TestNullable()
+    {
+        int? i1 = null;
+        Console.WriteLine(i1 ??= GetInt());
+    }
+    static int GetInt()
+    {
+        Console.WriteLine(""In GetInt"");
+        return 0;
+    }
+}
+").VerifyIL("C.TestNullable()", "");
+            /*var verifier = CompileAndVerify(source, expectedOutput: @"
 In GetInt
 0
 In GetString
@@ -59,7 +75,6 @@ Test
 As Statement
 ");
 
-            // PROTOTYPE(null-operator-enhancements): lines 8 and 9 appear to be entirely redundant.
             verifier.VerifyIL("C.TestNullable()", @"
 {
   // Code size       43 (0x2b)
@@ -134,7 +149,7 @@ As Statement
   IL_0014:  nop
   IL_0015:  ret
 }
-");
+");*/
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
@@ -2043,12 +2043,16 @@ class C
     {
         int? a1 = null, b1 = null, c1 = 1;
         Console.WriteLine(a1 ??= b1 ??= c1);
+        Console.WriteLine(b1);
         int? a2 = null, b2 = null, c2 = 1;
         Console.WriteLine(a2 ??= (b2 ??= c2));
+        Console.WriteLine(b2);
     }
 }";
 
             CompileAndVerify(source, expectedOutput: @"
+1
+1
 1
 1
 ");

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
@@ -51,23 +51,7 @@ public class C
 }
 ";
 
-            CompileAndVerify(@"
-using System;
-class C
-{
-    static void TestNullable()
-    {
-        int? i1 = null;
-        Console.WriteLine(i1 ??= GetInt());
-    }
-    static int GetInt()
-    {
-        Console.WriteLine(""In GetInt"");
-        return 0;
-    }
-}
-").VerifyIL("C.TestNullable()", "");
-            /*var verifier = CompileAndVerify(source, expectedOutput: @"
+            var verifier = CompileAndVerify(source, expectedOutput: @"
 In GetInt
 0
 In GetString
@@ -149,7 +133,7 @@ As Statement
   IL_0014:  nop
   IL_0015:  ret
 }
-");*/
+");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -5746,5 +5746,24 @@ class Program
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "x").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(6, 16)
                 );
         }
+
+        [Fact]
+        public void TestNullCoalesce_UnconstrainedTypeParameter_OldLanguageVersion()
+        {
+            var source = @"
+class C
+{
+    void M<T>(T t1, T t2)
+    {
+        t1 = t1 ?? t2;
+    }
+}";
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_3);
+            comp.VerifyDiagnostics(
+                // (6,14): error CS8370: Feature 'unconstrained type parameters in null coalescing operator' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //         t1 = t1 ?? t2;
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "t1 ?? t2").WithArguments("unconstrained type parameters in null coalescing operator", "8.0").WithLocation(6, 14));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -1372,12 +1372,17 @@ static class Program
 {
     static void Main()
     {
-        Goo(default, 10);
-        Goo(1, 10);
+        Goo(default, 1000);
+        Goo(1, 1000);
         Goo(default, ""String parameter 1"");
         Goo(""String parameter 2"", ""Should not print"");
         Goo((int?)null, 4);
-        Goo((int?)5, 10);
+        Goo((int?)5, 1000);
+        Goo2(6, 1000);
+        Goo2<int?, object>(null, 7);
+        Goo2<int?, object>(8, 1000);
+        Goo2<int?, int?>(9, 1000);
+        Goo2<int?, int?>(null, 10);
     }
 
     static void Goo<T>(T x1, T x2)
@@ -1385,10 +1390,10 @@ static class Program
         Console.WriteLine(x1 ?? x2);
     }
 
-    static void Goo2<T1, T2>(T1 t1, T2 t2, dynamic d) where T1 : T2
+    static void Goo2<T1, T2>(T1 t1, T2 t2, dynamic d = null) where T1 : T2
     {
         // Verifying no type errors
-        T2 t = t1 ?? t2;
+        Console.WriteLine(t1 ?? t2);
         dynamic d2 = t1 ?? d;
     }
 }
@@ -1400,6 +1405,11 @@ String parameter 1
 String parameter 2
 4
 5
+6
+7
+8
+9
+10
 ");
 
             comp.VerifyIL("Program.Goo<T>(T, T)", expectedIL: @"
@@ -1418,6 +1428,32 @@ String parameter 2
   IL_000e:  box        ""T""
   IL_0013:  call       ""void System.Console.WriteLine(object)""
   IL_0018:  ret
+}
+");
+
+            comp.VerifyIL("Program.Goo2<T1, T2>(T1, T2, dynamic)", expectedIL: @"
+{
+  // Code size       44 (0x2c)
+  .maxstack  1
+  .locals init (T1 V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  box        ""T1""
+  IL_0008:  brtrue.s   IL_000d
+  IL_000a:  ldarg.1
+  IL_000b:  br.s       IL_0018
+  IL_000d:  ldloc.0
+  IL_000e:  box        ""T1""
+  IL_0013:  unbox.any  ""T2""
+  IL_0018:  box        ""T2""
+  IL_001d:  call       ""void System.Console.WriteLine(object)""
+  IL_0022:  ldarg.0
+  IL_0023:  stloc.0
+  IL_0024:  ldloc.0
+  IL_0025:  box        ""T1""
+  IL_002a:  pop
+  IL_002b:  ret
 }
 ");
         }

--- a/src/Compilers/Test/Utilities/VisualBasic/TestOptions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/TestOptions.vb
@@ -7,6 +7,7 @@ Public Class TestOptions
     Public Shared ReadOnly Script As New VisualBasicParseOptions(kind:=SourceCodeKind.Script)
     Public Shared ReadOnly Regular As New VisualBasicParseOptions(kind:=SourceCodeKind.Regular)
     Public Shared ReadOnly RegularWithFlowAnalysisFeature As VisualBasicParseOptions = Regular.WithFlowAnalysisFeature()
+    Public Shared ReadOnly Regular15_5 As VisualBasicParseOptions = Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5)
 
     Public Shared ReadOnly ReleaseDll As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel:=OptimizationLevel.Release)
     Public Shared ReadOnly ReleaseExe As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel:=OptimizationLevel.Release)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -1067,6 +1067,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return m_containingBinder.QuickAttributeChecker
             End Get
         End Property
+
+        Private Shared Function CheckFeatureAvailability(feature As InternalSyntax.Feature, node As SyntaxNode, diagnostics As DiagnosticBag) As Boolean
+            Dim langVersion As LanguageVersion = DirectCast(node.SyntaxTree.Options, VisualBasicParseOptions).LanguageVersion
+            Dim requiredVersion As LanguageVersion = InternalSyntax.FeatureExtensions.GetLanguageVersion(feature)
+
+            If langVersion >= requiredVersion Then
+                Return True
+            Else
+                Dim featureName = ErrorFactory.ErrorInfo(InternalSyntax.FeatureExtensions.GetResourceId(feature))
+                diagnostics.Add(ERRID.ERR_LanguageVersion, node.Location, langVersion.GetErrorName(), featureName, requiredVersion)
+                Return False
+            End If
+        End Function
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -1067,19 +1067,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return m_containingBinder.QuickAttributeChecker
             End Get
         End Property
-
-        Private Shared Function CheckFeatureAvailability(feature As InternalSyntax.Feature, node As SyntaxNode, diagnostics As DiagnosticBag) As Boolean
-            Dim langVersion As LanguageVersion = DirectCast(node.SyntaxTree.Options, VisualBasicParseOptions).LanguageVersion
-            Dim requiredVersion As LanguageVersion = InternalSyntax.FeatureExtensions.GetLanguageVersion(feature)
-
-            If langVersion >= requiredVersion Then
-                Return True
-            Else
-                Dim featureName = ErrorFactory.ErrorInfo(InternalSyntax.FeatureExtensions.GetResourceId(feature))
-                diagnostics.Add(ERRID.ERR_LanguageVersion, node.Location, langVersion.GetErrorName(), featureName, requiredVersion)
-                Return False
-            End If
-        End Function
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -2096,9 +2096,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 boundSecondArgWithConversions = MakeRValueAndIgnoreDiagnostics(boundSecondArg)
             End If
 
-            '  if there are still no errors check the original type of the first argument to be 
-            '       of a reference or nullable type, generate IllegalCondTypeInIIF otherwise
-            If Not hasErrors AndAlso Not (boundFirstArg.IsNothingLiteral OrElse boundFirstArg.Type.IsNullableType OrElse boundFirstArg.Type.IsReferenceType) Then
+            '  If there are still no errors check the original type of the first argument. If it's
+            '  a non-nullable value type, generate IllegalCondTypeInIIF
+            If Not hasErrors AndAlso Not boundFirstArg.IsNothingLiteral AndAlso boundFirstArg.Type.IsValueType AndAlso Not boundFirstArg.Type.IsNullableType() Then
                 ReportDiagnostic(diagnostics, node.FirstExpression, ERRID.ERR_IllegalCondTypeInIIF)
                 hasErrors = True
             End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -2096,16 +2096,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 boundSecondArgWithConversions = MakeRValueAndIgnoreDiagnostics(boundSecondArg)
             End If
 
-            '  If there are still no errors check the original type of the first argument. First, we check
+            ' If there are still no errors check the original type of the first argument. First, we check
             ' the pre-VB 16.0 condition, which is the first operand must be Nothing, a reference type, or
             ' a nullable value type
             If Not hasErrors AndAlso Not (boundFirstArg.IsNothingLiteral OrElse boundFirstArg.Type.IsNullableType OrElse boundFirstArg.Type.IsReferenceType) Then
                 ' VB 16 changed the requirements on the first operand to permit unconstrained type parameters. If we're in that scenario,
                 ' ensure that the feature is enabled and report an error if it is not
-                If Not boundFirstArg.Type.IsValueType AndAlso Not boundFirstArg.Type.IsNullableType() Then
-                    If Not CheckFeatureAvailability(InternalSyntax.Feature.UnconstrainedTypeParameterInConditional, node, diagnostics) Then
-                        hasErrors = True
-                    End If
+                If Not boundFirstArg.Type.IsValueType Then
+                    InternalSyntax.Parser.CheckFeatureAvailability(diagnostics,
+                                                                   node.Location,
+                                                                   DirectCast(node.SyntaxTree.Options, VisualBasicParseOptions).LanguageVersion,
+                                                                   InternalSyntax.Feature.UnconstrainedTypeParameterInConditional)
                 Else
                     ReportDiagnostic(diagnostics, node.FirstExpression, ERRID.ERR_IllegalCondTypeInIIF)
                     hasErrors = True

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
@@ -426,7 +426,7 @@
       <Field Name="ConstantValueOpt" PropertyOverrides="true" Type="ConstantValue" Null="allow"/>
     </Node>
 
-    <!-- NOTE: The first argument of IF(...) should be either of reference or nullable type. -->
+    <!-- NOTE: The first argument of IF(...) should not be a non-nullable value type. -->
     <Node Name="BoundBinaryConditionalExpression" Base="BoundExpression" HasValidate="true">
       <!-- Non-null type is required for this node kind -->
       <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundTernaryConditionalExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundTernaryConditionalExpression.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     WhenTrue.AssertRValue()
                     WhenFalse.AssertRValue()
                 End If
-                Debug.Assert(Condition.IsNothingLiteral() OrElse Condition.Type.IsBooleanType() OrElse Condition.Type.IsReferenceType() OrElse Not Condition.Type.IsValueType)
+                Debug.Assert(Condition.IsNothingLiteral() OrElse Condition.Type.IsBooleanType() OrElse Not Condition.Type.IsValueType)
                 Debug.Assert(WhenTrue.Type.IsSameTypeIgnoringAll(WhenFalse.Type))
                 Debug.Assert(Type.IsSameTypeIgnoringAll(WhenTrue.Type))
             End If

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundTernaryConditionalExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundTernaryConditionalExpression.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     WhenTrue.AssertRValue()
                     WhenFalse.AssertRValue()
                 End If
-                Debug.Assert(Condition.IsNothingLiteral() OrElse Condition.Type.IsBooleanType() OrElse Condition.Type.IsReferenceType())
+                Debug.Assert(Condition.IsNothingLiteral() OrElse Condition.Type.IsBooleanType() OrElse Condition.Type.IsReferenceType() OrElse Not Condition.Type.IsValueType)
                 Debug.Assert(WhenTrue.Type.IsSameTypeIgnoringAll(WhenFalse.Type))
                 Debug.Assert(Type.IsSameTypeIgnoringAll(WhenTrue.Type))
             End If

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -1297,14 +1297,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         '''   push x
         '''   dup x
         '''   if pop isnot null goto LEFT_NOT_NULL
-        '''     pop 
+        '''     pop
         '''     push y
         '''   LEFT_NOT_NULL:
         ''' </remarks>
         Private Sub EmitBinaryConditionalExpression(expr As BoundBinaryConditionalExpression, used As Boolean)
             Debug.Assert(expr.ConvertedTestExpression Is Nothing, "coalesce with nontrivial test conversions are lowered into ternary.")
             Debug.Assert(expr.Type = expr.ElseExpression.Type)
-            Debug.Assert(expr.Type.IsReferenceType OrElse Not expr.Type.IsValueType)
+            Debug.Assert(Not expr.Type.IsValueType)
 
             EmitExpression(expr.TestExpression, used:=True)
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -1304,7 +1304,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         Private Sub EmitBinaryConditionalExpression(expr As BoundBinaryConditionalExpression, used As Boolean)
             Debug.Assert(expr.ConvertedTestExpression Is Nothing, "coalesce with nontrivial test conversions are lowered into ternary.")
             Debug.Assert(expr.Type = expr.ElseExpression.Type)
-            Debug.Assert(expr.Type.IsReferenceType)
+            Debug.Assert(expr.Type.IsReferenceType OrElse Not expr.Type.IsValueType)
 
             EmitExpression(expr.TestExpression, used:=True)
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
@@ -800,8 +800,7 @@ OtherExpressions:
                     EmitExpression(condition, True)
 
                     Dim conditionType = condition.Type
-                    If (conditionType.IsReferenceType OrElse Not conditionType.IsValueType) AndAlso
-                        Not IsVerifierReference(conditionType) Then
+                    If Not conditionType.IsValueType AndAlso Not IsVerifierReference(conditionType) Then
                         EmitBox(conditionType, condition.Syntax)
                     End If
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
@@ -800,7 +800,8 @@ OtherExpressions:
                     EmitExpression(condition, True)
 
                     Dim conditionType = condition.Type
-                    If conditionType.IsReferenceType AndAlso Not IsVerifierReference(conditionType) Then
+                    If (conditionType.IsReferenceType OrElse Not conditionType.IsValueType) AndAlso
+                        Not IsVerifierReference(conditionType) Then
                         EmitBox(conditionType, condition.Syntax)
                     End If
 

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -2018,6 +2018,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         FEATURE_LeadingDigitSeparator
         FEATURE_PrivateProtected
         FEATURE_InterpolatedStrings
-        FEATURE_UnconstrainedTypeParameterInCondtional
+        FEATURE_UnconstrainedTypeParameterInConditional
     End Enum
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -2018,5 +2018,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         FEATURE_LeadingDigitSeparator
         FEATURE_PrivateProtected
         FEATURE_InterpolatedStrings
+        FEATURE_UnconstrainedTypeParameterInCondtional
     End Enum
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalExpressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalExpressions.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim convertedTestExpression As BoundExpression = node.ConvertedTestExpression
             If convertedTestExpression Is Nothing Then
                 Debug.Assert(node.TestExpressionPlaceholder Is Nothing)
-                Return TransformRewrittenBinaryConditionalExpression(MyBase.VisitBinaryConditionalExpression(node))
+                Return TransformReferenceOrUnconstrainedRewrittenBinaryConditionalExpression(MyBase.VisitBinaryConditionalExpression(node))
             End If
 
             If convertedTestExpression.Kind = BoundKind.Conversion Then
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Debug.Assert(boundConversion.Operand Is If(node.TestExpressionPlaceholder, node.TestExpression))
 
                     ' We can ignore conversion in this case
-                    Return TransformRewrittenBinaryConditionalExpression(
+                    Return TransformReferenceOrUnconstrainedRewrittenBinaryConditionalExpression(
                                 node.Update(VisitExpressionNode(node.TestExpression),
                                             Nothing,
                                             Nothing,
@@ -161,12 +161,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return node.Update(rewrittenTestExpression, rewrittenWhenTrue, Nothing, rewrittenWhenFalse, node.ConstantValueOpt, node.Type)
         End Function
 
-        Private Shared Function TransformRewrittenBinaryConditionalExpression(node As BoundNode) As BoundNode
+        Private Shared Function TransformReferenceOrUnconstrainedRewrittenBinaryConditionalExpression(node As BoundNode) As BoundNode
             Return If(node.Kind <> BoundKind.BinaryConditionalExpression, node,
-                      TransformRewrittenBinaryConditionalExpression(DirectCast(node, BoundBinaryConditionalExpression)))
+                      TransformReferenceOrUnconstrainedRewrittenBinaryConditionalExpression(DirectCast(node, BoundBinaryConditionalExpression)))
         End Function
 
-        Private Shared Function TransformRewrittenBinaryConditionalExpression(node As BoundBinaryConditionalExpression) As BoundExpression
+        Private Shared Function TransformReferenceOrUnconstrainedRewrittenBinaryConditionalExpression(node As BoundBinaryConditionalExpression) As BoundExpression
             Debug.Assert(node.ConvertedTestExpression Is Nothing)   ' Those should be rewritten by now
             Debug.Assert(node.TestExpressionPlaceholder Is Nothing)
 
@@ -181,8 +181,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim testExpr = node.TestExpression
             Dim elseExpr = node.ElseExpression
 
-            ' Test expression may not be a non-nullable value type
-            Debug.Assert(testExpr.IsNothingLiteral OrElse Not (testExpr.Type.IsValueType AndAlso Not testExpr.Type.IsNullableType()))
+            ' Nullable value types should have been handled earlier in lowering, so we can only have reference types and
+            ' unconstrained type parameters at this point
+            Debug.Assert(testExpr.IsNothingLiteral OrElse Not testExpr.Type.IsValueType)
 
             ' TODO: Checking type equality of test and else is not strictly needed.
             '       Consider removing this requirement.
@@ -200,8 +201,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             End If
 
-            ' At this point, we must either have a reference type, or an unconstrained type parameter (which is neither reference nor value)
-            Debug.Assert(testExpr.Type.IsReferenceType OrElse Not testExpr.Type.IsValueType)
+            Debug.Assert(Not testExpr.Type.IsValueType)
             Return node
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalExpressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalExpressions.vb
@@ -181,8 +181,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim testExpr = node.TestExpression
             Dim elseExpr = node.ElseExpression
 
-            ' Test expression may only be of a reference or nullable type
-            Debug.Assert(testExpr.IsNothingLiteral OrElse testExpr.Type.IsReferenceType OrElse testExpr.Type.IsNullableType)
+            ' Test expression may not be a non-nullable value type
+            Debug.Assert(testExpr.IsNothingLiteral OrElse Not (testExpr.Type.IsValueType AndAlso Not testExpr.Type.IsNullableType()))
 
             ' TODO: Checking type equality of test and else is not strictly needed.
             '       Consider removing this requirement.
@@ -200,7 +200,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             End If
 
-            Debug.Assert(testExpr.Type.IsReferenceType)
+            ' At this point, we must either have a reference type, or an unconstrained type parameter (which is neither reference nor value)
+            Debug.Assert(testExpr.Type.IsReferenceType OrElse Not testExpr.Type.IsValueType)
             Return node
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
@@ -166,7 +166,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Case Feature.InterpolatedStrings
                     Return ERRID.FEATURE_InterpolatedStrings
                 Case Feature.UnconstrainedTypeParameterInConditional
-                    Return ERRID.FEATURE_UnconstrainedTypeParameterInCondtional
+                    Return ERRID.FEATURE_UnconstrainedTypeParameterInConditional
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(feature)
             End Select

--- a/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
@@ -36,6 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         LeadingDigitSeparator
         NonTrailingNamedArguments
         PrivateProtected
+        UnconstrainedTypeParameterInConditional
     End Enum
 
     Friend Module FeatureExtensions
@@ -93,6 +94,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Feature.NonTrailingNamedArguments,
                     Feature.PrivateProtected
                     Return LanguageVersion.VisualBasic15_5
+
+                Case Feature.UnconstrainedTypeParameterInConditional
+                    Return LanguageVersion.VisualBasic16
 
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(feature)
@@ -161,6 +165,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return ERRID.FEATURE_PrivateProtected
                 Case Feature.InterpolatedStrings
                     Return ERRID.FEATURE_InterpolatedStrings
+                Case Feature.UnconstrainedTypeParameterInConditional
+                    Return ERRID.FEATURE_UnconstrainedTypeParameterInCondtional
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(feature)
             End Select

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -12226,11 +12226,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to unconstrained type parameter variables in two operand conditionals.
+        '''  Looks up a localized string similar to unconstrained type parameters in binary conditional expressions.
         '''</summary>
-        Friend ReadOnly Property FEATURE_UnconstrainedTypeParameterInCondtional() As String
+        Friend ReadOnly Property FEATURE_UnconstrainedTypeParameterInConditional() As String
             Get
-                Return ResourceManager.GetString("FEATURE_UnconstrainedTypeParameterInCondtional", resourceCulture)
+                Return ResourceManager.GetString("FEATURE_UnconstrainedTypeParameterInConditional", resourceCulture)
             End Get
         End Property
         

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -5171,7 +5171,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to First operand in a binary &apos;If&apos; expression must be nullable or a reference type..
+        '''  Looks up a localized string similar to First operand in a binary &apos;If&apos; expression must be a nullable value type, a reference type, or an unconstrained generic type..
         '''</summary>
         Friend ReadOnly Property ERR_IllegalCondTypeInIIF() As String
             Get

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -12226,6 +12226,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to unconstrained type parameter variables in two operand conditionals.
+        '''</summary>
+        Friend ReadOnly Property FEATURE_UnconstrainedTypeParameterInCondtional() As String
+            Get
+                Return ResourceManager.GetString("FEATURE_UnconstrainedTypeParameterInCondtional", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to warning directives.
         '''</summary>
         Friend ReadOnly Property FEATURE_WarningDirectives() As String
@@ -12251,7 +12260,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return ResourceManager.GetString("FieldInitializerSyntaxNotWithinSyntaxTree", resourceCulture)
             End Get
         End Property
-
+        
         '''<summary>
         '''  Looks up a localized string similar to File name &apos;{0}&apos; is empty, contains invalid characters, has a drive specification without an absolute path, or is too long.
         '''</summary>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -3029,7 +3029,7 @@
     <value>Cannot infer a common type for the second and third operands of the 'If' operator. One must have a widening conversion to the other.</value>
   </data>
   <data name="ERR_IllegalCondTypeInIIF" xml:space="preserve">
-    <value>First operand in a binary 'If' expression must be nullable or a reference type.</value>
+    <value>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</value>
   </data>
   <data name="ERR_CantCallIIF" xml:space="preserve">
     <value>'If' operator cannot be used in a 'Call' statement.</value>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5533,7 +5533,7 @@
   <data name="FEATURE_InterpolatedStrings" xml:space="preserve">
     <value>interpolated strings</value>
   </data>
-  <data name="FEATURE_UnconstrainedTypeParameterInCondtional" xml:space="preserve">
-    <value>unconstrained type parameter variables in two operand conditionals</value>
+  <data name="FEATURE_UnconstrainedTypeParameterInConditional" xml:space="preserve">
+    <value>unconstrained type parameters in binary conditional expressions</value>
   </data>
 </root>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5533,4 +5533,7 @@
   <data name="FEATURE_InterpolatedStrings" xml:space="preserve">
     <value>interpolated strings</value>
   </data>
+  <data name="FEATURE_UnconstrainedTypeParameterInCondtional" xml:space="preserve">
+    <value>unconstrained type parameter variables in two operand conditionals</value>
+  </data>
 </root>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">stromy({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">První operand v binárním výrazu If musí být typu, který připouští hodnotu Null, nebo typu odkazu.</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">První operand v binárním výrazu If musí být typu, který připouští hodnotu Null, nebo typu odkazu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">Bäume({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">Der erste Operand in einem binären If-Ausdruck muss ein Typ, der NULL-Werte zulässt, oder ein Referenztyp sein.</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">Der erste Operand in einem binären If-Ausdruck muss ein Typ, der NULL-Werte zulässt, oder ein Referenztyp sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">El primer operando de una expresión 'If' binaria debe ser un tipo que acepte valores NULL o un tipo de referencia.</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">El primer operando de una expresión 'If' binaria debe ser un tipo que acepte valores NULL o un tipo de referencia.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">árboles({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">Le premier opérande d'une expression binaire 'If' doit être de type nullable ou référence.</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">Le premier opérande d'une expression binaire 'If' doit être de type nullable ou référence.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">arborescences({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">alberi ({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">Il primo operando in un'espressione 'If' binaria deve essere nullable o un tipo riferimento.</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">Il primo operando in un'espressione 'If' binaria deve essere nullable o un tipo riferimento.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">ツリー ({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">バイナリ 'If' 式の最初のオペランドは Null 許容または参照型である必要があります。</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">バイナリ 'If' 式の最初のオペランドは Null 許容または参照型である必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">If' 이항 식의 첫 번째 피연산자는 nullable이거나 참조 형식이어야 합니다.</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">If' 이항 식의 첫 번째 피연산자는 nullable이거나 참조 형식이어야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">트리({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">trees({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">Typem pierwszego argumentu operacji w binarnym wyrażeniu „If” musi być typ dopuszczający wartość null lub typ referencyjny.</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">Typem pierwszego argumentu operacji w binarnym wyrażeniu „If” musi być typ dopuszczający wartość null lub typ referencyjny.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">O primeiro operando em uma expressão 'If' binária deve ser anulável ou um tipo de referência.</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">O primeiro operando em uma expressão 'If' binária deve ser anulável ou um tipo de referência.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">árvores({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">Первым операндом в бинарном выражении "If" должен быть тип, допускающий значения NULL, или ссылочный тип.</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">Первым операндом в бинарном выражении "If" должен быть тип, допускающий значения NULL, или ссылочный тип.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">деревья({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">İkili bir 'If' ifadesindeki ilk işlenen null yapılabilmeli veya bir başvuru türü olmalıdır.</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">İkili bir 'If' ifadesindeki ilk işlenen null yapılabilmeli veya bir başvuru türü olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">ağaçlar({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">树({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">二进制“If”表达式中的第一个操作数必须是可以为 null 的类型或引用类型。</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">二进制“If”表达式中的第一个操作数必须是可以为 null 的类型或引用类型。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../VBResources.resx">
     <body>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
+        <source>unconstrained type parameter variables in two operand conditionals</source>
+        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Trees0">
         <source>trees({0})</source>
         <target state="translated">trees({0})</target>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../VBResources.resx">
     <body>
-      <trans-unit id="FEATURE_UnconstrainedTypeParameterInCondtional">
-        <source>unconstrained type parameter variables in two operand conditionals</source>
-        <target state="new">unconstrained type parameter variables in two operand conditionals</target>
+      <trans-unit id="FEATURE_UnconstrainedTypeParameterInConditional">
+        <source>unconstrained type parameters in binary conditional expressions</source>
+        <target state="new">unconstrained type parameters in binary conditional expressions</target>
         <note />
       </trans-unit>
       <trans-unit id="Trees0">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
@@ -4858,8 +4858,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_IllegalCondTypeInIIF">
-        <source>First operand in a binary 'If' expression must be nullable or a reference type.</source>
-        <target state="translated">二進位 'If' 運算式的第一個運算元必須是可為 Null 或是參考類型。</target>
+        <source>First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.</source>
+        <target state="needs-review-translation">二進位 'If' 運算式的第一個運算元必須是可為 Null 或是參考類型。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantCallIIF">

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIfOperator.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIfOperator.vb
@@ -81,7 +81,7 @@ False
 
         End Sub
 
-        ' Function call in return expression 
+        ' Function call in return expression
         <WorkItem(541647, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541647")>
         <Fact()>
         Public Sub FunctionCallAsArgument()
@@ -125,7 +125,7 @@ False
 }]]>)
         End Sub
 
-        ' Lambda works  in return argument 
+        ' Lambda works  in return argument
         <Fact()>
         Public Sub LambdaAsArgument_1()
             Dim compilation1 = CompileAndVerify(
@@ -211,7 +211,7 @@ End Module
             Dim compilation1 = CompileAndVerify(
 <compilation>
     <file name="a.vb">
-Option Infer on  
+Option Infer on
 Imports System
 Imports System.Linq.Expressions
 Module Program
@@ -364,7 +364,7 @@ End Module
 
         End Sub
 
-        ' Not boolean type as conditional-argument 
+        ' Not boolean type as conditional-argument
         <WorkItem(541647, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541647")>
         <Fact()>
         Public Sub NotBooleanAsConditionalArgument()
@@ -405,7 +405,7 @@ End Module
 
         End Sub
 
-        ' Not boolean type as conditional-argument 
+        ' Not boolean type as conditional-argument
         <WorkItem(541647, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541647")>
         <Fact()>
         Public Sub NotBooleanAsConditionalArgument_2()
@@ -522,7 +522,7 @@ End Module
 }]]>).Compilation
         End Sub
 
-        ' IF used in Redim 
+        ' IF used in Redim
         <WorkItem(528563, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528563")>
         <Fact>
         Public Sub IfUsedInRedim()
@@ -560,7 +560,7 @@ End Module
 <compilation>
     <file name="a.vb">
 Imports System
-&lt;Assembly: CLSCompliant(If(True, False, True))&gt; 
+&lt;Assembly: CLSCompliant(If(True, False, True))&gt;
 Public Class base
     Public Shared sub Main()
     End Sub
@@ -615,7 +615,7 @@ End Module
 }]]>).Compilation
         End Sub
 
-        ' IF as Optional parameter 
+        ' IF as Optional parameter
         <Fact()>
         Public Sub IFAsOptionalParameter()
             Dim compilation1 = CompileAndVerify(
@@ -634,7 +634,7 @@ End Module
 </compilation>, expectedOutput:="61").Compilation
         End Sub
 
-        ' IF used in For step 
+        ' IF used in For step
         <Fact()>
         Public Sub IFUsedInForStep()
             CompileAndVerify(
@@ -651,7 +651,7 @@ End Module
 </compilation>, options:=TestOptions.ReleaseExe)
         End Sub
 
-        ' Passing IF as byref arg 
+        ' Passing IF as byref arg
         <WorkItem(541647, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541647")>
         <Fact()>
         Public Sub IFAsByrefArg()
@@ -894,7 +894,7 @@ Class Test1
     Public Function m2() As IBase
         Return If(Derived.mask = 0, Me, y)
     End Function
-    'version2 
+    'version2
 End Class
     </file>
 </compilation>, options:=TestOptions.ReleaseExe).VerifyIL("Test1.m1", <![CDATA[
@@ -955,7 +955,7 @@ Class Test1
     Public Function m2() As IBase
         Return If(Me, y)
     End Function
-    'version2 
+    'version2
 End Class
     </file>
 </compilation>, options:=TestOptions.ReleaseExe).VerifyIL("Test1.m1", <![CDATA[
@@ -1016,7 +1016,7 @@ Class Test1
     Public Function m2() As IBase
         Return If (DirectCast(Me, IBase), y)
     End Function
-    'version2 
+    'version2
 End Class
     </file>
 </compilation>, options:=TestOptions.ReleaseExe).VerifyIL("Test1.m1", <![CDATA[
@@ -1327,6 +1327,24 @@ String Parameter 1
   IL_0006:  call       "Sub System.Console.WriteLine(Object)"
   IL_000b:  ret
 }
+]]>)
+        End Sub
+
+        <Fact>
+        Public Sub IfOnUnconstrainedTypeParametersOldLanguageVersion()
+            CreateCompilation(
+<compilation>
+    <file name="a.vb">
+Friend Module Mod1
+        Sub M1(Of T)(arg1 As T, arg2 As T)
+            System.Console.WriteLine(If(arg1, arg2))
+        End Sub
+    End Module
+    </file>
+</compilation>, parseOptions:=TestOptions.Regular15_5).AssertTheseDiagnostics(<![CDATA[
+BC36716: Visual Basic 15.5 does not support unconstrained type parameter variables in two operand conditionals.
+            System.Console.WriteLine(If(arg1, arg2))
+                                     ~~~~~~~~~~~~~~
 ]]>)
         End Sub
     End Class

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIfOperator.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIfOperator.vb
@@ -1262,12 +1262,17 @@ Friend Module Mod1
     End Sub
 
     Sub Main()
-        M1(Nothing, 10)
-        M1(1, 10)
+        M1(Nothing, 1000)
+        M1(1, 1000)
         M1(Nothing, "String Parameter 1")
         M1("String Parameter 2", "Should not print")
         M1(Of Integer?)(Nothing, 4)
-        M1(Of Integer?)(5, 10)
+        M1(Of Integer?)(5, 1000)
+        M2(1000, 6)
+        M2(Of Object, Integer?)(7, Nothing)
+        M2(Of Object, Integer?)(1000, 8)
+        M2(Of Integer?, Integer?)(9, Nothing)
+        M2(Of Integer?, Integer?)(1000, 10)
     End Sub
 End Module
     </file>
@@ -1278,6 +1283,11 @@ String Parameter 1
 String Parameter 2
 4
 5
+6
+7
+8
+9
+10
 ]]>).VerifyIL("Mod1.M1", <![CDATA[
 {
   // Code size       22 (0x16)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIfOperator.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIfOperator.vb
@@ -1253,19 +1253,23 @@ Friend Module BIFOpResult0011mod
 <compilation>
     <file name="a.vb">
 Friend Module Mod1
-        Sub M1(Of T)(arg1 As T, arg2 As T)
-            System.Console.WriteLine(If(arg1, arg2))
-        End Sub
+    Sub M1(Of T)(arg1 As T, arg2 As T)
+        System.Console.WriteLine(If(arg1, arg2))
+    End Sub
 
-        Sub Main()
-            M1(Nothing, 10)
-            M1(1, 10)
-            M1(Nothing, "String Parameter 1")
-            M1("String Parameter 2", "Should not print")
-            M1(Of Integer?)(Nothing, 4)
-            M1(Of Integer?)(5, 10)
-        End Sub
-    End Module
+    Sub M2(Of T1, T2 As T1)(arg1 as T1, arg2 As T2)
+        System.Console.WriteLine(If(arg2, arg1))
+    End Sub
+
+    Sub Main()
+        M1(Nothing, 10)
+        M1(1, 10)
+        M1(Nothing, "String Parameter 1")
+        M1("String Parameter 2", "Should not print")
+        M1(Of Integer?)(Nothing, 4)
+        M1(Of Integer?)(5, 10)
+    End Sub
+End Module
     </file>
 </compilation>, expectedOutput:=<![CDATA[
 0
@@ -1287,6 +1291,22 @@ String Parameter 2
   IL_000b:  box        "T"
   IL_0010:  call       "Sub System.Console.WriteLine(Object)"
   IL_0015:  ret
+}
+]]>).VerifyIL("Mod1.M2", <![CDATA[
+{
+  // Code size       33 (0x21)
+  .maxstack  1
+  IL_0000:  ldarg.1
+  IL_0001:  box        "T2"
+  IL_0006:  brtrue.s   IL_000b
+  IL_0008:  ldarg.0
+  IL_0009:  br.s       IL_0016
+  IL_000b:  ldarg.1
+  IL_000c:  box        "T2"
+  IL_0011:  unbox.any  "T1"
+  IL_0016:  box        "T1"
+  IL_001b:  call       "Sub System.Console.WriteLine(Object)"
+  IL_0020:  ret
 }
 ]]>)
         End Sub
@@ -1336,15 +1356,15 @@ String Parameter 1
 <compilation>
     <file name="a.vb">
 Friend Module Mod1
-        Sub M1(Of T)(arg1 As T, arg2 As T)
-            System.Console.WriteLine(If(arg1, arg2))
-        End Sub
-    End Module
+    Sub M1(Of T)(arg1 As T, arg2 As T)
+        System.Console.WriteLine(If(arg1, arg2))
+    End Sub
+End Module
     </file>
 </compilation>, parseOptions:=TestOptions.Regular15_5).AssertTheseDiagnostics(<![CDATA[
-BC36716: Visual Basic 15.5 does not support unconstrained type parameter variables in two operand conditionals.
-            System.Console.WriteLine(If(arg1, arg2))
-                                     ~~~~~~~~~~~~~~
+BC36716: Visual Basic 15.5 does not support unconstrained type parameters in binary conditional expressions.
+        System.Console.WriteLine(If(arg1, arg2))
+                                 ~~~~~~~~~~~~~~
 ]]>)
         End Sub
     End Class

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
@@ -16059,10 +16059,10 @@ BC33035: Type 'c2' must define operator 'IsTrue' to be used in a 'OrElse' expres
     </compilation>)
 
             Dim expectedErrors1 = <errors>
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
                 Console.WriteLine(If(choice1 &lt; choice2, 1))
                                      ~~~~~~~~~~~~~~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
                 Console.WriteLine(If(booleanVar, "Test returns True."))
                                      ~~~~~~~~~~
                  </errors>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/ConditionalExpressionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/ConditionalExpressionsTests.vb
@@ -112,12 +112,7 @@ BC42021: Cannot infer a common type; 'Object' assumed.
         <Fact>
         Public Sub TestBinaryConditionalGenerics()
             TestCondition("if(GetUserGeneric(Of T), GetUserGeneric(Of T))", expectedType:="D(Of T)")
-            TestCondition("if(GetTypeParameter(Of T), GetTypeParameter(Of T))", expectedType:="T", errors:=
-<errors>
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
-        System.Console.WriteLine(if(GetTypeParameter(Of T), GetTypeParameter(Of T)))
-                                    ~~~~~~~~~~~~~~~~~~~~~~
-</errors>)
+            TestCondition("if(GetTypeParameter(Of T), GetTypeParameter(Of T))", expectedType:="T")
 
             TestCondition("if(GetUserGeneric(Of T), GetUserGeneric(Of T))", expectedType:="D(Of T)")
             TestCondition("if(GetUserGeneric(Of T), Nothing)", expectedType:="D(Of T)")
@@ -400,7 +395,7 @@ Class CX
 
     Public F2 As Integer = If 1
 
-    Public F3 As Integer = If(1, 
+    Public F3 As Integer = If(1,
 
     Public F4 As Integer = If(True, 2
 
@@ -424,9 +419,9 @@ Class CX
 
     Public F13 As Integer = If(True, S, 23)
 
-    Public F14 As Integer = If( 
+    Public F14 As Integer = If(
 
-    Public F15 As Integer = If() 
+    Public F15 As Integer = If()
 
     Public F16 As Integer = If(True
 
@@ -441,18 +436,18 @@ End Class
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
-BC33104: 'If' operator requires either two or three operands.
+    BC33104: 'If' operator requires either two or three operands.
     Public F1 As Integer = If(True, 2, 3, 4, 5)
                                         ~~~~~~
 BC30199: '(' expected.
     Public F2 As Integer = If 1
                               ~
 BC30198: ')' expected.
-    Public F3 As Integer = If(1, 
-                                 ~
+    Public F3 As Integer = If(1,
+                                ~
 BC30201: Expression expected.
-    Public F3 As Integer = If(1, 
-                                 ~
+    Public F3 As Integer = If(1,
+                                ~
 BC30198: ')' expected.
     Public F4 As Integer = If(True, 2
                                      ~
@@ -499,16 +494,16 @@ BC30491: Expression does not produce a value.
     Public F13 As Integer = If(True, S, 23)
                                      ~
 BC30198: ')' expected.
-    Public F14 As Integer = If( 
-                                ~
+    Public F14 As Integer = If(
+                               ~
 BC30201: Expression expected.
-    Public F14 As Integer = If( 
-                                ~
+    Public F14 As Integer = If(
+                               ~
 BC33104: 'If' operator requires either two or three operands.
-    Public F14 As Integer = If( 
-                                ~
+    Public F14 As Integer = If(
+                               ~
 BC33104: 'If' operator requires either two or three operands.
-    Public F15 As Integer = If() 
+    Public F15 As Integer = If()
                                ~
 BC30198: ')' expected.
     Public F16 As Integer = If(True
@@ -534,8 +529,8 @@ Class CX
     Public F1 As Integer = If(True, "", 23)
     Public F2 As Integer = If("error", 1, 2)
 
-        Public Sub S1() 
-        End Sub 
+        Public Sub S1()
+        End Sub
     Public F3 As Integer = If(True, S1(), (Nothing))
 
         Public Function FUNK1(x As Integer) As Integer
@@ -681,8 +676,8 @@ Imports System
 
 Class CX
 
-    Public Sub S1() 
-    End Sub 
+    Public Sub S1()
+    End Sub
 
     Public Function FUNK1(x As Integer) As Integer
         Return 0
@@ -767,13 +762,13 @@ BC36911: Cannot infer a common type.
 BC36912: Cannot infer a common type, and Option Strict On does not allow 'Object' to be assumed.
         Dim F9 As Object = If(G.P1, G.F2)
                            ~~~~~~~~~~~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F9_ As Object = If(G.P1, Nothing)
                                ~~~~
 BC36912: Cannot infer a common type, and Option Strict On does not allow 'Object' to be assumed.
         Dim F10 As Object = If(G.F2, G.P3)
                             ~~~~~~~~~~~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F12 As Object = If(G.F4, G.P3)
                                ~~~~
 BC36912: Cannot infer a common type, and Option Strict On does not allow 'Object' to be assumed.
@@ -793,7 +788,7 @@ BC42021: Cannot infer a common type because more than one type is possible; 'Obj
 BC42021: Cannot infer a common type because more than one type is possible; 'Object' assumed.
         Dim F2 As Object = If(23, "")
                            ~~~~~~~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F2 As Object = If(23, "")
                               ~~
 BC30491: Expression does not produce a value.
@@ -811,28 +806,27 @@ BC36911: Cannot infer a common type.
 BC42021: Cannot infer a common type; 'Object' assumed.
         Dim F9 As Object = If(G.P1, G.F2)
                            ~~~~~~~~~~~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F9 As Object = If(G.P1, G.F2)
                               ~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F9_ As Object = If(G.P1, Nothing)
                                ~~~~
 BC42021: Cannot infer a common type; 'Object' assumed.
         Dim F10 As Object = If(G.F2, G.P3)
                             ~~~~~~~~~~~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F10 As Object = If(G.F2, G.P3)
                                ~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F12 As Object = If(G.F4, G.P3)
                                ~~~~
+BC42016: Implicit conversion from 'Object' to 'T1'.
+        Dim v1 As T1 = If(x1, x2)
+                       ~~~~~~~~~~
 BC42021: Cannot infer a common type; 'Object' assumed.
         Dim v1 As T1 = If(x1, x2)
                        ~~~~~~~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
-        Dim v1 As T1 = If(x1, x2)
-                          ~~
-
 ]]>
 </expected>)
         End Sub
@@ -842,7 +836,7 @@ BC33107: First operand in a binary 'If' expression must be nullable or a referen
         Public Sub TestInvalidBinaryIfOperatorsStrictOff()
             TestInvalidBinaryIfOperatorsStrict(OptionStrict.Off,
 <expected><![CDATA[
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F2 As Object = If(23, "")
                               ~~
 BC30491: Expression does not produce a value.
@@ -857,21 +851,18 @@ BC36911: Cannot infer a common type.
 BC36911: Cannot infer a common type.
         Dim F8 As Func(Of Integer, Integer) = If(Nothing, AddressOf FUNK2)
                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F9 As Object = If(G.P1, G.F2)
                               ~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F9_ As Object = If(G.P1, Nothing)
                                ~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F10 As Object = If(G.F2, G.P3)
                                ~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
+BC33107: First operand in a binary 'If' expression must be a nullable value type, a reference type, or an unconstrained generic type.
         Dim F12 As Object = If(G.F4, G.P3)
                                ~~~~
-BC33107: First operand in a binary 'If' expression must be nullable or a reference type.
-        Dim v1 As T1 = If(x1, x2)
-                          ~~
         ]]>
 </expected>)
         End Sub

--- a/src/Test/Utilities/Portable/Platform/Desktop/DesktopRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Portable/Platform/Desktop/DesktopRuntimeEnvironment.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
-using static Roslyn.Test.Utilities.RuntimeEnvironmentUtilities; 
+using static Roslyn.Test.Utilities.RuntimeEnvironmentUtilities;
 
 namespace Roslyn.Test.Utilities.Desktop
 {
@@ -77,7 +77,7 @@ namespace Roslyn.Test.Utilities.Desktop
         }
 
         /// <summary>
-        /// Profiling demonstrates the creation of AppDomains take up a significant amount of time in the 
+        /// Profiling demonstrates the creation of AppDomains take up a significant amount of time in the
         /// test run time.  Hence we re-use them so long as there are no conflicts with the existing loaded
         /// modules.
         /// </summary>
@@ -106,7 +106,7 @@ namespace Roslyn.Test.Utilities.Desktop
 
             var runtimeData = GetOrCreateRuntimeData(allModules);
 
-            // Many prominent assemblys like mscorlib are already in the RuntimeAssemblyManager.  Only 
+            // Many prominent assemblys like mscorlib are already in the RuntimeAssemblyManager.  Only
             // add in the delta values to reduce serialization overhead going across AppDomains.
             var manager = runtimeData.Manager;
             var missingList = manager
@@ -152,7 +152,7 @@ namespace Roslyn.Test.Utilities.Desktop
                     if (data.ConflictCount > 5)
                     {
                         // Once a RuntimeAssemblyManager is proven to have conflicts it's likely subsequent runs
-                        // will also have conflicts.  Take it out of the cache. 
+                        // will also have conflicts.  Take it out of the cache.
                         data.Dispose();
                         s_runtimeDataCache.RemoveAt(i);
                     }
@@ -307,11 +307,11 @@ namespace Roslyn.Test.Utilities.Desktop
                     throw new Exception("Verification succeeded unexpectedly");
                 }
             }
-            catch (RuntimePeVerifyException)
+            catch (RuntimePeVerifyException ex)
             {
                 if (shouldSucceed)
                 {
-                    throw new Exception("Verification failed");
+                    throw new Exception($"Verification failed: {ex.Message}");
                 }
             }
         }


### PR DESCRIPTION
This brings it inline with C#'s handling, and implements https://github.com/dotnet/vblang/issues/339. @AlekseyTs @cston @dotnet/roslyn-compiler for review. /cc @KathleenDollard.