### PR TITLE
Add option keywords to enable searchability

### DIFF
--- a/src/VisualStudio/CSharp/Impl/VSPackage.resx
+++ b/src/VisualStudio/CSharp/Impl/VSPackage.resx
@@ -142,23 +142,140 @@
     <comment>"C#" node help text in profile Import/Export.</comment>
   </data>
   <data name="306" xml:space="preserve">
-    <value>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</value>
+    <value>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</value>
     <comment>C# Advanced options page keywords</comment>
   </data>
   <data name="307" xml:space="preserve">
-    <value>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</value>
+    <value>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</value>
     <comment>C# Formatting &gt; General options page keywords</comment>
   </data>
   <data name="308" xml:space="preserve">
-    <value>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</value>
+    <value>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</value>
     <comment>C# Formatting &gt; Indentation options page keywords</comment>
   </data>
   <data name="309" xml:space="preserve">
-    <value>New line formatting option for braces;New line formatting options for keywords</value>
+    <value>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</value>
     <comment>C# Formatting &gt; New Lines options page keywords</comment>
   </data>
   <data name="310" xml:space="preserve">
-    <value>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</value>
+    <value>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</value>
     <comment>C# Formatting &gt; Spacing options page keywords</comment>
   </data>
   <data name="311" xml:space="preserve">
@@ -166,7 +283,20 @@
     <comment>C# Formatting &gt; Wrapping options page keywords</comment>
   </data>
   <data name="312" xml:space="preserve">
