### PR TITLE
Revert LangVersion default/latest. Mark C# 8.0 and VB 16 as beta

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -280,6 +280,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     consoleOutput.WriteLine($"{v.ToDisplayString()} (latest)");
                 }
+                else if (v == LanguageVersion.CSharp8)
+                {
+                    // https://github.com/dotnet/roslyn/issues/29819 This should be removed once we are ready to move C# 8.0 out of beta
+                    consoleOutput.WriteLine($"{v.ToDisplayString()} *beta*");
+                }
                 else
                 {
                     consoleOutput.WriteLine(v.ToDisplayString());

--- a/src/Compilers/CSharp/Portable/LanguageVersion.cs
+++ b/src/Compilers/CSharp/Portable/LanguageVersion.cs
@@ -332,9 +332,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (version)
             {
                 case LanguageVersion.Latest:
-                    return LanguageVersion.CSharp8;
+                    return LanguageVersion.CSharp7_3;
                 case LanguageVersion.Default:
-                    return LanguageVersion.CSharp8;
+                    return LanguageVersion.CSharp7;
                 default:
                     return version;
             }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1412,12 +1412,15 @@ d.cs
             InlineData(LanguageVersion.CSharp7_1, LanguageVersion.CSharp7_1),
             InlineData(LanguageVersion.CSharp7_2, LanguageVersion.CSharp7_2),
             InlineData(LanguageVersion.CSharp7_3, LanguageVersion.CSharp7_3),
-            InlineData(LanguageVersion.CSharp8, LanguageVersion.Default),
-            InlineData(LanguageVersion.CSharp8, LanguageVersion.Latest)]
+            InlineData(LanguageVersion.CSharp8, LanguageVersion.CSharp8),
+            InlineData(LanguageVersion.CSharp7, LanguageVersion.Default),
+            InlineData(LanguageVersion.CSharp7_3, LanguageVersion.Latest)]
         public void LanguageVersion_MapSpecifiedToEffectiveVersion(LanguageVersion expectedMappedVersion, LanguageVersion input)
         {
             Assert.Equal(expectedMappedVersion, input.MapSpecifiedToEffectiveVersion());
             Assert.True(expectedMappedVersion.IsValid());
+
+            // https://github.com/dotnet/roslyn/issues/29819 Once we are ready to remove the beta tag from C# 8.0, we should update Default/Latest accordingly
 
             // The canary check is a reminder that this test needs to be updated when a language version is added
             LanguageVersionAdded_Canary();

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -211,6 +211,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     consoleOutput.WriteLine($"{v.ToDisplayString()} (default)")
                 ElseIf v = latestVersion Then
                     consoleOutput.WriteLine($"{v.ToDisplayString()} (latest)")
+                ElseIf v = LanguageVersion.VisualBasic16 Then
+                    ' https://github.com/dotnet/roslyn/issues/29819 This should be removed once we are ready to move VB 16 out of beta
+                    consoleOutput.WriteLine($"{v.ToDisplayString()} *beta*")
                 Else
                     consoleOutput.WriteLine(v.ToDisplayString())
                 End If

--- a/src/Compilers/VisualBasic/Portable/LanguageVersion.vb
+++ b/src/Compilers/VisualBasic/Portable/LanguageVersion.vb
@@ -81,9 +81,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function MapSpecifiedToEffectiveVersion(version As LanguageVersion) As LanguageVersion
             Select Case version
                 Case LanguageVersion.Latest
-                    Return LanguageVersion.VisualBasic16
+                    Return LanguageVersion.VisualBasic15_5
                 Case LanguageVersion.Default
-                    Return LanguageVersion.VisualBasic16
+                    Return LanguageVersion.VisualBasic15
                 Case Else
                     Return version
             End Select

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1734,9 +1734,9 @@ End Module").Path
         <Fact>
         Public Sub LanguageVersionAdded_Canary()
             ' When a new version is added, this test will break. This list must be checked:
-            ' - update the command-line error for bad /langver flag (<see cref="ERRID.IDS_VBCHelp"/>)
             ' - update the "UpgradeProject" codefixer (not yet supported in VB)
             ' - update the IDE drop-down for selecting Language Version (not yet supported in VB)
+            ' - update project-system to recognize the new value and pass it through
             ' - update all the tests that call this canary
             ' - update the command-line documentation (CommandLine.md)
             AssertEx.SetEqual({"default", "9", "10", "11", "12", "14", "15", "15.3", "15.5", "16", "latest"},
@@ -1781,8 +1781,10 @@ End Module").Path
             Assert.Equal(LanguageVersion.VisualBasic15_5, LanguageVersion.VisualBasic15_5.MapSpecifiedToEffectiveVersion())
             Assert.Equal(LanguageVersion.VisualBasic16, LanguageVersion.VisualBasic16.MapSpecifiedToEffectiveVersion())
 
-            Assert.Equal(LanguageVersion.VisualBasic16, LanguageVersion.Default.MapSpecifiedToEffectiveVersion())
-            Assert.Equal(LanguageVersion.VisualBasic16, LanguageVersion.Latest.MapSpecifiedToEffectiveVersion())
+            Assert.Equal(LanguageVersion.VisualBasic15, LanguageVersion.Default.MapSpecifiedToEffectiveVersion())
+            Assert.Equal(LanguageVersion.VisualBasic15_5, LanguageVersion.Latest.MapSpecifiedToEffectiveVersion())
+
+            ' https//github.com/dotnet/roslyn/issues/29819 Once we are ready to remove the beta tag from VB 16 we should update Default/Latest accordingly
 
             ' The canary check is a reminder that this test needs to be updated when a language version is added
             LanguageVersionAdded_Canary()

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
@@ -81,9 +81,11 @@ Public Class VisualBasicParseOptionsTests
         Dim highest = System.Enum.
             GetValues(GetType(LanguageVersion)).
             Cast(Of LanguageVersion).
-            Where(Function(x) x <> LanguageVersion.Latest).
+            Where(Function(x) x <> LanguageVersion.Latest AndAlso x <> LanguageVersion.VisualBasic16).
             Max().
             ToDisplayString()
+
+        ' https//github.com/dotnet/roslyn/issues/29819 Once we are ready to remove the beta tag from VB 16 we should update Default/Latest accordingly
 
         Assert.Equal(highest, PredefinedPreprocessorSymbols.CurrentVersionNumber.ToString(CultureInfo.InvariantCulture))
     End Sub

--- a/src/EditorFeatures/CSharpTest/CodeActions/LambdaSimplifier/LambdaSimplifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/LambdaSimplifier/LambdaSimplifierTests.cs
@@ -349,7 +349,7 @@ class A
 }", parameters: new TestParameters(parseOptions: new CSharpParseOptions(LanguageVersion.CSharp7)));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/pull/29820"), Trait(Traits.Feature, Traits.Features.CodeActionsLambdaSimplifier)]
         public async Task TestOnAmbiguity()
         {
             await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
@@ -1535,7 +1535,7 @@ internal class T
 {
     public T(out DateTime d)
     {
-        d = default;
+        d = default(DateTime);
     }
 }",
 index: 1);
