### PR TITLE
DebuggerTextView to support ITextView2

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
@@ -18,7 +18,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense
 {
-    internal partial class DebuggerTextView : IWpfTextView, IDebuggerTextView
+    internal partial class DebuggerTextView : IWpfTextView, IDebuggerTextView, ITextView2
     {
         /// <summary>
         /// The actual debugger view of the watch or immediate window that we're wrapping
@@ -291,6 +291,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             }
         }
 
+        public bool InOuterLayout => throw new NotImplementedException();
+
+        public IMultiSelectionBroker MultiSelectionBroker => throw new NotImplementedException();
+
         public void Close()
         {
             throw new NotSupportedException();
@@ -348,6 +352,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
         }
 
         private event EventHandler ClosedInternal;
+        public event EventHandler MaxTextRightCoordinateChanged;
 
         public event EventHandler Closed
         {

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
@@ -26,6 +26,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
         private readonly IWpfTextView _innerTextView;
         private readonly IVsTextLines _debuggerTextLinesOpt;
 
+        private IMultiSelectionBroker _multiSelectionBroker;
+
         public DebuggerTextView(
             IWpfTextView innerTextView,
             IBufferGraph bufferGraph,
@@ -293,7 +295,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
 
         public bool InOuterLayout => throw new NotImplementedException();
 
-        public IMultiSelectionBroker MultiSelectionBroker => throw new NotImplementedException();
+        public IMultiSelectionBroker MultiSelectionBroker
+        {
+            get
+            {
+                if (_multiSelectionBroker == null)
+                {
+                    _multiSelectionBroker = _innerTextView.GetMultiSelectionBroker();
+                }
+
+                return _multiSelectionBroker;
+            }
+        }
 
         public void Close()
         {
@@ -352,7 +365,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
         }
 
         private event EventHandler ClosedInternal;
+
+#pragma warning disable 67
         public event EventHandler MaxTextRightCoordinateChanged;
+#pragma warning restore 67
 
         public event EventHandler Closed
         {


### PR DESCRIPTION
fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/673905 on Roslyn side. 
To fix the work item properly GetMultiSelectionBroker on the VS side should force accepting ITextView2 as well.