### PR TITLE
Check for missing types/members. Improve diagnostics and exception handling.

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - VS2019.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - VS2019.md
@@ -21,3 +21,6 @@
     2. get_Property
     3. GetInt()
     4. set_Property
+
+- https://github.com/dotnet/roslyn/issues/29656 Previously, ref-returning async local functions would compile, by ignoring the `ref` modifier of the return type.
+    In Visual Studio 2019, this now produces an error, just like ref-returning async methods do.

--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -212,19 +212,11 @@ return;
 
 The `MoveNext()` method of the state machine also includes exception handling.
 For regular `async` methods, we catch any such exception and pass it on to the caller of the state machine, by setting the exception in the task being awaited by the caller.
-For async-iterators, we also catch any such exception and pass it on to the caller of the state machine (`WaitForNextAsync` and `TryGetNext`) via the promise of value-or-end:
+For async-iterators, when the promise of value-or-end is active, we also catch any such exception and pass it on to the caller of the state machine (`WaitForNextAsync` and `TryGetNext`) via the promise:
 
 ```C#
-catch (Exception ex)
+catch (Exception ex) when { this.state = finishedState; promiseIsActive }
 {
-    this.state = finishedState
-    if (promiseIsActive)
-    {
-        this.promiseOfValueOrEnd.SetException(ex);
-    }
-    else
-    {
-        throw;
-    }
+    this.promiseOfValueOrEnd.SetException(ex);
 }
 ```

--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -54,7 +54,7 @@ async IAsyncEnumerable<int> GetValuesFromServer()
 }
 ```
 
-PROTOTYPE(async-streams): TODO: async LINQ
+**open issue**: Design async LINQ
 
 ### Detailed design for async `foreach` statement
 PROTOTYPE(async-streams): TODO
@@ -116,7 +116,7 @@ If the promise is active:
 - a call to `WaitForNextAsync` will not move the state machine forward (ie. it won't call `MoveNext()`),
 - a call to `TryGetNext` APIs will throw.
 
-PROTOTYPE(async-streams): The compiler leverages existing BCL types (including some recently added types from the `System.Threading.Tasks.Extensions` NuGet package) in the state machine it generates. But as part of this feature, we may introduce some additional BCL types, so that the state machine can be further simplified and optimized.
+**open issue**: The compiler leverages existing BCL types (including some recently added types from the `System.Threading.Tasks.Extensions` NuGet package) in the state machine it generates. But as part of this feature, we may introduce some additional BCL types, so that the state machine can be further simplified and optimized.
 
 ```C#
 ValueTask<bool> WaitForNextAsync()

