### PR TITLE
Update cross-platform build docs...

### DIFF
--- a/docs/infrastructure/cross-platform.md
+++ b/docs/infrastructure/cross-platform.md
@@ -10,7 +10,7 @@ Build all cross-platform projects with:
 
 ```
 cd <roslyn-git-directory>
-./build/scripts/restore.sh
+./build.sh --restore
 dotnet build Compilers.sln
 ```
 


### PR DESCRIPTION
...to reflect the fact that build/scripts/restore.sh has been removed and its contents merged into build.sh.
See https://github.com/dotnet/roslyn/commit/0762ad41dfcc3fc707b2fa98b7b4e557e3011d18