### PR TITLE
Add a protected helper for logging exceptions to servicehub log

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
@@ -253,15 +253,20 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             if (!cancellationToken.IsCancellationRequested)
             {
-                LogError("Exception: " + ex.ToString());
-
-                LogExtraInformation(ex);
-
-                var callStack = new StackTrace().ToString();
-                LogError("From: " + callStack);
+                LogException(ex);    
             }
 
             return false;
+        }
+        
+        protected void LogException(Exception ex)
+        {
+            LogError("Exception: " + ex.ToString());
+
+            LogExtraInformation(ex);
+
+            var callStack = new StackTrace().ToString();
+            LogError("From: " + callStack);
         }
 
         private void LogExtraInformation(Exception ex)


### PR DESCRIPTION
This will allow derived types to log exceptions that are handled before RunServiceAsync() can see them.