### PR TITLE
Revert "Fix #30091 throwing exceptions"

### DIFF
--- a/src/Features/Core/Portable/RemoveUnusedVariable/AbstractRemoveUnusedVariableCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveUnusedVariable/AbstractRemoveUnusedVariableCodeFixProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedVariable
 
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            Diagnostic diagnostic = context.Diagnostics.First();
+            Diagnostic diagnostic = context.Diagnostics.Single();
             context.RegisterCodeFix(new MyCodeAction(c => FixAsync(context.Document, diagnostic, c)), diagnostic);
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Reverts dotnet/roslyn#30093

I committed without knowing it was targetting 15.9.x