-    <value>Change completion list settings;Pre-select most recently used member</value>
+    <value>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</value>
     <comment>C# IntelliSense options page keywords</comment>
   </data>
   <data name="107" xml:space="preserve">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.cs.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.cs.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">Zvýrazňovat odkazy na symbol pod kurzorem;Zvýrazňovat související klíčová slova pod kurzorem;Po otevření souborů vejít do režimu osnovy;Zobrazit oddělovače řádků procedury;Generovat komentáře dokumentace XML;Zobrazit diagnostiku pro zavřené soubory;Zobrazit náhled pro sledování přejmenování;Umísťovat první direktivy System při řazení direktiv using;Nevkládat ref ani out do vlastních struktur</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">Automaticky formátovat příkaz při středníku;Automaticky formátovat blok při složené závorce;Automaticky formátovat při vložení;vyčištění kódu;</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">Automaticky formátovat příkaz při středníku;Automaticky formátovat blok při složené závorce;Automaticky formátovat při vložení;vyčištění kódu;</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">Odsadit obsah bloku; odsadit pravé a levé složené závorky;odsadit obsah příkazu case;odsadit návěští case;odsazení návěští</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">Odsadit obsah bloku; odsadit pravé a levé složené závorky;odsadit obsah příkazu case;odsadit návěští case;odsazení návěští</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">Možnost formátování nového řádku pro složené závorky;Možnosti formátování nového řádku pro klíčová slova</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">Možnost formátování nového řádku pro složené závorky;Možnosti formátování nového řádku pro klíčová slova</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">Nastavit mezery pro deklarace metod;nastavit mezery pro volání metod;nastavit jiné možnosti pro mezery;nastavit mezery pro kulaté závorky;nastavit mezery pro oddělovače;nastavit mezery pro operátory</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">Nastavit mezery pro deklarace metod;nastavit mezery pro volání metod;nastavit jiné možnosti pro mezery;nastavit mezery pro kulaté závorky;nastavit mezery pro oddělovače;nastavit mezery pro operátory</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">Změnit nastavení pro seznam dokončení;Předvolit naposledy použitou položku</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">Změnit nastavení pro seznam dokončení;Předvolit naposledy použitou položku</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.de.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.de.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">Verweise auf Symbole unter dem Cursor markieren;Zugehörige Schlüsselwörter unter dem Cursor markieren;Gliederungsmodus beim Öffnen von Dateien starten;Zeilentrennzeichen zwischen Prozeduren anzeigen;XML-Dokumentationskommentare generieren;Diagnoseinformationen für geschlossene Dateien anzeigen;Vorschau für das Nachverfolgen der Umbenennung anzeigen;Beim Sortieren von "Using"-Direktiven "System"-Direktiven zuerst platzieren;"ref" oder "out" nicht für benutzerdefinierte Strukturen zulassen</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">Anweisung bei Semikolon automatisch formatieren;Block bei geschweifter Klammer automatisch formatieren;Beim Einfügen automatisch formatieren;Codebereinigung;</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">Anweisung bei Semikolon automatisch formatieren;Block bei geschweifter Klammer automatisch formatieren;Beim Einfügen automatisch formatieren;Codebereinigung;</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">Blockinhalte einziehen;Öffnende und schließende geschweifte Klammern einziehen, case-Inhalte einziehen;case-Abschnitte einziehen;Bezeichnungseinzug</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">Blockinhalte einziehen;Öffnende und schließende geschweifte Klammern einziehen, case-Inhalte einziehen;case-Abschnitte einziehen;Bezeichnungseinzug</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">Zeilenwechsel-Formatierungsoption für geschweifte Klammern;Zeilenwechsel-Formatierungsoptionen für Schlüsselwörter</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">Zeilenwechsel-Formatierungsoption für geschweifte Klammern;Zeilenwechsel-Formatierungsoptionen für Schlüsselwörter</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">Abstand für Methodendeklarationen festlegen;Abstand für Methodenaufrufe festlegen;Weitere Abstandsoptionen festlegen;Abstand für geschweifte Klammern festlegen;Abstand für Trennzeichen festlegen;Abstand für Operatoren festlegen</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">Abstand für Methodendeklarationen festlegen;Abstand für Methodenaufrufe festlegen;Weitere Abstandsoptionen festlegen;Abstand für geschweifte Klammern festlegen;Abstand für Trennzeichen festlegen;Abstand für Operatoren festlegen</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">Einstellungen der Vervollständigungsliste ändern;Vorauswahl des zuletzt verwendeten Members</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">Einstellungen der Vervollständigungsliste ändern;Vorauswahl des zuletzt verwendeten Members</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.es.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.es.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">Resaltar referencias al símbolo bajo el cursor;Resaltar palabras clave relacionadas bajo el cursor;Especificar el modo de esquematización al abrir los archivos;Mostrar separadores de líneas de procedimientos;Generar comentarios de documentación XML;Mostrar diagnóstico para archivos cerrados;Mostrar vista previa para seguimiento de cambio de nombre;Al ordenar instrucciones Using, colocar primero las directivas 'System';No colocar 'out' o 'ref' en estructura personalizada</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">Formato automático en instrucciones al escribir punto y coma;Formato automático en bloques al escribir llave;Formato automático al pegar;Limpieza de código;</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">Formato automático en instrucciones al escribir punto y coma;Formato automático en bloques al escribir llave;Formato automático al pegar;Limpieza de código;</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">Aplicar sangría al contenido del bloque;Aplicar sangría a llaves de apertura y cierre; Aplicar sangría al contenido de case;Aplicar sangría a etiquetas case;Sangría de etiquetas</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">Aplicar sangría al contenido del bloque;Aplicar sangría a llaves de apertura y cierre; Aplicar sangría al contenido de case;Aplicar sangría a etiquetas case;Sangría de etiquetas</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">Opción de formato de nueva línea para llaves;Opciones de formato de nueva línea para palabras clave</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">Opción de formato de nueva línea para llaves;Opciones de formato de nueva línea para palabras clave</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">Establecer espaciado para declaraciones de método;Establecer espaciado para llamadas a métodos;Establecer otras opciones de espaciado;Establecer espaciado para corchetes;Establecer espaciado para delimitadores;Establecer espaciado para operadores</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">Establecer espaciado para declaraciones de método;Establecer espaciado para llamadas a métodos;Establecer otras opciones de espaciado;Establecer espaciado para corchetes;Establecer espaciado para delimitadores;Establecer espaciado para operadores</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">Cambiar configuración de la lista de finalización;Preseleccionar el miembro usado recientemente</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">Cambiar configuración de la lista de finalización;Preseleccionar el miembro usado recientemente</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.fr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.fr.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">Mettre en évidence les références au symbole sous le curseur ; Mettre en évidence les mots clés associés sous le curseur ; Passer en mode Plan à l'ouverture des fichiers ; Afficher les séparateurs de ligne des procédures ; Générer des commentaires de documentation XML ; Afficher les diagnostics pour les fichiers fermés ; Afficher un aperçu du suivi du renommage ; Placer les directives 'System' en premier durant le tri des directives using ; Ne pas placer ref ou out sur les structs personnalisés</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">Mettre en forme automatiquement l'instruction lors de l'entrée d’un point-virgule;Mettre en forme automatiquement le bloc lors de l'entrée d’une accolade;Mettre en forme automatiquement lors du collage;Nettoyage du code;</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">Mettre en forme automatiquement l'instruction lors de l'entrée d’un point-virgule;Mettre en forme automatiquement le bloc lors de l'entrée d’une accolade;Mettre en forme automatiquement lors du collage;Nettoyage du code;</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">Mettre en retrait le contenu d'un bloc ; Mettre en retrait les accolades ouvrantes et fermantes ; Mettre en retrait le contenu de case ; Mettre en retrait des étiquettes case ; Mise en retrait d'étiquette</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">Mettre en retrait le contenu d'un bloc ; Mettre en retrait les accolades ouvrantes et fermantes ; Mettre en retrait le contenu de case ; Mettre en retrait des étiquettes case ; Mise en retrait d'étiquette</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">Nouvelle option de mise en forme de ligne pour les accolades ; Nouvelles options de mise en forme de ligne pour les mots clés</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">Nouvelle option de mise en forme de ligne pour les accolades ; Nouvelles options de mise en forme de ligne pour les mots clés</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">Définir l'espacement des déclarations de méthode ; Définir l'espacement des appels de méthode ; Définir d'autres options d'espacement ; Définir l'espacement des crochets ; Définir l'espacement des délimiteurs ; Définir l'espacement des opérateurs</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">Définir l'espacement des déclarations de méthode ; Définir l'espacement des appels de méthode ; Définir d'autres options d'espacement ; Définir l'espacement des crochets ; Définir l'espacement des délimiteurs ; Définir l'espacement des opérateurs</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">Modifier les paramètres de la liste de saisie semi-automatique ; Présélectionner le dernier membre utilisé</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">Modifier les paramètres de la liste de saisie semi-automatique ; Présélectionner le dernier membre utilisé</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.it.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.it.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">Evidenzia riferimenti a simbolo sotto il cursore;Evidenzia parole chiave correlate sotto il cursore;Attiva modalità struttura all'apertura del file;Mostra separatori di riga routine;Genera commenti in formato documentazione XML;Mostra diagnostica per file chiusi;Visualizza anteprima per verifica ridenominazione;Inserisci prima le direttive 'System' durante l'ordinamento delle using;Non inserire out o ref in struct personalizzato</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">Formatta automaticamente istruzione dopo l'immissione del punto e virgola;Formatta automaticamente blocco dopo l'immissione della parentesi graffa;Formatta automaticamente dopo operazione Incolla;Pulizia codice</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">Formatta automaticamente istruzione dopo l'immissione del punto e virgola;Formatta automaticamente blocco dopo l'immissione della parentesi graffa;Formatta automaticamente dopo operazione Incolla;Pulizia codice</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">Rientra contenuto blocco;Rientra parentesi graffe di apertura e chiusura;Rientra contenuto case;Rientra etichette case;Rientro etichetta</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">Rientra contenuto blocco;Rientra parentesi graffe di apertura e chiusura;Rientra contenuto case;Rientra etichette case;Rientro etichetta</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">Nuova opzione formattazione riga per parentesi graffe;Nuove opzioni formattazione riga per parole chiave</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">Nuova opzione formattazione riga per parentesi graffe;Nuove opzioni formattazione riga per parole chiave</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">Imposta spaziatura per dichiarazioni di metodi;Imposta spaziatura per chiamate ai metodi;Imposta altre opzioni di spaziatura;Imposta spaziatura per parentesi quadre;Imposta spaziatura per delimitatori;Imposta spaziatura per operatori</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">Imposta spaziatura per dichiarazioni di metodi;Imposta spaziatura per chiamate ai metodi;Imposta altre opzioni di spaziatura;Imposta spaziatura per parentesi quadre;Imposta spaziatura per delimitatori;Imposta spaziatura per operatori</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">Modifica impostazioni di completamento elenco;Preseleziona membri usati più di recente</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">Modifica impostazioni di completamento elenco;Preseleziona membri usati più di recente</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ja.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ja.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">カーソルの下にあるシンボルへの参照をハイライトする;カーソルの下にあるキーワードの関連キーワードをハイライトする;ファイルを開くときにアウトライン モードに入る;プロシージャ行の区切り記号を表示する;XML ドキュメント コメントを生成する;閉じているファイルの診断結果を表示する;名前変更の追跡用プレビューの表示;using を並べ替える際に、'System' ディレクティブを先頭に配置する;カスタム構造体に ref または out を設定しない</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">セミコロンでステートメントをオート フォーマットする;中かっこでブロックをオート フォーマットする;貼り付け時にオート フォーマットする;コードをクリーンアップする</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">セミコロンでステートメントをオート フォーマットする;中かっこでブロックをオート フォーマットする;貼り付け時にオート フォーマットする;コードをクリーンアップする</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">ブロックの内容をインデントする;始めと終わりの中かっこをインデントする、case の内容をインデントする;case ラベルをインデントする;ラベル インデント</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">ブロックの内容をインデントする;始めと終わりの中かっこをインデントする、case の内容をインデントする;case ラベルをインデントする;ラベル インデント</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">中かっこの改行書式オプション;キーワードの改行書式オプション</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">中かっこの改行書式オプション;キーワードの改行書式オプション</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">メソッド宣言子のスペースを設定する;メソッドの呼び出しのスペースを設定する;他のスペース オプションを設定する;大かっこのスペースを設定する;区切り記号のスペースを設定する;演算子のスペースを設定する</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">メソッド宣言子のスペースを設定する;メソッドの呼び出しのスペースを設定する;他のスペース オプションを設定する;大かっこのスペースを設定する;区切り記号のスペースを設定する;演算子のスペースを設定する</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">入力候補一覧の設定を変更する;最近使用されたメンバーをあらかじめ選択する</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">入力候補一覧の設定を変更する;最近使用されたメンバーをあらかじめ選択する</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ko.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ko.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">커서 아래의 기호에 대한 참조 강조;커서 아래의 관련 키워드 강조;개요 모드로 파일 열기;프로시저 줄 구분선 표시;XML 문서 주석 생성;닫힌 파일에 대한 진단 표시;이름 바꾸기 추적 미리 보기 표시;using 정렬 시 'System' 지시문 먼저 배치;사용자 지정 구조체에 ref 또는 out 추가 안 함</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">세미콜론 입력 시 문 서식 자동 지정;중괄호 입력 시 블록 서식 자동 지정;붙여넣을 때 서식 자동 지정;코드 정리;</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">세미콜론 입력 시 문 서식 자동 지정;중괄호 입력 시 블록 서식 자동 지정;붙여넣을 때 서식 자동 지정;코드 정리;</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">블록 내용 들여쓰기;여는 중괄호 및 닫는 중괄호 들여쓰기case 내용 들여쓰기;case 레이블 들여쓰기;레이블 들여쓰기</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">블록 내용 들여쓰기;여는 중괄호 및 닫는 중괄호 들여쓰기case 내용 들여쓰기;case 레이블 들여쓰기;레이블 들여쓰기</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">중괄호에 대한 줄 바꿈 서식 옵션;키워드에 대한 줄 바꿈 서식 옵션</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">중괄호에 대한 줄 바꿈 서식 옵션;키워드에 대한 줄 바꿈 서식 옵션</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">메서드 선언 간격 설정;메서드 호출 간격 설정;기타 간격 옵션 설정;대괄호 간격 설정;구분 기호 간격 설정;연산자 간격 설정</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">메서드 선언 간격 설정;메서드 호출 간격 설정;기타 간격 옵션 설정;대괄호 간격 설정;구분 기호 간격 설정;연산자 간격 설정</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">완성 목록 설정 변경;가장 최근에 사용한 멤버 미리 선택</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">완성 목록 설정 변경;가장 최근에 사용한 멤버 미리 선택</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pl.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pl.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">Wyróżnij odwołania do symbolu pod kursorem;Wyróżnij pokrewne słowa kluczowe pod kursorem;Przejdź do trybu konspektu po otwarciu plików;Pokaż separatory wierszy procedury;Generuj komentarze dokumentacji XML;Pokaż diagnostykę zamkniętych plików;Pokaż podglad śledzenia zmian nazw;Umieść na początku dyrektywy System podczas sortowania użyć;Nie umieszczaj klauzul ref lub out w niestandardowych strukturach</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">Automatycznie sformatuj instrukcję w pozycji średnika;Automatycznie sformatuj blok w pozycji nawiasu klamrowego;Automatycznie sformatuj przy wklejeniu;czyszczenie kodu;</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">Automatycznie sformatuj instrukcję w pozycji średnika;Automatycznie sformatuj blok w pozycji nawiasu klamrowego;Automatycznie sformatuj przy wklejeniu;czyszczenie kodu;</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">Wcięcie zawartości bloku;Wcięcie otwierających i zamykających nawiasów klamrowych, wcięcie zawartości elementu case;wcięcie etykiet elementu case;wcięcia etykiet</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">Wcięcie zawartości bloku;Wcięcie otwierających i zamykających nawiasów klamrowych, wcięcie zawartości elementu case;wcięcie etykiet elementu case;wcięcia etykiet</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">Opcja formatowania nowego wiersza dla nawiasów;Opcje formatowania nowego wiersza dla słów kluczowych</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">Opcja formatowania nowego wiersza dla nawiasów;Opcje formatowania nowego wiersza dla słów kluczowych</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">Ustaw odstępy dla deklaracji metod;ustaw odstępy dla wywołań metod;ustaw inne opcje ostępów;ustaw odstępy dla nawiasów klamrowych;ustaw odstępy dla ograniczników;ustaw odstępy dla operatorów</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">Ustaw odstępy dla deklaracji metod;ustaw odstępy dla wywołań metod;ustaw inne opcje ostępów;ustaw odstępy dla nawiasów klamrowych;ustaw odstępy dla ograniczników;ustaw odstępy dla operatorów</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">Zmień ustawienia listy uzupełniania;Wybierz wstępnie ostatnio używaną składową</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">Zmień ustawienia listy uzupełniania;Wybierz wstępnie ostatnio używaną składową</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pt-BR.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pt-BR.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">Realçar as referências para símbolo sob o cursor;Realçar palavras-chave relacionadas sob o cursor;Entrar no modo de estrutura de tópicos ao abrir arquivos;Mostrar separadores de linha de procedimento;Gerar comentário da documentação XML;Mostrar o diagnóstico para arquivos fechados;Mostrar visualização de renomeação de controle;Colocar diretivas de 'Sistema' primeiro ao classificar usos;Não colocar ref ou out em estruturas personalizadas</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">Formatar automaticamente a instrução concluída com ponto e vírgula;Formatar automaticamente o bloco concluído com chave;Formatar automaticamente ao colar;limpeza de código;</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">Formatar automaticamente a instrução concluída com ponto e vírgula;Formatar automaticamente o bloco concluído com chave;Formatar automaticamente ao colar;limpeza de código;</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">Recuar conteúdos do bloco; recuar chaves de abertura e fechamento, recuar conteúdo de case, recuar rótulos case; indentação do rótulo</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">Recuar conteúdos do bloco; recuar chaves de abertura e fechamento, recuar conteúdo de case, recuar rótulos case; indentação do rótulo</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">Opção de formatação de nova linha para chaves;Opção de formatação de nova linha para palavras-chave</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">Opção de formatação de nova linha para chaves;Opção de formatação de nova linha para palavras-chave</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">Definir espaçamento para declarações de método; definir o espaçamento para chamadas de método; definir outras opções de espaçamento; definir espaçamento de colchetes; Definir espaçamento de delimitadores; Definir espaçamento de operadores</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">Definir espaçamento para declarações de método; definir o espaçamento para chamadas de método; definir outras opções de espaçamento; definir espaçamento de colchetes; Definir espaçamento de delimitadores; Definir espaçamento de operadores</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">Alterar as configurações de lista de conclusão;pre-selecionar membro usado recentemente</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">Alterar as configurações de lista de conclusão;pre-selecionar membro usado recentemente</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ru.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ru.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">Выделить ссылки на символ под курсором;Выделить связанные ключевые слова под курсором;Войти в режим структуры при открытии файлов;Показывать разделители линий процедур;Формировать комментарии XML-документации; Показывать диагностики для закрытых файлов;Предварительный просмотр для отслеживания переименований;Размещать "системные" директивы сначала при сортировке директив Using;Не размещать "ref" или "out" в пользовательских структурах</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">Автоматически форматировать оператор при вводе точки с запятой;Автоматически форматировать блок при вводе фигурной скобки;Автоматически форматировать при вставке;очистить код;</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">Автоматически форматировать оператор при вводе точки с запятой;Автоматически форматировать блок при вводе фигурной скобки;Автоматически форматировать при вставке;очистить код;</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">Отступ в блоке комментариев; отступ перед открывающимися и закрывающимися фигурными скобками, отступ в конструкции отступов для блоков case; отступ в метках case; отступ для метки</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">Отступ в блоке комментариев; отступ перед открывающимися и закрывающимися фигурными скобками, отступ в конструкции отступов для блоков case; отступ в метках case; отступ для метки</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">Параметры форматирования новой строки для фигурных скобок; Параметры форматирования новой строки для ключевых слов</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">Параметры форматирования новой строки для фигурных скобок; Параметры форматирования новой строки для ключевых слов</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">Установить интервалы для объявления метода; установить интервалы для вызовов метода; задать другие параметры для интервалов; установить интервалы для квадратных скобок; установить интервалы для разделителей; установить интервалы для операторов</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">Установить интервалы для объявления метода; установить интервалы для вызовов метода; задать другие параметры для интервалов; установить интервалы для квадратных скобок; установить интервалы для разделителей; установить интервалы для операторов</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">Изменение параметров списка завершения; Предварительный выбор наиболее часто используемого члена</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">Изменение параметров списка завершения; Предварительный выбор наиболее часто используемого члена</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.tr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.tr.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">İmlecin altındaki sembole başvuruları vurgula;İmlecin altındaki ilişkili anahtar sözcükleri vurgula;Dosyalar açıldığında anahat moduna gir;Yordam satır ayraçlarını göster;XML belge açıklamaları oluştur;Kapatılan dosyalar için tanılamaları göster;Yeniden adlandırma izlemesi için önizleme göster;Kullanımları sıralarken önce 'System' yönergelerini yerleştir;Özel yapılara ref veya out koyma</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">Noktalı virgül girildiğinde deyimi otomatik biçimlendir;Küme ayracı girildiğinde bloğu otomatik biçimlendir;Yapıştırma sonrasında otomatik biçimlendir;kod temizleme;</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">Noktalı virgül girildiğinde deyimi otomatik biçimlendir;Küme ayracı girildiğinde bloğu otomatik biçimlendir;Yapıştırma sonrasında otomatik biçimlendir;kod temizleme;</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">Blok içeriklerini girintile;Açık ve kapalı küme ayraçlarını girintile;durum içeriklerini girintile;durum etiketlerini girintile;etiket girintileme</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">Blok içeriklerini girintile;Açık ve kapalı küme ayraçlarını girintile;durum içeriklerini girintile;durum etiketlerini girintile;etiket girintileme</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">Küme ayraçları için yeni satır biçimlendirme seçeneği;Anahtar sözcükler için yeni satır biçimlendirme seçenekleri</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">Küme ayraçları için yeni satır biçimlendirme seçeneği;Anahtar sözcükler için yeni satır biçimlendirme seçenekleri</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">Yöntem bildirimleri için aralama ayarla;yöntem çağrıları için aralama ayarla;diğer aralama seçeneklerini ayarla;köşeli ayraçlar için aralamayı ayarla;sınırlayıcılar için aralamaları ayarla;operatörler için aralamaları ayarla</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">Yöntem bildirimleri için aralama ayarla;yöntem çağrıları için aralama ayarla;diğer aralama seçeneklerini ayarla;köşeli ayraçlar için aralamayı ayarla;sınırlayıcılar için aralamaları ayarla;operatörler için aralamaları ayarla</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">Tamamlanma listesi ayarlarını değiştir;en son kullanılan üyeyi önceden seç</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">Tamamlanma listesi ayarlarını değiştir;en son kullanılan üyeyi önceden seç</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hans.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hans.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">突出显示对光标下符号的引用;突出显示光标下相关的关键字;打开文件时进入大纲模式;显示过程行分隔符;生成 XML 文档注释;显示对已关闭文件的诊断;显示重命名跟踪的预览;对 using 排序时将“System”指令排在第一位;不要在自定义结构上放置 ref 或 out</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">输入分号时自动设置语句的格式;输入大括号时自动设置块的格式;粘贴时自动设置格式;代码清理;</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">输入分号时自动设置语句的格式;输入大括号时自动设置块的格式;粘贴时自动设置格式;代码清理;</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">缩进块内容;缩进左大括号和右大括号;缩进 case 内容;缩进 case 标签;标签缩进</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">缩进块内容;缩进左大括号和右大括号;缩进 case 内容;缩进 case 标签;标签缩进</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">大括号的新行格式选项;关键字的新行格式选项</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">大括号的新行格式选项;关键字的新行格式选项</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">设置方法声明的间距;设置方法调用的间距;设置其他间距选项;设置中括号的间距;设置分隔符的间距;设置运算符的间距</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">设置方法声明的间距;设置方法调用的间距;设置其他间距选项;设置中括号的间距;设置分隔符的间距;设置运算符的间距</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">更改完成列表设置;预先选择最近使用过的成员</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">更改完成列表设置;预先选择最近使用过的成员</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hant.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hant.xlf
