### PR TITLE
fix embeded type issue

### DIFF
--- a/build/Targets/VisualStudio.targets
+++ b/build/Targets/VisualStudio.targets
@@ -81,7 +81,7 @@
 
   <!-- Microsoft.VisualStudio.SDK.EmbedInteropTypes sets a bunch of EmbedInteropTypes attributes, but Roslyn is somewhat special
        and has to do things differently. After the NuGet package does its thing, do further changes. -->
-  <Target Name="FixVSSDKEmbeddableAssemblies" AfterTargets="LinkVSSDKEmbeddableAssemblies" >
+  <Target Name="FixVSSDKEmbeddableAssemblies" AfterTargets="LinkVSSDKEmbeddableAssemblies" BeforeTargets="FindReferenceAssembliesForReferences">
     <ItemGroup>
       <!-- The official NuGet package tries to embed EnvDTE, which is problematic because we implement the interfaces and use
            them in generic type parameters. Because of this, we can't embed them. -->
@@ -100,6 +100,10 @@
       <ReferencePath Condition="'%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.10.0'
                              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.11.0'">
         <EmbedInteropTypes>false</EmbedInteropTypes>
+      </ReferencePath>
+
+      <ReferencePath Condition="'%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'">
+        <EmbedInteropTypes>true</EmbedInteropTypes>
       </ReferencePath>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
fix issue @dpoeschl mentioned

Erroring out with
```
CSC : error CS1762: A reference was created to embedded interop assembly 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, Publi
cKeyToken=b03f5f7f11d50a3a' because of an indirect reference to that assembly created by assembly 'Microsoft.CodeAnalysis.EditorFeatures, Version=42.42.42.42, Culture=neu
tral, PublicKeyToken=31bf3856ad364e35'. Consider changing the 'Embed Interop Types' property on either assembly. [C:\src\roslyn\src\EditorFeatures\Core.Wpf\Microsoft.Code
Analysis.EditorFeatures.Wpf.csproj]
```
but I don't know how to fix it yet.

...

this fixes the issue. but not sure how this happens since LinkVSSDKEmbeddableAssemblies should already have this.