### PR TITLE
fixed DebugType ArgumentNullException in CommandLineArgumentReader

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/CommandLineArgumentReader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/CommandLineArgumentReader.cs
@@ -167,8 +167,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             if (emitDebugInfo)
             {
                 var debugType = Project.ReadPropertyString(PropertyNames.DebugType);
-
-                if (s_debugTypeValues.TryGetValue(debugType, out var value))
+                if (debugType != null && s_debugTypeValues.TryGetValue(debugType, out var value))
                 {
                     Add("debug", value);
                 }

--- a/src/Workspaces/CoreTestUtilities/Resources/ProjectFiles/CSharp/ProjectLoadErrorOnMissingDebugType.csproj
+++ b/src/Workspaces/CoreTestUtilities/Resources/ProjectFiles/CSharp/ProjectLoadErrorOnMissingDebugType.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B2417A38-6B3D-4482-9354-14AAF628340D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ProjectLoadErrorOnMissingDebugType</RootNamespace>
+    <AssemblyName>ProjectLoadErrorOnMissingDebugType</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <!--<DebugType>full</DebugType>-->
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Workspaces/CoreTestUtilities/Resources/SolutionFiles/ProjectLoadErrorOnMissingDebugType.sln
+++ b/src/Workspaces/CoreTestUtilities/Resources/SolutionFiles/ProjectLoadErrorOnMissingDebugType.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2036
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectLoadErrorOnMissingDebugType", "ProjectLoadErrorOnMissingDebugType\ProjectLoadErrorOnMissingDebugType.csproj", "{B2417A38-6B3D-4482-9354-14AAF628340D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2417A38-6B3D-4482-9354-14AAF628340D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2417A38-6B3D-4482-9354-14AAF628340D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2417A38-6B3D-4482-9354-14AAF628340D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2417A38-6B3D-4482-9354-14AAF628340D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9A9BD150-2994-4451-B166-D44022E8F764}
+	EndGlobalSection
+EndGlobal

--- a/src/Workspaces/CoreTestUtilities/TestFiles/Resources.cs
+++ b/src/Workspaces/CoreTestUtilities/TestFiles/Resources.cs
@@ -90,6 +90,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
             public static string MissingEndProject2 => GetText("SolutionFiles.MissingEndProject2.sln");
             public static string MissingEndProject3 => GetText("SolutionFiles.MissingEndProject3.sln");
             public static string NonExistentProject => GetText("SolutionFiles.NonExistentProject.sln");
+            public static string ProjectLoadErrorOnMissingDebugType => GetText("SolutionFiles.ProjectLoadErrorOnMissingDebugType.sln");
             public static string SolutionFolder => GetText("SolutionFiles.SolutionFolder.sln");
             public static string VB_and_CSharp => GetText("SolutionFiles.VB_and_CSharp.sln");
         }
@@ -134,6 +135,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
                 public static string NetCoreMultiTFM_ProjectReferenceWithReversedTFMs_Library => GetText("NetCoreMultiTFM_ProjectReferenceWithReversedTFMs.Library.csproj");
                 public static string NetCoreMultiTFM_ProjectReferenceWithReversedTFMs_Project => GetText("NetCoreMultiTFM_ProjectReferenceWithReversedTFMs.Project.csproj");
                 public static string PortableProject => GetText("ProjectFiles.CSharp.PortableProject.csproj");
+                public static string ProjectLoadErrorOnMissingDebugType => GetText("ProjectFiles.CSharp.ProjectLoadErrorOnMissingDebugType.csproj");
                 public static string ProjectReference => GetText("ProjectFiles.CSharp.ProjectReference.csproj");
                 public static string ReferencesPortableProject => GetText("ProjectFiles.CSharp.ReferencesPortableProject.csproj");
                 public static string Wildcards => GetText("ProjectFiles.CSharp.Wildcards.csproj");

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -3033,6 +3033,20 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        public async Task TestOpenProject_CSharp_WithMissingDebugType()
+        {
+            CreateFiles(new FileSet(
+                (@"ProjectLoadErrorOnMissingDebugType.sln", Resources.SolutionFiles.ProjectLoadErrorOnMissingDebugType),
+                (@"ProjectLoadErrorOnMissingDebugType\ProjectLoadErrorOnMissingDebugType.csproj", Resources.ProjectFiles.CSharp.ProjectLoadErrorOnMissingDebugType)));
+            var solutionFilePath = GetSolutionFileName(@"ProjectLoadErrorOnMissingDebugType.sln");
+
+            using (var workspace = CreateMSBuildWorkspace())
+            {
+                await workspace.OpenSolutionAsync(solutionFilePath);
+            }
+        }
+
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         [WorkItem(991528, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/991528")]
         public async Task MSBuildProjectShouldHandleCodePageProperty()
         {


### PR DESCRIPTION
in the situation where DebugType is mising and the DebugSymbols property is set to true when loading project information using CommandLineArgumentReader, the TryGetValue method of the s_debugTypeValues dictionary would throw an exception


reproduceable using the following method on the attached solution:

```csharp
        public static async Task ReproduceDebugTypeError()
        {
            var workspace = Microsoft.CodeAnalysis.MSBuild.MSBuildWorkspace.Create();
            var solution = await workspace.OpenSolutionAsync(@"C:\Repros\ProjectLoadErrorOnMissingDebugTypeRepro\ProjectLoadErrorOnMissingDebugTypeRepro.sln");
        }
```

[ProjectLoadErrorOnMissingDebugTypeRepro.zip](https://github.com/dotnet/roslyn/files/2427898/ProjectLoadErrorOnMissingDebugTypeRepro.zip)
