### PR TITLE
Implement ValEscape rules for ?? operator

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2203,10 +2203,8 @@ moreArguments:
                 case BoundKind.NullCoalescingOperator:
                     var coalescingOp = (BoundNullCoalescingOperator)expr;
 
-                    var leftEscape = GetValEscape(coalescingOp.LeftOperand, scopeOfTheContainingExpression);
-                    var rightEscape = GetValEscape(coalescingOp.RightOperand, scopeOfTheContainingExpression);
-
-                    return Math.Max(leftEscape, rightEscape);
+                    return Math.Max(GetValEscape(coalescingOp.LeftOperand, scopeOfTheContainingExpression),
+                                    GetValEscape(coalescingOp.RightOperand, scopeOfTheContainingExpression));
 
                 case BoundKind.FieldAccess:
                     var fieldAccess = (BoundFieldAccess)expr;

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2200,6 +2200,14 @@ moreArguments:
                     return Math.Max(consEscape,
                                     GetValEscape(conditional.Alternative, scopeOfTheContainingExpression));
 
+                case BoundKind.NullCoalescingOperator:
+                    var coalescingOp = (BoundNullCoalescingOperator)expr;
+
+                    var leftEscape = GetValEscape(coalescingOp.LeftOperand, scopeOfTheContainingExpression);
+                    var rightEscape = GetValEscape(coalescingOp.RightOperand, scopeOfTheContainingExpression);
+
+                    return Math.Max(leftEscape, rightEscape);
+
                 case BoundKind.FieldAccess:
                     var fieldAccess = (BoundFieldAccess)expr;
                     var fieldSymbol = fieldAccess.FieldSymbol;
@@ -2346,7 +2354,6 @@ moreArguments:
                 case BoundKind.AsOperator:
                 case BoundKind.AwaitExpression:
                 case BoundKind.ConditionalAccess:
-                case BoundKind.NullCoalescingOperator:
                 case BoundKind.ArrayAccess:
                     // only possible in error cases (if possible at all)
                     return scopeOfTheContainingExpression;
@@ -2502,6 +2509,11 @@ moreArguments:
                     }
 
                     return CheckValEscape(conditional.Alternative.Syntax, conditional.Alternative, escapeFrom, escapeTo, checkingReceiver: false, diagnostics: diagnostics);
+
+                case BoundKind.NullCoalescingOperator:
+                    var coalescingOp = (BoundNullCoalescingOperator)expr;
+                    return CheckValEscape(coalescingOp.LeftOperand.Syntax, coalescingOp.LeftOperand, escapeFrom, escapeTo, checkingReceiver, diagnostics) &&
+                            CheckValEscape(coalescingOp.RightOperand.Syntax, coalescingOp.RightOperand, escapeFrom, escapeTo, checkingReceiver, diagnostics);
 
                 case BoundKind.FieldAccess:
                     var fieldAccess = (BoundFieldAccess)expr;
@@ -2673,7 +2685,6 @@ moreArguments:
                 case BoundKind.AsOperator:
                 case BoundKind.AwaitExpression:
                 case BoundKind.ConditionalAccess:
-                case BoundKind.NullCoalescingOperator:
                 case BoundKind.ArrayAccess:
                     // only possible in error cases (if possible at all)
                     return false;


### PR DESCRIPTION
- Implement GetValEscape/CheckValEscape for the null coalescing operator
  - Previous implementation assumed it wasn't possible for this to occur, but the implicit conversion on the FX span type mean it's a valid case
- Fixes using a coalescing operator in a return statement causing an emit failure
- Fixes a valid no escaping coalesce assignment being marked as escaping
  - Previous rules meant that a non escaping local assignment would be marked as escaping if assigned via null coalescing
- Add tests for cases that were failing before
- Add test for case that should still be invalid

Fixes #29927