### PR TITLE
Move to Mono Nightly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -198,6 +198,10 @@ then
     if [[ "${use_mono}" == true ]]
     then
         test_runtime=mono
+
+        # Echo out the mono version to the comamnd line so it's visible in CI logs. It's not fixed
+        # as we're using a feed vs. a hard coded package. 
+        mono --version
     else
         test_runtime=dotnet
     fi

--- a/build/scripts/docker/Dockerfile
+++ b/build/scripts/docker/Dockerfile
@@ -33,8 +33,9 @@ RUN apt-get install -y  libunwind8 \
 
 # Install Mono
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-    (echo "deb http://download.mono-project.com/repo/ubuntu stable-xenial main" | \
-    tee /etc/apt/sources.list.d/mono-official.list) && \
+    apt install apt-transport-https && \
+    (echo "deb https://download.mono-project.com/repo/ubuntu nightly-xenial main" | tee /etc/apt/sources.list.d/mono-official-nightly.list) && \
+    (echo "deb https://download.mono-project.com/repo/ubuntu preview-xenial main" | tee /etc/apt/sources.list.d/mono-official-preview.list) && \
     apt-get update && \
     apt-get install -y mono-devel && \
     apt-get clean

--- a/build/scripts/dockerrun.sh
+++ b/build/scripts/dockerrun.sh
@@ -10,7 +10,7 @@ dir="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 dockerfile="$dir"/docker/
 
 [ -z "$CONTAINER_TAG" ] && CONTAINER_TAG="roslyn-build"
-[ -z "$CONTAINER_NAME" ] && CONTAINER_NAME="roslyn-build-container"
+[ -z "$CONTAINER_NAME" ] && CONTAINER_NAME="roslyn-build-container-mono-nightly"
 [ -z "$DOCKER_HOST_SHARE_dir" ] && DOCKER_HOST_SHARE_DIR="$dir"/../..
 
 # Make container names CI-specific if we're running in CI

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -46,8 +46,6 @@ elif [[ "${runtime}" =~ ^(mono|mono-debug)$ ]]; then
     file_list=( "${unittest_dir}"/*/net46/*.UnitTests.dll )
     file_skiplist=(
         'Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.dll'
-        # Missing mscoree.dll, other problems
-        'Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.dll'
         # Omitted because we appear to be missing things necessary to compile vb.net.
         # See https://github.com/mono/mono/issues/10679
         'Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests.dll'
@@ -63,8 +61,6 @@ elif [[ "${runtime}" =~ ^(mono|mono-debug)$ ]]; then
         'Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests.dll'
         # Multiple test failures
         'Microsoft.Build.Tasks.CodeAnalysis.UnitTests.dll'
-        # Various failures related to PDBs, along with a runtime crash
-        'Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.dll'
         # Disabling on assumption
         'Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.dll'
         # A zillion test failures + crash

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -71,7 +71,7 @@ elif [[ "${runtime}" =~ ^(mono|mono-debug)$ ]]; then
         'VBCSCompiler.UnitTests.dll'
         # Mono serialization errors breaking tests that have traits
         # https://github.com/mono/mono/issues/10945
-        'Microsoft.CodeAnalysis.CSharp.Symbols.UnitTests.dll'
+        'Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.dll'
     )
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/net452/xunit.console.exe
 else

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -69,6 +69,9 @@ elif [[ "${runtime}" =~ ^(mono|mono-debug)$ ]]; then
         # Currently fails on CI against old versions of mono
         # See https://github.com/dotnet/roslyn/pull/30166#issuecomment-425571629
         'VBCSCompiler.UnitTests.dll'
+        # Mono serialization errors breaking tests that have traits
+        # https://github.com/mono/mono/issues/10945
+        'Microsoft.CodeAnalysis.CSharp.Symbols.UnitTests.dll'
     )
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/net452/xunit.console.exe
 else


### PR DESCRIPTION
This moves our Mono test infrastructure from using the stable feed to the nightly feed. 

Additionally enabled the C# emit tests which can be run on this newer Mono runtime.