### PR TITLE
Allow disabling nullable warnings with NonNullTypes attribute

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -350,6 +350,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             if (member.NonNullTypes != null &&
+                member.NullableWarnings &&
                 compilation.LanguageVersion >= MessageID.IDS_FeatureStaticNullChecking.RequiredVersion())
             {
                 NullableWalker.Analyze(compilation, member, node, diagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/EventWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/EventWellKnownAttributeData.cs
@@ -26,6 +26,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SetDataStored();
             }
         }
+
+        private bool? _nullableWarnings;
+        public bool? NullableWarnings
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableWarnings;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableWarnings = value;
+                SetDataStored();
+            }
+        }
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/FieldWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/FieldWellKnownAttributeData.cs
@@ -26,6 +26,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SetDataStored();
             }
         }
+
+        private bool? _nullableWarnings;
+        public bool? NullableWarnings
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableWarnings;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableWarnings = value;
+                SetDataStored();
+            }
+        }
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/MethodWellKnownAttributeData.cs
@@ -26,6 +26,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SetDataStored();
             }
         }
+
+        private bool? _nullableWarnings;
+        public bool? NullableWarnings
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableWarnings;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableWarnings = value;
+                SetDataStored();
+            }
+        }
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/ModuleWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/ModuleWellKnownAttributeData.cs
@@ -26,6 +26,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SetDataStored();
             }
         }
+
+        private bool? _nullableWarnings;
+        public bool? NullableWarnings
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableWarnings;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableWarnings = value;
+                SetDataStored();
+            }
+        }
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/PropertyWellKnownAttributeData.cs
@@ -26,6 +26,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SetDataStored();
             }
         }
+
+        private bool? _nullableWarnings;
+        public bool? NullableWarnings
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableWarnings;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableWarnings = value;
+                SetDataStored();
+            }
+        }
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/TypeWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/TypeWellKnownAttributeData.cs
@@ -50,6 +50,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SetDataStored();
             }
         }
+
+        private bool? _nullableWarnings;
+        public bool? NullableWarnings
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _nullableWarnings;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                Debug.Assert(value.HasValue);
+                _nullableWarnings = value;
+                SetDataStored();
+            }
+        }
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -100,6 +100,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool NullableWarnings
+        {
+            get
+            {
+                Debug.Assert(IsDefinition);
+                return ContainingType?.NullableWarnings ?? true;
+            }
+        }
+
         /// <summary>
         /// Gets the attributes on event's associated field, if any.
         /// Returns an empty <see cref="ImmutableArray&lt;AttributeData&gt;"/> if

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -166,6 +166,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool NullableWarnings
+        {
+            get
+            {
+                Debug.Assert(IsDefinition);
+                return (AssociatedSymbol ?? ContainingType)?.NullableWarnings ?? true;
+            }
+        }
+
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -962,12 +962,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal abstract int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree);
 
         public override bool? NonNullTypes
-        {
-            get
-            {
-                return (AssociatedSymbol ?? ContainingSymbol)?.NonNullTypes;
-            }
-        }
+            => (AssociatedSymbol ?? ContainingSymbol)?.NonNullTypes;
+
+        public override bool NullableWarnings
+            => (AssociatedSymbol ?? ContainingSymbol)?.NullableWarnings ?? true;
 
         #region IMethodSymbol Members
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1293,6 +1293,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool NullableWarnings
+        {
+            get
+            {
+                Debug.Assert(IsDefinition);
+                return ((Symbol)ContainingType ?? base.ContainingModule)?.NullableWarnings ?? true;
+            }
+        }
+
         /// <summary>
         /// Marshalling charset of string data fields within the type (string formatting flags in metadata).
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -239,6 +239,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool NullableWarnings
+        {
+            get
+            {
+                Debug.Assert(IsDefinition);
+                return ContainingSymbol?.NullableWarnings ?? true;
+            }
+        }
+
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -178,6 +178,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool NullableWarnings
+        {
+            get
+            {
+                Debug.Assert(IsDefinition);
+                return ContainingType?.NullableWarnings ?? true;
+            }
+        }
+
         /// <summary>
         /// The 'get' accessor of the property, or null if the property is write-only.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
@@ -236,7 +236,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (attribute.IsTargetAttribute(this, AttributeDescription.NonNullTypesAttribute))
             {
                 bool value = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
-                arguments.GetOrCreateData<FieldWellKnownAttributeData>().NonNullTypes = value;
+                var data = arguments.GetOrCreateData<FieldWellKnownAttributeData>();
+                data.NonNullTypes = value;
+                bool warnings = attribute.DecodeNamedArgument(InjectedNonNullTypesAttributeSymbol.Warnings, SpecialType.System_Boolean, defaultValue: true);
+                data.NullableWarnings = warnings;
             }
         }
 
