### PR TITLE
Fix #30091 throwing exceptions

### DIFF
--- a/src/Features/Core/Portable/RemoveUnusedVariable/AbstractRemoveUnusedVariableCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveUnusedVariable/AbstractRemoveUnusedVariableCodeFixProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedVariable
 
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            Diagnostic diagnostic = context.Diagnostics.Single();
+            Diagnostic diagnostic = context.Diagnostics.First();
             context.RegisterCodeFix(new MyCodeAction(c => FixAsync(context.Document, diagnostic, c)), diagnostic);
             return Task.CompletedTask;
         }


### PR DESCRIPTION
The general pattern when registering code fixes seems to be
either passing diagnostics[0] or diagnostics.First().

RemoveUnusedVariable seems to be the only outlier in this case,
doing .Single().

Having multiple diagnostics on a span would cause the code fix
to throw an exception