@@ -33,28 +33,145 @@
         <note>"C#" node help text in profile Import/Export.</note>
       </trans-unit>
       <trans-unit id="306">
-        <source>Highlight references to symbol under cursor;Highlight related keywords under cursor;Enter outlining mode when files open;Show procedure line separators;Generate XML documentation comments;Show diagnostics for closed files;Show preview for rename tracking;Place 'System' directives first when sorting usings;Don't put ref or out on custom structs;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions</source>
+        <source>Show diagnostics for closed files;
+Colorize regular expression; 
+Highlight related components under cursor; 
+Report invalid regular expressions;
+Enable full solution analysis;
+Perform editor feature analysis in external process;
+Enable navigation to decompiled sources;
+Using directives;
+Place system directives first when sorting usings;
+Separate using directive groups;
+Suggest usings for types in reference assemblies;
+Suggest usings for types in NuGet packages;
+Highlighting;
+Highlight references to symbol under cursor;
+Highlight related keywords under cursor;
+Outlining;
+Enter outlining mode when files open;
+Show procedure line separators;
+Show outlining for declaration level constructs;
+Show outlining for code level constructs;
+Show outlining for comments and preprocessor regions;
+Collapse regions when collapsing to definitions;
+Fading;
+Fade out unused usings;
+Fade out unreachable code;
+Block Structure Guides;
+Show guides for declaration level constructs;
+Show guides for code level constructs;
+Editor Help;
+Generate XML documentation comments for ///;
+Insert * at the start of new lines when writing /* */ comments;
+Show preview for rename tracking;
+Split string literals on Enter;
+Report invalid placeholders in string.Format calls;
+Extract Method;
+Don't put ref or out on custom struct;
+Implement Interface or Abstract Class;
+When inserting properties, events and methods, place them;
+with other members of the same kind;
+at the end;
+When generating property;
+prefer throwing properties;
+prefer auto properties;</source>
         <target state="needs-review-translation">反白資料指標下符號的參考項目; 反白資料指標下相關的關鍵字; 檔案開啟時輸入大綱模式; 顯示程序行分隔符號; 產生 XML 文件註解; 顯示關閉的檔案之診斷; 顯示重新命名追踨的預覽; 排序 usings 時先放置 'System' 指示詞; 自訂結構上不要放置 ref 或 out</target>
         <note>C# Advanced options page keywords</note>
       </trans-unit>
       <trans-unit id="307">
