### PR TITLE
Generate variables for contextual keywords

### DIFF
--- a/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
@@ -12,6 +12,8 @@ using Microsoft.CodeAnalysis.GenerateMember.GenerateVariable;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Classification;
+using Microsoft.CodeAnalysis.Classification;
 
 namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
 {
@@ -23,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
             => node is PropertyDeclarationSyntax;
 
         protected override bool IsIdentifierNameGeneration(SyntaxNode node)
-            => node is IdentifierNameSyntax identifier && !identifier.Identifier.CouldBeKeyword();
+            => node is IdentifierNameSyntax identifier && ClassificationHelpers.GetClassification(node.GetFirstToken()) == ClassificationTypeNames.Identifier;
 
         protected override bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)
             => containingType.ContainingTypesOrSelfHasUnsafeKeyword();


### PR DESCRIPTION
Fixes #27646 

Currently, we don't offer to generate a variable for any C# contextual keywords.  

This PR uses a ClassificationHelpers method to determine if a contextual keyword can be used as an identifier in it's current context.

@sharwell, @dpoeschl , @heejaechang, @mavasani , @CyrusNajmabadi , I still need to add tests for this, but would like feedback on the approach and any specific tests you would like to see included. 