### PR TITLE
Disable VB semantic tests on Linux

### DIFF
--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -69,6 +69,14 @@ do
     echo Running "${runtime} ${file_name[@]}"
     if [[ "${runtime}" == "dotnet" ]]; then
         runner="dotnet exec --depsfile ${deps_json} --runtimeconfig ${runtimeconfig_json}"
+
+        # Disable the VB Semantic tests while we investigate the core dump issue
+        # https://github.com/dotnet/roslyn/issues/29660
+        if [[ "${file_name[@]}" == *'Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.dll' ]] 
+        then
+            echo "Skipping ${file_name[@]}"
+            continue
+        fi
     elif [[ "${runtime}" == "mono" ]]; then
         runner=mono
     fi


### PR DESCRIPTION
Looks like that's not quite fixed yet. Disabling and seeing if I can get
this failing locally.

Issue #29660 continues to track this area