### PR TITLE
don't crash on span mismatch but send NFW and continue

### DIFF
--- a/src/EditorFeatures/Core/Tagging/TaggerContext.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerContext.cs
@@ -76,6 +76,11 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             tagSpans.Add(tag);
         }
 
+        public void ClearTags()
+        {
+            tagSpans.Clear();
+        }
+
         /// <summary>
         /// Used to allow taggers to indicate what spans were actually tagged.  This is useful 
         /// when the tagger decides to tag a different span than the entire file.  If a sub-span


### PR DESCRIPTION
this is for this https://devdiv.visualstudio.com/DevDiv/_workitems/edit/678681?src=WorkItemMention&amp%3Bsrc-action=artifact_link

this is not fixing the cause. typescript will follow up on that.

this change is for us to stop crashing VS on the non-critical issue and move to NFW.

one can see NFW here
https://features.vsdata.io/featuredetails?mt=MAC_ADDRESS_HASHES&et=FAULT&sd=2018-08-06&ed=2018-09-05&pn=vs&fn=ide/vbcs/nonfatalwatson&en=nonfatalwatson&ex=devenv&ut=external

from here, you can find watson dump as well.