### PR TITLE
Fix TypeParamRefs in included xml docs in C# not resolving correctly:

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
@@ -600,7 +600,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
                                 break;
                         }
-                    } while (isTypeParameterRef && (currentSymbol = currentSymbol.ContainingSymbol) != null);
+                        currentSymbol = currentSymbol.ContainingSymbol;
+                    } while (isTypeParameterRef && !(currentSymbol is null));
                 }
 
                 return binder;

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
@@ -220,12 +220,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                             if (ElementNameIs(element, DocumentationCommentXmlNames.ParameterElementName) ||
                                 ElementNameIs(element, DocumentationCommentXmlNames.ParameterReferenceElementName))
                             {
-                                BindName(attribute, originatingSyntax, isParameter: true);
+                                BindName(attribute, originatingSyntax, isParameter: true, isTypeRef: false);
                             }
-                            else if (ElementNameIs(element, DocumentationCommentXmlNames.TypeParameterElementName) ||
-                                ElementNameIs(element, DocumentationCommentXmlNames.TypeParameterReferenceElementName))
+                            else if (ElementNameIs(element, DocumentationCommentXmlNames.TypeParameterElementName))
                             {
-                                BindName(attribute, originatingSyntax, isParameter: false);
+                                BindName(attribute, originatingSyntax, isParameter: false, isTypeRef: false);
+                            }
+                            else if(ElementNameIs(element, DocumentationCommentXmlNames.TypeParameterReferenceElementName))
+                            {
+                                BindName(attribute, originatingSyntax, isParameter: false, isTypeRef: true);
                             }
                         }
                     }
@@ -514,7 +517,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 crefDiagnostics.Free();
             }
 
-            private void BindName(XAttribute attribute, CSharpSyntaxNode originatingSyntax, bool isParameter)
+            private void BindName(XAttribute attribute, CSharpSyntaxNode originatingSyntax, bool isParameter, bool isTypeRef)
             {
                 XmlNameAttributeSyntax attrSyntax = ParseNameAttribute(attribute.ToString(), attribute.Parent.Name.LocalName);
 
@@ -529,7 +532,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     "Why are we processing a documentation comment that is not attached to a member declaration?");
 
                 DiagnosticBag nameDiagnostics = DiagnosticBag.GetInstance();
-                Binder binder = MakeNameBinder(isParameter, _memberSymbol, _compilation);
+                Binder binder = MakeNameBinder(isParameter, isTypeRef, _memberSymbol, _compilation);
                 DocumentationCommentCompiler.BindName(attrSyntax, binder, _memberSymbol, ref _documentedParameters, ref _documentedTypeParameters, nameDiagnostics);
                 RecordBindingDiagnostics(nameDiagnostics, sourceLocation); // Respects DocumentationMode.
                 nameDiagnostics.Free();
@@ -538,7 +541,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // NOTE: We're not sharing code with the BinderFactory visitor, because we already have the
             // member symbol in hand, which makes things much easier.
-            private static Binder MakeNameBinder(bool isParameter, Symbol memberSymbol, CSharpCompilation compilation)
+            private static Binder MakeNameBinder(bool isParameter, bool isTypeRef, Symbol memberSymbol, CSharpCompilation compilation)
             {
                 Binder binder = new BuckStopsHereBinder(compilation);
 
@@ -576,23 +579,27 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    switch (memberSymbol.Kind)
+                    bool continueSearch = true;
+                    for (var currentSymbol = memberSymbol; currentSymbol != null && continueSearch; currentSymbol = currentSymbol.ContainingSymbol, continueSearch = isTypeRef)
                     {
-                        case SymbolKind.NamedType: // Includes delegates.
-                        case SymbolKind.ErrorType:
-                            NamedTypeSymbol typeSymbol = (NamedTypeSymbol)memberSymbol;
-                            if (typeSymbol.Arity > 0)
-                            {
-                                binder = new WithClassTypeParametersBinder(typeSymbol, binder);
-                            }
-                            break;
-                        case SymbolKind.Method:
-                            MethodSymbol methodSymbol = (MethodSymbol)memberSymbol;
-                            if (methodSymbol.Arity > 0)
-                            {
-                                binder = new WithMethodTypeParametersBinder(methodSymbol, binder);
-                            }
-                            break;
+                        switch (currentSymbol.Kind)
+                        {
+                            case SymbolKind.NamedType: // Includes delegates.
+                            case SymbolKind.ErrorType:
+                                NamedTypeSymbol typeSymbol = (NamedTypeSymbol)currentSymbol;
+                                if (typeSymbol.Arity > 0)
+                                {
+                                    binder = new WithClassTypeParametersBinder(typeSymbol, binder);
+                                }
+                                break;
+                            case SymbolKind.Method:
+                                MethodSymbol methodSymbol = (MethodSymbol)currentSymbol;
+                                if (methodSymbol.Arity > 0)
+                                {
+                                    binder = new WithMethodTypeParametersBinder(methodSymbol, binder);
+                                }
+                                break;
+                        }
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 BindName(attribute, originatingSyntax, isParameter: false, isTypeParameterRef: false);
                             }
-                            else if(ElementNameIs(element, DocumentationCommentXmlNames.TypeParameterReferenceElementName))
+                            else if (ElementNameIs(element, DocumentationCommentXmlNames.TypeParameterReferenceElementName))
                             {
                                 BindName(attribute, originatingSyntax, isParameter: false, isTypeParameterRef: true);
                             }
@@ -579,7 +579,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    var currentSymbol = memberSymbol;
+                    Symbol currentSymbol = memberSymbol;
                     do
                     {
                         switch (currentSymbol.Kind)


### PR DESCRIPTION
 - When resolving TypeParamRefs in an included xml comment in c#, ensure we add any parent generic types to the binder we create
 - Add a repro test (essentially a copy of the VB test Include_TypeParamAndTypeParamRefHandling)

Fixes #21348 