### PR TITLE
Enable C# emit tests for Mono

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
@@ -289,7 +289,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Diagnostic(ErrorCode.ERR_InvalidAssemblyCultureForExe, @"""pt-BR""").WithLocation(1, 46));
         }
 
-        [Fact, WorkItem(1032718, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1032718")]
+        [WorkItem(1032718, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1032718")]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10839")]
         public void MismatchedSurrogateInAssemblyCultureAttribute()
         {
             string s = @"[assembly: System.Reflection.AssemblyCultureAttribute(""\uD800"")]";

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -1878,7 +1878,7 @@ public class MyClass
 No DecimalConstantAttribute");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/23760")]
         public void DecimalConstant_Indexers()
         {
             string source = @"
@@ -1913,7 +1913,7 @@ public class C
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/23760")]
         public void DecimalConstant_Delegates()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/Attributes/EmitTestStrongNameProvider.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/EmitTestStrongNameProvider.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(209695, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=209694")]
         public void ExceptionInReadAllBytes()
         {
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Diagnostic(ErrorCode.ERR_PublicKeyFileFailure).WithArguments(keyFile, ex.Message).WithLocation(1, 1));
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void ExceptionInReadKeysFromContainer()
         {
             var ex = new Exception("Crazy exception you could never have predicted!");
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Diagnostic(ErrorCode.ERR_PublicKeyContainerFailure).WithArguments("RoslynTestContainer", ex.Message).WithLocation(1, 1));
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void BadInputStream()
         {
             string src = @"

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         #region Naming Tests
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(529419, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529419")]
         public void AssemblyKeyFileAttributeNotExistFile()
         {
@@ -68,7 +68,7 @@ public class Test
                 Diagnostic(ErrorCode.ERR_PublicKeyFileFailure).WithArguments("MyKey.snk", CodeAnalysisResources.FileNotFound));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileAttribute()
         {
             var x = s_keyPairFile;
@@ -95,7 +95,7 @@ public class Test
             });
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileAttribute_AssemblyKeyFileResolver()
         {
             string keyFileDir = Path.GetDirectoryName(s_keyPairFile);
@@ -123,7 +123,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, comp.Assembly.Identity.PublicKey));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileAttribute_AssemblyKeyFileResolver_RelativeToCurrentParent()
         {
             string keyFileDir = Path.GetDirectoryName(s_keyPairFile);
@@ -151,7 +151,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, comp.Assembly.Identity.PublicKey));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SigningNotAvailable001()
         {
             string keyFileDir = Path.GetDirectoryName(s_keyPairFile);
@@ -179,7 +179,7 @@ public class Test
             );
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyContainerAttribute()
         {
             var x = s_keyPairFile;
@@ -206,7 +206,7 @@ public class Test
             });
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileOptions()
         {
             string s = "public class C {}";
@@ -216,7 +216,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, other.Assembly.Identity.PublicKey));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileOptions_ReferenceResolver()
         {
             string keyFileDir = Path.GetDirectoryName(s_keyPairFile);
@@ -245,7 +245,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, comp.Assembly.Identity.PublicKey));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileOptionsJustPublicKey()
         {
             string s = "public class C {}";
@@ -255,7 +255,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(TestResources.General.snPublicKey.AsImmutableOrNull(), other.Assembly.Identity.PublicKey));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileOptionsJustPublicKey_ReferenceResolver()
         {
             string publicKeyFileDir = Path.GetDirectoryName(s_publicKeyFile);
@@ -287,7 +287,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, comp.Assembly.Identity.PublicKey));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFileNotFoundOptions()
         {
             string s = "public class C {}";
@@ -300,7 +300,7 @@ public class Test
             Assert.True(other.Assembly.Identity.PublicKey.IsEmpty);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFileBogusOptions()
         {
             var tempFile = Temp.CreateFile().WriteAllBytes(new byte[] { 1, 2, 3, 4 });
@@ -314,7 +314,7 @@ public class Test
         }
 
         [WorkItem(5662, "https://github.com/dotnet/roslyn/issues/5662")]
-        [ConditionalFact(typeof(IsEnglishLocal),typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(IsEnglishLocal),typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyContainerBogusOptions()
         {
             string s = "public class C {}";
@@ -332,7 +332,7 @@ public class Test
             Assert.True(other.Assembly.Identity.PublicKey.IsEmpty);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyFileAttributeOptionConflict()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyFile(""bogus"")] public class C {}";
@@ -344,7 +344,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, other.Assembly.Identity.PublicKey));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyContainerAttributeOptionConflict()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyName(""bogus"")] public class C {}";
@@ -356,7 +356,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, other.Assembly.Identity.PublicKey));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyFileAttributeEmpty()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyFile("""")] public class C {}";
@@ -366,7 +366,7 @@ public class Test
             other.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyContainerEmpty()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyName("""")] public class C {}";
@@ -376,7 +376,7 @@ public class Test
             other.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicKeyFromOptions_DelaySigned()
         {
             string source = @"
@@ -395,7 +395,7 @@ public class C {}";
             Assert.Equal(CorFlags.ILOnly, metadata.Module.PEReaderOpt.PEHeaders.CorHeader.Flags);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(9150, "https://github.com/dotnet/roslyn/issues/9150")]
         public void PublicKeyFromOptions_PublicSign()
         {
@@ -453,7 +453,7 @@ public class C {}
             );
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(9150, "https://github.com/dotnet/roslyn/issues/9150")]
         public void KeyFileFromAttributes_PublicSign()
         {
@@ -472,7 +472,7 @@ public class C {}
             Assert.True(c.Options.PublicSign);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(9150, "https://github.com/dotnet/roslyn/issues/9150")]
         public void KeyContainerFromAttributes_PublicSign()
         {
@@ -505,7 +505,7 @@ public class C {}
             }
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SnkFile_PublicSign()
         {
             var snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey);