--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -218,5 +218,6 @@ For async-iterators, when the promise of value-or-end is active, we also catch a
 catch (Exception ex) when { this.state = finishedState; promiseIsActive }
 {
     this.promiseOfValueOrEnd.SetException(ex);
+    return;
 }
 ```

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -1157,7 +1157,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             var returnType = waitForNextAsyncMethodCandidate.OriginalDefinition.ReturnType;
             if (!returnType.IsGenericTaskType(Compilation))
             {
-                // PROTOTYPE(async-streams): Add tests for other task-like return types for WaitForNextAsync
                 return false;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         Error(elementTypeDiagnostics, ErrorCode.ERR_BadIteratorReturnRef, _methodSymbol.Locations[0], _methodSymbol);
                     }
-                    else
+                    else if (!returnType.IsErrorType())
                     {
                         Error(elementTypeDiagnostics, ErrorCode.ERR_BadIteratorReturn, _methodSymbol.Locations[0], _methodSymbol, returnType);
                     }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -701,6 +701,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Async foreach statement cannot operate on variables of type &apos;{0}&apos; because &apos;{0}&apos; does not contain a public definition for &apos;{1}&apos;.
+        /// </summary>
+        internal static string ERR_AsyncForEachMissingMember {
+            get {
+                return ResourceManager.GetString("ERR_AsyncForEachMissingMember", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos;: an attribute argument cannot use type parameters.
         /// </summary>
         internal static string ERR_AttrArgWithTypeVars {
@@ -998,7 +1007,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The return type of an async method must be void, Task or Task&lt;T&gt;.
+        ///   Looks up a localized string similar to The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;.
         /// </summary>
         internal static string ERR_BadAsyncReturn {
             get {
@@ -1579,6 +1588,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_BadForeachDecl {
             get {
                 return ResourceManager.GetString("ERR_BadForeachDecl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Async foreach requires that the return type &apos;{0}&apos; of &apos;{1}&apos; must have suitable public WaitForNextAsync and TryGetNext methods.
+        /// </summary>
+        internal static string ERR_BadGetAsyncEnumerator {
+            get {
+                return ResourceManager.GetString("ERR_BadGetAsyncEnumerator", resourceCulture);
             }
         }
         
@@ -6659,6 +6677,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Async foreach statement cannot operate on variables of type &apos;{0}&apos; because it implements multiple instantiations of &apos;{1}&apos;; try casting to a specific interface instantiation.
+        /// </summary>
+        internal static string ERR_MultipleIAsyncEnumOfT {
+            get {
+                return ResourceManager.GetString("ERR_MultipleIAsyncEnumOfT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to foreach statement cannot operate on variables of type &apos;{0}&apos; because it implements multiple instantiations of &apos;{1}&apos;; try casting to a specific interface instantiation.
         /// </summary>
         internal static string ERR_MultipleIEnumOfT {
@@ -7024,6 +7051,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_NoConversionForNubDefaultParam {
             get {
                 return ResourceManager.GetString("ERR_NoConversionForNubDefaultParam", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in an async using statement must be implicitly convertible to &apos;System.IAsyncDisposable&apos;.
+        /// </summary>
+        internal static string ERR_NoConvToIAsyncDisp {
+            get {
+                return ResourceManager.GetString("ERR_NoConvToIAsyncDisp", resourceCulture);
             }
         }
         
@@ -10481,6 +10517,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string IDS_FeatureAsyncMain {
             get {
                 return ResourceManager.GetString("IDS_FeatureAsyncMain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to async streams.
+        /// </summary>
+        internal static string IDS_FeatureAsyncStreams {
+            get {
+                return ResourceManager.GetString("IDS_FeatureAsyncStreams", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -710,6 +710,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Async foreach statement cannot operate on variables of type &apos;{0}&apos; because &apos;{0}&apos; does not contain a public definition for &apos;{1}&apos;. Did you mean &apos;foreach&apos; rather than &apos;foreach await&apos;?.
+        /// </summary>
+        internal static string ERR_AsyncForEachMissingMemberWrongAsync {
+            get {
+                return ResourceManager.GetString("ERR_AsyncForEachMissingMemberWrongAsync", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos;: an attribute argument cannot use type parameters.
         /// </summary>
         internal static string ERR_AttrArgWithTypeVars {
@@ -4927,6 +4936,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_ForEachMissingMember {
             get {
                 return ResourceManager.GetString("ERR_ForEachMissingMember", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to foreach statement cannot operate on variables of type &apos;{0}&apos; because &apos;{0}&apos; does not contain a public instance definition for &apos;{1}&apos;. Did you mean &apos;foreach await&apos;?.
+        /// </summary>
+        internal static string ERR_ForEachMissingMemberWrongAsync {
+            get {
+                return ResourceManager.GetString("ERR_ForEachMissingMemberWrongAsync", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3618,7 +3618,7 @@ Give the compiler some way to differentiate the methods. For example, you can gi
     <value>Since '{0}' is an async method that returns 'Task', a return keyword must not be followed by an object expression. Did you intend to return 'Task&lt;T&gt;'?</value>
   </data>
   <data name="ERR_BadAsyncReturn" xml:space="preserve">
-    <value>The return type of an async method must be void, Task or Task&lt;T&gt;</value>
+    <value>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</value>
   </data>
   <data name="ERR_CantReturnVoid" xml:space="preserve">
     <value>Cannot return an expression of type 'void'</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2635,6 +2635,12 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
   <data name="ERR_AsyncForEachMissingMember" xml:space="preserve">
     <value>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</value>
   </data>
+  <data name="ERR_ForEachMissingMemberWrongAsync" xml:space="preserve">
+    <value>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</value>
+  </data>
+  <data name="ERR_AsyncForEachMissingMemberWrongAsync" xml:space="preserve">
+    <value>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</value>
+  </data>
   <data name="WRN_BadXMLRefParamType" xml:space="preserve">
     <value>Invalid type for parameter {0} in XML comment cref attribute: '{1}'</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -905,11 +905,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                 _builder.OpenLocalScope(ScopeType.Catch, exceptionType);
 
-                if (catchBlock.IsSynthesizedAsyncCatchAll)
-                {
-                    Debug.Assert(_asyncCatchHandlerOffset < 0); // only one expected
-                    _asyncCatchHandlerOffset = _builder.AllocateILMarker();
-                }
+                RecordAsyncCatchHandlerOffset(catchBlock);
 
                 // Dev12 inserts the sequence point on catch clause without a filter, just before 
                 // the exception object is assigned to the variable.
@@ -941,6 +937,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             else
             {
                 _builder.OpenLocalScope(ScopeType.Filter);
+
+                RecordAsyncCatchHandlerOffset(catchBlock);
 
                 // Filtering starts with simulating regular catch through a 
                 // type check. If this is not our type then we are done.
@@ -1063,6 +1061,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             EmitBlock(catchBlock.Body);
 
             _builder.CloseLocalScope();
+        }
+
+        private void RecordAsyncCatchHandlerOffset(BoundCatchBlock catchBlock)
+        {
+            if (catchBlock.IsSynthesizedAsyncCatchAll)
+            {
+                Debug.Assert(_asyncCatchHandlerOffset < 0); // only one expected
+                _asyncCatchHandlerOffset = _builder.AllocateILMarker();
+            }
         }
 
         private void EmitSwitchStatement(BoundSwitchStatement switchStatement)

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1410,7 +1410,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // This is a heuristic since it's possible that there is no user code awaiting the task.
                     moveNextBodyDebugInfoOpt = new AsyncMoveNextBodyDebugInfo(
                         kickoffMethod,
-                        kickoffMethod.ReturnsVoid ? asyncCatchHandlerOffset : -1,
+                        catchHandlerOffset: kickoffMethod.ReturnsVoid ? asyncCatchHandlerOffset : -1,
                         asyncYieldPoints,
                         asyncResumePoints);
                 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1589,6 +1589,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AsyncForEachMissingMember = 9001,
         ERR_BadGetAsyncEnumerator = 9002,
         ERR_MultipleIAsyncEnumOfT = 9003,
+        ERR_ForEachMissingMemberWrongAsync = 9004,
+        ERR_AsyncForEachMissingMemberWrongAsync = 9005,
         #endregion diagnostics introduced for C# 8.0
 
         // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -220,6 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // C# 8.0 features.
                 case MessageID.IDS_FeatureAltInterpolatedVerbatimStrings:
+                case MessageID.IDS_FeatureAsyncStreams:
                     return LanguageVersion.CSharp8;
 
                 // C# 7.3 features.
@@ -239,7 +240,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return LanguageVersion.CSharp7_3;
 
                 // C# 7.2 features.
-                case MessageID.IDS_FeatureAsyncStreams: // PROTOTYPE(async-streams) Finalize LangVersion
                 case MessageID.IDS_FeatureNonTrailingNamedArguments: // semantic check
                 case MessageID.IDS_FeatureLeadingDigitSeparator:
                 case MessageID.IDS_FeaturePrivateProtected:

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -147,17 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // [body]
                         rewrittenBody
                     ),
-                    F.CatchBlocks(
-                        new BoundCatchBlock(
-                            F.Syntax,
-                            ImmutableArray.Create(exceptionLocal),
-                            F.Local(exceptionLocal),
-                            exceptionLocal.Type,
-                            exceptionFilterOpt: null,
-                            body: GenerateExceptionHandling(exceptionLocal),
-                            isSynthesizedAsyncCatchAll: true)
-                        )
-                    )
+                    F.CatchBlocks(GenerateExceptionHandling(exceptionLocal)))
                 );
 
             // ReturnLabel (for the rewritten return expressions in the user's method body)
@@ -231,61 +221,64 @@ namespace Microsoft.CodeAnalysis.CSharp
             F.CloseMethod(newBody);
         }
 
-        // PROTOTYPE(async-streams): use an exception filter instead, to avoid re-throwing:
-        // catch (Exception ex) where { this.state = finishedState; value = promiseIsActive } // pseudo-code for a BoundSequence
-        // {
-        //     this.promiseOfValueOrEnd.SetException(ex);
-        //     return;
-        // }
-        private BoundBlock GenerateExceptionHandling(LocalSymbol exceptionLocal)
+        private BoundCatchBlock GenerateExceptionHandling(LocalSymbol exceptionLocal)
         {
+            // For regular async method, produce:
+            // catch (Exception ex)
+            // {
+            //     this.state = finishedState
+            //     builder.SetException(ex)
+            // }
+
+            // For an async-iterator method, produce:
+            // catch (Exception ex) when { this.state = finishedState; promiseIsActive }
+            // {
+            //     this.promiseOfValueOrEnd.SetException(ex);
+            //     return;
+            // }
+
             // this.state = finishedState
-            BoundExpressionStatement assignFinishedState =
-                F.Assignment(F.Field(F.This(), stateField), F.Literal(StateMachineStates.FinishedStateMachine));
+            BoundExpression assignFinishedState =
+                F.AssignmentExpression(F.Field(F.This(), stateField), F.Literal(StateMachineStates.FinishedStateMachine));
 
             if (_asyncIteratorInfo == null)
             {
-                return F.Block(
-                    // this.state = finishedState
-                    assignFinishedState,
-                    // builder.SetException(ex)
-                    F.ExpressionStatement(
-                        F.Call(
-                            F.Field(F.This(), _asyncMethodBuilderField),
-                            _asyncMethodBuilderMemberCollection.SetException,
-                            F.Local(exceptionLocal))),
-                    GenerateReturn(false));
+                return new BoundCatchBlock(
+                    F.Syntax,
+                    ImmutableArray.Create(exceptionLocal),
+                    F.Local(exceptionLocal),
+                    exceptionLocal.Type,
+                    exceptionFilterOpt: null,
+                    body: F.Block(
+                        // this.state = finishedState
+                        F.ExpressionStatement(assignFinishedState),
+                        // builder.SetException(ex)
+                        F.ExpressionStatement(
+                            F.Call(
+                                F.Field(F.This(), _asyncMethodBuilderField),
+                                _asyncMethodBuilderMemberCollection.SetException,
+                                F.Local(exceptionLocal))),
+                        GenerateReturn(false)),
+                    isSynthesizedAsyncCatchAll: true);
             }
             else
             {
-                // this.state = finishedState
-                // if (promiseIsActive)
-                // {
-                //     this.promiseOfValueOrEnd.SetException(ex);
-                //     return;
-                // }
-                // else
-                // {
-                //     throw;
-                // }
-
                 // this.promiseOfValueOrEnd.SetException(ex);
                 var callSetException = F.ExpressionStatement(F.Call(
                     F.Field(F.This(), _asyncIteratorInfo.PromiseOfValueOrEndField),
                     _asyncIteratorInfo.SetExceptionMethod,
                     F.Local(exceptionLocal)));
 
-                return F.Block(
-                    // this.state = finishedState
-                    assignFinishedState,
-                    F.If(
-                        // if (promiseIsActive)
-                        F.Field(F.This(), _asyncIteratorInfo.PromiseIsActiveField),
-                        // this.promiseOfValueOrEnd.SetException(ex); return;
-                        thenClause: F.Block(callSetException, GenerateReturn(true)),
-                        // throw;
-                        elseClauseOpt: F.Throw()),
-                    GenerateReturn(false));
+                return new BoundCatchBlock(
+                    F.Syntax,
+                    ImmutableArray.Create(exceptionLocal),
+                    F.Local(exceptionLocal),
+                    exceptionLocal.Type,
+                    // when { this.state = finishedState; promiseIsActive }
+                    exceptionFilterOpt: F.Sequence(new BoundExpression[] { assignFinishedState }, F.Field(F.This(), _asyncIteratorInfo.PromiseIsActiveField)),
+                    // this.promiseOfValueOrEnd.SetException(ex);
+                    body: F.Block(callSetException, GenerateReturn(true)),
+                    isSynthesizedAsyncCatchAll: true);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     exceptionLocal.Type,
                     // when { this.state = finishedState; promiseIsActive }
                     exceptionFilterOpt: F.Sequence(new BoundExpression[] { assignFinishedState }, F.Field(F.This(), _asyncIteratorInfo.PromiseIsActiveField)),
-                    // this.promiseOfValueOrEnd.SetException(ex);
+                    // this.promiseOfValueOrEnd.SetException(ex); return;
                     body: F.Block(callSetException, GenerateReturn(true)),
                     isSynthesizedAsyncCatchAll: true);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -36,6 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             protected override void VerifyPresenceOfRequiredAPIs(DiagnosticBag bag)
             {
+                base.VerifyPresenceOfRequiredAPIs(bag);
                 EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerable_T__GetAsyncEnumerator, bag);
                 EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerator_T__WaitForNextAsync, bag);
                 EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerator_T__TryGetNext, bag);

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -42,6 +42,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerator_T__TryGetNext, bag);
                 EnsureWellKnownMember(WellKnownMember.System_IAsyncDisposable__DisposeAsync, bag);
                 EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_ValueTask_T__ctor, bag);
+
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__ctor, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__GetResult, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__GetStatus, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__get_Version, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__OnCompleted, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__Reset, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__SetException, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__SetResult, bag);
+
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_Sources_IValueTaskSource_T__GetResult, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_Sources_IValueTaskSource_T__GetStatus, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_Sources_IValueTaskSource_T__OnCompleted, bag);
+
+                EnsureWellKnownMember(WellKnownMember.System_Runtime_CompilerServices_IStrongBox_T__get_Value, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Runtime_CompilerServices_IStrongBox_T__Value, bag);
             }
 
             protected override void GenerateMethodImplementations()
@@ -447,17 +463,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // var inst = this;
                 // this._builder.Start(ref inst);
 
-                // PROTOTYPE(async-streams): Can we factor this code? (copied and modified from below)
-
                 LocalSymbol instSymbol = F.SynthesizedLocal(this.stateMachineType);
                 MethodSymbol startMethod = _asyncMethodBuilderMemberCollection.Start.Construct(this.stateMachineType);
                 BoundLocal instLocal = F.Local(instSymbol);
-
-                // PROTOTYPE(async-streams): Test constraints scenario
-                //if (_asyncMethodBuilderMemberCollection.CheckGenericMethodConstraints)
-                //{
-                //    startMethod.CheckConstraints(F.Compilation.Conversions, F.Syntax, F.Compilation, diagnostics);
-                //}
+                Debug.Assert(!_asyncMethodBuilderMemberCollection.CheckGenericMethodConstraints);
 
                 // this._builder.Start(ref inst);
                 BoundExpressionStatement startCall = F.ExpressionStatement(
@@ -520,16 +529,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     setExceptionMethod = (MethodSymbol)setExceptionMethod.SymbolAsMember((NamedTypeSymbol)_promiseOfValueOrEndField.Type);
                 }
-
-                // PROTOTYPE(async-streams): We should have checked for required members earlier
-                //if (setResultMethod is null)
-                //{
-                //    var descriptor = WellKnownMembers.GetDescriptor(member);
-                //    var diagnostic = new CSDiagnostic(
-                //        new CSDiagnosticInfo(ErrorCode.ERR_MissingPredefinedMember, (customBuilder ? (object)builderType : descriptor.DeclaringTypeMetadataName), descriptor.Name),
-                //        F.Syntax.Location);
-                //    F.Diagnostics.Add(diagnostic);
-                //}
 
                 var rewriter = new AsyncMethodToStateMachineRewriter(
                     method: method,

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -34,6 +34,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // PROTOTYPE(async-streams): Why does AsyncRewriter have logic to ignore accessibility?
             }
 
+            protected override void VerifyPresenceOfRequiredAPIs(MethodSymbol method, DiagnosticBag bag)
+            {
+                EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerable_T__GetAsyncEnumerator, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerator_T__WaitForNextAsync, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerator_T__TryGetNext, bag);
+                EnsureWellKnownMember(WellKnownMember.System_IAsyncDisposable__DisposeAsync, bag);
+                EnsureWellKnownMember(WellKnownMember.System_Threading_Tasks_ValueTask_T__ctor, bag);
+            }
+
             protected override void GenerateMethodImplementations()
             {
                 // IAsyncStateMachine and constructor
@@ -297,7 +306,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     F.WellKnownMethod(WellKnownMember.System_Threading_Tasks_Sources_IValueTaskSource_T__GetResult)
                     .AsMember(IValueTaskSourceOfBool);
 
-                // PROTOTYPE(async-streams): Should we be looking those members up as optional?
                 MethodSymbol promise_GetResult =
                     F.WellKnownMethod(WellKnownMember.System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__GetResult)
                     .AsMember((NamedTypeSymbol)_promiseOfValueOrEndField.Type);

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // PROTOTYPE(async-streams): Why does AsyncRewriter have logic to ignore accessibility?
             }
 
-            protected override void VerifyPresenceOfRequiredAPIs(MethodSymbol method, DiagnosticBag bag)
+            protected override void VerifyPresenceOfRequiredAPIs(DiagnosticBag bag)
             {
                 EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerable_T__GetAsyncEnumerator, bag);
                 EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerator_T__WaitForNextAsync, bag);

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ? new AsyncIteratorRewriter(bodyWithAwaitLifted, method, methodOrdinal, stateMachineType, slotAllocatorOpt, compilationState, diagnostics)
                 : new AsyncRewriter(bodyWithAwaitLifted, method, methodOrdinal, stateMachineType, slotAllocatorOpt, compilationState, diagnostics);
 
-            if (!rewriter.VerifyPresenceOfRequiredAPIs())
+            if (!rewriter.VerifyPresenceOfRequiredAPIs(method))
             {
                 return body;
             }
@@ -81,12 +81,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <returns>
         /// Returns true if all types and members we need are present and good
         /// </returns>
-        protected bool VerifyPresenceOfRequiredAPIs()
+        protected bool VerifyPresenceOfRequiredAPIs(MethodSymbol method)
         {
             DiagnosticBag bag = DiagnosticBag.GetInstance();
 
-            EnsureWellKnownMember(WellKnownMember.System_Runtime_CompilerServices_IAsyncStateMachine_MoveNext, bag);
-            EnsureWellKnownMember(WellKnownMember.System_Runtime_CompilerServices_IAsyncStateMachine_SetStateMachine, bag);
+            VerifyPresenceOfRequiredAPIs(method, bag);
 
             bool hasErrors = bag.HasAnyErrors();
             if (hasErrors)
@@ -96,6 +95,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bag.Free();
             return !hasErrors && _constructedSuccessfully;
+        }
+
+        protected virtual void VerifyPresenceOfRequiredAPIs(MethodSymbol method, DiagnosticBag bag)
+        {
+            EnsureWellKnownMember(WellKnownMember.System_Runtime_CompilerServices_IAsyncStateMachine_MoveNext, bag);
+            EnsureWellKnownMember(WellKnownMember.System_Runtime_CompilerServices_IAsyncStateMachine_SetStateMachine, bag);
         }
 
         private Symbol EnsureWellKnownMember(WellKnownMember member, DiagnosticBag bag)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ? new AsyncIteratorRewriter(bodyWithAwaitLifted, method, methodOrdinal, stateMachineType, slotAllocatorOpt, compilationState, diagnostics)
                 : new AsyncRewriter(bodyWithAwaitLifted, method, methodOrdinal, stateMachineType, slotAllocatorOpt, compilationState, diagnostics);
 
-            if (!rewriter.VerifyPresenceOfRequiredAPIs(method))
+            if (!rewriter.VerifyPresenceOfRequiredAPIs())
             {
                 return body;
             }
@@ -81,11 +81,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <returns>
         /// Returns true if all types and members we need are present and good
         /// </returns>
-        protected bool VerifyPresenceOfRequiredAPIs(MethodSymbol method)
+        protected bool VerifyPresenceOfRequiredAPIs()
         {
             DiagnosticBag bag = DiagnosticBag.GetInstance();
 
-            VerifyPresenceOfRequiredAPIs(method, bag);
+            VerifyPresenceOfRequiredAPIs(bag);
 
             bool hasErrors = bag.HasAnyErrors();
             if (hasErrors)
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return !hasErrors && _constructedSuccessfully;
         }
 
-        protected virtual void VerifyPresenceOfRequiredAPIs(MethodSymbol method, DiagnosticBag bag)
+        protected virtual void VerifyPresenceOfRequiredAPIs(DiagnosticBag bag)
         {
             EnsureWellKnownMember(WellKnownMember.System_Runtime_CompilerServices_IAsyncStateMachine_MoveNext, bag);
             EnsureWellKnownMember(WellKnownMember.System_Runtime_CompilerServices_IAsyncStateMachine_SetStateMachine, bag);

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -312,18 +312,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 && method.ReturnType.IsIAsyncEnumerableType(compilation);
         }
 
-        public static bool IsBadAsyncReturn(this MethodSymbol method, TypeSymbol returnType)
-        {
-            // Note: we're passing the return type explicitly to avoid cycles
-            Debug.Assert(method.IsAsync);
-            CSharpCompilation declaringCompilation = method.DeclaringCompilation;
-
-            return returnType.SpecialType != SpecialType.System_Void &&
-                !returnType.IsNonGenericTaskType(declaringCompilation) &&
-                !returnType.IsGenericTaskType(declaringCompilation) &&
-                !returnType.IsIAsyncEnumerableType(declaringCompilation);
-        }
-
         internal static CSharpSyntaxNode ExtractReturnTypeSyntax(this MethodSymbol method)
         {
             method = method.PartialDefinitionPart ?? method;

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -312,11 +312,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 && method.ReturnType.IsIAsyncEnumerableType(compilation);
         }
 
-        public static bool IsBadAsyncReturn(this MethodSymbol method, TypeSymbol returnType)
+        public static bool IsBadAsyncReturn(this MethodSymbol method)
         {
             Debug.Assert(method.IsAsync);
+            TypeSymbol returnType = method.ReturnType;
             CSharpCompilation declaringCompilation = method.DeclaringCompilation;
-
             return returnType.SpecialType != SpecialType.System_Void &&
                 !returnType.IsNonGenericTaskType(declaringCompilation) &&
                 !returnType.IsGenericTaskType(declaringCompilation) &&

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -307,8 +307,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             CSharpCompilation declaringCompilation = method.DeclaringCompilation;
 
-            return method.IsAsync &&
-                returnType.SpecialType != SpecialType.System_Void &&
+            return returnType.SpecialType != SpecialType.System_Void &&
                 !returnType.IsNonGenericTaskType(declaringCompilation) &&
                 !returnType.IsGenericTaskType(declaringCompilation) &&
                 !returnType.IsIAsyncEnumerableType(declaringCompilation);

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -312,11 +312,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 && method.ReturnType.IsIAsyncEnumerableType(compilation);
         }
 
-        public static bool IsBadAsyncReturn(this MethodSymbol method)
+        public static bool IsBadAsyncReturn(this MethodSymbol method, TypeSymbol returnType)
         {
+            // Note: we're passing the return type explicitly to avoid cycles
             Debug.Assert(method.IsAsync);
-            TypeSymbol returnType = method.ReturnType;
             CSharpCompilation declaringCompilation = method.DeclaringCompilation;
+
             return returnType.SpecialType != SpecialType.System_Void &&
                 !returnType.IsNonGenericTaskType(declaringCompilation) &&
                 !returnType.IsGenericTaskType(declaringCompilation) &&

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -303,13 +303,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 && method.ReturnType.IsGenericTaskType(compilation);
         }
 
-        /// <summary>
-        /// Returns whether this method is async and returns an async-enumerable.
-        /// </summary>
-        public static bool IsEnumerableReturningAsync(this MethodSymbol method, CSharpCompilation compilation)
+        public static bool IsBadAsyncReturn(this MethodSymbol method, TypeSymbol returnType)
         {
-            return method.IsAsync
-                && method.ReturnType.IsIAsyncEnumerableType(compilation);
+            CSharpCompilation declaringCompilation = method.DeclaringCompilation;
+
+            return method.IsAsync &&
+                returnType.SpecialType != SpecialType.System_Void &&
+                !returnType.IsNonGenericTaskType(declaringCompilation) &&
+                !returnType.IsGenericTaskType(declaringCompilation) &&
+                !returnType.IsIAsyncEnumerableType(declaringCompilation);
         }
 
         internal static CSharpSyntaxNode ExtractReturnTypeSyntax(this MethodSymbol method)

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -305,6 +305,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public static bool IsBadAsyncReturn(this MethodSymbol method, TypeSymbol returnType)
         {
+            Debug.Assert(method.IsAsync);
             CSharpCompilation declaringCompilation = method.DeclaringCompilation;
 
             return returnType.SpecialType != SpecialType.System_Void &&

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -303,6 +303,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 && method.ReturnType.IsGenericTaskType(compilation);
         }
 
+        /// <summary>
+        /// Returns whether this method is async and returns an IAsyncEnumerable`1.
+        /// </summary>
+        public static bool IsIAsyncEnumerableReturningAsync(this MethodSymbol method, CSharpCompilation compilation)
+        {
+            return method.IsAsync
+                && method.ReturnType.IsIAsyncEnumerableType(compilation);
+        }
+
         public static bool IsBadAsyncReturn(this MethodSymbol method, TypeSymbol returnType)
         {
             Debug.Assert(method.IsAsync);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     ReportBadRefToken(returnTypeSyntax, diagnostics);
                 }
