### PR TITLE
Enable MS.CA.UnitTests on Mono

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/mono/mono/issues/10960")]
         public void TestAnalyzerLoading_Error()
         {
             var analyzerSource = @"
@@ -247,6 +247,7 @@ public class TestAnalyzer : DiagnosticAnalyzer
                 // Test analyzer load failure.
                 var remoteTest = (RemoteAnalyzerFileReferenceTest)loadDomain.CreateInstanceAndUnwrap(typeof(RemoteAnalyzerFileReferenceTest).Assembly.FullName, typeof(RemoteAnalyzerFileReferenceTest).FullName);
                 var exception = remoteTest.LoadAnalyzer(analyzerFile.Path);
+                Console.WriteLine(exception);
                 Assert.NotNull(exception as TypeLoadException);
             }
             finally

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
@@ -247,7 +247,6 @@ public class TestAnalyzer : DiagnosticAnalyzer
                 // Test analyzer load failure.
                 var remoteTest = (RemoteAnalyzerFileReferenceTest)loadDomain.CreateInstanceAndUnwrap(typeof(RemoteAnalyzerFileReferenceTest).Assembly.FullName, typeof(RemoteAnalyzerFileReferenceTest).FullName);
                 var exception = remoteTest.LoadAnalyzer(analyzerFile.Path);
-                Console.WriteLine(exception);
                 Assert.NotNull(exception as TypeLoadException);
             }
             finally

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
                 ("data1//", false),
                 (null, false),
                 ("", false),
-                ("  ", ExecutionConditionUtil.IsCoreClr),
+                ("  ", ExecutionConditionUtil.IsCoreClrUnix),
                 ("path/?.txt", !ExecutionConditionUtil.IsWindowsDesktop),
                 ("path/*.txt", !ExecutionConditionUtil.IsWindowsDesktop),
                 ("path/:.txt", !ExecutionConditionUtil.IsWindowsDesktop),

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -309,16 +309,16 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
                 ("data1//", false),
                 (null, false),
                 ("", false),
-                ("  ", PathUtilities.IsUnixLikePlatform),
-                ("path/?.txt", ExecutionConditionUtil.IsCoreClr),
-                ("path/*.txt", ExecutionConditionUtil.IsCoreClr),
-                ("path/:.txt", ExecutionConditionUtil.IsCoreClr),
-                ("path/\".txt", ExecutionConditionUtil.IsCoreClr),
+                ("  ", ExecutionConditionUtil.IsCoreClr),
+                ("path/?.txt", !ExecutionConditionUtil.IsWindowsDesktop),
+                ("path/*.txt", !ExecutionConditionUtil.IsWindowsDesktop),
+                ("path/:.txt", !ExecutionConditionUtil.IsWindowsDesktop),
+                ("path/\".txt", !ExecutionConditionUtil.IsWindowsDesktop),
                 ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII" +
             "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII" +
             "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII" +
             "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII" +
-            "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII.txt", ExecutionConditionUtil.IsCoreClr)
+            "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII.txt", !ExecutionConditionUtil.IsWindowsDesktop)
             };
 
             foreach (var (path, isValid) in cases)

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityComparerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityComparerTests.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-// Tests COM call into the CLR to compare identities
-#if NET46
-
 using System.IO;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests
