### PR TITLE
[Not for merging] Repro of integration test failure

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Example.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Example.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
+
+namespace Roslyn.VisualStudio.IntegrationTests
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class Example : AbstractIntegrationTest
+    {
+        public Example(VisualStudioInstanceFactory instanceFactory)
+            : base(instanceFactory)
+        {
+        }
+
+        [WpfFact]
+        public void Test1()
+        {
+            VisualStudio.SolutionExplorer.CreateSolution(SolutionName);
+            VisualStudio.SolutionExplorer.AddProject(
+                new ProjectUtils.Project(ProjectName),
+                WellKnownProjectTemplates.CSharpNetCoreClassLibrary,
+                LanguageNames.CSharp);
+        }
+
+        [WpfFact]
+        public void Test2()
+        {
+            VisualStudio.SolutionExplorer.CreateSolution(SolutionName);
+            VisualStudio.SolutionExplorer.AddProject(
+                new ProjectUtils.Project(ProjectName),
+                WellKnownProjectTemplates.CSharpNetCoreClassLibrary,
+                LanguageNames.CSharp);
+        }
+    }
+}


### PR DESCRIPTION
*For demonstration purposes only (do not merge)*

This is a minimum repro to show the integration test failures encountered in https://github.com/dotnet/roslyn/pull/25875#issuecomment-424718571

@sharwell Can you please take a quick look at this very small repro to see if there's anything I'm doing wrong? If I run both tests in the `Example` class this error dialog appears:
![integrationtesterror](https://user-images.githubusercontent.com/11444821/46083360-934d1d00-c1a1-11e8-9e2d-00e32355f456.png)

`Test1` and `Test2` are identical. Running only one of them does not reproduce this. Changing `WellKnownProjectTemplates.CSharpNetCoreClassLibrary` to `WellKnownProjectTemplates.ClassLibrary` fixes the error.