-        <source>Automatically format statement on semicolon;Automatically format block on brace;Automatically format on paste;code cleanup;</source>
-        <target state="translated">於分號處自動格式化陳述式; 於大括弧處自動格式化區塊; 貼上時自動格式化; 清除程式碼;</target>
+        <source>Automatically format when typing;
+Automatically format statement on semicolon ;
+Automatically format block on end brace;
+Automatically format on return;
+Automatically format on paste;
+Format Document Settings;
+Apply all C# formatting rules indentation, wrapping, spacing;
+Perform additional code cleanup during formatting;
+Remove unnecessary usings;
+Sort usings;
+Add remove braces for single-line control statements;
+Add accessibility modifiers;
+Sort accessibility modifiers;
+Apply expression block/body preferences;
+Apply implicit/explicit type preferences;
+Apply inline out variables preferences;
+Apply language/framework type preferences;
+Apply object/collection initialization preferences;
+Apply this qualification preferences;
+Make private fields readonly when possible;
+Remove unnecessary casts;
+Remove unused variables;</source>
+        <target state="needs-review-translation">於分號處自動格式化陳述式; 於大括弧處自動格式化區塊; 貼上時自動格式化; 清除程式碼;</target>
         <note>C# Formatting &gt; General options page keywords</note>
       </trans-unit>
       <trans-unit id="308">
