### PR TITLE
Enable DeadCodeAnalysis rules and address design/review feedback.

### DIFF
--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -49,11 +49,11 @@ Friend Module ParserTestUtilities
     End Function
 
     Public Function ParseAndVerify(code As XCData, ParamArray expectedDiagnostics() As DiagnosticDescription) As SyntaxTree
-        Return ParseAndVerify(TestBase.NormalizeNewLines(code), VisualBasicParseOptions.Default, expectedDiagnostics, errorCodesOnly:=False)
+        Return ParseAndVerify(TestHelpers.NormalizeNewLines(code), VisualBasicParseOptions.Default, expectedDiagnostics, errorCodesOnly:=False)
     End Function
 
     Public Function ParseAndVerify(code As XCData, options As VisualBasicParseOptions, ParamArray expectedDiagnostics() As DiagnosticDescription) As SyntaxTree
-        Return ParseAndVerify(TestBase.NormalizeNewLines(code), options, expectedDiagnostics, errorCodesOnly:=False)
+        Return ParseAndVerify(TestHelpers.NormalizeNewLines(code), options, expectedDiagnostics, errorCodesOnly:=False)
     End Function
 
     Public Function ParseAndVerify(source As String, ParamArray expectedDiagnostics() As DiagnosticDescription) As SyntaxTree

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
@@ -1849,7 +1849,7 @@ End Structure
                                         Optional latestReferences As Boolean = False,
                                         Optional addXmlReferences As Boolean = False,
                                         Optional diagnostics() As DiagnosticDescription = Nothing)
-            TestExpressionTrees(sourceFile, TestBase.NormalizeNewLines(result), checked, optimize, latestReferences, addXmlReferences, diagnostics)
+            TestExpressionTrees(sourceFile, TestHelpers.NormalizeNewLines(result), checked, optimize, latestReferences, addXmlReferences, diagnostics)
         End Sub
 
         Private Class ExpressionTreeTest

--- a/src/EditorFeatures/CSharpTest/Diagnostics/FixAllProvider/BatchFixerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/FixAllProvider/BatchFixerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.SimplifyTyp
                     var symbol = context.SemanticModel.GetSymbolInfo(node).Symbol;
                     if (symbol != null && symbol.Kind == SymbolKind.Field)
                     {
-                        var diagnostic = CodeAnalysis.Diagnostic.Create(Descriptor, node.GetLocation());
+                        var diagnostic = Diagnostic.Create(Descriptor, node.GetLocation());
                         context.ReportDiagnostic(diagnostic);
                     }
                 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/RemoveSuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/RemoveSuppressionTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Suppression
             {
                 var classDecl = (ClassDeclarationSyntax)context.Node;
                 var location = _reportDiagnosticsWithoutLocation ? Location.None : classDecl.Identifier.GetLocation();
-                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Decsciptor, location));
+                context.ReportDiagnostic(Diagnostic.Create(Decsciptor, location));
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixMultipleTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixMultipleTests.cs
@@ -47,8 +47,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Suppression
                 {
                     var classDecl = (ClassDeclarationSyntax)context.Node;
                     var location = classDecl.Identifier.GetLocation();
-                    context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Decsciptor1, location));
-                    context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Decsciptor2, location));
+                    context.ReportDiagnostic(Diagnostic.Create(Decsciptor1, location));
+                    context.ReportDiagnostic(Diagnostic.Create(Decsciptor2, location));
                 }
             }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -468,7 +468,7 @@ int Method()
                     public void AnalyzeNode(SyntaxNodeAnalysisContext context)
                     {
                         var classDecl = (ClassDeclarationSyntax)context.Node;
-                        context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Decsciptor, classDecl.Identifier.GetLocation()));
+                        context.ReportDiagnostic(Diagnostic.Create(Decsciptor, classDecl.Identifier.GetLocation()));
                     }
                 }
 
