### PR TITLE
Don't mark Microsoft.CodeAnalysis.Elfie as a private package

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -269,7 +269,6 @@
   <ItemGroup>
     <PrivateVisualStudioPackage Include="EnvDTE"/>
     <PrivateVisualStudioPackage Include="EnvDTE80"/>
-    <PrivateVisualStudioPackage Include="Microsoft.CodeAnalysis.Elfie" />
     <PrivateVisualStudioPackage Include="Microsoft.Internal.Performance.CodeMarkers.DesignTime"/>
     <PrivateVisualStudioPackage Include="Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime"/>
     <PrivateVisualStudioPackage Include="Microsoft.MSXML"/>


### PR DESCRIPTION
This is a package we depend on via normal means, and expect it to be referenced in our NuGet packages as they are today. With this set, we weren't deploying this with our VSIX.