-                else if (this.IsBadAsyncReturn(returnType))
+                else if (returnType.IsBadAsyncReturn(this.DeclaringCompilation))
                 {
                     diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, this.Locations[0]);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     ReportBadRefToken(returnTypeSyntax, diagnostics);
                 }
-                else if (this.IsBadAsyncReturn(returnType))
+                else if (this.IsBadAsyncReturn())
                 {
                     diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, this.Locations[0]);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     ReportBadRefToken(returnTypeSyntax, diagnostics);
                 }
-                else if (this.IsBadAsyncReturn())
+                else if (this.IsBadAsyncReturn(returnType))
                 {
                     diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, this.Locations[0]);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -211,15 +211,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var diagnostics = DiagnosticBag.GetInstance();
-            TypeSyntax returnTypeSyntax = _syntax.ReturnType.SkipRef();
-            TypeSymbol returnType = _binder.BindType(returnTypeSyntax, diagnostics);
-            if (IsAsync &&
-                returnType.SpecialType != SpecialType.System_Void &&
-                !returnType.IsNonGenericTaskType(_binder.Compilation) &&
-                !returnType.IsGenericTaskType(_binder.Compilation))
+            TypeSyntax returnTypeSyntax = _syntax.ReturnType;
+            TypeSymbol returnType = _binder.BindType(returnTypeSyntax.SkipRef(), diagnostics);
+
+            if (this.IsAsync)
             {
-                // The return type of an async method must be void, Task or Task<T>
-                diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, this.Locations[0]);
+                if (this.RefKind != RefKind.None)
+                {
+                    ReportBadRefToken(returnTypeSyntax, diagnostics);
+                }
+                else if (this.IsBadAsyncReturn(returnType))
+                {
+                    diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, this.Locations[0]);
+                }
             }
 
             if (_refKind == RefKind.RefReadOnly)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public abstract ImmutableArray<TypeParameterConstraintClause> TypeParameterConstraintClauses { get; }
 
