### PR TITLE
Prevent Format String analyzer from crashing on a local function named Format

### DIFF
--- a/src/EditorFeatures/CSharpTest/ValidateFormatString/ValidateFormatStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ValidateFormatString/ValidateFormatStringTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.ValidateFormatString;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ValidateFormatString
@@ -963,6 +964,20 @@ class Program
                 diagnosticId: IDEDiagnosticIds.ValidateFormatStringDiagnosticID,
                 diagnosticSeverity: DiagnosticSeverity.Warning,
                 diagnosticMessage: FeaturesResources.Format_string_contains_invalid_placeholder);
+        }
+
+        [WorkItem(29398, "https://github.com/dotnet/roslyn/issues/29398")]
+        [Fact, Trait(Traits.Feature, Traits.Features.ValidateFormatString)]
+        public async Task LocalFunctionNamedFormat()
+        {
+            await TestDiagnosticMissingAsync(@"public class C
+{
+    public void M()
+    {
+        Forma[||]t();
+        void Format() { }
+    }
+}");
         }
     }
 }

--- a/src/Features/Core/Portable/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
@@ -298,6 +298,11 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
                 return null;
             }
 
+            if (((IMethodSymbol)symbolInfo.Symbol).MethodKind == MethodKind.LocalFunction)
+            {
+                return null;
+            }
+
             var containingType = (INamedTypeSymbol)symbolInfo.Symbol.ContainingSymbol;
 
             if (containingType.SpecialType != SpecialType.System_String)

--- a/src/Features/Core/Portable/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
@@ -303,7 +303,11 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
                 return null;
             }
 
-            var containingType = (INamedTypeSymbol)symbolInfo.Symbol.ContainingSymbol;
+            var containingType = symbolInfo.Symbol.ContainingType;
+            if (containingType == null)
+            {
+                return null;
+            }
 
             if (containingType.SpecialType != SpecialType.System_String)
             {


### PR DESCRIPTION
Fixes #29398 

Added a check to see if the Format method is a local function in CSharp.