@@ -69,7 +67,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Mscorlib()
         {
             // mscorlib is special - all identities with simple name "mscorlib" are considered equivalent
@@ -127,7 +125,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 partial: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void SimpleName()
         {
             TestMatch(
@@ -149,7 +147,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 partial: false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Version_StrongDefinition()
         {
             TestMatch(
@@ -213,7 +211,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 partial: false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Version_WeakDefinition()
         {
             // if the reference is partial version is ignored
@@ -321,7 +319,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 partial: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Culture_StrongDefinition()
         {
             TestMatch(
@@ -343,7 +341,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 partial: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Culture_WeakDefinition()
         {
             TestMatch(
@@ -383,7 +381,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 partial: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void PublicKeyToken()
         {
             TestMatch(
@@ -447,7 +445,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 partial: false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void IgnoreOrFwUnifyVersion()
         {
             TestMatch(
@@ -572,7 +570,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void AsymmetricUnification()
         {
             // Note:
@@ -594,7 +592,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 unificationApplied: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Portability()
         {
             TestMatch(
@@ -630,7 +628,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 policyPath: appConfig.Path);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Retargetable_Reference()
         {
             TestMatch(
@@ -649,7 +647,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 AssemblyIdentityComparer.ComparisonResult.NotEquivalent);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Retargetable_Reference_Partial()
         {
             TestMatch(
@@ -665,7 +663,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 partial: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Retargetable_Reference_Portable()
         {
             TestMatch(
@@ -703,7 +701,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 partial: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Retargetable_RefAndDef()
         {
             TestMatch(
@@ -713,7 +711,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 unificationApplied: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void WinRT_Basic()
         {
             TestMatch(
@@ -823,4 +821,3 @@ namespace Microsoft.CodeAnalysis.UnitTests
     }
 }
 
-#endif

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityDisplayNameTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityDisplayNameTests.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-// Tests COM call into the CLR to compare identities
-#if NET46
-
 using System;
 using System.Reflection;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests
@@ -119,7 +117,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(expectedParts, actualParts);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void GetDisplayName()
         {
             var id = new AssemblyIdentity("goo");
@@ -156,7 +154,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(@"Goo, Version=0.0.0.0, Culture=""  \'\t\r\n\\\=\,  "", PublicKeyToken=null", id.GetDisplayName());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void TryParseDisplayName_QuotingAndEscaping()
         {
             // escapes:
@@ -329,7 +327,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TestParseSimpleName(dn, simpleName);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void GetDisplayName_QuotingAndEscaping()
         {
             TestQuotingAndEscaping(",", "\\,");
@@ -352,7 +350,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TestQuotingAndEscaping("\u2000", "\u2000");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void TryParseDisplayName()
         {
             string V = "\\u" + ((int)'V').ToString("X4") + ";";
@@ -399,7 +397,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TestParseDisplayName("goo, Culture=neutral, Version=1.0.0.0, Culture=en-US", null);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void TryParseDisplayName_Version()
         {
             TestParseDisplayName("Version=1.2.3.4, goo", null);
@@ -421,7 +419,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 AssemblyIdentityParts.Name | AssemblyIdentityParts.Culture);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void TestParseVersion_Parts()
         {
             TestParseVersionInvalid("a");
@@ -468,7 +466,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TestParseVersionInvalid("1.2.3.4.5");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void TestParseVersionAll()
         {
             // all combinations:
@@ -492,7 +490,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void TryParseDisplayName_Culture()
         {
             TestParseDisplayName("goo, Version=1.0.0.1, Culture=null",
@@ -518,7 +516,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 new AssemblyIdentity("Goo", new Version(1, 0, 0, 0), cultureName: null), NVCT);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void TryParseDisplayName_Keys()
         {
             // empty keys:
@@ -559,7 +557,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TestParseDisplayName("goo, Culture=neutral, Version=1.0.0.0, PublicKey=" + StrPublicKey1 + ", PublicKeyToken=1111111111111111", null);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void TryParseDisplayName_ContentType()
         {
             TestParseDisplayName("goo, Version=1.0.0.1, ContentType=WindowsRuntime",
@@ -571,7 +569,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TestParseDisplayName("goo, Version=1.0.0.1, ContentType=Default", null);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void TryParseDisplayName_Retargetable()
         {
             // for some reason the Fusion rejects to parse Retargetable if they are not full names
@@ -605,4 +603,3 @@ namespace Microsoft.CodeAnalysis.UnitTests
     }
 }
 
-#endif

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         public void ToAssemblyName_Errors()
         {
             var ai = new AssemblyIdentity("goo", cultureName: "*");

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-// Tests COM call into the CLR to compare identities
-#if NET46
-
 using System;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -361,7 +358,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertEx.Equal(PublicKeyToken1, aiPkt);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void FullKeyAndToken()
         {
             string displayPkt = "Goo, Version=1.0.0.0, Culture=neutral, PublicKeyToken=" + StrPublicKeyToken1;
@@ -384,4 +381,3 @@ namespace Microsoft.CodeAnalysis.UnitTests
     }
 }
 
-#endif

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyPortabilityPolicyTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyPortabilityPolicyTests.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-// Tests COM call into the CLR to compare identities
-#if NET46
-
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -67,7 +64,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             return result == FusionAssemblyIdentityComparer.AssemblyComparisonResult.EquivalentFullMatch;
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_Errors()
         {
             var appConfig = Temp.CreateFile();
@@ -105,7 +102,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<XmlException>(() => AssemblyPortabilityPolicy.LoadFromXml(stream));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_LeadingWhitespace()
         {
             var appConfig = Temp.CreateFile();
@@ -127,7 +124,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<XmlException>(() => AssemblyPortabilityPolicy.LoadFromXml(stream));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_LinkedConfiguration()
         {
             var appConfig1 = Temp.CreateFile();
@@ -160,7 +157,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertIsEnabled(appConfig1.Path, platform: false, nonPlatform: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_NoValues()
         {
             var appConfig = Temp.CreateFile();
@@ -208,7 +205,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertIsEnabled(appConfig.Path, platform: true, nonPlatform: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_Values_MissingNamespace()
         {
             var appConfig = Temp.CreateFile();
@@ -226,7 +223,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertIsEnabled(appConfig.Path, platform: true, nonPlatform: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_Values1()
         {
             var appConfig = Temp.CreateFile();
@@ -244,7 +241,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertIsEnabled(appConfig.Path, platform: false, nonPlatform: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_Values2()
         {
             var appConfig = Temp.CreateFile();
@@ -262,7 +259,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertIsEnabled(appConfig.Path, platform: true, nonPlatform: false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_Values4()
         {
             var appConfig = Temp.CreateFile();
@@ -280,7 +277,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertIsEnabled(appConfig.Path, platform: true, nonPlatform: false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_DuplicateSupportPortability1()
         {
             var appConfig = Temp.CreateFile();
@@ -299,7 +296,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertIsEnabled(appConfig.Path, platform: false, nonPlatform: false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_DuplicateSupportPortability2()
         {
             var appConfig = Temp.CreateFile();
@@ -319,7 +316,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertIsEnabled(appConfig.Path, platform: true, nonPlatform: false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_UnknownAttributes2()
         {
             var appConfig = Temp.CreateFile();
@@ -343,7 +340,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertIsEnabled(appConfig.Path, platform: true, nonPlatform: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_InterleavingElements()
         {
             var appConfig = Temp.CreateFile();
@@ -363,7 +360,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertIsEnabled(appConfig.Path, platform: true, nonPlatform: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void LoadFromFile_EmptyElement()
         {
             var appConfig = Temp.CreateFile();
@@ -380,7 +377,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertIsEnabled(appConfig.Path, platform: true, nonPlatform: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Fusion_Dispose()
         {
             var appConfig = Temp.CreateFile().WriteAllText(correctAppConfigText);
@@ -393,7 +390,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(IntPtr.Zero, policy.ConfigCookie);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void Fusion_TestEquals()
         {
             var appConfig = Temp.CreateFile().WriteAllText(correctAppConfigText);
@@ -435,4 +432,3 @@ namespace Microsoft.CodeAnalysis.UnitTests
     }
 }
 
-#endif

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/FusionAssemblyIdentityTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/FusionAssemblyIdentityTests.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-// Tests COM call into the CLR to compare identities
-#if NET46
-
 using System;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
 using Xunit;
+using Roslyn.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.UnitTests.MetadataReferences
 {
@@ -76,7 +74,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.MetadataReferences
             Assert.Equal(name.ContentType, rtName.ContentType);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void FusionAssemblyNameRoundTrip()
         {
             RoundTrip(new AssemblyName("goo"));
@@ -108,7 +106,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.MetadataReferences
             RoundTrip(new AssemblyIdentity("goo", contentType: AssemblyContentType.WindowsRuntime).ToAssemblyName());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void FusionGetBestMatch()
         {
             var goo = FusionAssemblyIdentity.ToAssemblyNameObject("goo");
@@ -150,7 +148,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.MetadataReferences
             Assert.Equal(goo3, m);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsFusion)]
         public void FusionToAssemblyName()
         {
             var nameObject = FusionAssemblyIdentity.ToAssemblyNameObject("mscorlib");
@@ -225,4 +223,3 @@ namespace Microsoft.CodeAnalysis.UnitTests.MetadataReferences
     }
 }
 
-#endif

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentException>(() => ModuleMetadata.CreateFromStream(new TestStream(canRead: true, canSeek: false)));
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
         public void CreateFromFile()
         {
             Assert.Throws<ArgumentNullException>(() => ModuleMetadata.CreateFromFile((string)null));

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentException>(() => ModuleMetadata.CreateFromStream(new TestStream(canRead: true, canSeek: false)));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
         public void CreateFromFile()
         {
             Assert.Throws<ArgumentNullException>(() => ModuleMetadata.CreateFromFile((string)null));

--- a/src/Compilers/Core/CodeAnalysisTest/StrongNameProviderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/StrongNameProviderTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 {
     public class StrongNameProviderTests
     {
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsWindowsTypes)]
         public void ResolveStrongNameKeyFile()
         {
             string fileName = "f.snk";

--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -742,7 +742,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10961")]
         public void TestMergeChanges_NoMiddleMan()
         {
-            try {
             var original = SourceText.From("Hell");
 
             var final = GetChangesWithoutMiddle(
@@ -756,7 +755,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(1, changes.Count);
             Assert.Equal(new TextSpan(4, 0), changes[0].Span);
             Assert.Equal("o World", changes[0].NewText);
-            } catch (Exception e) { Console.WriteLine(e.StackTrace);}
         }
 
         private SourceText GetChangesWithoutMiddle(

--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -739,9 +739,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal("o World", changes[0].NewText);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10961")]
         public void TestMergeChanges_NoMiddleMan()
         {
+            try {
             var original = SourceText.From("Hell");
 
             var final = GetChangesWithoutMiddle(
@@ -755,6 +756,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(1, changes.Count);
             Assert.Equal(new TextSpan(4, 0), changes[0].Span);
             Assert.Equal("o World", changes[0].NewText);
+            } catch (Exception e) { Console.WriteLine(e.StackTrace);}
         }
 
         private SourceText GetChangesWithoutMiddle(

--- a/src/Compilers/Core/CodeAnalysisTest/Win32Res.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Win32Res.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 {
     public class Win32ResTests
     {
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsWindowsTypes)]
         public void BasicResources2()
         {
             //confirm that we can read resources produced by RC.EXE. 
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(3, list.Count);
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsWindowsTypes)]
         public void BasicResourcesWithStringTypes()
         {
             //confirm that we can read resources produced by RC.EXE. 
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             yield return new Win32Resource(null, 0, 0, 1, null, -1, "A");//2
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsWindowsTypes)]
         public void EnsureResourceSorting()
         {
             //confirm that we sort the resources in the order required by the serialization format.
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal("b", elem.Name);
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsWindowsTypes)]
         public void BasicResources()
         {
             System.IO.MemoryStream strm = new System.IO.MemoryStream();

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -136,7 +136,7 @@ namespace Roslyn.Test.Utilities
     public static class ExecutionConditionUtil
     {
         public static bool IsWindows => Path.DirectorySeparatorChar == '\\';
-        public static bool IsUnix => Path.DirectorySeparatorChar == '/';
+        public static bool IsUnix => !IsWindows;
         public static bool IsDesktop => CoreClrShim.AssemblyLoadContext.Type == null;
         public static bool IsWindowsDesktop => IsWindows && IsDesktop;
         public static bool IsMonoDesktop => Type.GetType("Mono.Runtime") != null;

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -39,6 +39,7 @@ namespace Roslyn.Test.Utilities
 
         public const string TestExecutionHasCOMInterop = "Test execution depends on COM Interop";
         public const string TestHasWindowsPaths = "Test depends on Windows style paths";
+        public const string TestExecutionNeedsFusion = "Test depends on desktop fusion loader API";
 
         /// <summary>
         /// Edit and continue is only supported on desktop at the moment.

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -136,10 +136,12 @@ namespace Roslyn.Test.Utilities
     public static class ExecutionConditionUtil
     {
         public static bool IsWindows => Path.DirectorySeparatorChar == '\\';
+        public static bool IsUnix => Path.DirectorySeparatorChar == '/';
         public static bool IsDesktop => CoreClrShim.AssemblyLoadContext.Type == null;
         public static bool IsWindowsDesktop => IsWindows && IsDesktop;
         public static bool IsMonoDesktop => Type.GetType("Mono.Runtime") != null;
         public static bool IsCoreClr => !IsDesktop;
+        public static bool IsCoreClrUnix => IsCoreClr && IsUnix;
     }
 
     public class x86 : ExecutionCondition


### PR DESCRIPTION
This makes the changes such that MS.CA.UnitTests can execute on Mono.