-        protected void ReportBadRefToken(TypeSyntax returnTypeSyntax, DiagnosticBag diagnostics)
+        protected static void ReportBadRefToken(TypeSyntax returnTypeSyntax, DiagnosticBag diagnostics)
         {
             if (!returnTypeSyntax.HasErrors)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -17,5 +18,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// If a type parameter does not have constraints, the corresponding entry in the array is null.
         /// </summary>
         public abstract ImmutableArray<TypeParameterConstraintClause> TypeParameterConstraintClauses { get; }
+
+        protected void ReportBadRefToken(TypeSyntax returnTypeSyntax, DiagnosticBag diagnostics)
+        {
+            if (!returnTypeSyntax.HasErrors)
+            {
+                var refKeyword = returnTypeSyntax.GetFirstToken();
+                diagnostics.Add(ErrorCode.ERR_UnexpectedToken, refKeyword.GetLocation(), refKeyword.ToString());
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -410,7 +410,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 ReportBadRefToken(GetSyntax().ReturnType, diagnostics);
             }
-            else if (this.IsBadAsyncReturn(this.ReturnType))
+            else if (this.IsBadAsyncReturn())
             {
                 diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, errorLocation);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -408,19 +408,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (this.RefKind != RefKind.None)
             {
-                var returnTypeSyntax = GetSyntax().ReturnType;
-                if (!returnTypeSyntax.HasErrors)
-                {
-                    var refKeyword = returnTypeSyntax.GetFirstToken();
-                    diagnostics.Add(ErrorCode.ERR_UnexpectedToken, refKeyword.GetLocation(), refKeyword.ToString());
-                }
+                ReportBadRefToken(GetSyntax().ReturnType, diagnostics);
             }
-            else if (!this.IsGenericTaskReturningAsync(this.DeclaringCompilation) && !this.IsTaskReturningAsync(this.DeclaringCompilation)
-                && !this.IsVoidReturningAsync() && !this.IsEnumerableReturningAsync(this.DeclaringCompilation))
+            else if (this.IsBadAsyncReturn(this.ReturnType))
             {
-                // The return type of an async method must be void, Task or Task<T>
                 diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, errorLocation);
-                // PROTOTYPE(async-streams): Update diagnostic message
             }
 
             for (NamedTypeSymbol curr = this.ContainingType; (object)curr != null; curr = curr.ContainingType)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -410,7 +410,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 ReportBadRefToken(GetSyntax().ReturnType, diagnostics);
             }