@@ -1654,7 +1654,7 @@ index: 1);
     {
         public T(out X d)
         {
-            d = default;
+            d = default(X);
         }
     }
 }",

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -266,7 +266,7 @@ class Program
         #endregion C# 7.3
 
         #region C# 8.0
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/pull/29820")]
         public async Task UpgradeProjectFromCSharp7_3ToLatest()
         {
             await TestLanguageVersionUpgradedAsync(
@@ -279,7 +279,7 @@ class Program
                 new CSharpParseOptions(LanguageVersion.CSharp7_3));
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/pull/29820")]
         public async Task UpgradeProjectFromCSharp7_3To8_0()
         {
             await TestLanguageVersionUpgradedAsync(
@@ -360,7 +360,8 @@ class C
     </Project>
 </Workspace>",
                 new[] {
-                    string.Format(CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0, "7.0")
+                    string.Format(CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0, "7.0"),
+                    string.Format(CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0, "7.0")
                 });
         }
 

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
@@ -3,6 +3,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddConstructorParametersFromMembers;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -297,7 +298,7 @@ index: 1);
     (int, string) i;
     (string, int) s;
 
-    public Program((int, string) i, (string, int) s = default)
+    public Program((int, string) i, (string, int) s = default((string, int)))
     {
         this.i = i;
         this.s = s;
@@ -325,7 +326,7 @@ index: 1);
     (int a, string b) i;
     (string c, int d) s;
 