@@ -530,7 +530,7 @@ class Class
                     public void AnalyzeNode(SyntaxNodeAnalysisContext context)
                     {
                         var classDecl = (ClassDeclarationSyntax)context.Node;
-                        context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()));
+                        context.ReportDiagnostic(Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()));
                     }
                 }
 
@@ -595,7 +595,7 @@ class Class
                     public void AnalyzeNode(SyntaxNodeAnalysisContext context)
                     {
                         var classDecl = (ClassDeclarationSyntax)context.Node;
-                        context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()));
+                        context.ReportDiagnostic(Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()));
                     }
                 }
 
@@ -647,7 +647,7 @@ using System;
                 public void AnalyzeNode(SyntaxNodeAnalysisContext context)
                 {
                     var classDecl = (ClassDeclarationSyntax)context.Node;
-                    context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Decsciptor, classDecl.GetLocation()));
+                    context.ReportDiagnostic(Diagnostic.Create(Decsciptor, classDecl.GetLocation()));
                 }
             }
 
@@ -760,39 +760,39 @@ class Class
                         {
                             case SyntaxKind.ClassDeclaration:
                                 var classDecl = (ClassDeclarationSyntax)context.Node;
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Descriptor, classDecl.Identifier.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Descriptor, classDecl.Identifier.GetLocation()));
                                 break;
 
                             case SyntaxKind.NamespaceDeclaration:
                                 var ns = (NamespaceDeclarationSyntax)context.Node;
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Descriptor, ns.Name.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Descriptor, ns.Name.GetLocation()));
                                 break;
 
                             case SyntaxKind.MethodDeclaration:
                                 var method = (MethodDeclarationSyntax)context.Node;
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Descriptor, method.Identifier.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Descriptor, method.Identifier.GetLocation()));
                                 break;
 
                             case SyntaxKind.PropertyDeclaration:
                                 var property = (PropertyDeclarationSyntax)context.Node;
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Descriptor, property.Identifier.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Descriptor, property.Identifier.GetLocation()));
                                 break;
 
                             case SyntaxKind.FieldDeclaration:
                                 var field = (FieldDeclarationSyntax)context.Node;
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Descriptor, field.Declaration.Variables.First().Identifier.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Descriptor, field.Declaration.Variables.First().Identifier.GetLocation()));
                                 break;
 
                             case SyntaxKind.EventDeclaration:
                                 var e = (EventDeclarationSyntax)context.Node;
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Descriptor, e.Identifier.GetLocation()));
+                                context.ReportDiagnostic(Diagnostic.Create(Descriptor, e.Identifier.GetLocation()));
                                 break;
 
                             case SyntaxKind.EnumDeclaration:
                                 // Report diagnostic on each descendant comment trivia
                                 foreach (var trivia in context.Node.DescendantTrivia().Where(t => t.Kind() == SyntaxKind.SingleLineCommentTrivia || t.Kind() == SyntaxKind.MultiLineCommentTrivia))
                                 {
-                                    context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Descriptor, trivia.GetLocation()));
+                                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, trivia.GetLocation()));
                                 }
                                 break;
                         }