-            else if (this.IsBadAsyncReturn(this.ReturnType))
+            else if (ReturnType.IsBadAsyncReturn(this.DeclaringCompilation))
             {
                 diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, errorLocation);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -418,9 +418,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (!this.IsGenericTaskReturningAsync(this.DeclaringCompilation) && !this.IsTaskReturningAsync(this.DeclaringCompilation)
                 && !this.IsVoidReturningAsync() && !this.IsEnumerableReturningAsync(this.DeclaringCompilation))
             {
-                // PROTOTYPE(async-streams): Update diagnostic message
                 // The return type of an async method must be void, Task or Task<T>
                 diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, errorLocation);
+                // PROTOTYPE(async-streams): Update diagnostic message
             }
 
             for (NamedTypeSymbol curr = this.ContainingType; (object)curr != null; curr = curr.ContainingType)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -410,7 +410,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 ReportBadRefToken(GetSyntax().ReturnType, diagnostics);
             }
-            else if (this.IsBadAsyncReturn())
+            else if (this.IsBadAsyncReturn(this.ReturnType))
             {
                 diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, errorLocation);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1571,5 +1571,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return globalNamespace != null && globalNamespace.IsGlobalNamespace;
         }
+
+        public static bool IsBadAsyncReturn(this TypeSymbol returnType, CSharpCompilation declaringCompilation)
+        {
+            // Note: we're passing the return type explicitly (rather than using `method.ReturnType`) to avoid cycles
+            return returnType.SpecialType != SpecialType.System_Void &&
+                !returnType.IsNonGenericTaskType(declaringCompilation) &&
+                !returnType.IsGenericTaskType(declaringCompilation) &&
+                !returnType.IsIAsyncEnumerableType(declaringCompilation);
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -5974,8 +5974,8 @@ Poskytněte kompilátoru nějaký způsob, jak metody rozlišit. Můžete např�
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">Návratový typ asynchronní metody musí být void, Task nebo Task&lt;T&gt;.</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">Návratový typ asynchronní metody musí být void, Task nebo Task&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -5974,8 +5974,8 @@ Unterstützen Sie den Compiler bei der Unterscheidung zwischen den Methoden. Daz
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">Der Rückgabetyp einer Async-Methode muss "void", "Task" oder "Task&lt;T&gt;" sein</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">Der Rückgabetyp einer Async-Methode muss "void", "Task" oder "Task&lt;T&gt;" sein</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -5974,8 +5974,8 @@ Indique al compilador alguna forma de diferenciar los métodos. Por ejemplo, pue
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">El tipo de valor devuelto de un método asincrónico debe ser void, Task o Task&lt;T&gt;</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">El tipo de valor devuelto de un método asincrónico debe ser void, Task o Task&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -5974,8 +5974,8 @@ Permettez au compilateur de différencier les méthodes. Par exemple, vous pouve
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">Le type de retour d'une méthode async doit être void, Task ou Task&lt;T&gt;</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">Le type de retour d'une méthode async doit être void, Task ou Task&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -5974,8 +5974,8 @@ Impostare il compilatore in modo tale da distinguere i metodi, ad esempio assegn
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">Il tipo restituito di un metodo asincrono deve essere void, Task o Task&lt;T&gt;</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">Il tipo restituito di un metodo asincrono deve essere void, Task o Task&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -5974,8 +5974,8 @@ C# では out と ref を区別しますが、CLR では同じと認識します
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">非同期メソッドの戻り値の型は、void、Task、または Task&lt;T&gt; であることが必要です</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">非同期メソッドの戻り値の型は、void、Task、または Task&lt;T&gt; であることが必要です</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -5974,8 +5974,8 @@ C#에서는 out과 ref를 구분하지만 CLR에서는 동일한 것으로 간�
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">비동기 메서드의 반환 형식은 void, Task 또는 Task&lt;T&gt;여야 합니다.</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">비동기 메서드의 반환 형식은 void, Task 또는 Task&lt;T&gt;여야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -5974,8 +5974,8 @@ Musisz umożliwić kompilatorowi rozróżnienie metod. Możesz na przykład nada
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">Zwracany typ metody asynchronicznej musi mieć wartość „void”, „Task” lub „Task&lt;T&gt;”.</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">Zwracany typ metody asynchronicznej musi mieć wartość „void”, „Task” lub „Task&lt;T&gt;”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -5974,8 +5974,8 @@ Forneça ao compilador alguma forma de diferenciar os métodos. Por exemplo, voc
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">O tipo de retorno de um método assíncrono deve ser void, Task ou Task&lt;T&gt;</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">O tipo de retorno de um método assíncrono deve ser void, Task ou Task&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -5974,8 +5974,8 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">Возвращаемым типом асинхронного метода должен быть void, Task или Task&lt;T&gt;</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">Возвращаемым типом асинхронного метода должен быть void, Task или Task&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -5974,8 +5974,8 @@ Derleyiciye yöntemleri ayrıştırma yolu verin. Örneğin, bunlara farklı adl
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">Zaman uyumsuz bir yöntemin dönüş türü void, Task ve Task&lt;T&gt; olmalıdır&gt;</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">Zaman uyumsuz bir yöntemin dönüş türü void, Task ve Task&lt;T&gt; olmalıdır&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -5974,8 +5974,8 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">异步方法的返回类型必须为 void、Task 或 Task&lt;T&gt;</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">异步方法的返回类型必须为 void、Task 或 Task&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -5974,8 +5974,8 @@ Give the compiler some way to differentiate the methods. For example, you can gi
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadAsyncReturn">
-        <source>The return type of an async method must be void, Task or Task&lt;T&gt;</source>
-        <target state="translated">非同步方法的傳回類型必須為 void、Task 或 Task&lt;T&gt;</target>
+        <source>The return type of an async method must be void, Task, Task&lt;T&gt;, a task-like type, or IAsyncEnumerable&lt;T&gt;</source>
+        <target state="needs-review-translation">非同步方法的傳回類型必須為 void、Task 或 Task&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_CantReturnVoid">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="new">To use '@$' instead of '$@' for an interpolated verbatim string, please use language version {0} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ERR_FeatureNotAvailableInVersion8">
         <source>Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</source>
         <target state="new">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</source>
+        <target state="new">foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncDisposableTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncDisposableTests.cs
@@ -28,7 +28,7 @@ namespace System
 ";
 
         [Fact]
-        public void TestWithCSharp7_1()
+        public void TestWithCSharp7_3()
         {
             string source = @"
 class C : System.IAsyncDisposable
@@ -45,13 +45,12 @@ class C : System.IAsyncDisposable
     }
 }
 ";
