### PR TITLE
Fix race in SourceEventSymbol.GetAttributesBag

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly DeclarationModifiers _modifiers;
         internal readonly SourceMemberContainerTypeSymbol containingType;
 
-        protected SymbolCompletionState state;
+        private SymbolCompletionState _state;
         private CustomAttributesBag<CSharpAttributeData> _lazyCustomAttributesBag;
         private string _lazyDocComment;
         private OverriddenOrHiddenMembersResult _lazyOverriddenOrHiddenMembers;
@@ -62,12 +62,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override bool HasComplete(CompletionPart part)
         {
-            return state.HasComplete(part);
+            return _state.HasComplete(part);
         }
 
         internal override void ForceComplete(SourceLocation locationOpt, CancellationToken cancellationToken)
         {
-            state.DefaultForceComplete(this);
+            if (!_state.HasComplete(CompletionPart.Attributes))
+            {
+                _ = GetAttributes();
+
+                // Consider the following items:
+                //  1. It is possible for parallel calls to GetAttributes to exist
+                //  2. GetAttributes will return when the attributes are available, not when the part is noted
+                //     as complete.
+                //  3. The thread which actually completes the attributes is the one which must set the CompletionParts.Attributes
+                //     value.
+                //  4. This call cannot correctly return until this part is set. 
+                //
+                // That is why it is necessary to check this value again. 
+                //
+                // Note: #2 above is common practice amongst all of the symbols.
+                //
+                // Note: #3 above is an invariant that has existed in the code for some time. It's not clear if this invariant
+                // is 100% correct. After inspection though it seems likely to be correct as the code is asserting that 
+                // SymbolDeclaredEvent is raised before CompletionPart.Attributes is noted as completed. Also this is a common
+                // pattern amongst the GetAttributes implementations.
+                _state.SpinWaitComplete(CompletionPart.Attributes, cancellationToken);
+            }
+
+            _state.NotePartComplete(CompletionPart.All);
         }
 
         public override abstract string Name { get; }
@@ -180,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 LoadAndValidateAttributes(OneOrMany.Create(this.AttributeDeclarationSyntaxList), ref _lazyCustomAttributesBag))
             {
                 DeclaringCompilation.SymbolDeclaredEvent(this);
-                var wasCompletedThisThread = state.NotePartComplete(CompletionPart.Attributes);
+                var wasCompletedThisThread = _state.NotePartComplete(CompletionPart.Attributes);
                 Debug.Assert(wasCompletedThisThread);
             }
 


### PR DESCRIPTION
There is a race condition around the setting of
`CompletionPart.Attributes` in `SourceEventSymbol`. This can be exposed
when the following execution pattern occurs:

- Thread1: Calls `GetAttributesBag` and pauses execution on the line `
`DeclaringCompilation.SymbolDeclaredEvent(this)`
- Thread2: Calls `ForceComplete` which will unconditionally call
`state.NotePartComplete(CompletionPart.Attributes)`
- Thread1: Resumes and hits an assert because `NotePartComplete` returns
`false`.

The root problem here is the unconditional call of `NotePartComplete`
inside of `ForceComplete`. The pattern in all of our other symbols for
`ForceComplete` is the following:

- Call `GetAttributes`
- Call `SpinWaitComplete(CompletionPart.Attributes, cancellationToken)`

This ensures that `NotePartComplete` is executed on the thread which
actually completes the loading of attributes.

As a part of fixing this I looked through all other uses of
`NotePartComplete(CompletionPart.Attributes)` to ensure they didn't have
this problem. Checked VB as well and it doesn't seem to have this issue.

Struggled to find a good way to test this as it's a race condition.
Given the high number of bugs we've recently filed on this assert I'm
confident we have the indirect coverage in our suites.

closes #28954