@@ -347,6 +350,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var data = GetDecodedWellKnownAttributeData();
                 return data?.NonNullTypes ?? base.NonNullTypes;
+            }
+        }
+
+        public sealed override bool NullableWarnings
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.NullableWarnings ?? base.NullableWarnings;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -237,6 +237,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (parameterType.IsReferenceType &&
                 convertedExpression.ConstantValue?.IsNull == true &&
                 !suppressNullableWarning(convertedExpression) &&
+                NullableWarnings &&
                 DeclaringCompilation.LanguageVersion >= MessageID.IDS_FeatureStaticNullChecking.RequiredVersion())
             {
                 // Note: Eagerly calling IsNullable causes a cycle, so we delay the check

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -303,7 +303,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (attribute.IsTargetAttribute(this, AttributeDescription.NonNullTypesAttribute))
             {
                 bool value = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
-                arguments.GetOrCreateData<EventWellKnownAttributeData>().NonNullTypes = value;
+                var data = arguments.GetOrCreateData<EventWellKnownAttributeData>();
+                data.NonNullTypes = value;
+                bool warnings = attribute.DecodeNamedArgument(InjectedNonNullTypesAttributeSymbol.Warnings, SpecialType.System_Boolean, defaultValue: true);
+                data.NullableWarnings = warnings;
             }
         }
 
@@ -349,6 +352,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var data = GetDecodedWellKnownAttributeData();
                 return data?.NonNullTypes ?? base.NonNullTypes;
+            }
+        }
+
+        public override bool NullableWarnings
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.NullableWarnings ?? base.NullableWarnings;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -190,6 +190,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool NullableWarnings
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.NullableWarnings ?? base.NullableWarnings;
+            }
+        }
+
         internal ImmutableArray<Diagnostic> SetDiagnostics(ImmutableArray<Diagnostic> newSet, out bool diagsWritten)
         {
             //return the diagnostics that were actually saved in the event that there were two threads racing. 
@@ -1210,7 +1219,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (attribute.IsTargetAttribute(this, AttributeDescription.NonNullTypesAttribute))
             {
                 bool value = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
-                arguments.GetOrCreateData<MethodWellKnownAttributeData>().NonNullTypes = value;
+                var data = arguments.GetOrCreateData<MethodWellKnownAttributeData>();
+                data.NonNullTypes = value;
+                bool warnings = attribute.DecodeNamedArgument(InjectedNonNullTypesAttributeSymbol.Warnings, SpecialType.System_Boolean, defaultValue: true);
+                data.NullableWarnings = warnings;
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -514,7 +514,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (attribute.IsTargetAttribute(this, AttributeDescription.NonNullTypesAttribute))
             {
                 bool value = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
-                arguments.GetOrCreateData<ModuleWellKnownAttributeData>().NonNullTypes = value;
+                var data = arguments.GetOrCreateData<ModuleWellKnownAttributeData>();
+                data.NonNullTypes = value;
+                bool warnings = attribute.DecodeNamedArgument(InjectedNonNullTypesAttributeSymbol.Warnings, SpecialType.System_Boolean, defaultValue: true);
+                data.NullableWarnings = warnings;
             }
         }
 
@@ -524,6 +527,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                var data = GetDecodedWellKnownAttributeData();
                return data?.NonNullTypes;
+            }
+        }
+
+        public override bool NullableWarnings
+        {
+            get
+            {
+               var data = GetDecodedWellKnownAttributeData();
+               return data?.NullableWarnings ?? true;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -941,7 +941,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 var data = GetDecodedWellKnownAttributeData();
-                return data?.NullableWarnings ?? ((Symbol)ContainingType ?? base.ContainingModule).NullableWarnings;
+                return data?.NullableWarnings ?? base.NullableWarnings;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -751,7 +751,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (attribute.IsTargetAttribute(this, AttributeDescription.NonNullTypesAttribute))
             {
                 bool value = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
-                arguments.GetOrCreateData<TypeWellKnownAttributeData>().NonNullTypes = value;
+                var data = arguments.GetOrCreateData<TypeWellKnownAttributeData>();
+                data.NonNullTypes = value;
+                bool warnings = attribute.DecodeNamedArgument(InjectedNonNullTypesAttributeSymbol.Warnings, SpecialType.System_Boolean, defaultValue: true);
+                data.NullableWarnings = warnings;
             }
             else
             {
@@ -930,6 +933,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var data = GetDecodedWellKnownAttributeData();
                 return data?.NonNullTypes ?? base.NonNullTypes;
+            }
+        }
+
+        public override bool NullableWarnings
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.NullableWarnings ?? ((Symbol)ContainingType ?? base.ContainingModule).NullableWarnings;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1315,8 +1315,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.NonNullTypesAttribute))
             {
+                var data = arguments.GetOrCreateData<PropertyWellKnownAttributeData>();
                 bool value = attribute.GetConstructorArgument<bool>(0, SpecialType.System_Boolean);
-                arguments.GetOrCreateData<PropertyWellKnownAttributeData>().NonNullTypes = value;
+                data.NonNullTypes = value;
+                bool warnings = attribute.DecodeNamedArgument(InjectedNonNullTypesAttributeSymbol.Warnings, SpecialType.System_Boolean, defaultValue: true);
+                data.NullableWarnings = warnings;
             }
         }
 