-            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, parseOptions: TestOptions.Regular7_1);
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, parseOptions: TestOptions.Regular7_3);
             comp.VerifyDiagnostics(
-                // (6,15): error CS8302: Feature 'async streams' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (6,15): error CS8370: Feature 'async streams' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //         using await (var x = new C())
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "await").WithArguments("async streams", "7.2").WithLocation(6, 15)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "await").WithArguments("async streams", "8.0").WithLocation(6, 15)
                 );
-            // PROTOTYPE(async-streams) LangVersion for async-streams will be adjusted before release
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
@@ -1202,7 +1202,7 @@ class C
         }
 
         [Fact]
-        public void TestWithPattern_WithStruct_SimpleImplementation()
+        public void TestWithPattern_WithStruct_WaitForNextAsyncReturnsTask()
         {
             string source = @"
 using static System.Console;
@@ -1255,7 +1255,7 @@ class C
         }
 
         [Fact]
-        public void TestWithPattern_WaitForNextReturnsValueTask()
+        public void TestWithPattern_WaitForNextAsyncReturnsValueTask()
         {
             string source = @"
 using static System.Console;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -30,6 +30,38 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     [CompilerTrait(CompilerFeature.LocalFunctions)]
     public class LocalFunctionTests : LocalFunctionsTestBase
     {
+        [Fact, WorkItem(29656, "https://github.com/dotnet/roslyn/issues/29656")]
+        public void RefReturningAyncLocalFunction()
+        {
+            var source = @"
+public class C
+{
+    async ref System.Threading.Tasks.Task M() { }
+
+    public void M2()
+    {
+        _ = local();
+
+        async ref System.Threading.Tasks.Task local() { }
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,11): error CS1073: Unexpected token 'ref'
+                //     async ref System.Threading.Tasks.Task M() { }
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "ref").WithArguments("ref").WithLocation(4, 11),
+                // (4,43): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     async ref System.Threading.Tasks.Task M() { }
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(4, 43),
+                // (10,15): error CS1073: Unexpected token 'ref'
+                //         async ref System.Threading.Tasks.Task local() { }
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "ref").WithArguments("ref").WithLocation(10, 15),
+                // (10,47): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //         async ref System.Threading.Tasks.Task local() { }
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "local").WithLocation(10, 47)
+                );
+        }
+
         [ConditionalFact(typeof(DesktopOnly))]
         public void LocalFunctionResetsLockScopeFlag()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class LocalFunctionTests : LocalFunctionsTestBase
     {
         [Fact, WorkItem(29656, "https://github.com/dotnet/roslyn/issues/29656")]
-        public void RefReturningAyncLocalFunction()
+        public void RefReturningAsyncLocalFunction()
         {
             var source = @"
 public class C

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncStreamsParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncStreamsParsingTests.cs
@@ -266,7 +266,7 @@ class C
             var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_3));
             tree.GetDiagnostics().Verify(
                 // (6,17): error CS8370: Feature 'async streams' is not available in C# 7.3. Please use language version 8.0 or greater.
-                //         foreach await (var (i, j) in collection)
+                //         foreach await (var i in collection)
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "await").WithArguments("async streams", "8.0").WithLocation(6, 17)
                 );
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncStreamsParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncStreamsParsingTests.cs
@@ -14,16 +14,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
-            return SyntaxFactory.ParseSyntaxTree(text, options: (options ?? TestOptions.Regular).WithLanguageVersion(LanguageVersion.CSharp7_2)); // PROTOTYPE(async-streams) Finalize LangVersion
+            return SyntaxFactory.ParseSyntaxTree(text, options: (options ?? TestOptions.Regular).WithLanguageVersion(LanguageVersion.CSharp8));
         }
 
         protected override CSharpSyntaxNode ParseNode(string text, CSharpParseOptions options = null)
         {
-            return SyntaxFactory.ParseExpression(text, options: (options ?? TestOptions.Regular).WithLanguageVersion(LanguageVersion.CSharp7_2)); // PROTOTYPE(async-streams) Finalize LangVersion
+            return SyntaxFactory.ParseExpression(text, options: (options ?? TestOptions.Regular).WithLanguageVersion(LanguageVersion.CSharp8));
         }
 
         [Fact]
