### PR TITLE
Fixed langversions

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
@@ -67,7 +67,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         internal void UsingExpression(string text, ParseOptions options, params DiagnosticDescription[] expectedErrors)
         {
-            var node = SyntaxFactory.ParseExpression(text, options: options);
+            // https://github.com/dotnet/roslyn/issues/29819 Revert options coalesce
+            var node = SyntaxFactory.ParseExpression(text, options: options ?? TestOptions.Regular8);
             // we validate the text roundtrips
             Assert.Equal(text, node.ToFullString());
             var actualErrors = node.GetDiagnostics();

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -11,7 +11,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
     {
         // Disable diagnosing documentation comments by default so that we don't need to
         // document every public member of every test input.
-        public static readonly CSharpParseOptions Regular = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.Parse).WithLanguageVersion(LanguageVersion.Latest);
+        // https://github.com/dotnet/roslyn/issues/29819 revert explicit C# 8 langversion
+        public static readonly CSharpParseOptions Regular = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.Parse, languageVersion: LanguageVersion.CSharp8);
         public static readonly CSharpParseOptions Script = Regular.WithKind(SourceCodeKind.Script);
         public static readonly CSharpParseOptions Regular6 = Regular.WithLanguageVersion(LanguageVersion.CSharp6);
         public static readonly CSharpParseOptions Regular7 = Regular.WithLanguageVersion(LanguageVersion.CSharp7);
@@ -24,7 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 
         private static readonly SmallDictionary<string, string> s_experimentalFeatures = new SmallDictionary<string, string> { };
         public static readonly CSharpParseOptions ExperimentalParseOptions =
-            new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.None, languageVersion: LanguageVersion.Latest).WithFeatures(s_experimentalFeatures);
+            // https://github.com/dotnet/roslyn/issues/29819 revert explicit C# 8 langversion
+            new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.None, languageVersion: LanguageVersion.CSharp8).WithFeatures(s_experimentalFeatures);
 
         // Enable pattern-switch translation even for switches that use no new syntax. This is used
         // to help ensure compatibility of the semantics of the new switch binder with the old switch

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -241,6 +241,11 @@ Friend Module CompilationUtils
             assemblyName = sources.@name
         End If
 
+        ' https://github.com/dotnet/roslyn/issues/29819 remove when VB 16 is latest
+        If parseOptions Is Nothing Then
+            parseOptions = TestOptions.Regular
+        End If
+
         Dim sourcesTreesAndSpans = From f In sources.<file> Select CreateParseTreeAndSpans(f, parseOptions)
         spans = From t In sourcesTreesAndSpans Select s = t.spans
         Return From t In sourcesTreesAndSpans Select t.tree

--- a/src/Compilers/Test/Utilities/VisualBasic/TestOptions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/TestOptions.vb
@@ -5,25 +5,26 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
 Public Class TestOptions
     Public Shared ReadOnly Script As New VisualBasicParseOptions(kind:=SourceCodeKind.Script)
-    Public Shared ReadOnly Regular As New VisualBasicParseOptions(kind:=SourceCodeKind.Regular)
+    ' https://github.com/dotnet/roslyn/issues/29819 remove explicit language version when VB 16 is latest
+    Public Shared ReadOnly Regular As New VisualBasicParseOptions(kind:=SourceCodeKind.Regular, languageVersion:=LanguageVersion.VisualBasic16)
     Public Shared ReadOnly RegularWithFlowAnalysisFeature As VisualBasicParseOptions = Regular.WithFlowAnalysisFeature()
     Public Shared ReadOnly Regular15_5 As VisualBasicParseOptions = Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5)
 
-    Public Shared ReadOnly ReleaseDll As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel:=OptimizationLevel.Release)
-    Public Shared ReadOnly ReleaseExe As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel:=OptimizationLevel.Release)
+    Public Shared ReadOnly ReleaseDll As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel:=OptimizationLevel.Release).WithParseOptions(Regular)
+    Public Shared ReadOnly ReleaseExe As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel:=OptimizationLevel.Release).WithParseOptions(Regular)
 
     Public Shared ReadOnly ReleaseDebugDll As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel:=OptimizationLevel.Release).
