### PR TITLE
Ensure docker stopped on cancel

### DIFF
--- a/.vsts-dnceng.yml
+++ b/.vsts-dnceng.yml
@@ -111,6 +111,8 @@ phases:
         _name: Mono
   steps:
     - script: ./build/scripts/cibuild.sh $(_args)
+    - script: ./build/scripts/dockerstop.sh
+      condition: eq(variables['_name'], 'Mono')
     - task: PublishTestResults@1
       inputs:
         testRunner: XUnit

--- a/build/scripts/dockerrun.sh
+++ b/build/scripts/dockerrun.sh
@@ -13,6 +13,9 @@ dockerfile="$dir"/docker/
 [ -z "$CONTAINER_NAME" ] && CONTAINER_NAME="roslyn-build-container"
 [ -z "$DOCKER_HOST_SHARE_dir" ] && DOCKER_HOST_SHARE_DIR="$dir"/../..
 
+# Ensure the container isn't already running. Can happened for cancelled jobs in CI
+docker kill $CONTAINER_NAME || true
+
 # Make container names CI-specific if we're running in CI
 #  Jenkins
 [ ! -z "$BUILD_TAG" ] && CONTAINER_NAME="$BUILD_TAG"

--- a/build/scripts/dockerstop.sh
+++ b/build/scripts/dockerstop.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# This script is meant to ensure that all docker containers are stopped when
+# we exit CI. Hence exit with true even if "kill" failed as it will fail if 
+# they stopped gracefully
+docker kill $(docker ps -q) || true
+


### PR DESCRIPTION
When a job is canceled while it is running the Mono leg then the docker
container will be left in a zombie state. Need to explicitly clean this
up in a canceled step.