@@ -1571,7 +1571,7 @@ class Class { }
 
                 public void AnalyzeNode(SyntaxNodeAnalysisContext context)
                 {
-                    context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(Descriptor, Location.None));
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.None));
                 }
             }
 

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -151,6 +151,76 @@ class MyClass
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task GenericMethodIsUnused()
+        {
+            await TestInRegularAndScriptAsync(
+@"class MyClass
+{
+    private int [|M|]<T>() => 0;
+}",
+@"class MyClass
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task MethodInGenericTypeIsUnused()
+        {
+            await TestInRegularAndScriptAsync(
+@"class MyClass<T>
+{
+    private int [|M|]() => 0;
+}",
+@"class MyClass<T>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task InstanceConstructorIsUnused_NoArguments()
+        {
+            // We only flag constructors with arguments.
+            await TestMissingInRegularAndScriptAsync(
+@"class MyClass
+{
+    private [|MyClass()|] { }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task InstanceConstructorIsUnused_WithArguments()
+        {
+            await TestInRegularAndScriptAsync(
+@"class MyClass
+{
+    private [|MyClass(int i)|] { }
+}",
+@"class MyClass
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task StaticConstructorIsNotFlagged()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class MyClass
+{
+    static [|MyClass()|] { }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task DestructorIsNotFlagged()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class MyClass
+{
+    ~[|MyClass()|] { }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task PropertyIsUnused()
         {
             await TestInRegularAndScriptAsync(
@@ -598,6 +668,83 @@ class MyClass
     {
         System.Func<int> m1 = M1;
     }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task GenericMethodIsInvoked_ExplicitTypeArguments()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class MyClass
+{
+    private int [|M1|]<T>() => 0;
+    private int M2() => M1<int>();
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task GenericMethodIsInvoked_ImplicitTypeArguments()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class MyClass
+{
+    private T [|M1|]<T>(T t) => t;
+    private int M2() => M1(0);
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task MethodInGenericTypeIsInvoked_NoTypeArguments()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class MyClass<T>
+{
+    private int [|M1|]() => 0;
+    private int M2() => M1();
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task MethodInGenericTypeIsInvoked_NonConstructedType()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class MyClass<T>
+{
+    private int [|M1|]() => 0;
+    private int M2(MyClass<T> m) => m.M1();
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task MethodInGenericTypeIsInvoked_ConstructedType()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class MyClass<T>
+{
+    private int [|M1|]() => 0;
+    private int M2(MyClass<int> m) => m.M1();
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task InstanceConstructorIsUsed_NoArguments()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class MyClass
+{
+    private [|MyClass()|] { }
+    public static readonly MyClass Instance = new MyClass();
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task InstanceConstructorIsUsed_WithArguments()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class MyClass
+{
+    private [|MyClass(int i)|] { }
+    public static readonly MyClass Instance = new MyClass(0);
 }");
         }
 

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -37,6 +37,37 @@ $@"class MyClass
         [InlineData("protected")]
         [InlineData("protected internal")]
         [InlineData("private protected")]
+        public async Task NonPrivateFieldWithConstantInitializer(string accessibility)
+        {
+            await TestMissingInRegularAndScriptAsync(
+$@"class MyClass
+{{
+    {accessibility} int [|_goo|] = 0;
+}}");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [InlineData("public")]
+        [InlineData("internal")]
+        [InlineData("protected")]
+        [InlineData("protected internal")]
+        [InlineData("private protected")]
+        public async Task NonPrivateFieldWithNonConstantInitializer(string accessibility)
+        {
+            await TestMissingInRegularAndScriptAsync(
+$@"class MyClass
+{{
+    {accessibility} int [|_goo|] = _goo2;
+    private static readonly int _goo2 = 0;
+}}");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [InlineData("public")]
+        [InlineData("internal")]
+        [InlineData("protected")]
+        [InlineData("protected internal")]
+        [InlineData("private protected")]
         public async Task NonPrivateMethod(string accessibility)
         {
             await TestMissingInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -5,17 +5,16 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnusedMembers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
-using Microsoft.CodeAnalysis.RemoveUnusedMembers;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
+using static Roslyn.Test.Utilities.TestHelpers;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedMembers
 {
     public class RemoveUnusedMembersTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
-            => (new CSharpRemoveUnusedMembersDiagnosticAnalyzer(forceEnableRules: true),
-            new CSharpRemoveUnusedMembersCodeFixProvider());
+            => (new CSharpRemoveUnusedMembersDiagnosticAnalyzer(), new CSharpRemoveUnusedMembersCodeFixProvider());
 
         [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         [InlineData("public")]

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -26,7 +26,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 {
     [UseExportProvider]
-    public abstract class AbstractCodeActionOrUserDiagnosticTest : TestBase
+    public abstract class AbstractCodeActionOrUserDiagnosticTest
     {
         public struct TestParameters
         {

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
@@ -629,7 +629,7 @@ End Class]]>
 
                     Private Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
                         Dim classDecl = DirectCast(context.Node, ClassStatementSyntax)
-                        context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()))
+                        context.ReportDiagnostic(Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()))
                     End Sub
                 End Class
 
@@ -703,7 +703,7 @@ End Class]]>
 
                     Private Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
                         Dim classDecl = DirectCast(context.Node, ClassStatementSyntax)
-                        context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()))
+                        context.ReportDiagnostic(Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()))
                     End Sub
                 End Class
 
@@ -747,7 +747,7 @@ End Class]]>
 
                     Public Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
                         Dim classDecl = DirectCast(context.Node, ClassStatementSyntax)
-                        context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()))
+                        context.ReportDiagnostic(Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()))
                     End Sub
                 End Class
 
@@ -811,7 +811,7 @@ End Class]]>
 
                     Public Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
                         Dim classDecl = DirectCast(context.Node, ClassStatementSyntax)
-                        context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()))
+                        context.ReportDiagnostic(Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()))
                     End Sub
                 End Class
 
@@ -931,32 +931,32 @@ End Class]]>
                         Select Case context.Node.Kind()
                             Case SyntaxKind.ClassStatement
                                 Dim classDecl = DirectCast(context.Node, ClassStatementSyntax)
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()))
+                                context.ReportDiagnostic(Diagnostic.Create(_descriptor, classDecl.Identifier.GetLocation()))
                                 Exit Select
 
                             Case SyntaxKind.NamespaceStatement
                                 Dim ns = DirectCast(context.Node, NamespaceStatementSyntax)
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, ns.Name.GetLocation()))
+                                context.ReportDiagnostic(Diagnostic.Create(_descriptor, ns.Name.GetLocation()))
                                 Exit Select
 
                             Case SyntaxKind.SubStatement, SyntaxKind.FunctionStatement
                                 Dim method = DirectCast(context.Node, MethodStatementSyntax)
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, method.Identifier.GetLocation()))
+                                context.ReportDiagnostic(Diagnostic.Create(_descriptor, method.Identifier.GetLocation()))
                                 Exit Select
 
                             Case SyntaxKind.PropertyStatement
                                 Dim p = DirectCast(context.Node, PropertyStatementSyntax)
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, p.Identifier.GetLocation()))
+                                context.ReportDiagnostic(Diagnostic.Create(_descriptor, p.Identifier.GetLocation()))
                                 Exit Select
 
                             Case SyntaxKind.FieldDeclaration
                                 Dim f = DirectCast(context.Node, FieldDeclarationSyntax)
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, f.Declarators.First().Names.First.GetLocation()))
+                                context.ReportDiagnostic(Diagnostic.Create(_descriptor, f.Declarators.First().Names.First.GetLocation()))
                                 Exit Select
 
                             Case SyntaxKind.EventStatement
                                 Dim e = DirectCast(context.Node, EventStatementSyntax)