-        <source>Indent block contents;Indent open and close braces, indent case contents;indent case labels;label indentation</source>
-        <target state="translated">縮排區塊內容;縮排左括號與右括號, 縮排 case 內容;縮排 case 標籤;標籤縮排</target>
+        <source>Indent block contents; 
+indent open and close braces; 
+indent case contents; 
+indent case contents (when block); 
+indent case labels; 
+label indentation; 
+place goto labels in leftmost column; 
+indent labels normally; 
+place goto labels one indent less than current;</source>
+        <target state="needs-review-translation">縮排區塊內容;縮排左括號與右括號, 縮排 case 內容;縮排 case 標籤;標籤縮排</target>
         <note>C# Formatting &gt; Indentation options page keywords</note>
       </trans-unit>
       <trans-unit id="309">
-        <source>New line formatting option for braces;New line formatting options for keywords</source>
-        <target state="translated">括號的新行格式化選項;關鍵字的新行格式化選項</target>
+        <source>New line formatting option for braces;New line formatting options for keywords;New line options for braces;
+Place open brace on new line for types;
+Place open brace on new line for methods and local functions;
+Place open brace on new line for properties, indexers, and events;
+Place open brace on new line for property, indexer, and event accessors;
+Place open brace on new line for anonymous methods;
+Place open brace on new line for control blocks;
+Place open brace on new line for anonymous types;
+Place open brace on new line for object, collection and array initializers;
+New line options for keywords;
+Place else on new line;
+Place catch on new line;
+Place finally on new line;
+New line options for expression;
+Place members in object initializers on new line;
+Place members in anonymous types on new line;
+Place query expression clauses on new line;</source>
+        <target state="needs-review-translation">括號的新行格式化選項;關鍵字的新行格式化選項</target>
         <note>C# Formatting &gt; New Lines options page keywords</note>
       </trans-unit>
       <trans-unit id="310">