-        WithDebugPlusMode(True)
+        WithDebugPlusMode(True).WithParseOptions(Regular)
 
     Public Shared ReadOnly ReleaseDebugExe As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel:=OptimizationLevel.Release).
-        WithDebugPlusMode(True)
+        WithDebugPlusMode(True).WithParseOptions(Regular)
 
-    Public Shared ReadOnly DebugDll As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel:=OptimizationLevel.Debug)
-    Public Shared ReadOnly DebugExe As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel:=OptimizationLevel.Debug)
+    Public Shared ReadOnly DebugDll As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel:=OptimizationLevel.Debug).WithParseOptions(Regular)
+    Public Shared ReadOnly DebugExe As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel:=OptimizationLevel.Debug).WithParseOptions(Regular)
 
-    Public Shared ReadOnly ReleaseModule As New VisualBasicCompilationOptions(OutputKind.NetModule, optimizationLevel:=OptimizationLevel.Release)
-    Public Shared ReadOnly ReleaseWinMD As New VisualBasicCompilationOptions(OutputKind.WindowsRuntimeMetadata, optimizationLevel:=OptimizationLevel.Release)
-    Public Shared ReadOnly DebugWinMD As New VisualBasicCompilationOptions(OutputKind.WindowsRuntimeMetadata, optimizationLevel:=OptimizationLevel.Debug)
+    Public Shared ReadOnly ReleaseModule As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.NetModule, optimizationLevel:=OptimizationLevel.Release).WithParseOptions(Regular)
+    Public Shared ReadOnly ReleaseWinMD As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.WindowsRuntimeMetadata, optimizationLevel:=OptimizationLevel.Release).WithParseOptions(Regular)
+    Public Shared ReadOnly DebugWinMD As VisualBasicCompilationOptions = New VisualBasicCompilationOptions(OutputKind.WindowsRuntimeMetadata, optimizationLevel:=OptimizationLevel.Debug).WithParseOptions(Regular)
 End Class
 
 Friend Module TestOptionExtensions

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EntryPointTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EntryPointTests.vb
@@ -743,9 +743,10 @@ Class C
     End Sub
 End Class
 </text>
+            ' https://github.com/dotnet/roslyn/issues/29819 remove explicit language version when VB 16 is latest
             Dim compilation = CreateCompilationWithMscorlib40(
                 {VisualBasicSyntaxTree.ParseText(vbx.Value, options:=TestOptions.Script),
-                 VisualBasicSyntaxTree.ParseText(vb.Value, options:=TestOptions.Regular)}, options:=TestOptions.ReleaseExe.WithMainTypeName("C"))
+                 VisualBasicSyntaxTree.ParseText(vb.Value, options:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.Default))}, options:=TestOptions.ReleaseExe.WithMainTypeName("C"))
 
             ' TODO: compilation.VerifyDiagnostics(Diagnostic(ErrorCode.WRN_MainIgnored).WithArguments("C"))
         End Sub

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
@@ -24122,7 +24122,8 @@ End Sub
 End Module
 ]]>
 
-            compilation = compilation.AddSyntaxTrees(Parse(text))
+            ' https://github.com/dotnet/roslyn/issues/29819 remove explicit options when VB 16 is latest
+            compilation = compilation.AddSyntaxTrees(Parse(text, options:=TestOptions.Regular))
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/GroupClassTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/GroupClassTests.vb
@@ -2457,7 +2457,8 @@ BC30109: 'Form2' is a class type and cannot be used as an expression.
             compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(compilationDef, {SystemRef},
                                                                                  TestOptions.ReleaseDll.WithRootNamespace("WindowsApplication1"))
 
-            compilation = compilation.AddSyntaxTrees(VisualBasicSyntaxTree.ParseText(WindowsFormsMyTemplateSource))
+            ' https://github.com/dotnet/roslyn/issues/29819 remove explicit options when VB 16 is latest
+            compilation = compilation.AddSyntaxTrees(VisualBasicSyntaxTree.ParseText(WindowsFormsMyTemplateSource, options:=TestOptions.Regular))
 
             compilation.MyTemplate = Nothing
 


### PR DESCRIPTION
Broken by the last merge, because the tests weren't rerun after I merged the `??=` feature. @dotnet/roslyn-compiler for a very quick review, test only changes.