-        public void UsingAwaitDeclaration_WithCSharp71()
+        public void UsingAwaitDeclaration_WithCSharp73()
         {
             string source = @"
 class C
@@ -36,11 +36,11 @@ class C
     }
 }
 ";
-            var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1)); // PROTOTYPE(async-streams) Finalize LangVersion
+            var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_3));
             tree.GetDiagnostics().Verify(
-                // (6,15): error CS8302: Feature 'async streams' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (6,15): error CS8370: Feature 'async streams' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //         using await (var x = this)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "await").WithArguments("async streams", "7.2").WithLocation(6, 15)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "await").WithArguments("async streams", "8.0").WithLocation(6, 15)
                 );
 
             UsingTree(source);
@@ -250,7 +250,7 @@ class C
         }
 
         [Fact]
-        public void ForeachAwait_WithCSharp71()
+        public void ForeachAwait_WithCSharp73()
         {
             string source = @"
 class C
@@ -263,11 +263,11 @@ class C
     }
 }
 ";
-            var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1)); // PROTOTYPE(async-streams) Finalize LangVersion
+            var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_3));
             tree.GetDiagnostics().Verify(
-                // (6,17): error CS8302: Feature 'async streams' is not available in C# 7.1. Please use language version 7.2 or greater.
-                //         foreach await (var i in collection)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "await").WithArguments("async streams", "7.2").WithLocation(6, 17)
+                // (6,17): error CS8370: Feature 'async streams' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //         foreach await (var (i, j) in collection)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "await").WithArguments("async streams", "8.0").WithLocation(6, 17)
                 );
 
             UsingTree(source);
