### PR TITLE
Updates for running roslyn tests on Mono

### DIFF
--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -2,15 +2,18 @@
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-# USAGE:
-# build/scripts/tests.sh (Debug|Release) (dotnet|mono|mono-debug) [test assembly name] [xunit args]
-# If specified, the test assembly name must be a substring match for one or more test assemblies.
-# Note that it's a substring match so '.dll' would match all unit test DLLs and run them all.
-# Any xunit args specified after the assembly name will be passed directly to the test runner
-#  so you can run individual tests, i.e. -method "*.Query_01"
-
 set -e
 set -u
+
+if [[ "${1}" =~ ^(-h|-help|--help|-\?|/\?)$ ]]; then
+    echo "USAGE:"
+    echo "build/scripts/tests.sh (Debug|Release) (dotnet|mono|mono-debug) [test assembly name] [xunit args]"
+    echo "If specified, the test assembly name must be a substring match for one or more test assemblies."
+    echo "Note that it's a substring match so '.dll' would match all unit test DLLs and run them all."
+    echo "Any xunit args specified after the assembly name will be passed directly to the test runner so you can run individual tests, i.e. -method \"*.Query_01\""
+
+    exit 1
+fi
 
 build_configuration=${1:-Debug}
 runtime=${2:-dotnet}

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -2,11 +2,20 @@
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+# USAGE:
+# build/scripts/tests.sh (Debug|Release) (dotnet|mono|mono-debug) [test assembly name] [xunit args]
+# If specified, the test assembly name must be a substring match for one or more test assemblies.
+# Note that it's a substring match so '.dll' would match all unit test DLLs and run them all.
+# Any xunit args specified after the assembly name will be passed directly to the test runner
+#  so you can run individual tests, i.e. -method "*.Query_01"
+
 set -e
 set -u
 
 build_configuration=${1:-Debug}
 runtime=${2:-dotnet}
+single_test_assembly=${3:-}
+xunit_args=(${@:4})
 
 this_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${this_dir}"/build-utils.sh
@@ -20,10 +29,9 @@ xunit_console_version="$(get_package_version xunitrunnerconsole)"
 dotnet_runtime_version="$(get_tool_version dotnetRuntime)"
 
 if [[ "${runtime}" == "dotnet" ]]; then