-        <source>Set spacing for method declarations;set spacing for method calls;set other spacing options;set spacing for brackets;set spacing for delimiters;set spacing for operators</source>
-        <target state="translated">設定方法宣告的間距;設定方法呼叫的間距;設定其他間距選項;設定括號間距;設定分隔符號間距;設定運算子間距</target>
+        <source>Set spacing for method declarations;
+Insert space between method name and its opening parenthesis;
+Insert space within parameter list parentheses;
+Insert space within empty parameter list parentheses;
+Set spacing for method calls;
+Insert space within argument list parentheses;
+Insert space within empty argument list parentheses;
+Set other spacing options;
+Insert space after keywords in control flow statements;
+Insert space within parentheses of expressions;
+Insert space within parentheses of type casts;
+Insert spaces within parentheses of control flow statements;
+Insert space after cast;
+Ignore spaces in declaration statements;
+Set spacing for brackets;
+Insert space before open square bracket;
+Insert space within empty square brackets;
+Insert spaces within square brackets;
+Set spacing for delimiters;
+Insert space after colon for base or interface in type declaration;
+Insert space after comma;
+Insert space after dot;
+Insert space after semicolon in for statement;
+Insert space before colon for base or interface in type declaration;
+Insert space before comma;
+Insert space before dot;
+Insert space before semicolon in for statement;
+Set spacing for operators;
+Ignore spaces around binary operators;
+Remove spaces before and after binary operators;
+Insert space before and after binary operators;</source>
+        <target state="needs-review-translation">設定方法宣告的間距;設定方法呼叫的間距;設定其他間距選項;設定括號間距;設定分隔符號間距;設定運算子間距</target>
         <note>C# Formatting &gt; Spacing options page keywords</note>
       </trans-unit>
       <trans-unit id="311">
@@ -63,8 +180,21 @@
         <note>C# Formatting &gt; Wrapping options page keywords</note>
       </trans-unit>
       <trans-unit id="312">
-        <source>Change completion list settings;Pre-select most recently used member</source>
-        <target state="translated">變更完成清單設定;預先選取最近使用的成員</target>
+        <source>Change completion list settings;Pre-select most recently used member; Completion Lists;
+Show completion list after a character is typed;
+Show completion list after a character is deleted;
+Highlight matching portions of completion list items;
+Show completion item filters;
+Snippets behavior;
+Never include snippets;
+Always include snippets;
+Include snippets when ?-Tab is typed after an identifier;
+Enter key behavior;
+Never add new line on enter;
+Only add new line on enter after end of fully typed word;
+Always add new line on enter;
+Show name suggestions;</source>
+        <target state="needs-review-translation">變更完成清單設定;預先選取最近使用的成員</target>
         <note>C# IntelliSense options page keywords</note>
       </trans-unit>
       <trans-unit id="107">


### PR DESCRIPTION
Fixes #29681 and more.

In Tools|Options, many of our options are not included in the list of keywords so they don't show up in the Option Search results.  This PR adds the display text for each of the options pages to the list of searchable keywords.  