@@ -525,7 +525,7 @@ public class C {}
             VerifySignedBitSetAfterEmit(comp);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicKeyFile_PublicSign()
         {
             var pubKeyFile = Temp.CreateFile().WriteAllBytes(TestResources.General.snPublicKey);
@@ -545,7 +545,7 @@ public class C {}
             VerifySignedBitSetAfterEmit(comp);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicSign_DelaySignAttribute()
         {
             var pubKeyFile = Temp.CreateFile().WriteAllBytes(TestResources.General.snPublicKey);
@@ -569,7 +569,7 @@ public class C {}",
             VerifySignedBitSetAfterEmit(comp);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyContainerNoSNProvider_PublicSign()
         {
             var comp = CreateCompilation("public class C {}",
@@ -584,7 +584,7 @@ public class C {}",
     Diagnostic(ErrorCode.ERR_PublicSignButNoKey).WithLocation(1, 1));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyContainerDesktopProvider_PublicSign()
         {
             var comp = CreateCompilation("public class C {}",
@@ -605,7 +605,7 @@ public class C {}",
             Assert.NotNull(comp.Options.CryptoKeyContainer);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicSignAndDelaySign()
         {
             var snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey);
@@ -624,7 +624,7 @@ public class C {}",
             Assert.True(comp.Options.DelaySign);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicSignAndDelaySignFalse()
         {
             var snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey);
@@ -641,7 +641,7 @@ public class C {}",
             Assert.False(comp.Options.DelaySign);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicSignNoKey()
         {
             var comp = CreateCompilation("public class C {}",
@@ -655,7 +655,7 @@ public class C {}",
             Assert.True(comp.Assembly.PublicKey.IsDefaultOrEmpty);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicKeyFromOptions_InvalidCompilationOptions()
         {
             string source = @"public class C {}";
@@ -679,7 +679,7 @@ public class C {}",
 
         #region IVT Access Checking
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTBasicCompilation()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""WantsIVTAccess"")]
@@ -728,7 +728,7 @@ public class C {}",
             Assert.Empty(c2.GetDiagnostics());
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTBasicMetadata()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""WantsIVTAccess"")]
@@ -774,7 +774,7 @@ public class C {}",
             Assert.Empty(c2.GetDiagnostics());
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTSigned()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -804,7 +804,7 @@ public class C {}",
             Assert.Empty(requestor.GetDiagnostics());
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTNotBothSigned_CStoCS()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -836,7 +836,7 @@ public class C {}",
             requestor.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void CS0281Method()
         {
             var friendClass = CreateCompilation(@"
@@ -885,7 +885,7 @@ public class Test
                     );
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void CS0281Class()
         {
             var friendClass = CreateCompilation(@"
@@ -918,7 +918,7 @@ public class Test
             );
         }
         
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTNotBothSigned_VBtoCS()
         {
             string s = @"<assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>
@@ -957,7 +957,7 @@ public class Test
             requestor.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTDeferredSuccess()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -984,7 +984,7 @@ public class A
             Assert.Empty(requestor.GetDiagnostics());
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTDeferredFailSignMismatch()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -1012,7 +1012,7 @@ public class A
                 Diagnostic(ErrorCode.ERR_FriendRefSigningMismatch, arguments: new object[] { "Paul, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" }));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTDeferredFailKeyMismatch()
         {
             //key is wrong in the first digit. correct key starts with 0
@@ -1047,7 +1047,7 @@ public class A
                 );
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTSuccessThroughIAssembly()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -1074,7 +1074,7 @@ public class A
             Assert.Empty(requestor.GetDiagnostics());
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTDeferredFailKeyMismatchIAssembly()
         {
             //key is wrong in the first digit. correct key starts with 0
@@ -1111,7 +1111,7 @@ public class A
         }
 
         [WorkItem(820450, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/820450")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTGivesAccessToUsingDifferentKeys()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -1145,7 +1145,7 @@ namespace ClassLibrary2
 
         #region IVT instantiations
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTHasCulture()
         {
             var other = CreateCompilation(
@@ -1161,7 +1161,7 @@ public class C
             other.VerifyDiagnostics(Diagnostic(ErrorCode.ERR_FriendAssemblyBadArgs, @"InternalsVisibleTo(""WantsIVTAccess, Culture=neutral"")").WithArguments("WantsIVTAccess, Culture=neutral"));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTNoKey()
         {
             var other = CreateCompilation(
@@ -1181,7 +1181,7 @@ public class C
 
         #region Signing
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void MaxSizeKey()
         {
             var pubKey = TestResources.General.snMaxSizePublicKeyString;
@@ -1243,7 +1243,7 @@ options: TestOptions.ReleaseExe
             Assert.Equal<byte>(pubKeyTokenBytes, comp3.Assembly.Identity.PublicKeyToken);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignIt()
         {
             var other = CreateCompilation(
@@ -1319,7 +1319,7 @@ public class Z
             Assert.True(IsFileFullSigned(tempFile));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileAttr()
         {
             var x = s_keyPairFile;
@@ -1333,7 +1333,7 @@ public class Z
             ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(outStrm, AttributeDescription.AssemblyKeyFileAttribute, legacyStrongName: false);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileAttr_Legacy()
         {
             var x = s_keyPairFile;
@@ -1347,7 +1347,7 @@ public class Z
             ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(outStrm, AttributeDescription.AssemblyKeyFileAttribute, legacyStrongName: true);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyContainerAttr_Legacy()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyName(""roslynTestContainer"")] public class C {}";
@@ -1361,7 +1361,7 @@ public class Z
         }
 
         [WorkItem(5665, "https://github.com/dotnet/roslyn/issues/5665")]
-        [ConditionalFact(typeof(IsEnglishLocal), typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(IsEnglishLocal), typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyContainerBogus()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyName(""bogus"")] public class C {}";
@@ -1383,7 +1383,7 @@ public class Z
             Assert.True(((string)err.Arguments[1]).EndsWith(" HRESULT: 0x80090016)", StringComparison.Ordinal));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileBogus()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyFile(""bogus"")] public class C {}";
@@ -1399,7 +1399,7 @@ public class Z
             other.VerifyDiagnostics(Diagnostic(ErrorCode.ERR_PublicKeyFileFailure).WithArguments("bogus", CodeAnalysisResources.FileNotFound));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AttemptToStrongNameWithOnlyPublicKey()
         {
             string s = "public class C {}";
@@ -1416,7 +1416,7 @@ public class Z
             Assert.True(success.Diagnostics[0].Code == (int)ErrorCode.ERR_SignButNoPrivateKey);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AttemptToStrongNameWithOnlyPublicKey_Legacy()
         {
             string s = "public class C {}";
@@ -1434,7 +1434,7 @@ public class Z
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyContainerCmdLine_Legacy()
         {
             string s = "public class C {}";
@@ -1450,7 +1450,7 @@ public class Z
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyContainerCmdLine_1_Legacy()
         {
             string s = @"
@@ -1469,7 +1469,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyContainerCmdLine_2()
         {
             string s = @"
@@ -1488,7 +1488,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileCmdLine()
         {
             string s = "public class C {}";
@@ -1503,7 +1503,7 @@ public class C {}";
             ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(outStrm, AttributeDescription.AssemblyKeyFileAttribute, legacyStrongName: false);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void BothLegacyAndNonLegacyGiveTheSameOutput()
         {
             string s = "public class C {}";
@@ -1531,7 +1531,7 @@ public class C {}";
             Assert.True(portable.SequenceEqual(desktop));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignRefAssemblyKeyFileCmdLine()
         {
             string s = "public class C {}";
@@ -1552,7 +1552,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileCmdLine_Legacy()
         {
             string s = "public class C {}";
@@ -1568,7 +1568,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileCmdLine_1()
         {
             var x = s_keyPairFile;
@@ -1585,7 +1585,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileCmdLine_1_Legacy()
         {
             var x = s_keyPairFile;
@@ -1602,7 +1602,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileCmdLine_2()
         {
             var x = s_keyPairFile;
@@ -1618,7 +1618,7 @@ public class C {}";
                 Diagnostic(ErrorCode.ERR_CmdOptionConflictsSource).WithArguments("System.Reflection.AssemblyKeyFileAttribute", "CryptoKeyFile"));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignItWithOnlyPublicKey()
         {
             var other = CreateCompilation(
@@ -1642,7 +1642,7 @@ public class C
             assembly.VerifyDiagnostics(Diagnostic(ErrorCode.ERR_SignButNoPrivateKey).WithArguments(s_publicKeyFile));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void DelaySignItWithOnlyPublicKey()
         {
             var other = CreateCompilation(
@@ -1660,7 +1660,7 @@ public class C
             }
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void DelaySignButNoKey()
         {
             var other = CreateCompilation(
@@ -1681,7 +1681,7 @@ public class C
             Assert.True(emitResult.Success);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignInMemory()
         {
             var other = CreateCompilation(
@@ -1696,7 +1696,7 @@ public class C
             Assert.True(emitResult.Success);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void DelaySignConflict()
         {
             var other = CreateCompilation(
@@ -1714,7 +1714,7 @@ public class C
             Assert.True(emitResult.Success);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void DelaySignNoConflict()
         {
             var other = CreateCompilation(
@@ -1732,7 +1732,7 @@ public class C
             Assert.True(emitResult.Success);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void DelaySignWithAssemblySignatureKey()
         {
             DelaySignWithAssemblySignatureKeyHelper(s_defaultPortableProvider);
@@ -1776,7 +1776,7 @@ public class C
 
         [WorkItem(545720, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545720")]
         [WorkItem(530050, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530050")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void InvalidAssemblyName()
         {
             var il = @"
@@ -1817,7 +1817,7 @@ class Derived : Base
         }
 
         [WorkItem(546331, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546331")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IvtVirtualCall1()
         {
             var source1 = @"
@@ -1923,7 +1923,7 @@ public class C : B
         }
 
         [WorkItem(546331, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546331")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IvtVirtualCall2()
         {
             var source1 = @"
@@ -2043,7 +2043,7 @@ public class D : C
 }");
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IvtVirtual_ParamsAndDynamic()
         {
             var source1 = @"
@@ -2165,7 +2165,7 @@ public class C : B
                 Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "c[1]").WithArguments("a", "B.this[int, int[]]").WithLocation(10, 17));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(529779, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529779")]
         public void Bug529779_1()
         {
@@ -2192,7 +2192,7 @@ public class C
             CompileAndVerify(other.WithReferences(new[] { other.References.ElementAt(0), MetadataReference.CreateFromStream(unsigned.EmitToStream()) })).VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(529779, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529779")]
         public void Bug529779_2()
         {
@@ -2234,7 +2234,7 @@ public class C
 // !!!DO NOT MERGE
 // TODO: FIX THIS 
 #if NET46
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(399, "https://github.com/dotnet/roslyn/issues/399")]
         public void Bug399()
         {
@@ -2271,7 +2271,7 @@ e29df38b5c72727c1333f32001949a0a0e2c10f8af0a344300ab2123052840cb16e30176c7281810
         }
 #endif
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_1()
         {
             var other = CreateEmptyCompilation(
@@ -2297,7 +2297,7 @@ public class C
             Assert.True(IsFileFullSigned(tempFile));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_2()
         {
             var other = CreateEmptyCompilation(
@@ -2325,7 +2325,7 @@ public class C
             }
         }
 
-        [ConditionalFact(typeof(IsEnglishLocal), typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(IsEnglishLocal), typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_3()
         {
             var source = @"
@@ -2354,7 +2354,7 @@ public class C
             }
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_4()
         {
             var other = CreateEmptyCompilation(
@@ -2383,7 +2383,7 @@ public class C
             }
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_5()
         {
             var other = CreateEmptyCompilation(
@@ -2407,7 +2407,7 @@ public class C
             }
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_6()
         {
             var other = CreateEmptyCompilation(
@@ -2436,7 +2436,7 @@ public class C
             }
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_7()
         {
             var other = CreateEmptyCompilation(
@@ -2461,7 +2461,7 @@ public class C
         }
 
         [WorkItem(781312, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/781312")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void Bug781312()
         {
             var ca = CreateCompilation(
@@ -2493,7 +2493,7 @@ internal class B
         }
 
         [WorkItem(1072350, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072350")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void Bug1072350()
         {
             const string sourceA = @"
@@ -2520,7 +2520,7 @@ class B
         }
 
         [WorkItem(1072339, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072339")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void Bug1072339()
         {
             const string sourceA = @"
@@ -2547,7 +2547,7 @@ class B
         }
 
         [WorkItem(1095618, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1095618")]
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void Bug1095618()
         {
             const string source = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""System.Runtime.Serialization, PublicKey = 10000000000000000400000000000000"")]";
@@ -2566,7 +2566,7 @@ class B
             });
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(11497, "https://github.com/dotnet/roslyn/issues/11497")]
         public void ConsistentErrorMessageWhenProvidingNullKeyFile()
         {
@@ -2576,7 +2576,7 @@ class B
             VerifySignedBitSetAfterEmit(compilation, expectedToBeSigned: false);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(11497, "https://github.com/dotnet/roslyn/issues/11497")]
         public void ConsistentErrorMessageWhenProvidingEmptyKeyFile()
         {
@@ -2586,7 +2586,7 @@ class B
             VerifySignedBitSetAfterEmit(compilation, expectedToBeSigned: false);
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(11497, "https://github.com/dotnet/roslyn/issues/11497")]
         public void ConsistentErrorMessageWhenProvidingNullKeyFile_PublicSign()
         {
@@ -2596,7 +2596,7 @@ class B
                 Diagnostic(ErrorCode.ERR_PublicSignButNoKey).WithLocation(1, 1));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(11497, "https://github.com/dotnet/roslyn/issues/11497")]
         public void ConsistentErrorMessageWhenProvidingEmptyKeyFile_PublicSign()
         {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -1,5 +1,4 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-#if !NETCOREAPP2_1
 using System;
 using System.Collections.Immutable;
 using System.IO;
@@ -13,7 +12,6 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
-using Roslyn.Test.Utilities.Desktop;
 using Roslyn.Utilities;
 using Xunit;
 using static Roslyn.Test.Utilities.SigningTestHelpers;
@@ -41,7 +39,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         #region Naming Tests
 
-        [Fact, WorkItem(529419, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529419")]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [WorkItem(529419, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529419")]
         public void AssemblyKeyFileAttributeNotExistFile()
         {
             string source = @"
@@ -69,7 +68,7 @@ public class Test
                 Diagnostic(ErrorCode.ERR_PublicKeyFileFailure).WithArguments("MyKey.snk", CodeAnalysisResources.FileNotFound));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileAttribute()
         {
             var x = s_keyPairFile;
@@ -96,7 +95,7 @@ public class Test
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileAttribute_AssemblyKeyFileResolver()
         {
             string keyFileDir = Path.GetDirectoryName(s_keyPairFile);
@@ -124,7 +123,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, comp.Assembly.Identity.PublicKey));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileAttribute_AssemblyKeyFileResolver_RelativeToCurrentParent()
         {
             string keyFileDir = Path.GetDirectoryName(s_keyPairFile);
@@ -152,7 +151,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, comp.Assembly.Identity.PublicKey));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SigningNotAvailable001()
         {
             string keyFileDir = Path.GetDirectoryName(s_keyPairFile);
@@ -180,7 +179,7 @@ public class Test
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyContainerAttribute()
         {
             var x = s_keyPairFile;
@@ -207,7 +206,7 @@ public class Test
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileOptions()
         {
             string s = "public class C {}";
@@ -217,7 +216,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, other.Assembly.Identity.PublicKey));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileOptions_ReferenceResolver()
         {
             string keyFileDir = Path.GetDirectoryName(s_keyPairFile);
@@ -246,7 +245,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, comp.Assembly.Identity.PublicKey));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileOptionsJustPublicKey()
         {
             string s = "public class C {}";
@@ -256,7 +255,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(TestResources.General.snPublicKey.AsImmutableOrNull(), other.Assembly.Identity.PublicKey));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFromKeyFileOptionsJustPublicKey_ReferenceResolver()
         {
             string publicKeyFileDir = Path.GetDirectoryName(s_publicKeyFile);
@@ -288,7 +287,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, comp.Assembly.Identity.PublicKey));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFileNotFoundOptions()
         {
             string s = "public class C {}";
@@ -301,7 +300,7 @@ public class Test
             Assert.True(other.Assembly.Identity.PublicKey.IsEmpty);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyFileBogusOptions()
         {
             var tempFile = Temp.CreateFile().WriteAllBytes(new byte[] { 1, 2, 3, 4 });
@@ -315,7 +314,7 @@ public class Test
         }
 
         [WorkItem(5662, "https://github.com/dotnet/roslyn/issues/5662")]
-        [ConditionalFact(typeof(IsEnglishLocal))]
+        [ConditionalFact(typeof(IsEnglishLocal),typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PubKeyContainerBogusOptions()
         {
             string s = "public class C {}";
@@ -333,7 +332,7 @@ public class Test
             Assert.True(other.Assembly.Identity.PublicKey.IsEmpty);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyFileAttributeOptionConflict()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyFile(""bogus"")] public class C {}";
@@ -345,7 +344,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, other.Assembly.Identity.PublicKey));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyContainerAttributeOptionConflict()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyName(""bogus"")] public class C {}";
@@ -357,7 +356,7 @@ public class Test
             Assert.True(ByteSequenceComparer.Equals(s_publicKey, other.Assembly.Identity.PublicKey));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyFileAttributeEmpty()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyFile("""")] public class C {}";
@@ -367,7 +366,7 @@ public class Test
             other.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyContainerEmpty()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyName("""")] public class C {}";
@@ -377,7 +376,7 @@ public class Test
             other.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicKeyFromOptions_DelaySigned()
         {
             string source = @"
@@ -396,7 +395,8 @@ public class C {}";
             Assert.Equal(CorFlags.ILOnly, metadata.Module.PEReaderOpt.PEHeaders.CorHeader.Flags);
         }
 
-        [Fact, WorkItem(9150, "https://github.com/dotnet/roslyn/issues/9150")]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [WorkItem(9150, "https://github.com/dotnet/roslyn/issues/9150")]
         public void PublicKeyFromOptions_PublicSign()
         {
             // attributes are ignored
@@ -453,7 +453,8 @@ public class C {}
             );
         }
 
-        [Fact, WorkItem(9150, "https://github.com/dotnet/roslyn/issues/9150")]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [WorkItem(9150, "https://github.com/dotnet/roslyn/issues/9150")]
         public void KeyFileFromAttributes_PublicSign()
         {
             string source = @"
@@ -471,7 +472,8 @@ public class C {}
             Assert.True(c.Options.PublicSign);
         }
 
-        [Fact, WorkItem(9150, "https://github.com/dotnet/roslyn/issues/9150")]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
+        [WorkItem(9150, "https://github.com/dotnet/roslyn/issues/9150")]
         public void KeyContainerFromAttributes_PublicSign()
         {
             string source = @"
@@ -503,7 +505,7 @@ public class C {}
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SnkFile_PublicSign()
         {
             var snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey);
@@ -523,7 +525,7 @@ public class C {}
             VerifySignedBitSetAfterEmit(comp);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicKeyFile_PublicSign()
         {
             var pubKeyFile = Temp.CreateFile().WriteAllBytes(TestResources.General.snPublicKey);
@@ -543,7 +545,7 @@ public class C {}
             VerifySignedBitSetAfterEmit(comp);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicSign_DelaySignAttribute()
         {
             var pubKeyFile = Temp.CreateFile().WriteAllBytes(TestResources.General.snPublicKey);
@@ -567,7 +569,7 @@ public class C {}",
             VerifySignedBitSetAfterEmit(comp);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyContainerNoSNProvider_PublicSign()
         {
             var comp = CreateCompilation("public class C {}",
@@ -582,7 +584,7 @@ public class C {}",
     Diagnostic(ErrorCode.ERR_PublicSignButNoKey).WithLocation(1, 1));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void KeyContainerDesktopProvider_PublicSign()
         {
             var comp = CreateCompilation("public class C {}",
@@ -603,7 +605,7 @@ public class C {}",
             Assert.NotNull(comp.Options.CryptoKeyContainer);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicSignAndDelaySign()
         {
             var snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey);
@@ -622,7 +624,7 @@ public class C {}",
             Assert.True(comp.Options.DelaySign);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicSignAndDelaySignFalse()
         {
             var snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey);
@@ -639,7 +641,7 @@ public class C {}",
             Assert.False(comp.Options.DelaySign);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicSignNoKey()
         {
             var comp = CreateCompilation("public class C {}",
@@ -653,7 +655,7 @@ public class C {}",
             Assert.True(comp.Assembly.PublicKey.IsDefaultOrEmpty);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void PublicKeyFromOptions_InvalidCompilationOptions()
         {
             string source = @"public class C {}";
@@ -677,7 +679,7 @@ public class C {}",
 
         #region IVT Access Checking
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTBasicCompilation()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""WantsIVTAccess"")]
@@ -726,7 +728,7 @@ public class C {}",
             Assert.Empty(c2.GetDiagnostics());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTBasicMetadata()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""WantsIVTAccess"")]
@@ -772,7 +774,7 @@ public class C {}",
             Assert.Empty(c2.GetDiagnostics());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTSigned()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -802,7 +804,7 @@ public class C {}",
             Assert.Empty(requestor.GetDiagnostics());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTNotBothSigned_CStoCS()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -834,7 +836,7 @@ public class C {}",
             requestor.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void CS0281Method()
         {
             var friendClass = CreateCompilation(@"
@@ -883,7 +885,7 @@ public class Test
                     );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void CS0281Class()
         {
             var friendClass = CreateCompilation(@"
@@ -916,7 +918,7 @@ public class Test
             );
         }
         
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTNotBothSigned_VBtoCS()
         {
             string s = @"<assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")>
@@ -955,7 +957,7 @@ public class Test
             requestor.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTDeferredSuccess()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -982,7 +984,7 @@ public class A
             Assert.Empty(requestor.GetDiagnostics());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTDeferredFailSignMismatch()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -1010,7 +1012,7 @@ public class A
                 Diagnostic(ErrorCode.ERR_FriendRefSigningMismatch, arguments: new object[] { "Paul, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" }));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTDeferredFailKeyMismatch()
         {
             //key is wrong in the first digit. correct key starts with 0
@@ -1045,7 +1047,7 @@ public class A
                 );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTSuccessThroughIAssembly()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -1072,7 +1074,7 @@ public class A
             Assert.Empty(requestor.GetDiagnostics());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTDeferredFailKeyMismatchIAssembly()
         {
             //key is wrong in the first digit. correct key starts with 0
@@ -1109,7 +1111,7 @@ public class A
         }
 
         [WorkItem(820450, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/820450")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTGivesAccessToUsingDifferentKeys()
         {
             string s = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""John, PublicKey=00240000048000009400000006020000002400005253413100040000010001002b986f6b5ea5717d35c72d38561f413e267029efa9b5f107b9331d83df657381325b3a67b75812f63a9436ceccb49494de8f574f8e639d4d26c0fcf8b0e9a1a196b80b6f6ed053628d10d027e032df2ed1d60835e5f47d32c9ef6da10d0366a319573362c821b5f8fa5abc5bb22241de6f666a85d82d6ba8c3090d01636bd2bb"")]
@@ -1143,7 +1145,7 @@ namespace ClassLibrary2
 
         #region IVT instantiations
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTHasCulture()
         {
             var other = CreateCompilation(
@@ -1159,7 +1161,7 @@ public class C
             other.VerifyDiagnostics(Diagnostic(ErrorCode.ERR_FriendAssemblyBadArgs, @"InternalsVisibleTo(""WantsIVTAccess, Culture=neutral"")").WithArguments("WantsIVTAccess, Culture=neutral"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IVTNoKey()
         {
             var other = CreateCompilation(
@@ -1179,7 +1181,7 @@ public class C
 
         #region Signing
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void MaxSizeKey()
         {
             var pubKey = TestResources.General.snMaxSizePublicKeyString;
@@ -1241,7 +1243,7 @@ options: TestOptions.ReleaseExe
             Assert.Equal<byte>(pubKeyTokenBytes, comp3.Assembly.Identity.PublicKeyToken);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignIt()
         {
             var other = CreateCompilation(
@@ -1317,7 +1319,7 @@ public class Z
             Assert.True(IsFileFullSigned(tempFile));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileAttr()
         {
             var x = s_keyPairFile;
@@ -1331,7 +1333,7 @@ public class Z
             ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(outStrm, AttributeDescription.AssemblyKeyFileAttribute, legacyStrongName: false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileAttr_Legacy()
         {
             var x = s_keyPairFile;
@@ -1345,7 +1347,7 @@ public class Z
             ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(outStrm, AttributeDescription.AssemblyKeyFileAttribute, legacyStrongName: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyContainerAttr_Legacy()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyName(""roslynTestContainer"")] public class C {}";
@@ -1359,7 +1361,7 @@ public class Z
         }
 
         [WorkItem(5665, "https://github.com/dotnet/roslyn/issues/5665")]
-        [ConditionalFact(typeof(IsEnglishLocal))]
+        [ConditionalFact(typeof(IsEnglishLocal), typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyContainerBogus()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyName(""bogus"")] public class C {}";
@@ -1381,7 +1383,7 @@ public class Z
             Assert.True(((string)err.Arguments[1]).EndsWith(" HRESULT: 0x80090016)", StringComparison.Ordinal));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileBogus()
         {
             string s = @"[assembly: System.Reflection.AssemblyKeyFile(""bogus"")] public class C {}";
@@ -1397,7 +1399,7 @@ public class Z
             other.VerifyDiagnostics(Diagnostic(ErrorCode.ERR_PublicKeyFileFailure).WithArguments("bogus", CodeAnalysisResources.FileNotFound));
         }
 
-        [Fact()]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AttemptToStrongNameWithOnlyPublicKey()
         {
             string s = "public class C {}";
@@ -1414,7 +1416,7 @@ public class Z
             Assert.True(success.Diagnostics[0].Code == (int)ErrorCode.ERR_SignButNoPrivateKey);
         }
 
-        [Fact()]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AttemptToStrongNameWithOnlyPublicKey_Legacy()
         {
             string s = "public class C {}";
@@ -1432,7 +1434,7 @@ public class Z
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [Fact()]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyContainerCmdLine_Legacy()
         {
             string s = "public class C {}";
@@ -1448,7 +1450,7 @@ public class Z
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [Fact()]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyContainerCmdLine_1_Legacy()
         {
             string s = @"
@@ -1467,7 +1469,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [Fact()]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyContainerCmdLine_2()
         {
             string s = @"
@@ -1486,7 +1488,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [Fact()]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileCmdLine()
         {
             string s = "public class C {}";
@@ -1501,7 +1503,7 @@ public class C {}";
             ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(outStrm, AttributeDescription.AssemblyKeyFileAttribute, legacyStrongName: false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void BothLegacyAndNonLegacyGiveTheSameOutput()
         {
             string s = "public class C {}";
@@ -1529,7 +1531,7 @@ public class C {}";
             Assert.True(portable.SequenceEqual(desktop));
         }
 
-        [Fact()]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignRefAssemblyKeyFileCmdLine()
         {
             string s = "public class C {}";
@@ -1550,7 +1552,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [Fact()]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileCmdLine_Legacy()
         {
             string s = "public class C {}";
@@ -1566,7 +1568,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [Fact()]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileCmdLine_1()
         {
             var x = s_keyPairFile;
@@ -1583,7 +1585,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [Fact()]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileCmdLine_1_Legacy()
         {
             var x = s_keyPairFile;
@@ -1600,7 +1602,7 @@ public class C {}";
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
-        [Fact()]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignModuleKeyFileCmdLine_2()
         {
             var x = s_keyPairFile;
@@ -1616,7 +1618,7 @@ public class C {}";
                 Diagnostic(ErrorCode.ERR_CmdOptionConflictsSource).WithArguments("System.Reflection.AssemblyKeyFileAttribute", "CryptoKeyFile"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignItWithOnlyPublicKey()
         {
             var other = CreateCompilation(
@@ -1640,7 +1642,7 @@ public class C
             assembly.VerifyDiagnostics(Diagnostic(ErrorCode.ERR_SignButNoPrivateKey).WithArguments(s_publicKeyFile));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void DelaySignItWithOnlyPublicKey()
         {
             var other = CreateCompilation(
@@ -1658,7 +1660,7 @@ public class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void DelaySignButNoKey()
         {
             var other = CreateCompilation(
@@ -1679,7 +1681,7 @@ public class C
             Assert.True(emitResult.Success);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void SignInMemory()
         {
             var other = CreateCompilation(
@@ -1694,7 +1696,7 @@ public class C
             Assert.True(emitResult.Success);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void DelaySignConflict()
         {
             var other = CreateCompilation(
@@ -1712,7 +1714,7 @@ public class C
             Assert.True(emitResult.Success);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void DelaySignNoConflict()
         {
             var other = CreateCompilation(
@@ -1730,7 +1732,7 @@ public class C
             Assert.True(emitResult.Success);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void DelaySignWithAssemblySignatureKey()
         {
             DelaySignWithAssemblySignatureKeyHelper(s_defaultPortableProvider);
@@ -1774,7 +1776,7 @@ public class C
 
         [WorkItem(545720, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545720")]
         [WorkItem(530050, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530050")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void InvalidAssemblyName()
         {
             var il = @"
@@ -1815,7 +1817,7 @@ class Derived : Base
         }
 
         [WorkItem(546331, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546331")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IvtVirtualCall1()
         {
             var source1 = @"
@@ -1921,7 +1923,7 @@ public class C : B
         }
 
         [WorkItem(546331, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546331")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IvtVirtualCall2()
         {
             var source1 = @"
@@ -2041,7 +2043,7 @@ public class D : C
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void IvtVirtual_ParamsAndDynamic()
         {
             var source1 = @"
@@ -2163,7 +2165,7 @@ public class C : B
                 Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "c[1]").WithArguments("a", "B.this[int, int[]]").WithLocation(10, 17));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(529779, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529779")]
         public void Bug529779_1()
         {
@@ -2190,7 +2192,7 @@ public class C
             CompileAndVerify(other.WithReferences(new[] { other.References.ElementAt(0), MetadataReference.CreateFromStream(unsigned.EmitToStream()) })).VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(529779, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529779")]
         public void Bug529779_2()
         {
@@ -2229,12 +2231,15 @@ public class C
             }
         }
 
-        [Fact]
+// !!!DO NOT MERGE
+// TODO: FIX THIS 
+#if NET46
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(399, "https://github.com/dotnet/roslyn/issues/399")]
         public void Bug399()
         {
             // The referenced assembly Signed.dll from the repro steps
-            var signed = DesktopRuntimeUtil.CreateMetadataReferenceFromHexGZipImage(@"
+            var signed = Roslyn.Test.Utilities.Desktop.DesktopRuntimeUtil.CreateMetadataReferenceFromHexGZipImage(@"
 1f8b0800000000000400f38d9ac0c0ccc0c0c002c4ffff3330ec6080000706c2a00188f9e477f1316ce13cabb883d1e7ac62
 484666b14241517e7a5162ae4272625e5e7e894252aa4251699e42669e828b7fb0426e7e4aaa1e2f2f970ad48c005706061f
 4626869e0db74260e63e606052e466e486388a0922f64f094828c01d26006633419430302068860488f8790f06a0bf1c5a41
@@ -2264,8 +2269,9 @@ e29df38b5c72727c1333f32001949a0a0e2c10f8af0a344300ab2123052840cb16e30176c7281810
             // EXPECTED: no errors
             compilation.VerifyEmitDiagnostics();
         }
+#endif
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_1()
         {
             var other = CreateEmptyCompilation(
@@ -2291,7 +2297,7 @@ public class C
             Assert.True(IsFileFullSigned(tempFile));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_2()
         {
             var other = CreateEmptyCompilation(
@@ -2319,7 +2325,7 @@ public class C
             }
         }
 
-        [ConditionalFact(typeof(IsEnglishLocal))]
+        [ConditionalFact(typeof(IsEnglishLocal), typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_3()
         {
             var source = @"
@@ -2348,7 +2354,7 @@ public class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_4()
         {
             var other = CreateEmptyCompilation(
@@ -2377,7 +2383,7 @@ public class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_5()
         {
             var other = CreateEmptyCompilation(
@@ -2401,7 +2407,7 @@ public class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_6()
         {
             var other = CreateEmptyCompilation(
@@ -2430,7 +2436,7 @@ public class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void AssemblySignatureKeyAttribute_7()
         {
             var other = CreateEmptyCompilation(
@@ -2454,7 +2460,8 @@ public class C
             }
         }
 
-        [Fact, WorkItem(781312, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/781312")]
+        [WorkItem(781312, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/781312")]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void Bug781312()
         {
             var ca = CreateCompilation(
@@ -2485,7 +2492,8 @@ internal class B
             CompileAndVerify(cb, verify: Verification.Fails).Diagnostics.Verify();
         }
 
-        [Fact, WorkItem(1072350, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072350")]
+        [WorkItem(1072350, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072350")]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void Bug1072350()
         {
             const string sourceA = @"
@@ -2511,7 +2519,8 @@ class B
             CompileAndVerify(cb, expectedOutput: "42").Diagnostics.Verify();
         }
 
-        [Fact, WorkItem(1072339, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072339")]
+        [WorkItem(1072339, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072339")]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void Bug1072339()
         {
             const string sourceA = @"
@@ -2537,7 +2546,8 @@ class B
             CompileAndVerify(cb, expectedOutput: "42").Diagnostics.Verify();
         }
 
-        [Fact, WorkItem(1095618, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1095618")]
+        [WorkItem(1095618, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1095618")]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void Bug1095618()
         {
             const string source = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""System.Runtime.Serialization, PublicKey = 10000000000000000400000000000000"")]";
@@ -2556,7 +2566,7 @@ class B
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(11497, "https://github.com/dotnet/roslyn/issues/11497")]
         public void ConsistentErrorMessageWhenProvidingNullKeyFile()
         {
@@ -2566,7 +2576,7 @@ class B
             VerifySignedBitSetAfterEmit(compilation, expectedToBeSigned: false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(11497, "https://github.com/dotnet/roslyn/issues/11497")]
         public void ConsistentErrorMessageWhenProvidingEmptyKeyFile()
         {
@@ -2576,7 +2586,7 @@ class B
             VerifySignedBitSetAfterEmit(compilation, expectedToBeSigned: false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(11497, "https://github.com/dotnet/roslyn/issues/11497")]
         public void ConsistentErrorMessageWhenProvidingNullKeyFile_PublicSign()
         {
@@ -2586,7 +2596,7 @@ class B
                 Diagnostic(ErrorCode.ERR_PublicSignButNoKey).WithLocation(1, 1));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(11497, "https://github.com/dotnet/roslyn/issues/11497")]
         public void ConsistentErrorMessageWhenProvidingEmptyKeyFile_PublicSign()
         {
@@ -2599,5 +2609,3 @@ class B
         #endregion
     }
 }
-
-#endif

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -2231,9 +2231,7 @@ public class C
             }
         }
 
-// !!!DO NOT MERGE
-// TODO: FIX THIS 
-#if NET46
+#if !NETCOREAPP2_1
         [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         [WorkItem(399, "https://github.com/dotnet/roslyn/issues/399")]
         public void Bug399()

--- a/src/Compilers/CSharp/Test/Emit/BreakingChanges.cs
+++ b/src/Compilers/CSharp/Test/Emit/BreakingChanges.cs
@@ -1006,7 +1006,7 @@ public class c
             comp.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         [WorkItem(530518, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530518")]
         public void ExpressionTreeExplicitOpVsConvert()
         {
@@ -1035,7 +1035,7 @@ x => Convert(Convert(Convert(x)))
         }
 
         [WorkItem(530531, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530531")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         private void ExpressionTreeNoCovertForIdentityConversion()
         {
             var source = @"
@@ -1320,7 +1320,7 @@ namespace VS7_336319
         }
 
         [WorkItem(530666, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530666")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void ExpressionTreeWithNullableUDCandOperator()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -839,7 +839,7 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
 ");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
         public void AsyncInFinally002()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -839,7 +839,7 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
 ");
         }
 
-        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsWindowsTypes)]
         public void AsyncInFinally002()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         /// a maximum number of local functions, and a maximum scope depth to decide the
         /// limits of the combinations.
         /// </summary>
-        [NoIOperationValidationFact]
+        [ConditionalFact(typeof(WindowsOnly), typeof(NoIOperationValidation), Reason = "https://github.com/dotnet/roslyn/issues/30212")]
         public void AllCaptureTests()
         {
             var methods = MakeAllMethods().ToList();

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30212")]
         public void GenerateAllTest()
         {
             Assert.Equal(new[]
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             }, GenerateAllSetCombinations(3, 2));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30212")]
         public void ExpressionGeneratorTest01()
         {
             var ctx = new CaptureContext(1);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCheckedTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCheckedTests.cs
@@ -2368,7 +2368,7 @@ class Derived2 : Base1
 ");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void CheckedConversionsInExpressionTrees_Implicit()
         {
             // char
@@ -2467,14 +2467,14 @@ class Derived2 : Base1
             CheckedConversionInExpressionTree_Implicit("int", "long?", "arg => F(ConvertChecked(ConvertChecked(arg)))");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         [WorkItem(18459, "https://github.com/dotnet/roslyn/issues/18459")]
         public void CheckedConversionsInExpressionTrees_ImplicitTuple()
         {
             CheckedConversionInExpressionTree_Implicit("(int, int)", "(int, int)?", ConvertMethod.Convert);
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void CheckedConversionsInExpressionTrees_Explicit()
         {
             // char
@@ -2663,7 +2663,7 @@ class Derived2 : Base1
             CheckedConversionInExpressionTree_Explicit("int", "long?", "arg => ConvertChecked(ConvertChecked(arg))");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void CheckedConversionsInExpressionTrees_ExplicitTuple()
         {
             CheckedConversionInExpressionTree_Explicit("(int, int)", "(int, int)?", ConvertMethod.Convert);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
@@ -4244,7 +4244,7 @@ class Program
         }
 
         [WorkItem(1019237, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1019237")]
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10838")]
         public void OrderOfDelegateMembers()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExplicitImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExplicitImplementationTests.cs
@@ -686,7 +686,7 @@ Derived1.Method`2",
                 Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, "Y").WithArguments("Y", "Outer<T>.Inner<U>.Derived1<X, Y>"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10837")]
         public void TestExplicitImplementationInBaseGenericType()
         {
             // Tests:
@@ -754,7 +754,7 @@ Derived`2.Method()");
             comp.VerifyDiagnostics(); // No errors
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10837")]
         public void TestExplicitImplementationInBaseGenericType2()
         {
             // Tests:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -644,9 +644,9 @@ class Program : TestBase
                 new string[] { source, ExpressionTestLibrary },
                 expectedOutput: @"k");
         }
-        [WorkItem(544027, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544027")]
-        [Fact]
 
+        [WorkItem(544027, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544027")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void AnonymousCreation()
         {
             var source =
@@ -666,9 +666,9 @@ class Program : TestBase
                 new[] { source, ExpressionTestLibrary },
                 expectedOutput: @"k");
         }
+
         [WorkItem(544028, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544028")]
         [Fact]
-
         public void ArrayIndex()
         {
             var source =
@@ -1411,7 +1411,7 @@ class P
 @"Invoke(MemberAccess(Constant(P+<>c__DisplayClass0_0 Type:P+<>c__DisplayClass0_0).f Type:System.Func`2[System.Int32,System.Int32])(Constant(12 Type:System.Int32)) Type:System.Int32)
 () => Invoke(value(P+<>c__DisplayClass0_0).f, 12)");
         }
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10838")]
 
         public void GrabBag02()
         {
@@ -1833,7 +1833,7 @@ class Test
         }
 
         [WorkItem(544226, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544226")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void BinaryAddOperandTypesDelegate()
         {
             var text = @"
@@ -2046,7 +2046,7 @@ class Test
         }
 
         [WorkItem(544222, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544222")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void CoalesceWithImplicitUDC()
         {
             var text =
@@ -2235,7 +2235,7 @@ Lambda:
         }
 
         [WorkItem(544241, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544241")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void ArrayIndexTypeLong()
         {
             var text =
@@ -2317,7 +2317,7 @@ class Program
 
 
         [WorkItem(544276, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544276")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void UnsafeParamTypeInDelegate()
         {
             var text = @"
@@ -2555,7 +2555,7 @@ public class Test
             CompileAndVerifyUtil(text, expectedOutput: "45");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void AnonTypes2()
         {
             var text =
@@ -3186,7 +3186,7 @@ public class A
         }
 
         [WorkItem(544403, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544403")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void ConditionalWithOperandTypesObjectArrAndStringArr()
         {
             var text =
@@ -5151,7 +5151,7 @@ class Program
         }
 
         [WorkItem(579711, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/579711")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void CheckedEnumConversion()
         {
             var text =
@@ -5924,7 +5924,7 @@ public class Program
         }
 
         [WorkItem(3292, "https://github.com/dotnet/roslyn/issues/3292")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void EnumConversions001()
         {
             const string source = @"
@@ -5963,7 +5963,7 @@ class C //: TestBase
         }
 
         [WorkItem(3292, "https://github.com/dotnet/roslyn/issues/3292")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30160")]
         public void EnumConversions002()
         {
             const string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenImplicitImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenImplicitImplementationTests.cs
@@ -250,7 +250,7 @@ Base.Property.set(6)
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10837")]
         public void TestImplicitImplementationInBaseGenericType()
         {
             var source = @"
@@ -1553,7 +1553,7 @@ Base.Method()");
             comp.VerifyDiagnostics(); // No errors
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10837")]
         public void TestImplicitImplementationInBaseGenericType2()
         {
             // Tests:
@@ -1621,7 +1621,7 @@ Derived`2.Method()");
             comp.VerifyDiagnostics(); // No errors
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10837")]
         public void TestImplicitImplementationInBaseGenericType3()
         {
             // Tests:
@@ -1686,7 +1686,7 @@ Derived.Method()");
             comp.VerifyDiagnostics(); // No errors
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10837")]
         public void TestImplicitImplementationInBaseGenericType4()
         {
             // Tests:
@@ -1754,7 +1754,7 @@ Derived.Method()");
                 Diagnostic(ErrorCode.WRN_MultipleRuntimeImplementationMatches, "Interface<int>").WithArguments("Derived<int, string>.Method(int)", "Interface<int>.Method(int)", "Derived").WithLocation(20, 58)); // No errors
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10837")]
         public void TestImplicitImplementationInBaseGenericType5()
         {
             // Tests:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -1673,7 +1673,7 @@ public readonly struct S1
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10834")]
         public void InParamGenericReadonly()
         {
             var text = @"
@@ -1737,7 +1737,7 @@ public readonly struct S1
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10834")]
         public void InParamGenericReadonlyROstruct()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -5094,7 +5094,7 @@ class Test
             var result = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: "11461640193");
         }
 
-        [NoIOperationValidationFact]
+        [ConditionalFact(typeof(ClrOnly), typeof(NoIOperationValidation), Reason = "https://github.com/dotnet/roslyn/issues/29428")]
         [WorkItem(6077, "https://github.com/dotnet/roslyn/issues/6077")]
         [WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")]
         public void EmitSequenceOfBinaryExpressions_03()
@@ -5155,7 +5155,7 @@ class Test
             return builder.ToString();
         }
 
-        [NoIOperationValidationFact]
+        [ConditionalFact(typeof(ClrOnly), typeof(NoIOperationValidation), Reason = "https://github.com/dotnet/roslyn/issues/29428")]
         [WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")]
         public void EmitSequenceOfBinaryExpressions_04()
         {
@@ -5242,7 +5242,7 @@ class Test
 5180801");
         }
 
-        [NoIOperationValidationFact]
+        [ConditionalFact(typeof(ClrOnly), typeof(NoIOperationValidation), Reason = "https://github.com/dotnet/roslyn/issues/29428")]
         [WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")]
         public void EmitSequenceOfBinaryExpressions_06()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -1109,8 +1109,8 @@ class Test
 
             var comp = CompileAndVerify(source, expectedOutput: @"2545571191011111114151617");
         }
-        [Fact]
 
+        [ConditionalFact(typeof(ClrOnly), Reason = "Test of execution of expilicitly ambiguous IL")]
         private void TestAmbiguousOverridesWarningCase()
         {
             // Tests:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -1110,7 +1110,7 @@ class Test
             var comp = CompileAndVerify(source, expectedOutput: @"2545571191011111114151617");
         }
 
-        [ConditionalFact(typeof(ClrOnly), Reason = "Test of execution of expilicitly ambiguous IL")]
+        [ConditionalFact(typeof(ClrOnly), Reason = "Test of execution of explicitly ambiguous IL")]
         private void TestAmbiguousOverridesWarningCase()
         {
             // Tests:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
@@ -1243,7 +1243,7 @@ public class D
         }
 
         [WorkItem(16364, "https://github.com/dotnet/roslyn/issues/16364")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.RestrictedTypesNeedDesktop)]
         public void InplaceCtor005()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -1833,7 +1833,7 @@ public class D
 ");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsWindowsTypes)]
         public void TestAssignIdentity()
         {
             string source = @"
@@ -1879,7 +1879,7 @@ There are no context policies.
 ");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsWindowsTypes)]
         public void TestRefCast()
         {
             string source = @"
@@ -13332,7 +13332,7 @@ public static class P
         }
 
         [WorkItem(26113, "https://github.com/dotnet/roslyn/issues/26113")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsWindowsTypes)]
         public void VarargByRef()
         {
             var code = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTryFinally.cs
@@ -1021,7 +1021,7 @@ Exception: i != 0");
 ");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
         public void NestedExceptionHandlersThreadAbort01()
         {
             var source =
@@ -1103,7 +1103,7 @@ catch2
 ");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
         public void NestedExceptionHandlersThreadAbort02()
         {
             var source =
@@ -1203,7 +1203,7 @@ catch2
 ");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
         public void NestedExceptionHandlersThreadAbort03()
         {
             var source =
@@ -1322,7 +1322,7 @@ finally2
 ");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
         public void NestedExceptionHandlersThreadAbort04()
         {
             var source =
@@ -1454,7 +1454,7 @@ finally2
 ");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void NestedExceptionHandlersThreadAbort05()
         {
             var source =
@@ -1587,7 +1587,7 @@ catch3
 }");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
         public void NestedExceptionHandlersThreadAbort06()
         {
             var source =
@@ -1726,7 +1726,7 @@ catch3
 ");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
         public void NestedExceptionHandlersThreadAbort07()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -10146,7 +10146,7 @@ CS0151ERR_IntegralTypeValueExpected}
             Assert.Throws<ArgumentNullException>(() => Compilation.GetRequiredLanguageVersion(null));
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/28045")]
         public void DefaultAndFriendlyElementNames_01()
         {
             var source = @"
@@ -21317,8 +21317,7 @@ namespace System
         }
 
         // https://github.com/dotnet/roslyn/issues/25141
-#if NET46
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void ValueTupleBase_AssemblyUnification()
         {
             var source0v1 =
@@ -21368,7 +21367,6 @@ public class A
                 // error CS8182: Predefined type 'ValueTuple`2' must be a struct.
                 Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeMustBeStruct).WithArguments("ValueTuple`2").WithLocation(1, 1));
         }
-#endif
 
         [ConditionalFact(typeof(DesktopOnly))]
         [WorkItem(13472, "https://github.com/dotnet/roslyn/issues/13472")]

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -619,7 +619,7 @@ public class C
             CompareAssemblies(sourceTemplate, left, right, expectedMatch, includePrivateMembers: false);
         }
 
-        [ConditionalFact(typeof(ClrOnly), typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NoPiaNeedsDesktop)]
         public void RefAssembly_NoPia()
         {
             string piaSource = @"
@@ -697,7 +697,7 @@ public class D : ITest1
             }
         }
 
-        [ConditionalFact(typeof(ClrOnly), typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NoPiaNeedsDesktop)]
         public void RefAssembly_NoPia_ReferenceFromMethodBody()
         {
             string piaSource = @"
@@ -4114,7 +4114,7 @@ public class Test
             CompileAndVerify(source2, references: new[] { metadataRef }, options: TestOptions.ReleaseModule, verify: Verification.Fails);
         }
 
-        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         [WorkItem(530879, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530879")]
         public void TestCompilationEmitUsesDifferentStreamsForBinaryAndPdb()
         {
@@ -4157,7 +4157,7 @@ class Program
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "b").WithArguments("b"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         public void PlatformMismatch_01()
         {
             var emitOptions = new EmitOptions(runtimeMetadataVersion: "v1234");
@@ -4241,7 +4241,7 @@ public interface IUsePlatform
             useCompilation.VerifyEmitDiagnostics(emitOptions);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         public void PlatformMismatch_02()
         {
             var emitOptions = new EmitOptions(runtimeMetadataVersion: "v1234");
@@ -4285,7 +4285,7 @@ public interface IUsePlatform
             useCompilation.VerifyEmitDiagnostics(emitOptions);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         public void PlatformMismatch_03()
         {
             var emitOptions = new EmitOptions(runtimeMetadataVersion: "v1234");
@@ -4340,7 +4340,7 @@ public interface IUsePlatform
                 Diagnostic(ErrorCode.WRN_ConflictingMachineAssembly).WithArguments("PlatformMismatch, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         public void PlatformMismatch_04()
         {
             var emitOptions = new EmitOptions(runtimeMetadataVersion: "v1234");
@@ -4370,7 +4370,7 @@ public interface IUsePlatform
                 Diagnostic(ErrorCode.ERR_ConflictingMachineModule).WithArguments("PlatformMismatch.netmodule"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         public void PlatformMismatch_05()
         {
             var emitOptions = new EmitOptions(runtimeMetadataVersion: "v1234");
@@ -4417,7 +4417,7 @@ public interface IUsePlatform
             useCompilation.VerifyEmitDiagnostics(emitOptions);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         public void PlatformMismatch_06()
         {
             var emitOptions = new EmitOptions(runtimeMetadataVersion: "v1234");
@@ -4445,7 +4445,7 @@ public interface IUsePlatform
             useCompilation.VerifyEmitDiagnostics(emitOptions);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         public void PlatformMismatch_07()
         {
             var emitOptions = new EmitOptions(runtimeMetadataVersion: "v1234");
@@ -4492,7 +4492,7 @@ public interface IUsePlatform
             useCompilation.VerifyEmitDiagnostics(emitOptions);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         public void PlatformMismatch_08()
         {
             var emitOptions = new EmitOptions(runtimeMetadataVersion: "v1234");
@@ -4681,7 +4681,7 @@ class C
             }
         }
 
-        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/23760")]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/23760")]
         public void BrokenPDBStream()
         {
             string source = @"class Goo {}";

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -3730,7 +3730,7 @@ public sealed class ContentType
         }
 
         // Verify via MetadataReader - comp option
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void CheckUnsafeAttributes3()
         {
             string source = @"
@@ -3765,7 +3765,7 @@ class C
         }
 
         // Verify via MetadataReader - comp option, module case
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void CheckUnsafeAttributes4()
         {
             string source = @"
@@ -3787,7 +3787,7 @@ class C
         }
 
         // Verify via MetadataReader - attr in source
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void CheckUnsafeAttributes5()
         {
             // Writing the attributes in the source should have the same effect as the compilation option.
@@ -3834,7 +3834,7 @@ class C
         }
 
         // Verify via MetadataReader - two attrs in source, same action
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void CheckUnsafeAttributes6()
         {
             string source = @"
@@ -3895,7 +3895,7 @@ class C
         }
 
         // Verify via MetadataReader - two attrs in source, different actions
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void CheckUnsafeAttributes7()
         {
             string source = @"
@@ -3962,7 +3962,7 @@ class C
         }
 
         // Verify via MetadataReader - one attr in source, one synthesized, same action
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void CheckUnsafeAttributes8()
         {
             string source = @"
@@ -4019,7 +4019,7 @@ class C
         }
 
         // Verify via MetadataReader - one attr in source, one synthesized, different actions
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void CheckUnsafeAttributes9()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -1,6 +1,4 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-#if NET46
-
 using System;
 using System.Collections.Immutable;
 using System.IO;
@@ -1523,7 +1521,7 @@ comp => comp.VerifyDiagnostics(
             VerifyIdentitiesMatch(image, refOnlyImage, expectPublicKey: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void RefAssembly_StrongNameProvider()
         {
             var signedDllOptions = TestOptions.ReleaseDll.
@@ -1542,7 +1540,7 @@ comp => comp.VerifyDiagnostics(
             VerifyIdentitiesMatch(image, refOnlyImage, expectPublicKey: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void RefAssembly_StrongNameProvider_Arm64()
         {
             var signedDllOptions = TestOptions.ReleaseDll.
@@ -1563,7 +1561,7 @@ comp => comp.VerifyDiagnostics(
             VerifyIdentitiesMatch(image, refOnlyImage, expectPublicKey: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void RefAssembly_StrongNameProviderAndDelaySign()
         {
             var signedDllOptions = TestOptions.ReleaseDll
@@ -4116,7 +4114,7 @@ public class Test
             CompileAndVerify(source2, references: new[] { metadataRef }, options: TestOptions.ReleaseModule, verify: Verification.Fails);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/30169")]
         [WorkItem(530879, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530879")]
         public void TestCompilationEmitUsesDifferentStreamsForBinaryAndPdb()
         {
@@ -4130,11 +4128,11 @@ public class Test
 
             var result = c1.Emit(dllPath, pdbPath);
 
-            Assert.True(result.Success);
+            Assert.True(result.Success, "Compilation failed");
             Assert.Empty(result.Diagnostics);
 
-            Assert.True(File.Exists(dllPath));
-            Assert.True(File.Exists(pdbPath));
+            Assert.True(File.Exists(dllPath), "DLL does not exist");
+            Assert.True(File.Exists(pdbPath), "PDB does not exist");
         }
 
         [Fact, WorkItem(540777, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540777"), WorkItem(546354, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546354")]
@@ -4683,7 +4681,7 @@ class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/23760")]
         public void BrokenPDBStream()
         {
             string source = @"class Goo {}";
@@ -4713,7 +4711,7 @@ class C
             Assert.Equal(ioExceptionMessage, (string)err.Arguments[0]);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NetModulesNeedDesktop)]
         public void MultipleNetmodulesWithPrivateImplementationDetails()
         {
             var s1 = @"
@@ -4760,7 +4758,7 @@ public class Program
             CompileAndVerify(comp3, expectedOutput: "Hello, world!");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NetModulesNeedDesktop)]
         public void MultipleNetmodulesWithAnonymousTypes()
         {
             var s1 = @"
@@ -5048,5 +5046,3 @@ public class DerivingClass<T> : BaseClass<T>
         }
     }
 }
-
-#endif

--- a/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
@@ -1,5 +1,4 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-#if NET46
 
 using System.Collections.Immutable;
 using System.IO;
@@ -13,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public partial class DesktopStrongNameProviderTests : CSharpTestBase
     {
         [WorkItem(13995, "https://github.com/dotnet/roslyn/issues/13995")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void RespectCustomTempPath()
         {
             var tempDir = Temp.CreateDirectory();
@@ -24,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void RespectDefaultTempPath()
         {
             var provider = new DesktopStrongNameProvider(tempPath: null);
@@ -34,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void EmitWithCustomTempPath()
         {
             string src = @"
@@ -53,7 +52,7 @@ class C
             comp.VerifyEmitDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30152")]
         public void EmitWithDefaultTempPath()
         {
             string src = @"
@@ -71,4 +70,3 @@ class C
         }
     }
 }
-#endif

--- a/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
@@ -321,7 +321,7 @@ using System.Runtime.CompilerServices;
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "Static execution is runtime defined and this tests Clr behavior only")]
         public void TestPartialPartsDeterministic()
         {
             var x1 =

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
     /// </summary>
     public class EditAndContinueTests : EditAndContinueTestBase
     {
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void DeltaHeapsStartWithEmptyItem()
         {
             var source0 =
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void Delta_AssemblyDefTable()
         {
             var source0 = @"public class C { public static void F() { System.Console.WriteLine(1); } }";
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             Assert.False(diff1.GetMetadata().Reader.IsAssembly);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void SemanticErrors_MethodBody()
         {
             var source0 = MarkedSource(@"
@@ -170,7 +170,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void SemanticErrors_Declaration()
         {
             var source0 = MarkedSource(@"
@@ -219,7 +219,7 @@ class Bad : Bad
                 Diagnostic(ErrorCode.ERR_CircularBase, "Bad").WithArguments("Bad", "Bad").WithLocation(10, 7));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ModifyMethod()
         {
             var source0 =
@@ -283,7 +283,8 @@ class Bad : Bad
             }
         }
 
-        [Fact, CompilerTrait(CompilerFeature.Tuples)]
+        [CompilerTrait(CompilerFeature.Tuples)]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ModifyMethod_WithTuples()
         {
             var source0 =
@@ -348,7 +349,7 @@ class Bad : Bad
         }
 
         [WorkItem(962219, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/962219")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PartialMethod()
         {
             var source =
@@ -405,7 +406,7 @@ class Bad : Bad
         /// Specifically, normal parameters or return types with attributes.
         /// Add the method in the first edit, then modify the method in the second.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AddThenModifyMethod()
         {
             var source0 =
@@ -509,7 +510,7 @@ class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AddField()
         {
             var source0 =
@@ -570,7 +571,7 @@ class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ModifyProperty()
         {
             var source0 =
@@ -623,7 +624,7 @@ class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AddProperty()
         {
             var source0 =
@@ -778,7 +779,7 @@ class B
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AddEvent()
         {
             var source0 =
@@ -1012,7 +1013,8 @@ class B
             }
         }
 
-        [Fact, WorkItem(1175704, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1175704")]
+        [WorkItem(1175704, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1175704")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void EventFields()
         {
             var source0 = MarkedSource(@"
@@ -1078,7 +1080,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AddNestedTypeAndMembers()
         {
             var source0 =
@@ -1176,7 +1178,7 @@ class C
         /// Nested types should be emitted in the
         /// same order as full emit.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AddNestedTypesOrder()
         {
             var source0 =
@@ -1238,7 +1240,7 @@ class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AddNestedGenericType()
         {
             var source0 =
@@ -1344,7 +1346,7 @@ class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ModifyExplicitImplementation()
         {
             var source =
@@ -1394,7 +1396,7 @@ class C : I
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AddThenModifyExplicitImplementation()
         {
             var source0 =
@@ -1482,7 +1484,8 @@ class B : I
             }
         }
 
-        [Fact, WorkItem(930065, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/930065")]
+        [WorkItem(930065, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/930065")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ModifyConstructorBodyInPresenceOfExplicitInterfaceImplementation()
         {
             var source = @"
@@ -1534,7 +1537,7 @@ class C : I
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AddAttributeReferences()
         {
             var source0 =
@@ -1712,7 +1715,7 @@ delegate void D();
         /// [assembly: ...] and [module: ...] attributes should
         /// not be included in delta metadata.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AssemblyAndModuleAttributeReferences()
         {
             var source0 =
@@ -1765,7 +1768,7 @@ class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void OtherReferences()
         {
             var source0 =
@@ -1937,7 +1940,7 @@ class C
 </symbols>");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PInvokeModuleRefAndImplMap()
         {
             var source0 =
@@ -1990,7 +1993,7 @@ class C
         /// <summary>
         /// ClassLayout and FieldLayout tables.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ClassAndFieldLayout()
         {
             var source0 =
@@ -2055,7 +2058,7 @@ class B
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void NamespacesAndOverloads()
         {
             var compilation0 = CreateCompilation(options: TestOptions.DebugDll, source:
@@ -2161,7 +2164,7 @@ namespace M
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void TypesAndOverloads()
         {
             const string source =
@@ -2599,7 +2602,7 @@ class C
         /// Types should be retained in deleted locals
         /// for correct alignment of remaining locals.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void DeletedValueTypeLocal()
         {
             var source0 =
@@ -2700,7 +2703,7 @@ class C
         /// PrivateImplementationDetails should not be
         /// generated for delta.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PrivateImplementationDetails()
         {
             var source =
@@ -2758,7 +2761,7 @@ class C
 
         [WorkItem(780989, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/780989")]
         [WorkItem(829353, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/829353")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PrivateImplementationDetails_ArrayInitializer_FromMetadata()
         {
             var source0 =
@@ -2909,7 +2912,7 @@ class C
 
         [WorkItem(780989, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/780989")]
         [WorkItem(829353, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/829353")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PrivateImplementationDetails_ArrayInitializer_FromSource()
         {
             // PrivateImplementationDetails not needed initially.
@@ -3082,7 +3085,7 @@ class C
         /// the CLR only allows adding private members.
         /// </summary>
         [WorkItem(834086, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/834086")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PrivateImplementationDetails_ComputeStringHash()
         {
             var source =
@@ -3264,7 +3267,7 @@ class C
         /// Avoid adding references from method bodies
         /// other than the changed methods.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ReferencesInIL()
         {
             var source0 =
@@ -3313,7 +3316,7 @@ class C
         /// <summary>
         /// Local slots must be preserved based on signature.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PreserveLocalSlots()
         {
             var source0 =
@@ -3689,7 +3692,7 @@ class B : A<B>
         /// references to that slot, in a Watch window for instance.
         /// </summary>
         [WorkItem(843320, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/843320")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PreserveLocalTypes()
         {
             var source0 =
@@ -3747,7 +3750,7 @@ class B : A<B>
         /// <summary>
         /// Preserve locals if SemanticEdit.PreserveLocalVariables is set.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PreserveLocalVariablesFlag()
         {
             var source =
@@ -3870,7 +3873,7 @@ class B : A<B>
         }
 
         [WorkItem(779531, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/779531")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ChangeLocalType()
         {
             var source0 =
@@ -4053,7 +4056,7 @@ class C
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AnonymousTypes_Update()
         {
             var source0 = MarkedSource(@"
@@ -4156,7 +4159,7 @@ class C
             AssertEx.Equal(new[] { "[0x23000003] 0x000002af.0x000002bc" }, DumpTypeRefs(md2.Reader));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AnonymousTypes_UpdateAfterAdd()
         {
             var source0 = MarkedSource(@"
@@ -4254,7 +4257,7 @@ class C
         /// Reuse existing anonymous types.
         /// </summary>
         [WorkItem(825903, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/825903")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AnonymousTypes()
         {
             var source0 =
@@ -4451,7 +4454,7 @@ namespace M
         /// Update method with anonymous type that was
         /// not directly referenced in previous generation.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AnonymousTypes_SkipGeneration()
         {
             var source0 = MarkedSource(
@@ -4634,7 +4637,7 @@ class B
         /// Update another method (without directly referencing
         /// anonymous type) after updating method with anonymous type.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AnonymousTypes_SkipGeneration_2()
         {
             var source0 =
@@ -4757,7 +4760,7 @@ class B
         /// Local from previous generation is of an anonymous
         /// type not available in next generation.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AnonymousTypes_AddThenDelete()
         {
             var source0 =
@@ -4978,7 +4981,7 @@ class B
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AnonymousTypes_DifferentCase()
         {
             var source0 = MarkedSource(@"
@@ -5080,7 +5083,7 @@ class C
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AnonymousTypes_Nested1()
         {
             var template = @"
@@ -5203,7 +5206,7 @@ class C
             diff2.VerifyIL("C.F", expectedIL.Replace("<<VALUE>>", "2"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AnonymousTypes_Nested2()
         {
             var template = @"
@@ -5326,7 +5329,7 @@ class C
             diff2.VerifyIL("C.F", expectedIL.Replace("<<VALUE>>", "2"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AnonymousTypes_Query1()
         {
             var source0 = MarkedSource(@"
@@ -5443,7 +5446,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void AnonymousTypes_Dynamic1()
         {
             var template = @"
@@ -5725,7 +5728,7 @@ class C
         /// Temporaries for locals used within a single
         /// statement should not be preserved.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void TemporaryLocals_Other()
         {
             // Use increment as an example of a compiler generated
@@ -5790,7 +5793,7 @@ class C
         /// signature (from metadata) when the trailing slots are unnamed.
         /// </summary>
         [WorkItem(782270, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/782270")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void Bug782270()
         {
             var source =
@@ -5880,7 +5883,7 @@ class C
         /// Similar to above test but with no named locals in original.
         /// </summary>
         [WorkItem(782270, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/782270")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void Bug782270_NoNamedLocals()
         {
             // Equivalent to C#, but with unnamed locals.
@@ -5973,7 +5976,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void TemporaryLocals_ReferencedType()
         {
             var source =
@@ -6027,7 +6030,7 @@ class C
 
         [WorkItem(770502, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/770502")]
         [WorkItem(839565, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/839565")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void DynamicOperations()
         {
             var source =
@@ -6124,7 +6127,7 @@ class B
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void DynamicLocals()
         {
             var template = @"
@@ -6273,7 +6276,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ExceptionFilters()
         {
             var source0 = MarkedSource(@"
@@ -6414,7 +6417,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void MethodSignatureWithNoPIAType()
         {
             var sourcePIA = @"
@@ -6522,7 +6525,7 @@ class C
         /// <summary>
         /// Disallow edits that require NoPIA references.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NoPiaNeedsDesktop)]
         public void NoPIAReferences()
         {
             var sourcePIA =
@@ -6637,7 +6640,7 @@ public struct S
         }
 
         [WorkItem(844536, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/844536")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NoPiaNeedsDesktop)]
         public void NoPIATypeInNamespace()
         {
             var sourcePIA =
@@ -6710,7 +6713,7 @@ public interface IB
         /// local of a type defined in the original assembly.
         /// </summary>
         [WorkItem(910777, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/910777")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void UnrecognizedLocalOfTypeFromAssembly()
         {
             var source =
@@ -6795,7 +6798,7 @@ class C
         /// added in subsequent generation.
         /// </summary>
         [WorkItem(910777, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/910777")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void UnrecognizedLocalOfAnonymousTypeFromAssembly()
         {
             var source0 =
@@ -6894,7 +6897,7 @@ class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void BrokenOutputStreams()
         {
             var source0 =
@@ -6985,7 +6988,7 @@ class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void BrokenPortablePdbStream()
         {
             var source0 =
@@ -7078,7 +7081,7 @@ class C
         }
 
         [WorkItem(1058058, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1058058")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void BlobContainsInvalidValues()
         {
             var source0 =
@@ -7145,7 +7148,7 @@ class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ReferenceToMemberAddedToAnotherAssembly1()
         {
             var sourceA0 = @"
@@ -7216,7 +7219,7 @@ public class Y : X { }
                 Diagnostic(ErrorCode.ERR_EncReferenceToAddedMember, "M").WithArguments("M", "LibA").WithLocation(4, 17));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ReferenceToMemberAddedToAnotherAssembly2()
         {
             var sourceA = @"
@@ -7292,7 +7295,7 @@ public class B
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void UniqueSynthesizedNames_DynamicSiteContainer()
         {
             var source0 = @"
@@ -7348,7 +7351,7 @@ public class C
         }
 
         [WorkItem(918650, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/918650")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ManyGenerations()
         {
             var source =
@@ -7379,7 +7382,7 @@ public class C
         }
 
         [WorkItem(187868, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/187868")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PdbReadingErrors()
         {
             var source0 = MarkedSource(@"
@@ -7426,7 +7429,7 @@ class C
                 Diagnostic(ErrorCode.ERR_InvalidDebugInfo, "F").WithArguments("C.F()", "100663297", "PdbReadingErrorsAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(6, 14));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PdbReadingErrors_PassThruExceptions()
         {
             var source0 = MarkedSource(@"
@@ -7471,7 +7474,7 @@ class C
                     ImmutableArray.Create(new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true))));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PatternVariable_TypeChange()
         {
             var source0 = MarkedSource(@"
@@ -7632,7 +7635,7 @@ class C
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PatternVariable_DeleteInsert()
         {
             var source0 = MarkedSource(@"
@@ -7779,7 +7782,7 @@ class C
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PatternVariable_InConstructorInitializer()
         {
             var baseClass = "public class Base { public Base(bool x) { } }";
@@ -7888,7 +7891,7 @@ public class C : Base
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PatternVariable_InFieldInitializer()
         {
             var source0 = MarkedSource(@"
@@ -7996,7 +7999,7 @@ public class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void PatternVariable_InQuery()
         {
             var source0 = MarkedSource(@"
@@ -8193,7 +8196,7 @@ public class Program
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void Tuple_Parenthesized()
         {
             var source0 = MarkedSource(@"
@@ -8322,7 +8325,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void Tuple_Decomposition()
         {
             var source0 = MarkedSource(@"
@@ -8446,7 +8449,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void ForeachStatement()
         {
             var source0 = MarkedSource(@"
@@ -8663,7 +8666,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void OutVar()
         {
             var source0 = MarkedSource(@"
@@ -8777,7 +8780,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void OutVar_InConstructorInitializer()
         {
             var baseClass = "public class Base { public Base(int x) { } }";
@@ -8885,7 +8888,7 @@ public class C : Base
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void OutVar_InConstructorInitializer_WithLambda()
         {
             var baseClass = "public class Base { public Base(int x) { } }";
@@ -9034,7 +9037,7 @@ public class C : Base
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void OutVar_InMethodBody_WithLambda()
         {
             var source0 = MarkedSource(@"
@@ -9181,7 +9184,7 @@ public class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void OutVar_InFieldInitializer()
         {
             var source0 = MarkedSource(@"
@@ -9284,7 +9287,7 @@ public class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void OutVar_InFieldInitializer_WithLambda()
         {
             var source0 = MarkedSource(@"
@@ -9434,7 +9437,7 @@ public class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void OutVar_InQuery()
         {
             var source0 = MarkedSource(@"
@@ -9632,7 +9635,7 @@ public class Program
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.EditAndContinueRequiresDesktop)]
         public void OutVar_InQuery_WithLambda()
         {
             var source0 = MarkedSource(@"

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -6465,7 +6465,7 @@ class C
         }
 
         [WorkItem(844472, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/844472")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NoPiaNeedsDesktop)]
         public void LocalSignatureWithNoPIAType()
         {
             var sourcePIA = @"

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -1,6 +1,4 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-#if NET46
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -1835,7 +1833,7 @@ class C
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void ArrayInitializer()
         {
             var source0 = @"
@@ -3603,7 +3601,7 @@ class B : A<B>
         /// <summary>
         /// Preserve locals for method added after initial compilation.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void PreserveLocalSlots_NewMethod()
         {
             var source0 =
@@ -4351,7 +4349,7 @@ namespace M
         /// Anonymous type names with module ids
         /// and gaps in indices.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void AnonymousTypes_OtherTypeNames()
         {
             var ilSource =
@@ -7046,7 +7044,8 @@ class C
             }
         }
 
-        [Fact, WorkItem(923492, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/923492")]
+        [WorkItem(923492, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/923492")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void SymWriterErrors()
         {
             var source0 =
@@ -9872,5 +9871,3 @@ public class Program
         }
     }
 }
-
-#endif

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -2965,7 +2965,6 @@ class C
         [Fact]
         public void For()
         {
-            try {
             var source0 = @"
 class C
 {
@@ -3061,12 +3060,6 @@ class C
   IL_0020:  ret
 }
 ");
-            }catch (Exception e)
-            {
-                Console.WriteLine(e.Message);
-                Console.WriteLine(e.StackTrace);
-                throw;
-            }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -2965,6 +2965,7 @@ class C
         [Fact]
         public void For()
         {
+            try {
             var source0 = @"
 class C
 {
@@ -3060,6 +3061,12 @@ class C
   IL_0020:  ret
 }
 ");
+            }catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                Console.WriteLine(e.StackTrace);
+                throw;
+            }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -5177,7 +5177,8 @@ class UsePia5
             CompileAndVerify(compilation4, verify: Verification.Fails);
         }
 
-        [Fact, WorkItem(611578, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/611578")]
+        [ConditionalFact(typeof(ClrOnly), Reason = ConditionalSkipReason.NoPiaNeedsDesktop)]
+        [WorkItem(611578, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/611578")]
         public void Bug611578()
         {
             string IEvent_cs = @"

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
@@ -1,6 +1,4 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-#if NET46
-
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -32,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
 
         #endregion
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void TestUsings()
         {
             var text = @"
@@ -352,7 +350,7 @@ namespace X
 </symbols>");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void TestExternAliases1()
         {
             CSharpCompilation dummyCompilation1 = CreateDummyCompilation("a");
@@ -462,7 +460,8 @@ namespace X
 </symbols>");
         }
 
-        [Fact, WorkItem(1120579, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1120579")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [WorkItem(1120579, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1120579")]
         public void TestExternAliases2()
         {
             string source1 = @"
@@ -513,7 +512,8 @@ class A { void M() {  } }
 ");
         }
 
-        [Fact, WorkItem(1120579, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1120579")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [WorkItem(1120579, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1120579")]
         public void TestExternAliases3()
         {
             string source1 = @"
@@ -564,7 +564,7 @@ class A { void M() {  } }
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void ExternAliases4()
         {
             var src1 = @"
@@ -971,7 +971,8 @@ public class C
 ");
         }
 
-        [Fact, WorkItem(913022, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/913022")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [WorkItem(913022, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/913022")]
         public void ReferenceWithGlobalAndDuplicateAliases()
         {
             var source1 = @"
@@ -1394,7 +1395,7 @@ namespace X
 </symbols>", options: PdbValidationOptions.SkipConversionValidation); // TODO: https://github.com/dotnet/roslyn/issues/18004
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void TestSynthesizedConstructors()
         {
             var text = @"
@@ -1455,7 +1456,7 @@ namespace X
 </symbols>");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void TestFieldInitializerLambdas()
         {
             var text = @"
@@ -1535,7 +1536,7 @@ class C
 </symbols>");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void TestAccessors()
         {
             var text = @"
@@ -1638,7 +1639,7 @@ class C
 </symbols>");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void TestSynthesizedSealedAccessors()
         {
             var text = @"
@@ -1689,7 +1690,7 @@ class Derived : Base
 </symbols>");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void TestSynthesizedExplicitImplementation()
         {
             var text = @"
@@ -1751,7 +1752,7 @@ class C : I1, I2
         }
 
         [WorkItem(692496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/692496")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void SequencePointOnUsingExpression()
         {
             var source = @"
@@ -1989,7 +1990,7 @@ class D
 </symbols>");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void UsingExpression()
         {
             TestSequencePoints(
@@ -2009,7 +2010,7 @@ public class Test : IDisposable
 }", TestOptions.ReleaseExe, methodName: "Test.Main");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void UsingVariable()
         {
             TestSequencePoints(
@@ -2127,7 +2128,7 @@ namespace goo
         }
 
         [WorkItem(1084059, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1084059")]
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void StaticType()
         {
             var source = @"
@@ -2166,7 +2167,7 @@ class D
 </symbols>");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void UnusedImports()
         {
             var source = @"
@@ -2212,7 +2213,7 @@ class C
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void UnusedImports_Nonexisting()
         {
             var source = @"
@@ -2262,7 +2263,7 @@ class C
                 );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void EmittingPdbVsNot()
         {
             string source = @"
@@ -2293,7 +2294,7 @@ class C
             MetadataValidation.VerifyMetadataEqualModuloMvid(peStream1, peStream2);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void ImportedNoPiaTypes()
         {
             var sourceLib = @"
@@ -2471,7 +2472,7 @@ class C
 </symbols>");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void ImportScopeEquality()
         {
             var sources = new[] { @"
@@ -2558,4 +2559,3 @@ ImportScope (index: 0x35, size: 36):
         }
     }
 }
-#endif

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -2504,7 +2504,7 @@ class B8 : A<dynamic>
     internal override void M<U>() { }
 }
 // U as error type.
-class B9 : A<Unknown>
+o
 {
     internal override void M<U>() { }
 }";

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -2504,7 +2504,7 @@ class B8 : A<dynamic>
     internal override void M<U>() { }
 }
 // U as error type.
-o
+class B9 : A<Unknown>
 {
     internal override void M<U>() { }
 }";

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -37,6 +37,11 @@ namespace Roslyn.Test.Utilities
 
         public const string TestExecutionHasCOMInterop = "Test execution depends on COM Interop";
         public const string TestHasWindowsPaths = "Test depends on Windows style paths";
+
+        /// <summary>
+        /// Edit and continue is only supported on desktop at the moment.
+        /// </summary>
+        public const string EditAndContinueRequiresDesktop = "Edit and continue is only supported on desktop";
     }
 
     public class ConditionalFactAttribute : FactAttribute

--- a/src/Test/Utilities/Portable/Compilation/IRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Portable/Compilation/IRuntimeEnvironment.cs
@@ -206,9 +206,7 @@ namespace Roslyn.Test.Utilities
             {
                 var pdb = default(ImmutableArray<byte>);
                 var assembly = default(ImmutableArray<byte>);
-                var pdbStream = MonoHelpers.IsRunningOnMono()
-                    ? null
-                    : new MemoryStream();
+                var pdbStream = new MemoryStream();
 
                 EmitResult result;
                 try

--- a/src/Test/Utilities/Portable/CompilationVerifier.cs
+++ b/src/Test/Utilities/Portable/CompilationVerifier.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             {
                 if (_visualizeRealIL == null)
                 {
-                    throw new InvalidOperationException("IL visaalization function is not set");
+                    throw new InvalidOperationException("IL visualization function is not set");
                 }
 
 

--- a/src/Test/Utilities/Portable/CompilationVerifier.cs
+++ b/src/Test/Utilities/Portable/CompilationVerifier.cs
@@ -208,6 +208,16 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             if (sequencePoints != null)
             {
+                if (EmittedAssemblyPdb == null)
+                {
+                    throw new InvalidOperationException($"{nameof(EmittedAssemblyPdb)} is not set");
+                }
+
+                if (EmittedAssemblyData == null)
+                {
+                    throw new InvalidOperationException($"{nameof(EmittedAssemblyData)} is not set");
+                }
+
                 var actualPdbXml = PdbToXmlConverter.ToXml(
                     pdbStream: new MemoryStream(EmittedAssemblyPdb.ToArray()),
                     peStream: new MemoryStream(EmittedAssemblyData.ToArray()),
@@ -232,7 +242,18 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 _lazyModuleSymbol = GetSymbolFromMetadata(targetReference, MetadataImportOptions.All);
             }
 
-            return _lazyModuleSymbol != null ? _visualizeRealIL(_lazyModuleSymbol, methodData, markers) : null;
+            if (_lazyModuleSymbol != null)
+            {
+                if (_visualizeRealIL == null)
+                {
+                    throw new InvalidOperationException("IL visaalization function is not set");
+                }
+
+
+                return _visualizeRealIL(_lazyModuleSymbol, methodData, markers);
+            }
+
+            return null;
         }
 
         public CompilationVerifier VerifyMemberInIL(string methodName, bool expected)

--- a/src/Test/Utilities/Portable/FX/CappedStringWriter.cs
+++ b/src/Test/Utilities/Portable/FX/CappedStringWriter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         private void CapReached()
         {
-            Assert.True(false, "Test produced more output than expected (" + _expectedLength + " characters). Is it in an infinite loop? Output so far:\r\n" + GetStringBuilder());
+            throw new Exception($"Test produced more output than expected ({_expectedLength} characters). Is it in an infinite loop? Output so far:\r\n{GetStringBuilder()}");
         }
 
         public override void Write(char value)


### PR DESCRIPTION
This makes the necessary changes so that the C# emit tests will pass under Mono. 

This change does not enable them in CI. I'm holding off on that until #30166 is merged. Once that is done will flip over to Mono nightly and enable the Semantic + Emit tests