@@ -1536,6 +1539,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var data = GetDecodedWellKnownAttributeData();
                 return data?.NonNullTypes ?? base.NonNullTypes;
+            }
+        }
+
+        public override bool NullableWarnings
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data?.NullableWarnings ?? base.NullableWarnings;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -847,12 +847,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// which delays its evaluation using <see cref="INonNullTypesContext"/>.
         /// </summary>
         public virtual bool? NonNullTypes
-        {
-            get
-            {
-                throw ExceptionUtilities.Unreachable;
-            }
-        }
+            => throw ExceptionUtilities.Unreachable;
+
+        /// <summary>
+        /// Indicates whether the `Warnings` named argument was passed in the `[NonNullTypes]` attribute.
+        /// This value is only relevant if `NonNullTypes` is true.
+        /// It is also only relevant on source symbols.
+        /// </summary>
+        public virtual bool NullableWarnings
+            => throw ExceptionUtilities.Unreachable;
 
         internal DiagnosticInfo GetUseSiteDiagnosticForSymbolOrContainingType()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/InjectedNonNullTypesAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/InjectedNonNullTypesAttributeSymbol.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal sealed class InjectedNonNullTypesAttributeSymbol : InjectedAttributeSymbol
     {
         private ImmutableArray<CSharpAttributeData> _lazyCustomAttributes;
+        private FieldSymbol _warningsField;
+        public const string Warnings = "Warnings";
 
         private InjectedNonNullTypesAttributeSymbol(
             AttributeDescription description,
@@ -23,6 +25,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Func<CSharpCompilation, NamedTypeSymbol, DiagnosticBag, ImmutableArray<MethodSymbol>> getConstructors)
             : base(description, containingNamespace, compilation, getConstructors)
         {
+            _warningsField = new SynthesizedFieldSymbol(this, compilation.GetSpecialType(SpecialType.System_Boolean), Warnings, isPublic: true);
+            // PROTOTYPE: check use-site diagnostics for bool type
+
+        }
+
+        public override ImmutableArray<Symbol> GetMembers()
+        {
+            return base.GetMembers().Add(_warningsField);
+        }
+
+        public override ImmutableArray<Symbol> GetMembers(string name)
+        {
+            if (name == Warnings)
+            {
+                return ImmutableArray.Create<Symbol>(_warningsField);
+            }
+            return base.GetMembers(name);
         }
 
         public static InjectedNonNullTypesAttributeSymbol Create(NamespaceSymbol containingNamespace)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/InjectedNonNullTypesAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/InjectedNonNullTypesAttributeSymbol.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             _warningsField = new SynthesizedFieldSymbol(this, compilation.GetSpecialType(SpecialType.System_Boolean), Warnings, isPublic: true);
             // PROTOTYPE: check use-site diagnostics for bool type
-
         }
 
         public override ImmutableArray<Symbol> GetMembers()


### PR DESCRIPTION
BLOCKED: this PR is on hold, since the design for `[NonNullTypes]` is being revised. The tests will still be useful, but the implementation will likely be tossed.


Implements a `Warnings` field on `NonNullTypesAttribute` so you can do `[NonNullTypes(Warnings = false)]`. This is meant to allow the scenario of a library author who wants to annotate their public API but doesn't want to apply null discipline in their implementation yet.
Note that warnings for using `?` or `!` remain.

An open issue is whether `Warnings` should be an enum rather than a bool. Also whether the `flag` and the `Warnings` should be consolidated into a single enum. (Tracked by https://github.com/dotnet/roslyn/issues/30215)

Fixes https://github.com/dotnet/roslyn/issues/29616