-    public Program((int a, string b) i, (string c, int d) s = default)
+    public Program((int a, string b) i, (string c, int d) s = default((string c, int d)))
     {
         this.i = i;
         this.s = s;

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -3951,7 +3951,7 @@ class Program
 {
     void goo()
     {
-        sfoo xyz = default;
+        sfoo xyz = default(sfoo);
         bar(xyz);
     }
 

--- a/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -458,7 +458,7 @@ abstract class d
 
 class c : d
 {
-    public override void goo(b x = default)
+    public override void goo(b x = default(b))
     {
         throw new System.NotImplementedException();
     }
@@ -1529,7 +1529,7 @@ abstract class B
 }
 sealed class D : B
 {
-    public override void M1(int i = 0, string s = null, int? j = null, V v = default)
+    public override void M1(int i = 0, string s = null, int? j = null, V v = default(V))
     {
         throw new System.NotImplementedException();
     }

--- a/src/EditorFeatures/CSharpTest/UseNamedArguments/UseNamedArgumentsTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseNamedArguments/UseNamedArgumentsTests.cs
@@ -322,7 +322,7 @@ class C
 }", parameters: new TestParameters(parseOptions: new CSharpParseOptions(LanguageVersion.CSharp7)));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseNamedArguments)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/pull/29820"), Trait(Traits.Feature, Traits.Features.CodeActionsUseNamedArguments)]
         public async Task TestNotMissingWhenInsideSingleLineArgument2()
         {
             await TestInRegularAndScript1Async(

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1563,7 +1563,7 @@ class Goo
             End Using
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/pull/29820"), Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function KeywordsOrSymbolsAfterNamedParameter() As Task
             Using state = TestState.CreateCSharpTestState(
                                 <Document>
@@ -1948,7 +1948,7 @@ class D : C
                 state.SendTypeChars(" Goo")
                 state.SendTab()
                 Await state.AssertNoCompletionSession()
-                Assert.Contains("public override void Goo<S>(S x = default)", state.SubjectBuffer.CurrentSnapshot.GetText(), StringComparison.Ordinal)
+                Assert.Contains("public override void Goo<S>(S x = default(S))", state.SubjectBuffer.CurrentSnapshot.GetText(), StringComparison.Ordinal)
             End Using
         End Function
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
@@ -2160,7 +2160,7 @@ class C
 {
     string Name
     {
-        get => default;
+        get => default(string);
         set
         {
         }
@@ -2188,7 +2188,7 @@ class C
     {
         get
         {
-            return default;
+            return default(string);
         }
 
         set
@@ -2220,7 +2220,7 @@ class C$$
 <Code>
 class C
 {
-    string Name => default;
+    string Name => default(string);
 }
 </Code>
 
@@ -2244,7 +2244,7 @@ class C
     {
         get
         {
-            return default;
+            return default(string);
         }
     }
 }

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -1765,7 +1765,7 @@ class C1
         public async Task TestParseOptions_CSharp_LanguageVersion_Default()
         {
             CreateCSharpFiles();
-            await AssertCSParseOptionsAsync(CS.LanguageVersion.CSharp8, options => options.LanguageVersion);
+            await AssertCSParseOptionsAsync(CS.LanguageVersion.CSharp7, options => options.LanguageVersion);
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12466233/45459186-00de5100-b6ac-11e8-885e-70675d9b6043.png)

![image](https://user-images.githubusercontent.com/12466233/45459195-0cca1300-b6ac-11e8-8dea-434ce04e25b3.png)

Relates to https://github.com/dotnet/roslyn/issues/29150

I created a follow-up workitem (https://github.com/dotnet/roslyn/issues/29819) to revert this once we are ready to remove the beta label.