### PR TITLE
Fix #30091 throwing exceptions

### DIFF
--- a/src/Features/Core/Portable/RemoveUnusedVariable/AbstractRemoveUnusedVariableCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveUnusedVariable/AbstractRemoveUnusedVariableCodeFixProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedVariable
 
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            Diagnostic diagnostic = context.Diagnostics.Single();
+            Diagnostic diagnostic = context.Diagnostics.First();
             context.RegisterCodeFix(new MyCodeAction(c => FixAsync(context.Document, diagnostic, c)), diagnostic);
             return Task.CompletedTask;
         }


### PR DESCRIPTION
The general pattern when registering code fixes seems to be
either passing diagnostics[0] or diagnostics.First().

RemoveUnusedVariable seems to be the only outlier in this case,
doing .Single().

Having multiple diagnostics on a span would cause the code fix
to throw an exception


<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->


What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)


(either VSO or GitHub links)


Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW


This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code


(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")



How did we miss it?  What tests are we adding to guard against it in the future?


(E.g. customer reported it vs. ad hoc testing)


If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>