### PR TITLE
Restore an overload of `CommonCompletionUtilities.GetWordSpan` that broke an IVT reference

### DIFF
--- a/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
@@ -21,6 +21,12 @@ namespace Microsoft.CodeAnalysis.Completion
         private const string NonBreakingSpaceString = "\x00A0";
 
         public static TextSpan GetWordSpan(SourceText text, int position,
+            Func<char, bool> isWordStartCharacter, Func<char, bool> isWordCharacter)
+        {
+            return GetWordSpan(text, position, isWordStartCharacter, isWordCharacter, alwaysExtendEndSpan: false);
+        }
+
+        public static TextSpan GetWordSpan(SourceText text, int position,
             Func<char, bool> isWordStartCharacter, Func<char, bool> isWordCharacter, bool alwaysExtendEndSpan = false)
         {
             int start = position;


### PR DESCRIPTION
Fixes #30133 

This overload was removed in https://github.com/dotnet/roslyn/pull/29447/files#diff-1be1969f251b6e01f671985101baacc1R24, but an internal consumer of Roslyn was using that signature via IVT. This change restores an overload with the original signature.