### PR TITLE
Fix lowering for async-iterator method with type parameter

### DIFF
--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -59,6 +59,9 @@ async IAsyncEnumerable<int> GetValuesFromServer()
 ### Detailed design for async `foreach` statement
 PROTOTYPE(async-streams): TODO
 
+Async foreach is disallowed on collections of type dynamic, as there is no async equivalent of the non-generic `IEnumerable` interface.
+
+
 ```C#
 E e = ((C)(x)).GetAsyncEnumerator()
 try

--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -82,7 +82,7 @@ finally { await e.DisposeAsync(); }
 ### Detailed design for async-iterator methods
 
 The state machine for an async-iterator method primarily implements `IAsyncEnumerable<T>` and `IAsyncEnumerator<T>`.
-It is similar to a state machine produced for an async method. It contains builder and awaiter fields, used to run the state machine in the background (when an `await` is reached in the async-iterator).
+It is similar to a state machine produced for an async method. It contains builder and awaiter fields, used to run the state machine in the background (when an `await` is reached in the async-iterator). It also captures parameter values (if any) or `this` (if needed).
 But it contains additional state:
 - a promise of a value-or-end,
 - a `bool` flag indicating whether the promise is active or not,

--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -81,12 +81,17 @@ finally { await e.DisposeAsync(); }
 
 ### Detailed design for async-iterator methods
 
+An async-iterator method is replaced by a kick-off method, which initializes a state machine. It does not start running the state machine (unlike kick-off methods for regular async method).
+The kick-off method method is marked with both `AsyncStateMachineAttribute` and `IteratorStateMachineAttribute`.
+
 The state machine for an async-iterator method primarily implements `IAsyncEnumerable<T>` and `IAsyncEnumerator<T>`.
 It is similar to a state machine produced for an async method. It contains builder and awaiter fields, used to run the state machine in the background (when an `await` is reached in the async-iterator). It also captures parameter values (if any) or `this` (if needed).
 But it contains additional state:
 - a promise of a value-or-end,
 - a `bool` flag indicating whether the promise is active or not,
 - a current yielded value of type `T`.
+
+The central method of the state machine is `MoveNext()`. It gets run by `WaitForNextAsync()` and `TryGetNext()`, or as a background continuation initiated from these from an `await` in the method.
 
 The promise of a value-or-end is returned from `WaitForNextAsync`. It can be fulfilled with either:
 - `true` (when a value becomes available following background execution of the state machine),

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -262,10 +262,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                             if (IsDirectlyInIterator)
                             {
                                 diagnostics.Add(ErrorCode.ERR_BadIteratorLocalType, local.IdentifierToken.GetLocation());
+                                hasErrors = true;
                             }
                             else if (IsInAsyncMethod())
                             {
                                 diagnostics.Add(ErrorCode.ERR_BadAsyncLocalType, local.IdentifierToken.GetLocation());
+                                hasErrors = true;
                             }
                         }
 
@@ -369,8 +371,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return new BoundForEachStatement(
                     _syntax,
-                    null, // can't be sure that it's complete
-                    default(Conversion),
+                    enumeratorInfoOpt: null, // can't be sure that it's complete
+                    elementConversion: default,
                     boundIterationVariableType,
                     iterationVariables,
                     iterationErrorExpression,

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -685,6 +685,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return EnumeratorResult.FailedAndReported;
             }
 
+            if (collectionExprType.Kind == SymbolKind.DynamicType && IsAsync)
+            {
+                diagnostics.Add(ErrorCode.ERR_BadDynamicAsyncForEach, _syntax.Expression.Location);
+                return EnumeratorResult.FailedAndReported;
+            }
+
             // The spec specifically lists the collection, enumerator, and element types for arrays and dynamic.
             if (collectionExprType.Kind == SymbolKind.ArrayType || collectionExprType.Kind == SymbolKind.DynamicType)
             {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -701,7 +701,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Async foreach statement cannot operate on variables of type &apos;{0}&apos; because &apos;{0}&apos; does not contain a public definition for &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Async foreach statement cannot operate on variables of type &apos;{0}&apos; because &apos;{0}&apos; does not contain a public instance definition for &apos;{1}&apos;.
         /// </summary>
         internal static string ERR_AsyncForEachMissingMember {
             get {
@@ -710,7 +710,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Async foreach statement cannot operate on variables of type &apos;{0}&apos; because &apos;{0}&apos; does not contain a public definition for &apos;{1}&apos;. Did you mean &apos;foreach&apos; rather than &apos;foreach await&apos;?.
+        ///   Looks up a localized string similar to Async foreach statement cannot operate on variables of type &apos;{0}&apos; because &apos;{0}&apos; does not contain a public instance definition for &apos;{1}&apos;. Did you mean &apos;foreach&apos; rather than &apos;foreach await&apos;?.
         /// </summary>
         internal static string ERR_AsyncForEachMissingMemberWrongAsync {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -1421,6 +1421,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot use a collection of dynamic type in an asynchronous foreach.
+        /// </summary>
+        internal static string ERR_BadDynamicAsyncForEach {
+            get {
+                return ResourceManager.GetString("ERR_BadDynamicAsyncForEach", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos;: user-defined conversions to or from the dynamic type are not allowed.
         /// </summary>
         internal static string ERR_BadDynamicConversion {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2633,13 +2633,13 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</value>
   </data>
   <data name="ERR_AsyncForEachMissingMember" xml:space="preserve">
-    <value>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</value>
+    <value>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</value>
   </data>
   <data name="ERR_ForEachMissingMemberWrongAsync" xml:space="preserve">
     <value>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach await'?</value>
   </data>
   <data name="ERR_AsyncForEachMissingMemberWrongAsync" xml:space="preserve">
-    <value>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</value>
+    <value>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</value>
   </data>
   <data name="WRN_BadXMLRefParamType" xml:space="preserve">
     <value>Invalid type for parameter {0} in XML comment cref attribute: '{1}'</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5390,4 +5390,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureUnconstrainedTypeParameterInNullCoalescingOperator" xml:space="preserve">
     <value>unconstrained type parameters in null coalescing operator</value>
   </data>
+  <data name="ERR_BadDynamicAsyncForEach" xml:space="preserve">
+    <value>Cannot use a collection of dynamic type in an asynchronous foreach</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Compilation/ForEachStatementInfo.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/ForEachStatementInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -114,8 +113,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                    Hash.Combine(ElementType,
                    Hash.Combine(ElementConversion.GetHashCode(),
                    Hash.Combine(CurrentConversion.GetHashCode(),
-                   Hash.Combine(WaitForNextAsyncMethod.GetHashCode(),
-                                TryGetNextMethod.GetHashCode()))))))));
+                   Hash.Combine(WaitForNextAsyncMethod,
+                                TryGetNextMethod?.GetHashCode() ?? 0))))))));
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1592,6 +1592,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_MultipleIAsyncEnumOfT = 9003,
         ERR_ForEachMissingMemberWrongAsync = 9004,
         ERR_AsyncForEachMissingMemberWrongAsync = 9005,
+        ERR_BadDynamicAsyncForEach = 9006,
         #endregion diagnostics introduced for C# 8.0
 
         // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -2157,7 +2157,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 _pendingBranches.Add(new PendingBranch(node, this.State));
             }
-            //if (_trackExceptions) NotePossibleException(node); // PROTOTYPE(async-streams)
 
             return null;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -35,8 +35,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // the element type may contain method type parameters, which are now alpha-renamed into type parameters of the generated class
                 _elementType = stateMachineType.ElementType;
-
-                // PROTOTYPE(async-streams): Why does AsyncRewriter have logic to ignore accessibility?
             }
 
             protected override void VerifyPresenceOfRequiredAPIs(DiagnosticBag bag)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private sealed class AsyncIteratorRewriter : AsyncRewriter
         {
-            private readonly TypeSymbol _elementType;
-
             private FieldSymbol _promiseOfValueOrEndField; // this struct implements the IValueTaskSource logic
             private FieldSymbol _promiseIsActiveField;
             private FieldSymbol _currentField; // stores the current/yielded value
@@ -32,9 +30,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 : base(body, method, methodOrdinal, stateMachineType, slotAllocatorOpt, compilationState, diagnostics)
             {
                 Debug.Assert(method.IteratorElementType != null);
-
-                // the element type may contain method type parameters, which are now alpha-renamed into type parameters of the generated class
-                _elementType = stateMachineType.ElementType;
             }
 
             protected override void VerifyPresenceOfRequiredAPIs(DiagnosticBag bag)
@@ -104,8 +99,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     boolType,
                     GeneratedNames.MakeAsyncIteratorPromiseIsActiveFieldName(), isPublic: true);
 
+                // the element type may contain method type parameters, which are now alpha-renamed into type parameters of the generated class
+                TypeSymbol elementType = ((AsyncStateMachine)stateMachineType).ElementType;
+
                 // Add a field: T current
-                _currentField = F.StateMachineField(_elementType, GeneratedNames.MakeIteratorCurrentFieldName());
+                _currentField = F.StateMachineField(elementType, GeneratedNames.MakeIteratorCurrentFieldName());
             }
 
             /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         F.Field(F.Local(stateMachineVariable), _promiseIsActiveField.AsMember(frameType)),
                         F.Literal(true)));
 
-                // return local.$stateField;
+                // return local;
                 bodyBuilder.Add(F.Return(F.Local(stateMachineVariable)));
 
                 return F.Block(
@@ -506,10 +506,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MethodSymbol IAsyncEnumerableOfElementType_GetEnumerator =
                     F.WellKnownMethod(WellKnownMember.System_Collections_Generic_IAsyncEnumerable_T__GetAsyncEnumerator)
                     .AsMember(IAsyncEnumerableOfElementType);
-
-                // PROTOTYPE(async-streams): TODO
-                // result = this;
-                // result.parameter = this.parameterProxy; // copy all of the parameter proxies // PROTOTYPE(async-streams): No sure what this is for
 
                 // The implementation doesn't depend on the method body of the iterator method.
                 // Generates IAsyncEnumerator<elementType> IAsyncEnumerable<elementType>.GetEnumerator()

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     GeneratedNames.MakeAsyncIteratorPromiseIsActiveFieldName(), isPublic: true);
 
                 // the element type may contain method type parameters, which are now alpha-renamed into type parameters of the generated class
-                TypeSymbol elementType = ((AsyncStateMachine)stateMachineType).ElementType;
+                TypeSymbol elementType = ((AsyncStateMachine)stateMachineType).IteratorElementType;
 
                 // Add a field: T current
                 _currentField = F.StateMachineField(elementType, GeneratedNames.MakeIteratorCurrentFieldName());

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Produce the implementation for `T TryGetNext(out bool success)`:
                 // if (this._promiseIsActive)
                 // {
-                //     if (_valueOrEndPromise.GetStatus(_valueOrEndPromise.Version) == ValueTaskSourceStatus.Pending) throw new Exception(); // PROTOTYPE(NullableReferenceTypes): Add this safeguard code
+                //     if (_valueOrEndPromise.GetStatus(_valueOrEndPromise.Version) == ValueTaskSourceStatus.Pending) throw new Exception(); // https://github.com/dotnet/roslyn/issues/30109 Add this safeguard code
                 //     _promiseIsActive = false;
                 // }
                 // else
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // if (this._promiseIsActive)
                 // {
                 //     if (_valueOrEndPromise.GetStatus(_valueOrEndPromise.Version) == ValueTaskSourceStatus.Pending) throw new Exception();
-                //     if (State == StateMachineStates.NotStartedStateMachine) throw new Exception("You should call WaitForNextAsync first"); // PROTOTYPE(NullableReferenceTypes): Add this safeguard code
+                //     if (State == StateMachineStates.NotStartedStateMachine) throw new Exception("You should call WaitForNextAsync first"); // https://github.com/dotnet/roslyn/issues/30109 Add this safeguard code
                 //     _promiseIsActive = false;
                 // }
                 // else

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
@@ -12,7 +12,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly AsyncMethodBuilderMemberCollection _asyncMethodBuilderMemberCollection;
         private readonly bool _constructedSuccessfully;
         private readonly int _methodOrdinal;
-        private readonly bool _ignoreAccessibility;
 
         private FieldSymbol _builderField;
 
@@ -28,7 +27,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             _constructedSuccessfully = AsyncMethodBuilderMemberCollection.TryCreate(F, method, this.stateMachineType.TypeMap, out _asyncMethodBuilderMemberCollection);
             _methodOrdinal = methodOrdinal;
-            _ignoreAccessibility = compilationState.ModuleBuilderOpt.IgnoreAccessibility;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly TypeKind _typeKind;
         private readonly MethodSymbol _constructor;
         private readonly ImmutableArray<NamedTypeSymbol> _interfaces;
+        internal readonly TypeSymbol ElementType; // only for async-iterators
 
         public AsyncStateMachine(VariableSlotAllocator variableAllocatorOpt, TypeCompilationState compilationState, MethodSymbol asyncMethod, int asyncMethodOrdinal, TypeKind typeKind)
             : base(variableAllocatorOpt, compilationState, asyncMethod, asyncMethodOrdinal)
@@ -27,8 +28,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (asyncMethod.IsIterator)
             {
-                var elementType = asyncMethod.IteratorElementType;
-                //this.ElementType = TypeMap.SubstituteType(elementType).Type; // PROTOTYPE(async-streams): TODO
+                var elementType = TypeMap.SubstituteType(asyncMethod.IteratorElementType).Type;
+                this.ElementType = elementType;
 
                 // IAsyncEnumerable<TResult>
                 interfaces.Add(compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IAsyncEnumerable_T).Construct(elementType));

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly TypeKind _typeKind;
         private readonly MethodSymbol _constructor;
         private readonly ImmutableArray<NamedTypeSymbol> _interfaces;
-        internal readonly TypeSymbol ElementType; // only for async-iterators
+        internal readonly TypeSymbol IteratorElementType; // only for async-iterators
 
         public AsyncStateMachine(VariableSlotAllocator variableAllocatorOpt, TypeCompilationState compilationState, MethodSymbol asyncMethod, int asyncMethodOrdinal, TypeKind typeKind)
             : base(variableAllocatorOpt, compilationState, asyncMethod, asyncMethodOrdinal)
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (asyncMethod.IsIterator)
             {
                 var elementType = TypeMap.SubstituteType(asyncMethod.IteratorElementType).Type;
-                this.ElementType = elementType;
+                this.IteratorElementType = elementType;
 
                 // IAsyncEnumerable<TResult>
                 interfaces.Add(compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IAsyncEnumerable_T).Construct(elementType));

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -325,5 +325,33 @@ namespace Microsoft.CodeAnalysis.CSharp
             F.CurrentFunction = result;
             return result;
         }
+
+        /// <summary>
+        /// Produce Environment.CurrentManagedThreadId if available, otherwise CurrentThread.ManagedThreadId
+        /// </summary>
+        protected BoundExpression MakeCurrentThreadId()
+        {
+            Debug.Assert(CanGetThreadId());
+            var currentManagedThreadIdProperty = (PropertySymbol)F.WellKnownMember(WellKnownMember.System_Environment__CurrentManagedThreadId, isOptional: true);
+            if ((object)currentManagedThreadIdProperty != null)
+            {
+                MethodSymbol currentManagedThreadIdMethod = currentManagedThreadIdProperty.GetMethod;
+                if ((object)currentManagedThreadIdMethod != null)
+                {
+                    return F.Call(null, currentManagedThreadIdMethod);
+                }
+            }
+
+            return F.Property(F.Property(WellKnownMember.System_Threading_Thread__CurrentThread), WellKnownMember.System_Threading_Thread__ManagedThreadId);
+        }
+
+        /// <summary>
+        /// Returns true if either Thread.ManagedThreadId or Environment.CurrentManagedThreadId are available
+        /// </summary>
+        protected bool CanGetThreadId()
+        {
+            return (object)F.WellKnownMember(WellKnownMember.System_Threading_Thread__ManagedThreadId, isOptional: true) != null ||
+                (object)F.WellKnownMember(WellKnownMember.System_Environment__CurrentManagedThreadId, isOptional: true) != null;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -1613,34 +1613,43 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
 
-            if (this.IsAsync || this.IsIterator)
+            bool isAsync = this.IsAsync;
+            bool isIterator = this.IsIterator;
+            if (!isAsync && !isIterator)
             {
-                var compilation = this.DeclaringCompilation;
+                return;
+            }
 
-                // PROTOTYPE(async-streams): Need to review this
+            var compilation = this.DeclaringCompilation;
 
-                // The async state machine type is not synthesized until the async method body is rewritten. If we are
-                // only emitting metadata the method body will not have been rewritten, and the async state machine
-                // type will not have been created. In this case, omit the attribute.
-                NamedTypeSymbol stateMachineType;
-                if (moduleBuilder.CompilationState.TryGetStateMachineType(this, out stateMachineType))
+            // The async state machine type is not synthesized until the async method body is rewritten. If we are
+            // only emitting metadata the method body will not have been rewritten, and the async state machine
+            // type will not have been created. In this case, omit the attribute.
+            if (moduleBuilder.CompilationState.TryGetStateMachineType(this, out NamedTypeSymbol stateMachineType))
+            {
+                var arg = new TypedConstant(compilation.GetWellKnownType(WellKnownType.System_Type),
+                    TypedConstantKind.Type, stateMachineType.GetUnboundGenericTypeOrSelf());
+
+                if (isAsync)
                 {
-                    WellKnownMember ctor = this.IsAsync ?
-                        WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor :
-                        WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor;
-
-                    var arg = new TypedConstant(compilation.GetWellKnownType(WellKnownType.System_Type), TypedConstantKind.Type, stateMachineType.GetUnboundGenericTypeOrSelf());
-
-                    AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(ctor, ImmutableArray.Create(arg)));
+                    AddSynthesizedAttribute(ref attributes,
+                        compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor,
+                            ImmutableArray.Create(arg)));
                 }
-
-                if (this.IsAsync)
+                if (isIterator)
                 {
-                    // Async kick-off method calls MoveNext, which contains user code. 
-                    // This means we need to emit DebuggerStepThroughAttribute in order
-                    // to have correct stepping behavior during debugging.
-                    AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDebuggerStepThroughAttribute());
+                    AddSynthesizedAttribute(ref attributes,
+                        compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor,
+                            ImmutableArray.Create(arg)));
                 }
+            }
+
+            if (isAsync && !isIterator)
+            {
+                // Regular async (not async-iterator) kick-off method calls MoveNext, which contains user code.
+                // This means we need to emit DebuggerStepThroughAttribute in order
+                // to have correct stepping behavior during debugging.
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDebuggerStepThroughAttribute());
             }
         }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8818,8 +8818,8 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8831,8 +8831,8 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8805,8 +8805,8 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8806,8 +8806,8 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8807,8 +8807,8 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8831,8 +8831,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8831,8 +8831,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8810,8 +8810,8 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8811,8 +8811,8 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8813,8 +8813,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8819,8 +8819,8 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8831,8 +8831,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadDynamicAsyncForEach">
+        <source>Cannot use a collection of dynamic type in an asynchronous foreach</source>
+        <target state="new">Cannot use a collection of dynamic type in an asynchronous foreach</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="new">__arglist cannot have an argument passed by 'in' or 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMemberWrongAsync">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'foreach await'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadDynamicAsyncForEach">
@@ -8831,8 +8831,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_AsyncForEachMissingMember">
-        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</target>
+        <source>Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="new">Async foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
@@ -54,7 +54,7 @@ class C
 }";
             var comp = CreateCompilationWithMscorlib46(source);
             comp.VerifyDiagnostics(
-                // (6,33): error CS9001: Async foreach statement cannot operate on variables of type 'C' because 'C' does not contain a public definition for 'GetAsyncEnumerator'
+                // (6,33): error CS9001: Async foreach statement cannot operate on variables of type 'C' because 'C' does not contain a public instance definition for 'GetAsyncEnumerator'
                 //         foreach await (var i in new C())
                 Diagnostic(ErrorCode.ERR_AsyncForEachMissingMember, "new C()").WithArguments("C", "GetAsyncEnumerator").WithLocation(6, 33)
                 );
@@ -82,7 +82,7 @@ class C
 }";
             var comp = CreateCompilationWithMscorlib46(source);
             comp.VerifyDiagnostics(
-                // (6,33): error CS9001: Async foreach statement cannot operate on variables of type 'C' because 'C' does not contain a public definition for 'GetAsyncEnumerator'
+                // (6,33): error CS9001: Async foreach statement cannot operate on variables of type 'C' because 'C' does not contain a public instance definition for 'GetAsyncEnumerator'
                 //         foreach await (var i in new C())
                 Diagnostic(ErrorCode.ERR_AsyncForEachMissingMember, "new C()").WithArguments("C", "GetAsyncEnumerator").WithLocation(6, 33)
                 );
@@ -1099,7 +1099,7 @@ class C
 }";
             var comp = CreateCompilationWithTasksExtensions(source + s_interfaces);
             comp.VerifyDiagnostics(
-                // (7,33): error CS9005: Async foreach statement cannot operate on variables of type 'IEnumerable<int>' because 'IEnumerable<int>' does not contain a public definition for 'GetAsyncEnumerator'. Did you mean 'foreach' rather than 'foreach await'?
+                // (7,33): error CS9005: Async foreach statement cannot operate on variables of type 'IEnumerable<int>' because 'IEnumerable<int>' does not contain a public instance definition for 'GetAsyncEnumerator'. Did you mean 'foreach' rather than 'foreach await'?
                 //         foreach await (var i in collection)
                 Diagnostic(ErrorCode.ERR_AsyncForEachMissingMemberWrongAsync, "collection").WithArguments("System.Collections.Generic.IEnumerable<int>", "GetAsyncEnumerator").WithLocation(7, 33),
                 // (7,17): error CS4033: The 'await' operator can only be used within an async method. Consider marking this method with the 'async' modifier and changing its return type to 'Task'.
@@ -1161,7 +1161,7 @@ class C
 }";
             var comp = CreateCompilationWithTasksExtensions(source + s_interfaces);
             comp.VerifyDiagnostics(
-                // (6,33): error CS9005: Async foreach statement cannot operate on variables of type 'C' because 'C' does not contain a public definition for 'GetAsyncEnumerator'. Did you mean 'foreach' rather than 'foreach await'?
+                // (6,33): error CS9005: Async foreach statement cannot operate on variables of type 'C' because 'C' does not contain a public instance definition for 'GetAsyncEnumerator'. Did you mean 'foreach' rather than 'foreach await'?
                 //         foreach await (var i in new C())
                 Diagnostic(ErrorCode.ERR_AsyncForEachMissingMemberWrongAsync, "new C()").WithArguments("C", "GetAsyncEnumerator").WithLocation(6, 33)
                 );

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncForeachTests.cs
@@ -702,6 +702,26 @@ class Element
         }
 
         [Fact]
+        public void TestWithDynamicCollection()
+        {
+            string source = @"
+class C
+{
+    public static async System.Threading.Tasks.Task Main()
+    {
+        foreach await (var i in (dynamic)new C())
+        {
+        }
+    }
+}";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces });
+            comp.VerifyDiagnostics(
+                // (6,33): error CS9006: Cannot use a collection of dynamic type in an asynchronous foreach
+                //         foreach await (var i in (dynamic)new C())
+                Diagnostic(ErrorCode.ERR_BadDynamicAsyncForEach, "(dynamic)new C()").WithLocation(6, 33));
+        }
+
+        [Fact]
         public void TestWithIncompleteInterface()
         {
             string source = @"
@@ -3719,7 +3739,6 @@ class C
         }
 
         // PROTOTYPE(async-streams) More test ideas
-        // block dynamic
 
         // test with captures:
         //        int[] values = { 7, 9, 13 };
@@ -3740,6 +3759,7 @@ class C
         // IOperation
         // IDE
         // scripting?
+        // expression trees
 
         // Misc other test ideas:
         // Verify that async-dispose doesn't have a similar bug with struct resource

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -1758,7 +1758,7 @@ class C
 }";
             var comp = CreateCompilationWithTasksExtensions(new[] { source, s_common }, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            // PROTOTYPE(async-streams): need to implement the exception
+            // https://github.com/dotnet/roslyn/issues/30109 need to implement the guard/exception
             //CompileAndVerify(comp, expectedOutput: "Done");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -22,16 +22,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     public class CodeGenAsyncIteratorTests : EmitMetadataTestBase
     {
         // PROTOTYPE(async-streams) Add more tests:
-        // Test missing remaining types/members once BCL APIs are finalized (MRVTSL, IStrongBox, IValueTaskSource)
-        // test missing AsyncTaskMethodBuilder<T> or missing members Create(), Task, ...
         // Test with yield or await in try/catch/finally
         // More tests with exception thrown
         // There is a case in GetIteratorElementType with IsDirectlyInIterator that relates to speculation, needs testing
         // yield break disallowed in finally and top-level script (see BindYieldBreakStatement); same for yield return (see BindYieldReturnStatement)
         // binding for yield return (BindYieldReturnStatement) validates escape rules, needs testing
         // test yield in async lambda (still error)
-        // test exception handling (should capture and return the exception via the promise)
-        // test IAsyncEnumerable<U> M<U>() ...
         // test with IAsyncEnumerable<dynamic>
         // other tests with dynamic?
         // test should cover both case with AwaitOnCompleted and AwaitUnsafeOnCompleted
@@ -39,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         // Can we avoid making IAsyncEnumerable<T> special from the start? Making mark it with an attribute like we did for task-like?
         // Do some manual validation on debugging scenarios, including with exceptions (thrown after yield and after await).
         // Test with one or both or the threadID APIs missing.
-        // Test with parameters, including `this`
+        // Enable remaining windows/desktop-only to run on Core
 
         private void VerifyMissingMember(WellKnownMember member, params DiagnosticDescription[] expected)
         {
@@ -1837,7 +1833,6 @@ class C
             CompileAndVerify(comp, expectedOutput: "Done");
         }
 
-        // PROTOTYPE(async-streams): Consider moving this common test code to TestSources.cs
         private static readonly string s_common = @"
 namespace System.Collections.Generic
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -72,6 +72,35 @@ class C
             comp.VerifyEmitDiagnostics(expected);
         }
 
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        public void RefStructElementType()
+        {
+            string source = @"
+class C
+{
+    static async System.Collections.Generic.IAsyncEnumerable<S> M()
+    {
+        await System.Threading.Tasks.Task.CompletedTask;
+        yield return new S();
+    }
+    static async System.Threading.Tasks.Task Main()
+    {
+        foreach await (var s in M())
+        {
+        }
+    }
+}
+ref struct S
+{
+}";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_common }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (4,65): error CS0306: The type 'S' may not be used as a type argument
+                //     static async System.Collections.Generic.IAsyncEnumerable<S> M()
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "M").WithArguments("S").WithLocation(4, 65)
+                );
+        }
+
         [Fact]
         public void AttributesSynthesized()
         {


### PR DESCRIPTION
Fixes mismatch between `T` from the original method `C.M<T>()` and its lowered form `unpronounceable<T>.MoveNext()`.
Addresses various minor PROTOTYPE comments.