-    target_framework=netcoreapp2.1
     file_list=( "${unittest_dir}"/*/netcoreapp2.1/*.UnitTests.dll )
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/netcoreapp2.0/xunit.console.dll
-elif [[ "${runtime}" == "mono" ]]; then
+elif [[ "${runtime}" =~ ^(mono|mono-debug)$ ]]; then
     file_list=(
         "${unittest_dir}/Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests/net46/Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.dll"
         "${unittest_dir}/Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests/net46/Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests.dll"
@@ -55,41 +63,39 @@ mkdir -p "${log_dir}"
 exit_code=0
 for file_name in "${file_list[@]}"
 do
-    log_file="${log_dir}"/"$(basename "${file_name%.*}.xml")"
+    file_base_name=$(basename file_name)
+    log_file="${log_dir}/${file_base_name%.*}.xml"
     deps_json="${file_name%.*}".deps.json
     runtimeconfig_json="${file_name%.*}".runtimeconfig.json
 
-    # If the user specifies a test assembly on the command line, only run that one
-    # "${3:-}" => take second arg, empty string if unset
-    if [[ ("${3:-}" != "") && (! "${file_name}" =~ "${3:-}") ]]
+    if [[ ("${single_test_assembly}" != "") && (! "${file_name}" =~ "${single_test_assembly}") ]]
     then
         echo "Skipping ${file_name}"
         continue
     fi
 
-    echo Running "${runtime} ${file_name[@]}"
+    echo Running "${runtime} ${file_name}"
     if [[ "${runtime}" == "dotnet" ]]; then
         # Disable the VB Semantic tests while we investigate the core dump issue
         # https://github.com/dotnet/roslyn/issues/29660
-        if [[ "${file_name[@]}" == *'Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.dll' ]] 
+        if [[ "${file_name}" == *'Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.dll' ]] 
         then
-            echo "Skipping ${file_name[@]}"
+            echo "Skipping ${file_name}"
             continue
         fi
         runner="dotnet exec --fx-version ${dotnet_runtime_version} --depsfile ${deps_json} --runtimeconfig ${runtimeconfig_json}"
     elif [[ "${runtime}" == "mono" ]]; then
         runner=mono
+    elif [[ "${runtime}" == "mono-debug" ]]; then
+        runner="mono --debug"
     fi
 
     # https://github.com/dotnet/roslyn/issues/29380
-    # Pass additional arguments on to xunit_console directly.
-    # This allows you to (for example) run a single test method of a single test assembly, like so:
-    # ./build/scripts/tests.sh Debug dotnet Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests -method "*.Query_01"
-    if ${runner} "${xunit_console}" "${file_name[@]}" -xml "${log_file}" -parallel none "${@:4}"
+    if ${runner} "${xunit_console}" "${file_name}" -xml "${log_file}" -parallel none "${xunit_args[@]}"
     then
-        echo "Assembly ${file_name[@]} passed"
+        echo "Assembly ${file_name} passed"
     else
-        echo "Assembly ${file_name[@]} failed"
+        echo "Assembly ${file_name} failed"
         exit_code=1
     fi
 done

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -73,7 +73,8 @@ elif [[ "${runtime}" =~ ^(mono|mono-debug)$ ]]; then
         # A zillion test failures + crash
         # See https://github.com/mono/mono/issues/10756
         'Microsoft.CodeAnalysis.VisualBasic.Symbol.UnitTests.dll'
-
+        # Deadlocks. 
+        'Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.dll'
     )
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/net452/xunit.console.exe
 else

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -131,7 +131,7 @@ do
     fi
 
     # https://github.com/dotnet/roslyn/issues/29380
-    if ${runner} "${xunit_console}" "${file_name}" -xml "${log_file}" -parallel none "${xunit_args[@]:-}"
+    if ${runner} "${xunit_console}" "${file_name}" -xml "${log_file}" -parallel none ${xunit_args[@]+"${xunit_args[@]}"}
     then
         echo "Assembly ${file_name} passed"
     else

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -136,7 +136,7 @@ do
     fi
 
     # https://github.com/dotnet/roslyn/issues/29380
-    if ${runner} "${xunit_console}" "${file_name}" -xml "${log_file}" -parallel none "${xunit_args[@]}"
+    if ${runner} "${xunit_console}" "${file_name}" -xml "${log_file}" -parallel none ${xunit_args[@]:-}
     then
         echo "Assembly ${file_name} passed"
     else

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -70,6 +70,9 @@ elif [[ "${runtime}" =~ ^(mono|mono-debug)$ ]]; then
         # A zillion test failures + crash
         # See https://github.com/mono/mono/issues/10756
         'Microsoft.CodeAnalysis.VisualBasic.Symbol.UnitTests.dll'
+        # Currently fails on CI against old versions of mono
+        # See https://github.com/dotnet/roslyn/pull/30166#issuecomment-425571629
+        'VBCSCompiler.UnitTests.dll'
     )
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/net452/xunit.console.exe
 else

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -7129,7 +7129,7 @@ class Module1
             }
         }
 
-        [NoIOperationValidationFact]
+        [ConditionalFact(typeof(ClrOnly), typeof(NoIOperationValidation), Reason="https://github.com/mono/mono/issues/10917")]
         public void BinaryIntrinsicSymbols1()
         {
             BinaryOperatorKind[] operators =

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactsTest.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactsTest.vb
@@ -1001,6 +1001,7 @@ End Namespace
     End Sub
 
     <ConditionalFact(GetType(DesktopClrOnly))>
+    <WorkItem(10841, "https://github.com/mono/mono/issues/10841")>
     Public Sub AllowsLeadingOrTrailingImplicitLineContinuation()
 
         Dim cu = SyntaxFactory.ParseCompilationUnit(My.Resources.Resource.VBAllInOne)
@@ -1099,6 +1100,7 @@ End Namespace
     End Sub
 
     <ConditionalFact(GetType(DesktopClrOnly))>
+    <WorkItem(10841, "https://github.com/mono/mono/issues/10841")>
     Public Sub AllowsLeadingOrTrailingImplicitLineContinuationNegativeTests()
 
         Dim cu = SyntaxFactory.ParseCompilationUnit(My.Resources.Resource.VBAllInOne)

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactsTest.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactsTest.vb
@@ -1000,7 +1000,7 @@ End Namespace
         Assert.Equal(VarianceKind.None, SyntaxFacts.VarianceKindFromToken(keywordToken))
     End Sub
 
-    <ConditionalFact(GetType(DesktopOnly))>
+    <ConditionalFact(GetType(DesktopClrOnly))>
     Public Sub AllowsLeadingOrTrailingImplicitLineContinuation()
 
         Dim cu = SyntaxFactory.ParseCompilationUnit(My.Resources.Resource.VBAllInOne)
@@ -1098,7 +1098,7 @@ End Namespace
 
     End Sub
 
-    <ConditionalFact(GetType(DesktopOnly))>
+    <ConditionalFact(GetType(DesktopClrOnly))>
     Public Sub AllowsLeadingOrTrailingImplicitLineContinuationNegativeTests()
 
         Dim cu = SyntaxFactory.ParseCompilationUnit(My.Resources.Resource.VBAllInOne)

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -210,6 +210,12 @@ namespace Roslyn.Test.Utilities
         public override string SkipReason => "Test not supported on CoreCLR";
     }
 
+    public class DesktopClrOnly : ExecutionCondition
+    {
+        public override bool ShouldSkip => MonoHelpers.IsRunningOnMono() || !ExecutionConditionUtil.IsDesktop;
+        public override string SkipReason => "Test not supported on Mono or CoreCLR";
+    }
+
     public class NoIOperationValidation : ExecutionCondition
     {
         public override bool ShouldSkip => !CompilationExtensions.EnableVerifyIOperation;


### PR DESCRIPTION
I started over on some of my integration work (previously done on 2.8.2) to get things working properly on master-branch Mono. This PR contains some basic changes to make the rest of it easier.

This PR:
* Cleans up tests.sh to fix some shellcheck warnings
* Adds usage info to tests.sh (```tests.sh -?```)
* Moves to a blacklist model where tests.sh runs all test assemblies except those on a blacklist. This is the ideal way for this script to work (IMO) because it ensures that anyone adding a new assembly has to look at this script and decide whether they really want to blanket disable all their tests on Mono (the answer should usually be no). The current whitelist only had two assemblies in it, which doesn't seem right - in fact a considerable number of the test assemblies already pass without any changes to mono or the tests. The blacklist in this script is derived from my 2.8.2 blacklist so a few of the assemblies in it probably don't actually exist, given that all of them changed filenames.
* Adds a conditional for disabling a test both on coreclr and mono
* Disables two VB tests because everything else in that assembly passes on mono.

I previously had a few other assemblies working on 2.8.2 that no longer work, but it's my understanding that @jaredpar is working on that so it doesn't seem worthwhile for me to tackle that here. Similarly, I know that against 2.8.2 we don't need to disable ilasm tests on mono anymore - we can just use coreclr ilasm and all those tests will pass. That is out of scope for this PR too, since I suspect jared has a PR for it.

cc @marek-safar 