-                                context.ReportDiagnostic(CodeAnalysis.Diagnostic.Create(_descriptor, e.Identifier.GetLocation()))
+                                context.ReportDiagnostic(Diagnostic.Create(_descriptor, e.Identifier.GetLocation()))
                                 Exit Select
                         End Select
                     End Sub

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
@@ -130,6 +130,58 @@ End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function GenericMethodIsUnused() As Task
+            Await TestInRegularAndScriptAsync(
+"Class C
+    Private Sub [|M|](Of T)()
+    End Sub
+End Class",
+"Class C
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function MethodInGenericTypeIsUnused() As Task
+            Await TestInRegularAndScriptAsync(
+"Class C(Of T)
+    Private Sub [|M|]()
+    End Sub
+End Class",
+"Class C(Of T)
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function InstanceConstructorIsUnused_NoArguments() As Task
+            ' We only flag constructors with arguments.
+            Await TestMissingInRegularAndScriptAsync(
+"Class C
+    Private Sub [|New()|]
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function InstanceConstructorIsUnused_WithArguments() As Task
+            Await TestInRegularAndScriptAsync(
+"Class C
+    Private Sub [|New(i As Integer)|]
+    End Sub
+End Class",
+"Class C
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function StaticConstructorIsNotFlagged() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Class C
+    Shared Sub [|New()|]
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
         Public Async Function PropertyIsUnused() As Task
             Await TestInRegularAndScriptAsync(
 "Class C
@@ -402,6 +454,115 @@ End Class")
     Private Sub M2()
         Dim x As System.Action = AddressOf M
     End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function GenericMethodIsInvoked_ExplicitTypeArguments() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Class C
+    Private Sub [|M1|](Of T)()
+    End Sub
+
+    Private Sub M2()
+        M1(Of Integer)()
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function GenericMethodIsInvoked_ImplicitTypeArguments() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Class C
+    Private Sub [|M1|](Of T)(t1 As T)
+    End Sub
+
+    Private Sub M2()
+        M1(0)
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function MethodInGenericTypeIsInvoked_NoTypeArguments() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Class C(Of T)
+    Private Sub [|M1|]()
+    End Sub
+
+    Private Sub M2()
+        M1()
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function MethodInGenericTypeIsInvoked_NonConstructedType() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Class C(Of T)
+    Private Sub [|M1|]()
+    End Sub
+
+    Private Sub M2(m As C(Of T))
+        m.M1()
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function MethodInGenericTypeIsInvoked_ConstructedType() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Class C(Of T)
+    Private Sub [|M1|]()
+    End Sub
+
+    Private Sub M2(m As C(Of Integer))
+        m.M1()
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function InstanceConstructorIsUsed_NoArguments() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Class C
+    Private Sub [|New|]()
+    End Sub
+
+    Public Shared ReadOnly Instance As C = New C()
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function InstanceConstructorIsUsed_NoArguments_AsNew() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Class C
+    Private Sub [|New|]()
+    End Sub
+
+    Public Shared ReadOnly Instance As New C()
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function InstanceConstructorIsUsed_WithArguments() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Class C
+    Private Sub [|New|](i As Integer)
+    End Sub
+
+    Public Shared ReadOnly Instance As C = New C(0)
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function InstanceConstructorIsUsed_WithArguments_AsNew() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Class C
+    Private Sub [|New|](i As Integer)
+    End Sub
+
+    Public Shared ReadOnly Instance As New C(0)
 End Class")
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
@@ -33,6 +33,31 @@ End Class")
         <InlineData("Friend")>
         <InlineData("Protected")>
         <InlineData("Protected Friend")>
+        Public Async Function NonPrivateFieldWithConstantInitializer(accessibility As String) As Task
+            Await TestMissingInRegularAndScriptAsync(
+$"Class C
+    {accessibility} [|_goo|] As Integer = 0
+End Class")
+        End Function
+
+        <Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        <InlineData("Public")>
+        <InlineData("Friend")>
+        <InlineData("Protected")>
+        <InlineData("Protected Friend")>
+        Public Async Function NonPrivateFieldWithNonConstantInitializer(accessibility As String) As Task
+            Await TestMissingInRegularAndScriptAsync(
+$"Class C
+    {accessibility} [|_goo|] As Integer = _goo2
+    Private Shared ReadOnly _goo2 As Integer = 0
+End Class")
+        End Function
+
+        <Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        <InlineData("Public")>
+        <InlineData("Friend")>
+        <InlineData("Protected")>
+        <InlineData("Protected Friend")>
         Public Async Function NonPrivateMethod(accessibility As String) As Task
             Await TestMissingInRegularAndScriptAsync(
 $"Class C

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
@@ -3,16 +3,17 @@
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics
-Imports Microsoft.CodeAnalysis.RemoveUnusedMembers
 Imports Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedMembers
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.RemoveUnusedMembers
     Public Class RemoveUnusedMembersTests
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
-
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)
-            Return (New VisualBasicRemoveUnusedMembersDiagnosticAnalyzer(forceEnableRules:=True),
-                New VisualBasicRemoveUnusedMembersCodeFixProvider())
+            Return (New VisualBasicRemoveUnusedMembersDiagnosticAnalyzer(), New VisualBasicRemoveUnusedMembersCodeFixProvider())
+        End Function
+
+        Private Shared Function Diagnostic(id As String) As DiagnosticDescription
+            Return TestHelpers.Diagnostic(id)
         End Function
 
         <Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>

--- a/src/Features/CSharp/Portable/RemoveUnusedMembers/CSharpRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/RemoveUnusedMembers/CSharpRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -10,15 +10,5 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedMembers
     internal class CSharpRemoveUnusedMembersDiagnosticAnalyzer
         : AbstractRemoveUnusedMembersDiagnosticAnalyzer<DocumentationCommentTriviaSyntax, IdentifierNameSyntax>
     {
-        public CSharpRemoveUnusedMembersDiagnosticAnalyzer()
-            : base(forceEnableRules: false)
-        {
-        }
-
-        // For testing purposes only.
-        internal CSharpRemoveUnusedMembersDiagnosticAnalyzer(bool forceEnableRules)
-            : base(forceEnableRules)
-        {
-        }
     }
 }

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -19,20 +19,41 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
         where TIdentifierNameSyntax : SyntaxNode
     {
         // IDE0051: "Remove unused members" (Symbol is declared but never referenced)
-        private static readonly LocalizableResourceString s_removeUnusedMembersTitle = new LocalizableResourceString(nameof(FeaturesResources.Remove_unused_private_members), FeaturesResources.ResourceManager, typeof(FeaturesResources));
-        private static readonly LocalizableResourceString s_removeUnusedMembersMessage = new LocalizableResourceString(nameof(FeaturesResources.Type_0_has_an_unused_private_member_1_which_can_be_removed), FeaturesResources.ResourceManager, typeof(FeaturesResources));
-        private static readonly DiagnosticDescriptor s_removeUnusedMembersRule = CreateDescriptor(
-            IDEDiagnosticIds.RemoveUnusedMembersDiagnosticId, s_removeUnusedMembersTitle, s_removeUnusedMembersMessage, configurable: true, enabledByDefault: true);
-        private static readonly DiagnosticDescriptor s_removeUnusedMembersWithFadingRule = CreateUnnecessaryDescriptor(
-            IDEDiagnosticIds.RemoveUnusedMembersDiagnosticId, s_removeUnusedMembersTitle, s_removeUnusedMembersMessage, configurable: true, enabledByDefault: true);
+        private static readonly DiagnosticDescriptor s_removeUnusedMembersRule;
+        private static readonly DiagnosticDescriptor s_removeUnusedMembersWithFadingRule;
 
         // IDE0052: "Remove unread members" (Value is written and/or symbol is referenced, but the assigned value is never read)
-        private static readonly LocalizableResourceString s_removeUnreadMembersTitle = new LocalizableResourceString(nameof(FeaturesResources.Remove_unread_private_members), FeaturesResources.ResourceManager, typeof(FeaturesResources));
-        private static readonly LocalizableResourceString s_removeUnreadMembersMessage = new LocalizableResourceString(nameof(FeaturesResources.Type_0_has_a_private_member_1_that_can_be_removed_as_the_value_assigned_to_it_is_never_read), FeaturesResources.ResourceManager, typeof(FeaturesResources));
-        private static readonly DiagnosticDescriptor s_removeUnreadMembersRule = CreateDescriptor(
-            IDEDiagnosticIds.RemoveUnreadMembersDiagnosticId, s_removeUnreadMembersTitle, s_removeUnreadMembersMessage, configurable: true, enabledByDefault: true);
-        private static readonly DiagnosticDescriptor s_removeUnreadMembersWithFadingRule = CreateUnnecessaryDescriptor(
-            IDEDiagnosticIds.RemoveUnreadMembersDiagnosticId, s_removeUnreadMembersTitle, s_removeUnreadMembersMessage, configurable: true, enabledByDefault: true);
+        private static readonly DiagnosticDescriptor s_removeUnreadMembersRule;
+        private static readonly DiagnosticDescriptor s_removeUnreadMembersWithFadingRule;
+
+        static AbstractRemoveUnusedMembersDiagnosticAnalyzer()
+        {
+            var removeUnusedMembersTitle = new LocalizableResourceString(nameof(FeaturesResources.Remove_unused_private_members), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+            var removeUnusedMembersMessage = new LocalizableResourceString(nameof(FeaturesResources.Type_0_has_an_unused_private_member_1_which_can_be_removed), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+            s_removeUnusedMembersRule = CreateDescriptor(IDEDiagnosticIds.RemoveUnusedMembersDiagnosticId,
+                                                         removeUnusedMembersTitle,
+                                                         removeUnusedMembersMessage,
+                                                         configurable: true,
+                                                         enabledByDefault: true);
+            s_removeUnusedMembersWithFadingRule = CreateUnnecessaryDescriptor(IDEDiagnosticIds.RemoveUnusedMembersDiagnosticId,
+                                                                              removeUnusedMembersTitle,
+                                                                              removeUnusedMembersMessage,
+                                                                              configurable: true,
+                                                                              enabledByDefault: true);
+
+            var removeUnreadMembersTitle = new LocalizableResourceString(nameof(FeaturesResources.Remove_unread_private_members), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+            var removeUnreadMembersMessage = new LocalizableResourceString(nameof(FeaturesResources.Type_0_has_a_private_member_1_that_can_be_removed_as_the_value_assigned_to_it_is_never_read), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+            s_removeUnreadMembersRule = CreateDescriptor(IDEDiagnosticIds.RemoveUnreadMembersDiagnosticId,
+                                                         removeUnreadMembersTitle,
+                                                         removeUnreadMembersMessage,
+                                                         configurable: true,
+                                                         enabledByDefault: true);
+            s_removeUnreadMembersWithFadingRule = CreateUnnecessaryDescriptor(IDEDiagnosticIds.RemoveUnreadMembersDiagnosticId,
+                                                                              removeUnreadMembersTitle,
+                                                                              removeUnreadMembersMessage,
+                                                                              configurable: true,
+                                                                              enabledByDefault: true);
+        }
 
         protected AbstractRemoveUnusedMembersDiagnosticAnalyzer()
             : base (ImmutableArray.Create(s_removeUnusedMembersRule,
@@ -139,7 +160,10 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 {
                     foreach (var field in initializer.InitializedFields)
                     {
-                        OnSymbolUsage(field, ValueUsageInfo.Write);
+                        if (IsCandidateSymbol(field))
+                        {
+                            OnSymbolUsage(field, ValueUsageInfo.Write);
+                        }
                     }
                 }
             }

--- a/src/Features/VisualBasic/Portable/RemoveUnusedMembers/VisualBasicRemoveUnusedMembersDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/RemoveUnusedMembers/VisualBasicRemoveUnusedMembersDiagnosticAnalyzer.vb
@@ -9,14 +9,5 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedMembers
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Friend NotInheritable Class VisualBasicRemoveUnusedMembersDiagnosticAnalyzer
         Inherits AbstractRemoveUnusedMembersDiagnosticAnalyzer(Of DocumentationCommentTriviaSyntax, IdentifierNameSyntax)
-
-        Public Sub New()
-            MyBase.New(forceEnableRules:=False)
-        End Sub
-
-        ' For testing purposes only.
-        Friend Sub New(forceEnableRules As Boolean)
-            MyBase.New(forceEnableRules)
-        End Sub
     End Class
 End Namespace

--- a/src/Test/Utilities/Portable/TestBase.cs
+++ b/src/Test/Utilities/Portable/TestBase.cs
@@ -330,17 +330,13 @@ namespace Roslyn.Test.Utilities
             Func<SyntaxNode, bool> syntaxNodePredicate = null,
             bool argumentOrderDoesNotMatter = false)
         {
-            Debug.Assert(code is ErrorCode || code is ERRID || code is int || code is string);
-
-            return new DiagnosticDescription(
-                code as string ?? (object)(int)code,
-                false,
+            return TestHelpers.Diagnostic(
+                code,
                 squiggledText,
                 arguments,
                 startLocation,
                 syntaxNodePredicate,
-                argumentOrderDoesNotMatter,
-                code.GetType());
+                argumentOrderDoesNotMatter);
         }
 
         internal static DiagnosticDescription Diagnostic(
@@ -351,23 +347,13 @@ namespace Roslyn.Test.Utilities
            Func<SyntaxNode, bool> syntaxNodePredicate = null,
            bool argumentOrderDoesNotMatter = false)
         {
-            return Diagnostic(
+            return TestHelpers.Diagnostic(
                 code,
-                NormalizeNewLines(squiggledText),
+                squiggledText,
                 arguments,
                 startLocation,
                 syntaxNodePredicate,
                 argumentOrderDoesNotMatter);
-        }
-
-        public static string NormalizeNewLines(XCData data)
-        {
-            if (ExecutionConditionUtil.IsWindows)
-            {
-                return data.Value.Replace("\n", "\r\n");
-            }
-
-            return data.Value;
         }
 
         #endregion

--- a/src/Test/Utilities/Portable/TestHelpers.cs
+++ b/src/Test/Utilities/Portable/TestHelpers.cs
@@ -79,8 +79,6 @@ namespace Roslyn.Test.Utilities
             return result;
         }
 
-        #region Diagnostics
-
         internal static DiagnosticDescription Diagnostic(
             object code,
             string squiggledText = null,
@@ -131,7 +129,5 @@ namespace Roslyn.Test.Utilities
 
             return data.Value;
         }
-
-        #endregion
     }
 }

--- a/src/Test/Utilities/Portable/TestHelpers.cs
+++ b/src/Test/Utilities/Portable/TestHelpers.cs
@@ -7,7 +7,10 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Roslyn.Test.Utilities
 {
@@ -76,5 +79,59 @@ namespace Roslyn.Test.Utilities
             return result;
         }
 
+        #region Diagnostics
+
+        internal static DiagnosticDescription Diagnostic(
+            object code,
+            string squiggledText = null,
+            object[] arguments = null,
+            LinePosition? startLocation = null,
+            Func<SyntaxNode, bool> syntaxNodePredicate = null,
+            bool argumentOrderDoesNotMatter = false)
+        {
+            Debug.Assert(code is Microsoft.CodeAnalysis.CSharp.ErrorCode ||
+                         code is Microsoft.CodeAnalysis.VisualBasic.ERRID ||
+                         code is int ||
+                         code is string);
+
+            return new DiagnosticDescription(
+                code as string ?? (object)(int)code,
+                false,
+                squiggledText,
+                arguments,
+                startLocation,
+                syntaxNodePredicate,
+                argumentOrderDoesNotMatter,
+                code.GetType());
+        }
+
+        internal static DiagnosticDescription Diagnostic(
+           object code,
+           XCData squiggledText,
+           object[] arguments = null,
+           LinePosition? startLocation = null,
+           Func<SyntaxNode, bool> syntaxNodePredicate = null,
+           bool argumentOrderDoesNotMatter = false)
+        {
+            return Diagnostic(
+                code,
+                NormalizeNewLines(squiggledText),
+                arguments,
+                startLocation,
+                syntaxNodePredicate,
+                argumentOrderDoesNotMatter);
+        }
+
+        public static string NormalizeNewLines(XCData data)
+        {
+            if (ExecutionConditionUtil.IsWindows)
+            {
+                return data.Value.Replace("\n", "\r\n");
+            }
+
+            return data.Value;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Primarily addresses https://github.com/dotnet/roslyn/issues/29519#issuecomment-420067012

```
1. Enable the rules be default
2. Remove all the workaround/hacks for disabling the rules for product and enabling for tests.
3. Address offline feedback from @sharwell about avoiding deriving the tests from `TestBase`.
4. Separate out the pending non-design related work items from first comment into separate issues.
```

For 4, I have repurposed https://github.com/dotnet/roslyn/issues/29519 to track the pending issues with checkboxes in the first issue comment.