### PR TITLE
Add parameter CodefixProvider: Fix argument list handling of local functions 

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
@@ -2478,5 +2478,75 @@ public class C : B
             await TestInRegularAndScriptAsync(code, fix0, index: 0);
             await TestActionCountAsync(code, 1);
         }
+
+        [WorkItem(29753, "https://github.com/dotnet/roslyn/issues/29753")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task LocalFunction_AddParameterToLocalFunctionWithOneParameter()
+        {
+            // CS1501 No overload for method takes 2 arguments
+            var code =
+@"
+class Rsrp
+{
+  public void M()
+  {
+    [|Local|](""ignore this"", true);
+    void Local(string whatever)
+    {
+
+    }
+  }
+}";
+            var fix0 =
+@"
+class Rsrp
+{
+  public void M()
+  {
+    Local(""ignore this"", true);
+    void Local(string whatever, bool v)
+    {
+
+    }
+  }
+}";
+            await TestInRegularAndScriptAsync(code, fix0, index: 0);
+        }
+
+        [WorkItem(29752, "https://github.com/dotnet/roslyn/issues/29752")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task LocalFunction_AddNamedParameterToLocalFunctionWithOneParameter()
+        {
+            // CS1739: The best overload for 'Local' does not have a parameter named 'mynewparameter'
+            var code =
+@"
+class Rsrp
+{
+    public void M()
+    {
+        Local(""ignore this"", [|mynewparameter|]: true);
+        void Local(string whatever)
+        {
+
+        }
+    }
+}
+";
+            var fix0 =
+@"
+class Rsrp
+{
+    public void M()
+    {
+        Local(""ignore this"", mynewparameter: true);
+        void Local(string whatever, bool mynewparameter)
+        {
+
+        }
+    }
+}
+";
+            await TestInRegularAndScriptAsync(code, fix0, index: 0);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -2139,41 +2139,41 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     }
 
                 case SyntaxKind.VariableDeclaration:
-                {
-                    var vd = (VariableDeclarationSyntax)declaration;
-                    if (vd.Variables.Count == 1 && vd.Parent == null)
                     {
-                        // this node is the declaration if it contains only one variable and has no parent.
-                        return DeclarationKind.Variable;
-                    }
-                    else
-                    {
-                        return DeclarationKind.None;
-                    }
-                }
-
-                case SyntaxKind.VariableDeclarator:
-                {
-                    var vd = declaration.Parent as VariableDeclarationSyntax;
-
-                    // this node is considered the declaration if it is one among many, or it has no parent
-                    if (vd == null || vd.Variables.Count > 1)
-                    {
-                        if (ParentIsFieldDeclaration(vd))
+                        var vd = (VariableDeclarationSyntax)declaration;
+                        if (vd.Variables.Count == 1 && vd.Parent == null)
                         {
-                            return DeclarationKind.Field;
-                        }
-                        else if (ParentIsEventFieldDeclaration(vd))
-                        {
-                            return DeclarationKind.Event;
+                            // this node is the declaration if it contains only one variable and has no parent.
+                            return DeclarationKind.Variable;
                         }
                         else
                         {
-                            return DeclarationKind.Variable;
+                            return DeclarationKind.None;
                         }
                     }
-                    break;
-                }
+
+                case SyntaxKind.VariableDeclarator:
+                    {
+                        var vd = declaration.Parent as VariableDeclarationSyntax;
+
+                        // this node is considered the declaration if it is one among many, or it has no parent
+                        if (vd == null || vd.Variables.Count > 1)
+                        {
+                            if (ParentIsFieldDeclaration(vd))
+                            {
+                                return DeclarationKind.Field;
+                            }
+                            else if (ParentIsEventFieldDeclaration(vd))
+                            {
+                                return DeclarationKind.Event;
+                            }
+                            else
+                            {
+                                return DeclarationKind.Variable;
+                            }
+                        }
+                        break;
+                    }
 
                 case SyntaxKind.AttributeList:
                     var list = (AttributeListSyntax)declaration;
@@ -2680,6 +2680,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     return ((ParenthesizedLambdaExpressionSyntax)declaration).ParameterList;
                 case SyntaxKind.SimpleLambdaExpression:
                     return SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(((SimpleLambdaExpressionSyntax)declaration).Parameter));
+                case SyntaxKind.LocalFunctionStatement:
+                    return ((LocalFunctionStatementSyntax)declaration).ParameterList;
                 default:
                     return null;
             }
@@ -4217,7 +4219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         internal override SyntaxNode IdentifierName(SyntaxToken identifier)
             => SyntaxFactory.IdentifierName(identifier);
 
-        internal override SyntaxToken Identifier(string identifier) 
+        internal override SyntaxToken Identifier(string identifier)
             => SyntaxFactory.Identifier(identifier);
 
         internal override SyntaxNode NamedAnonymousObjectMemberDeclarator(SyntaxNode identifier, SyntaxNode expression)


### PR DESCRIPTION
Fixes #29752
Fixes #29753

Note to reviewers:
The diff shows a lot of changes for CSharpSyntaxGenerator.cs which are actually only whitespace related. 
You should turn on *[Hide whitespace changes](https://github.com/dotnet/roslyn/pull/29794/files?utf8=%E2%9C%93&diff=unified&w=1)* in the diff settings.