@@ -396,7 +396,7 @@ class C
         }
 
         [Fact]
-        public void DeconstructionForeachAwait_WithCSharp71()
+        public void DeconstructionForeachAwait_WithCSharp73()
         {
             string source = @"
 class C
@@ -409,11 +409,11 @@ class C
     }
 }
 ";
-            var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1)); // PROTOTYPE(async-streams) Finalize LangVersion
+            var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_3));
             tree.GetDiagnostics().Verify(
-                // (6,17): error CS8302: Feature 'async streams' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (6,17): error CS8370: Feature 'async streams' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //         foreach await (var (i, j) in collection)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "await").WithArguments("async streams", "7.2").WithLocation(6, 17)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "await").WithArguments("async streams", "8.0").WithLocation(6, 17)
                 );
 
             UsingTree(source);

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3580,7 +3580,6 @@ namespace Microsoft.CodeAnalysis
                 "WaitForNextAsync",                         // System_Collections_Generic_IAsyncEnumerator_T__WaitForNextAsync
                 "TryGetNext",                               // System_Collections_Generic_IAsyncEnumerator_T__TryGetNext
 
-                // PROTOTYPE(async-streams): Verify that all the well-known members ended up used
                 ".ctor",                                    // System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__ctor
                 "GetResult",                                // System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__GetResult
                 "GetStatus",                                // System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__GetStatus


### PR DESCRIPTION
Part of the async-streams [umbrella](https://github.com/dotnet/roslyn/issues/24037):
- Check for missing well-known types/members
- Attach async-streams feature to LangVersion 8
- Provide a diagnostic telling you to switch to a regular `foreach` or an async `foreach`
- Improve exception handler in async-iterator `MoveNext()` to use an exception filter and avoid re-throwing
- adds a check for bad `ref` on local functions (fixes https://github.com/dotnet/roslyn/issues/29656, I'll add a note to breaking changes)