### PR TITLE
Fix for InvalidCastException in "Invert If" refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InvertIf/InvertIfTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InvertIf/InvertIfTests.cs
@@ -927,5 +927,14 @@ class C
 @"string x; [||]if (x.Length > 0.0f) { GreaterThanZero(); } else { EqualsZero(); } } } ",
 @"string x; if (x.Length <= 0.0f) { EqualsZero(); } else { GreaterThanZero(); } } } ");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
+        [WorkItem(29434, "https://github.com/dotnet/roslyn/issues/29434")]
+        public async Task TestIsExpression()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C { void M(object o) { [||]if (o is C) { a(); } else { } } }",
+@"class C { void M(object o) { if (!(o is C)) { } else { a(); } } }");
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -69,13 +69,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var syntaxFacts = generator.SyntaxFacts;
             syntaxFacts.GetPartsOfBinaryExpression(expressionNode, out var leftOperand, out var operatorToken, out var rightOperand);
 
-            var operation = semanticModel.GetOperation(expressionNode, cancellationToken);
-            if (operation.Kind == OperationKind.IsPattern)
+            var binaryOperation = semanticModel.GetOperation(expressionNode, cancellationToken) as IBinaryOperation;
+            if (binaryOperation == null)
             {
+                // Apply the logical not operator if it is not a binary operation.
                 return generator.LogicalNotExpression(expressionNode);
             }
-
-            var binaryOperation = (IBinaryOperation)operation;
 
             if (!s_negatedBinaryMap.TryGetValue(binaryOperation.OperatorKind, out var negatedKind))
             {


### PR DESCRIPTION
Conservatively apply logical not operator to an expression being negated if it is not a binary operation.

Fixes #29434