### PR TITLE
Incorrect "Cast is redundant" code action when casting enum to int

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -3988,7 +3989,7 @@ static class Program
   }
 }");
         }
-        
+
         [WorkItem(29264, "https://github.com/dotnet/roslyn/issues/29264")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public async Task DontRemoveCastOnDictionaryIndexer()
@@ -4010,11 +4011,10 @@ static class Program
     {
         Dictionary<int, string> Icons = new Dictionary<int, string>
         {
-            [[|(int)|]TestEnum.Test] = null,
+            [[|(int)|] TestEnum.Test] = null,
         };
     }
-}
-");
+}");
         }
 
         [WorkItem(20630, "https://github.com/dotnet/roslyn/issues/20630")]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -3989,6 +3989,30 @@ static class Program
 }");
         }
 
+        [WorkItem(29264, "https://github.com/dotnet/roslyn/issues/29264")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveCastOnDictionaryIndexer()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+using Windows.UI.Xaml.Controls;
+
+static class Program
+{
+    static void Main()
+    {
+        Dictionary<int, string> Icons = new Dictionary<int, string>
+        {
+            [[|(int)|]SymbolKind.Alias] = null,
+        };
+    }
+}
+");
+        }
+
         [WorkItem(20630, "https://github.com/dotnet/roslyn/issues/20630")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public async Task DontRemoveCastOnCallToAttributeWithParamsArgsAndProperty()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -3988,7 +3988,7 @@ static class Program
   }
 }");
         }
-
+        
         [WorkItem(29264, "https://github.com/dotnet/roslyn/issues/29264")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public async Task DontRemoveCastOnDictionaryIndexer()
@@ -3998,15 +3998,19 @@ static class Program
 using System;
 using System.Reflection;
 using System.Collections.Generic;
-using Windows.UI.Xaml.Controls;
 
 static class Program
 {
+    enum TestEnum
+    {
+        Test,
+    }
+
     static void Main()
     {
         Dictionary<int, string> Icons = new Dictionary<int, string>
         {
-            [[|(int)|]SymbolKind.Alias] = null,
+            [[|(int)|]TestEnum.Test] = null,
         };
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -4017,6 +4017,53 @@ static class Program
 }");
         }
 
+        [WorkItem(29264, "https://github.com/dotnet/roslyn/issues/29264")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task RemoveCastOnDictionaryIndexer()
+        {
+            await TestInRegularAndScriptAsync(
+                @"
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+
+static class Program
+{
+    enum TestEnum
+    {
+        Test,
+    }
+
+    static void Main()
+    {
+        Dictionary<int, string> Icons = new Dictionary<int, string>
+        {
+            [[|(int)|] 0] = null,
+        };
+    }
+}",
+                @"
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+
+static class Program
+{
+    enum TestEnum
+    {
+        Test,
+    }
+
+    static void Main()
+    {
+        Dictionary<int, string> Icons = new Dictionary<int, string>
+        {
+            [0] = null,
+        };
+    }
+}");
+        }
+
         [WorkItem(20630, "https://github.com/dotnet/roslyn/issues/20630")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public async Task DontRemoveCastOnCallToAttributeWithParamsArgsAndProperty()

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -512,7 +512,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         {
             return node.IsKind(SyntaxKind.InvocationExpression) ||
                 node.IsKind(SyntaxKind.ElementAccessExpression) ||
-                node.IsKind(SyntaxKind.SimpleMemberAccessExpression);
+                node.IsKind(SyntaxKind.SimpleMemberAccessExpression) ||
+                node.IsKind(SyntaxKind.ImplicitElementAccess);
         }
 
         protected override ImmutableArray<ArgumentSyntax> GetArguments(ExpressionSyntax expression)


### PR DESCRIPTION
This is a fix for #29264.

`ReplacementChangesSemanticsForNode` did not correctly detect that the fixed expression would create an error in the new code.