### PR TITLE
OverrideCompletion: place caret before expression body

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests_ExpressionBody.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests_ExpressionBody.cs
@@ -73,13 +73,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     public virtual int A { get; }
     class C : B
     {
-        public override int A => base.A;$$
+        public override int A $$=> base.A;
     }
 }";
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, "A", expectedCodeAfterCommit);
         }
-
 
         [WorkItem(16331, "https://github.com/dotnet/roslyn/issues/16334")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -99,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     public virtual int A() => 2;
     class C : B
     {
-        public override int A() => base.A();$$
+        public override int A() $$=> base.A();
     }
 }";
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
@@ -504,7 +504,7 @@ partial class Bar
 partial class Bar
 {
     partial void Foo();
-    partial void Foo() => throw new NotImplementedException();$$
+    partial void Foo() $$=> throw new NotImplementedException();
 }
 "
 ;

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
@@ -119,16 +119,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         public static int GetTargetCaretPositionForMethod(MethodDeclarationSyntax methodDeclaration)
         {
-            if (methodDeclaration.Body == null)
+            if (methodDeclaration.ExpressionBody != null)
             {
-                return methodDeclaration.GetLocation().SourceSpan.End;
+                return methodDeclaration.ExpressionBody.ArrowToken.GetLocation().SourceSpan.Start;
             }
-            else
+            else if (methodDeclaration.Body != null)
             {
                 // move to the end of the last statement in the method
                 var lastStatement = methodDeclaration.Body.Statements.Last();
                 return lastStatement.GetLocation().SourceSpan.End;
             }
+
+            return methodDeclaration.GetLocation().SourceSpan.End;
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OverrideCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OverrideCompletionProvider.cs
@@ -197,10 +197,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             }
             else if (caretTarget is BasePropertyDeclarationSyntax propertyDeclaration)
             {
-                // property: no accessors; move to the end of the declaration
                 if (propertyDeclaration.AccessorList != null && propertyDeclaration.AccessorList.Accessors.Any())
                 {
-                    // move to the end of the last statement of the first accessor
+                    // property: move to the end of the last statement of the first accessor
                     var firstAccessor = propertyDeclaration.AccessorList.Accessors[0];
                     var firstAccessorStatement = (SyntaxNode)firstAccessor.Body?.Statements.LastOrDefault() ??
                         firstAccessor.ExpressionBody.Expression;
@@ -208,6 +207,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 }
                 else
                 {
+                    // property: move ahead of the arrow token
+                    var expressionBody = propertyDeclaration.GetExpressionBody();
+                    if (expressionBody != null)
+                    {
+                        return expressionBody.ArrowToken.GetLocation().SourceSpan.Start;
+                    }
+
+                    // property: no accessors; move to the end of the declaration
                     return propertyDeclaration.GetLocation().SourceSpan.End;
                 }
             }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var insertionRoot = await PrepareTreeForMemberInsertionAsync(memberContainingDocument, cancellationToken).ConfigureAwait(false);
             var insertionText = await GenerateInsertionTextAsync(memberContainingDocument, cancellationToken).ConfigureAwait(false);
 
-            var destinationSpan = ComputeDestinationSpan(insertionRoot, insertionText);
+            var destinationSpan = ComputeDestinationSpan(insertionRoot);
 
             var finalText = insertionRoot.GetText(text.Encoding)
                 .Replace(destinationSpan, insertionText.Trim());
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return resolution.Symbol;
         }
 
-        private TextSpan ComputeDestinationSpan(SyntaxNode insertionRoot, string insertionText)
+        private TextSpan ComputeDestinationSpan(SyntaxNode insertionRoot)
         {
             var targetToken = insertionRoot.GetAnnotatedTokens(_otherAnnotation).FirstOrNullable();
             var text = insertionRoot.GetText();


### PR DESCRIPTION
When triggering OverrideCompletion on a method override and the result produces an expression-bodied method, place the caret before the arrow.
Also fixed similar scenario with expression-bodied properties.

Note, I added some tests to illustrate the current behavior when a block body already exists (say, as a result of copy&pasting). I feel like OverrideCompletion should not generate a body in such case, but I want to hear what you think first.

Fixes https://github.com/dotnet/roslyn/issues/29495 (placing caret)