### PR TITLE
Remove last PROTOTYPE marker

### DIFF
--- a/src/Deployment/source.extension.vsixmanifest
+++ b/src/Deployment/source.extension.vsixmanifest
@@ -2,8 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="f6d4ae9d-5ca3-4e0b-9035-9457cccf53fa" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
-    <!-- PROTOTYPE(NullableReferenceTypes): Revert before merging to master. -->
-    <DisplayName>Roslyn Nullable Reference Types Preview</DisplayName>
+    <DisplayName>Roslyn Insiders (Without Tool Window)</DisplayName>
     <Description>Pre-release build of Roslyn compilers and language services.</Description>
   </Metadata>
   <Installation>


### PR DESCRIPTION
This was the only PROTOTYPE marker that remained.

The versioning of the package and the moniker now seems handled by [build/config/PublishData.json](https://github.com/dotnet/roslyn/blob/features/NullableReferenceTypes/build/config/PublishData.json) which is aware of branch names.