### PR TITLE
Enable hard links as a build option

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -104,6 +104,23 @@
     <RoslynPortableTargetFrameworks>netcoreapp2.0</RoslynPortableTargetFrameworks>
   </PropertyGroup>
 
+  <!-- 
+       Enable hard links for the build. This is not done by default due to fears about 
+       inadvertently corrupting the NuGet cache (hard links in the output directory will
+       point into the cache). The build itself will not due this but a developer directly
+       modifying this directory could cause it to happen.
+
+       Developers who do not modify the output directory directly can enable this safely 
+
+       Related discussion in https://github.com/dotnet/roslyn/issues/30005
+  -->
+  <PropertyGroup Condition="'$(ROSLYNUSEHARDLINKS)' != ''">
+    <CreateHardLinksForCopyFilesToOutputDirectoryIfPossible>true</CreateHardLinksForCopyFilesToOutputDirectoryIfPossible>
+    <CreateHardLinksForCopyAdditionalFilesIfPossible>true</CreateHardLinksForCopyAdditionalFilesIfPossible> 
+    <CreateHardLinksForCopyLocalIfPossible>true</CreateHardLinksForCopyLocalIfPossible>
+    <CreateHardLinksForPublishFilesIfPossible>true</CreateHardLinksForPublishFilesIfPossible>
+  </PropertyGroup>
+
   <!-- Windows specific settings -->
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <DeployExtension Condition="'$(VisualStudioVersion)' != '15.0' and '$(VisualStudioVersion)' != '16.0'">false</DeployExtension>


### PR DESCRIPTION
This adds a new option to our build to enable hard links:
`$(ROSLYNUSEHARDLINKS)`. This is done as a separate option versus just
letting interested parties use the four separate MSBuild properties for
the following reasons:

1. It's not really reasonable to have developers remember and always use
the four separate properties.
1. Having a separate name means you can specify this as global
environment variable and have it impact all Roslyn builds, including
from VS, without having it be used on builds that may not be safe for
hard links.

This option does produce measurable effects on builds:

| | Build Time | Binaries Size Explorer | Binaries Size DU |
|-|-|-|-|
| No hard link | 4:00 | 13.9GB | 14.9GB |
| Hard links | 3:28 | 13.8GB | 1.5GB |

Even so this is not being enabled by default due to fears of developers
inadverently corrupting the NuGet cache when directly writing to the
Binaries directory. The build itself is safe to use with hard links (our
correctness job validates we don't double write any output). Hence
normal use can use this option safely.

closes #30005