### PR TITLE
Move ILAsm publishing to a project

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -338,11 +338,6 @@ function Test-Determinism() {
 }
 
 function Test-XUnitCoreClr() {
-    Write-Host "Publishing ILAsm.csproj"
-    $toolsDir = Join-Path $binariesDir "Tools"
-    $ilasmDir = Join-Path $toolsDir "ILAsm"
-    Exec-Console $dotnet "publish src\Tools\ILAsm --no-restore --runtime win-x64 --self-contained -o $ilasmDir"
-
     $unitDir = Join-Path $configDir "UnitTests"
     $tf = "netcoreapp2.1"
     $xunitResultDir = Join-Path $unitDir "xUnitResults"

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -34,19 +34,6 @@ else
     exit 1
 fi
 
-UNAME="$(uname)"
-if [ "$UNAME" == "Darwin" ]; then
-    runtime_id=osx-x64
-elif [ "$UNAME" == "Linux" ]; then
-    runtime_id=linux-x64
-else
-    echo "Unknown OS: $UNAME" 1>&2
-    exit 1
-fi
-
-echo "Publishing ILAsm.csproj"
-dotnet publish "${root_path}/src/Tools/ILAsm" --no-restore --runtime ${runtime_id} --self-contained -o "${binaries_path}/Tools/ILAsm"
-
 echo "Using ${xunit_console}"
 
 # Discover and run the tests

--- a/src/Test/Utilities/Portable/Roslyn.Test.Utilities.csproj
+++ b/src/Test/Utilities/Portable/Roslyn.Test.Utilities.csproj
@@ -12,6 +12,12 @@
     <RootNamespace></RootNamespace>
     <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
     <IsShipping>false</IsShipping>
+
+    <!-- 
+      Directory where to deploy ILAsm when targeting .NET Core app.
+      IlasmUtilities relies on ILAsm being deployed to this location.
+    -->
+    <IlasmPublishDir>$(ArtifactsDir)Tools\ILAsm\</IlasmPublishDir>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Test\Resources\Core\Microsoft.CodeAnalysis.Compiler.Test.Resources.csproj" />
@@ -103,4 +109,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="ICSharpCode.Decompiler" Version="$(ICSharpCodeDecompilerVersion)" />
   </ItemGroup>
+
+  <Import Project="..\..\..\Tools\ILAsm\DeployILAsm.targets"/>
 </Project>

--- a/src/Tools/ILAsm/DeployILAsm.targets
+++ b/src/Tools/ILAsm/DeployILAsm.targets
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+  <Choose>
+    <When Condition="'$(OS)' == 'Windows_NT'">
+      <PropertyGroup>
+        <_IlasmRid>win-x64</_IlasmRid>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">
+      <PropertyGroup>
+        <_IlasmRid>osx-x64</_IlasmRid>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">
+      <PropertyGroup>
+        <_IlasmRid>linux-x64</_IlasmRid>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <_IlasmRid />
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <PropertyGroup>
+    <_IlasmDeployProj>$(MSBuildThisFileDirectory)ILAsmDeploy.csproj</_IlasmDeployProj>
+    <_IlasmIncrementalBuildMarker>$(IlasmPublishDir).timestamp</_IlasmIncrementalBuildMarker>
+  </PropertyGroup>
+
+  <Target Name="_PublishILAsm"
+          AfterTargets="Build"
+          Inputs="$(MSBuildThisFileFullPath);$(_IlasmDeployProj)"
+          Outputs="$(_IlasmIncrementalBuildMarker)"
+          Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+
+    <Error Text="Unknown OS" Condition="'$(_IlasmRid)' == ''" />
+
+    <MSBuild Projects="$(_IlasmDeployProj)"
+             Targets="Publish"
+             Properties="SelfContained=true;RuntimeIdentifier=$(_IlasmRid);PublishDir=$(IlasmPublishDir)" />
+
+    <Touch Files="$(_IlasmIncrementalBuildMarker)" AlwaysCreate="true">
+      <Output TaskParameter="TouchedFiles" ItemName="FileWrites"/>
+    </Touch>
+  </Target>
+</Project>

--- a/src/Tools/ILAsm/DeployILAsm.targets
+++ b/src/Tools/ILAsm/DeployILAsm.targets
@@ -25,7 +25,7 @@
   </Choose>
 
   <PropertyGroup>
-    <_IlasmDeployProj>$(MSBuildThisFileDirectory)ILAsmDeploy.csproj</_IlasmDeployProj>
+    <_IlasmDeployProj>$(MSBuildThisFileDirectory)IlAsmDeploy.csproj</_IlasmDeployProj>
     <_IlasmIncrementalBuildMarker>$(IlasmPublishDir).v$(MicrosoftNETCoreILAsmVersion)</_IlasmIncrementalBuildMarker>
   </PropertyGroup>
 

--- a/src/Tools/ILAsm/DeployILAsm.targets
+++ b/src/Tools/ILAsm/DeployILAsm.targets
@@ -26,7 +26,7 @@
 
   <PropertyGroup>
     <_IlasmDeployProj>$(MSBuildThisFileDirectory)ILAsmDeploy.csproj</_IlasmDeployProj>
-    <_IlasmIncrementalBuildMarker>$(IlasmPublishDir).timestamp</_IlasmIncrementalBuildMarker>
+    <_IlasmIncrementalBuildMarker>$(IlasmPublishDir).v$(MicrosoftNETCoreILAsmVersion)</_IlasmIncrementalBuildMarker>
   </PropertyGroup>
 
   <Target Name="_PublishILAsm"


### PR DESCRIPTION
This change removes an extra step in powershell and bash test running scripts and makes the tests work when building from VS without previously running tests from command line.
