### PR TITLE
Fix tuple deconstruction for field name containing escaped context keyword 

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseDeconstruction/UseDeconstructionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseDeconstruction/UseDeconstructionTests.cs
@@ -686,5 +686,40 @@ class C
     IEnumerable<(string name, int age)> GetPeople() => default;
 }");
         }
+
+        [WorkItem(27251, "https://github.com/dotnet/roslyn/issues/27251")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseDeconstruction)]
+        public async Task TestEscapedContextualKeywordAsTupleName()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System.Collections.Generic;
+class C
+{
+    void M()
+    {
+        var collection = new List<(int position, int @delegate)>();
+        foreach (var it[||]em in collection)
+        {
+            // Do something
+        }
+    }
+
+    IEnumerable<(string name, int age)> GetPeople() => default;
+}",
+@"using System.Collections.Generic;
+class C
+{
+    void M()
+    {
+        var collection = new List<(int position, int @delegate)>();
+        foreach (var (position, @delegate) in collection)
+        {
+            // Do something
+        }
+    }
+
+    IEnumerable<(string name, int age)> GetPeople() => default;
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/UseDeconstruction/CSharpUseDeconstructionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseDeconstruction/CSharpUseDeconstructionCodeFixProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
@@ -149,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDeconstruction
             => SyntaxFactory.DeclarationExpression(
                 typeNode, SyntaxFactory.ParenthesizedVariableDesignation(
                     SyntaxFactory.SeparatedList<VariableDesignationSyntax>(tupleType.TupleElements.Select(
-                        e => SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier(e.Name))))));
+                        e => SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier(e.Name.EscapeIdentifier()))))));
 
         private TupleExpressionSyntax CreateTupleExpression(TupleTypeSyntax typeNode)
             => SyntaxFactory.TupleExpression(


### PR DESCRIPTION
Fixes #27251 

