### PR TITLE
Add fallback to MSBuildProjectLoader when project reference is not backed by metadata reference

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker_ResolveReferences.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker_ResolveReferences.cs
@@ -136,6 +136,21 @@ namespace Microsoft.CodeAnalysis.MSBuild
                     return null;
                 }
 
+                public ImmutableArray<UnresolvedMetadataReference> GetUnresolvedMetadataReferences()
+                {
+                    var builder = ImmutableArray.CreateBuilder<UnresolvedMetadataReference>();
+
+                    foreach (var metadataReference in GetMetadataReferences())
+                    {
+                        if (metadataReference is UnresolvedMetadataReference unresolvedMetadataReference)
+                        {
+                            builder.Add(unresolvedMetadataReference);
+                        }
+                    }
+
+                    return builder.ToImmutable();
+                }
+
                 private ImmutableArray<MetadataReference> GetMetadataReferences()
                 {
                     var builder = ImmutableArray.CreateBuilder<MetadataReference>();
@@ -213,12 +228,30 @@ namespace Microsoft.CodeAnalysis.MSBuild
                     builder.AddProjectReference(newProjectReference);
                 }
 
+                // Are there still any unresolved metadata references? If so, remove them and report diagnostics.
+                foreach (var unresolvedMetadataReference in builder.GetUnresolvedMetadataReferences())
+                {
+                    var filePath = unresolvedMetadataReference.Reference;
+
+                    builder.Remove(filePath);
+
+                    _diagnosticReporter.Report(new ProjectDiagnostic(
+                        WorkspaceDiagnosticKind.Warning,
+                        string.Format(WorkspaceMSBuildResources.Unresolved_metadata_reference_removed_from_project_0, filePath),
+                        id));
+                }
+
                 return builder.ToResolvedReferences();
             }
 
             private async Task<bool> TryLoadAndAddReferenceAsync(ProjectId id, string projectReferencePath, ImmutableArray<string> aliases, ResolvedReferencesBuilder builder, CancellationToken cancellationToken)
             {
                 var projectReferenceInfos = await LoadProjectInfosFromPathAsync(projectReferencePath, _discoveredProjectOptions, cancellationToken).ConfigureAwait(false);
+
+                if (projectReferenceInfos.IsEmpty)
+                {
+                    return false;
+                }
 
                 // Find the project reference info whose output we have a metadata reference for.
                 ProjectInfo projectReferenceInfo = null;
@@ -234,7 +267,17 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
                 if (projectReferenceInfo == null)
                 {
-                    return false;
+                    // We didn't find the project reference info that matches any of our metadata references.
+                    // In this case, we'll go ahead and use the first project reference info that was found,
+                    // but report a warning because this likely means that either a metadata reference path
+                    // or a project output path is incorrect.
+
+                    projectReferenceInfo = projectReferenceInfos[0];
+
+                    _diagnosticReporter.Report(new ProjectDiagnostic(
+                        WorkspaceDiagnosticKind.Warning,
+                        string.Format(WorkspaceMSBuildResources.Found_project_reference_without_a_matching_metadata_reference_0, projectReferencePath),
+                        id));
                 }
 
                 if (!ProjectReferenceExists(to: id, from: projectReferenceInfo))

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/CommandLineArgumentReader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/CommandLineArgumentReader.cs
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             {
                 foreach (var reference in references)
                 {
-                    if (!reference.HasReferenceOutputAssemblyMetadataEqualToTrue())
+                    if (reference.ReferenceOutputAssemblyIsTrue())
                     {
                         var filePath = GetDocumentFilePath(reference);
 

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/CommandLineArgumentReader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/CommandLineArgumentReader.cs
@@ -167,8 +167,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             if (emitDebugInfo)
             {
                 var debugType = Project.ReadPropertyString(PropertyNames.DebugType);
-
-                if (s_debugTypeValues.TryGetValue(debugType, out var value))
+                if (debugType != null && s_debugTypeValues.TryGetValue(debugType, out var value))
                 {
                     Add("debug", value);
                 }

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/Extensions.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/Extensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public static IEnumerable<ProjectFileReference> GetProjectReferences(this MSB.Execution.ProjectInstance executedProject)
             => executedProject
                 .GetItems(ItemNames.ProjectReference)
-                .Where(i => !i.HasReferenceOutputAssemblyMetadataEqualToTrue())
+                .Where(i => i.ReferenceOutputAssemblyIsTrue())
                 .Select(CreateProjectFileReference);
 
         /// <summary>
@@ -35,9 +35,6 @@ namespace Microsoft.CodeAnalysis.MSBuild
         private static ProjectFileReference CreateProjectFileReference(MSB.Execution.ProjectItemInstance reference)
             => new ProjectFileReference(reference.EvaluatedInclude, reference.GetAliases());
 
-        public static bool HasReferenceOutputAssemblyMetadataEqualToTrue(this MSB.Framework.ITaskItem item)
-            => string.Equals(item.GetMetadata(MetadataNames.ReferenceOutputAssembly), bool.TrueString, StringComparison.OrdinalIgnoreCase);
-
         public static ImmutableArray<string> GetAliases(this MSB.Framework.ITaskItem item)
         {
             var aliasesText = item.GetMetadata(MetadataNames.Aliases);
@@ -45,6 +42,15 @@ namespace Microsoft.CodeAnalysis.MSBuild
             return !string.IsNullOrWhiteSpace(aliasesText)
                 ? ImmutableArray.CreateRange(aliasesText.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(a => a.Trim()))
                 : ImmutableArray<string>.Empty;
+        }
+
+        public static bool ReferenceOutputAssemblyIsTrue(this MSB.Framework.ITaskItem item)
+        {
+            var referenceOutputAssemblyText = item.GetMetadata(MetadataNames.ReferenceOutputAssembly);
+
+            return !string.IsNullOrWhiteSpace(referenceOutputAssemblyText)
+                ? !string.Equals(referenceOutputAssemblyText, bool.FalseString, StringComparison.OrdinalIgnoreCase)
+                : true;
         }
 
         public static string ReadPropertyString(this MSB.Execution.ProjectInstance executedProject, string propertyName)

--- a/src/Workspaces/Core/MSBuild/WorkspaceMSBuildResources.Designer.cs
+++ b/src/Workspaces/Core/MSBuild/WorkspaceMSBuildResources.Designer.cs
@@ -70,6 +70,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Found project reference without a matching metadata reference: {0}.
+        /// </summary>
+        internal static string Found_project_reference_without_a_matching_metadata_reference_0 {
+            get {
+                return ResourceManager.GetString("Found_project_reference_without_a_matching_metadata_reference_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Found project with the same file path and output path as another project: {0}.
         /// </summary>
         internal static string Found_project_with_the_same_file_path_and_output_path_as_another_project_0 {
@@ -102,6 +111,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Project_does_not_contain_0_target {
             get {
                 return ResourceManager.GetString("Project_does_not_contain_0_target", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unresolved metadata reference removed from project: {0}.
+        /// </summary>
+        internal static string Unresolved_metadata_reference_removed_from_project_0 {
+            get {
+                return ResourceManager.GetString("Unresolved_metadata_reference_removed_from_project_0", resourceCulture);
             }
         }
     }

--- a/src/Workspaces/Core/MSBuild/WorkspaceMSBuildResources.resx
+++ b/src/Workspaces/Core/MSBuild/WorkspaceMSBuildResources.resx
@@ -120,6 +120,9 @@
   <data name="Duplicate_project_discovered_and_skipped_0" xml:space="preserve">
     <value>Duplicate project discovered and skipped: {0}</value>
   </data>
+  <data name="Found_project_reference_without_a_matching_metadata_reference_0" xml:space="preserve">
+    <value>Found project reference without a matching metadata reference: {0}</value>
+  </data>
   <data name="Found_project_with_the_same_file_path_and_output_path_as_another_project_0" xml:space="preserve">
     <value>Found project with the same file path and output path as another project: {0}</value>
   </data>
@@ -131,5 +134,8 @@
   </data>
   <data name="Project_does_not_contain_0_target" xml:space="preserve">
     <value>Project does not contain '{0}' target.</value>
+  </data>
+  <data name="Unresolved_metadata_reference_removed_from_project_0" xml:space="preserve">
+    <value>Unresolved metadata reference removed from project: {0}</value>
   </data>
 </root>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.cs.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">Při zpracovávání souboru {0} došlo k chybě MSBuildu.</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">Byl zjištěn a vynechán duplicitní projekt: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.de.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">MSBuild-Fehler beim Verarbeiten der Datei "{0}"</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">Doppeltes Projekt ermittelt und übersprungen: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.es.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">Error de Msbuild al procesar el archivo "{0}"</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">Se detectó un proyecto duplicado y se omitió: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.fr.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">Échec de Msbuild pendant le traitement du fichier '{0}'</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">Projet dupliqué découvert et ignoré : {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.it.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">Errore di MSBuild durante l'elaborazione del file '{0}'</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">Un progetto duplicato è stato rilevato e ignorato: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ja.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">ファイル '{0}' の処理中に MSBuild が失敗しました</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">見つかってスキップされた、重複するプロジェクト: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ko.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">{0}' 파일 처리 시 Msbuild에서 실패했습니다.</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">중복된 프로젝트가 검색되어 건너뛰었습니다. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pl.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">Operacja programu MSBuild nie powiodła się podczas przetwarzania pliku „{0}”</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">Wykryto i pominięto zduplikowany projekt: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pt-BR.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">Falha do MSBuild ao processar o arquivo '{0}'</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">Projeto duplicado descoberto e ignorado: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ru.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">Сбой Msbuild при обработке файла "{0}"</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">Обнаружен и пропущен повторяющийся проект: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.tr.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">{0}' dosyası işlenirken MsBuild başarısız oldu</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">Yinelenen proje bulundu ve atlandı: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hans.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">处理文件“{0}”时，Msbuild 失败</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">发现并跳过了重复项目: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hant.xlf
+++ b/src/Workspaces/Core/MSBuild/xlf/WorkspaceMSBuildResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../WorkspaceMSBuildResources.resx">
     <body>
+      <trans-unit id="Found_project_reference_without_a_matching_metadata_reference_0">
+        <source>Found project reference without a matching metadata reference: {0}</source>
+        <target state="new">Found project reference without a matching metadata reference: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Msbuild_failed_when_processing_the_file_0">
         <source>Msbuild failed when processing the file '{0}'</source>
         <target state="translated">Msbuild 在處理檔案 '{0}' 時失敗</target>
@@ -25,6 +30,11 @@
       <trans-unit id="Duplicate_project_discovered_and_skipped_0">
         <source>Duplicate project discovered and skipped: {0}</source>
         <target state="translated">發現重複的專案，將予跳過: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unresolved_metadata_reference_removed_from_project_0">
+        <source>Unresolved metadata reference removed from project: {0}</source>
+        <target state="new">Unresolved metadata reference removed from project: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Workspaces/CoreTestUtilities/Resources/Issue29122/Proj1/ClassLibrary1.vbproj
+++ b/src/Workspaces/CoreTestUtilities/Resources/Issue29122/Proj1/ClassLibrary1.vbproj
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>
+    </SchemaVersion>
+    <ProjectGuid>{F8AE35AB-1AC5-4381-BB3E-0645519695F5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ClassLibrary1</RootNamespace>
+    <AssemblyName>ClassLibrary1</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <MyType>Windows</MyType>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionExplicit>On</OptionExplicit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionCompare>Binary</OptionCompare>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionStrict>On</OptionStrict>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionInfer>On</OptionInfer>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineDebug>true</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <OutputPath>..\Dev\</OutputPath>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <DefineTrace>true</DefineTrace>
+    <OutputPath>..\Dev\</OutputPath>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Class1.vb" />
+    <Compile Include="My Project\AssemblyInfo.vb" />
+    <Compile Include="My Project\Application.Designer.vb">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Application.myapp</DependentUpon>
+    </Compile>
+    <Compile Include="My Project\Resources.Designer.vb">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Include="My Project\Settings.Designer.vb">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="My Project\Resources.resx">
+      <Generator>VbMyResourcesResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.vb</LastGenOutput>
+      <CustomToolNamespace>My.Resources</CustomToolNamespace>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="My Project\Application.myapp">
+      <Generator>MyApplicationCodeGenerator</Generator>
+      <LastGenOutput>Application.Designer.vb</LastGenOutput>
+    </None>
+    <None Include="My Project\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <CustomToolNamespace>My</CustomToolNamespace>
+      <LastGenOutput>Settings.Designer.vb</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+</Project>

--- a/src/Workspaces/CoreTestUtilities/Resources/Issue29122/Proj2/ClassLibrary2.vbproj
+++ b/src/Workspaces/CoreTestUtilities/Resources/Issue29122/Proj2/ClassLibrary2.vbproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{65D39B82-9F22-4350-9BFF-3988C367809B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>ClassLibrary2</RootNamespace>
+    <AssemblyName>ClassLibrary2</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <MyType>Windows</MyType>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionExplicit>On</OptionExplicit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionCompare>Binary</OptionCompare>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionStrict>On</OptionStrict>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OptionInfer>On</OptionInfer>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineDebug>true</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <OutputPath>..\Dev\Modules\</OutputPath>
+    <NoWarn>
+    </NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <DefineDebug>false</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <Optimize>true</Optimize>
+    <OutputPath>..\Dev\Modules\</OutputPath>
+    <NoWarn>
+    </NoWarn>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Class1.vb" />
+    <Compile Include="My Project\AssemblyInfo.vb" />
+    <Compile Include="My Project\Application.Designer.vb">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Application.myapp</DependentUpon>
+    </Compile>
+    <Compile Include="My Project\Resources.Designer.vb">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Include="My Project\Settings.Designer.vb">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="My Project\Resources.resx">
+      <Generator>VbMyResourcesResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.vb</LastGenOutput>
+      <CustomToolNamespace>My.Resources</CustomToolNamespace>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="My Project\Application.myapp">
+      <Generator>MyApplicationCodeGenerator</Generator>
+      <LastGenOutput>Application.Designer.vb</LastGenOutput>
+    </None>
+    <None Include="My Project\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <CustomToolNamespace>My</CustomToolNamespace>
+      <LastGenOutput>Settings.Designer.vb</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Proj1\ClassLibrary1.vbproj">
+      <Project>{f8ae35ab-1ac5-4381-bb3e-0645519695f5}</Project>
+      <Name>ClassLibrary1</Name>
+	  <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+</Project>

--- a/src/Workspaces/CoreTestUtilities/Resources/Issue29122/TestVB2.sln
+++ b/src/Workspaces/CoreTestUtilities/Resources/Issue29122/TestVB2.sln
@@ -1,0 +1,39 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2018
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "ClassLibrary1", "Proj1\ClassLibrary1.vbproj", "{F8AE35AB-1AC5-4381-BB3E-0645519695F5}"
+EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "ClassLibrary2", "Proj2\ClassLibrary2.vbproj", "{65D39B82-9F22-4350-9BFF-3988C367809B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F8AE35AB-1AC5-4381-BB3E-0645519695F5}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{F8AE35AB-1AC5-4381-BB3E-0645519695F5}.Debug|x86.ActiveCfg = Debug|x86
+		{F8AE35AB-1AC5-4381-BB3E-0645519695F5}.Debug|x86.Build.0 = Debug|x86
+		{F8AE35AB-1AC5-4381-BB3E-0645519695F5}.Release|Any CPU.ActiveCfg = Release|x86
+		{F8AE35AB-1AC5-4381-BB3E-0645519695F5}.Release|x86.ActiveCfg = Release|x86
+		{F8AE35AB-1AC5-4381-BB3E-0645519695F5}.Release|x86.Build.0 = Release|x86
+		{65D39B82-9F22-4350-9BFF-3988C367809B}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{65D39B82-9F22-4350-9BFF-3988C367809B}.Debug|Any CPU.Build.0 = Debug|x86
+		{65D39B82-9F22-4350-9BFF-3988C367809B}.Debug|x86.ActiveCfg = Debug|x86
+		{65D39B82-9F22-4350-9BFF-3988C367809B}.Debug|x86.Build.0 = Debug|x86
+		{65D39B82-9F22-4350-9BFF-3988C367809B}.Release|Any CPU.ActiveCfg = Release|x86
+		{65D39B82-9F22-4350-9BFF-3988C367809B}.Release|Any CPU.Build.0 = Release|x86
+		{65D39B82-9F22-4350-9BFF-3988C367809B}.Release|x86.ActiveCfg = Release|x86
+		{65D39B82-9F22-4350-9BFF-3988C367809B}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {091C5642-C43A-4E23-A3BC-0CC533E3B5C1}
+	EndGlobalSection
+EndGlobal

--- a/src/Workspaces/CoreTestUtilities/Resources/ProjectFiles/CSharp/ProjectLoadErrorOnMissingDebugType.csproj
+++ b/src/Workspaces/CoreTestUtilities/Resources/ProjectFiles/CSharp/ProjectLoadErrorOnMissingDebugType.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B2417A38-6B3D-4482-9354-14AAF628340D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ProjectLoadErrorOnMissingDebugType</RootNamespace>
+    <AssemblyName>ProjectLoadErrorOnMissingDebugType</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <!--<DebugType>full</DebugType>-->
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Workspaces/CoreTestUtilities/Resources/SolutionFiles/ProjectLoadErrorOnMissingDebugType.sln
+++ b/src/Workspaces/CoreTestUtilities/Resources/SolutionFiles/ProjectLoadErrorOnMissingDebugType.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2036
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectLoadErrorOnMissingDebugType", "ProjectLoadErrorOnMissingDebugType\ProjectLoadErrorOnMissingDebugType.csproj", "{B2417A38-6B3D-4482-9354-14AAF628340D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2417A38-6B3D-4482-9354-14AAF628340D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2417A38-6B3D-4482-9354-14AAF628340D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2417A38-6B3D-4482-9354-14AAF628340D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2417A38-6B3D-4482-9354-14AAF628340D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9A9BD150-2994-4451-B166-D44022E8F764}
+	EndGlobalSection
+EndGlobal

--- a/src/Workspaces/CoreTestUtilities/Roslyn.Services.UnitTests.Utilities.csproj
+++ b/src/Workspaces/CoreTestUtilities/Roslyn.Services.UnitTests.Utilities.csproj
@@ -53,4 +53,7 @@
   <ItemGroup>
     <Compile Remove="Resources\**\*.*" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\Issue29122\" />
+  </ItemGroup>
 </Project>

--- a/src/Workspaces/CoreTestUtilities/TestFiles/Resources.cs
+++ b/src/Workspaces/CoreTestUtilities/TestFiles/Resources.cs
@@ -86,6 +86,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
             public static string DuplicatedGuidsBecomeSelfReferential => GetText("SolutionFiles.DuplicatedGuidsBecomeSelfReferential.sln");
             public static string DuplicatedGuidsBecomeCircularReferential => GetText("SolutionFiles.DuplicatedGuidsBecomeCircularReferential.sln");
             public static string EmptyLineBetweenProjectBlock => GetText("SolutionFiles.EmptyLineBetweenProjectBlock.sln");
+            public static string Issue29122_Solution => GetText("Issue29122.TestVB2.sln");
             public static string InvalidProjectPath => GetText("SolutionFiles.InvalidProjectPath.sln");
             public static string MissingEndProject1 => GetText("SolutionFiles.MissingEndProject1.sln");
             public static string MissingEndProject2 => GetText("SolutionFiles.MissingEndProject2.sln");
@@ -159,6 +160,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
                 public static string Circular_Target => GetText("ProjectFiles.VisualBasic.Circular_Target.vbproj");
                 public static string Circular_Top => GetText("ProjectFiles.VisualBasic.Circular_Top.vbproj");
                 public static string Embed => GetText("ProjectFiles.VisualBasic.Embed.vbproj");
+                public static string Issue29122_ClassLibrary1 => GetText("Issue29122.Proj1.ClassLibrary1.vbproj");
+                public static string Issue29122_ClassLibrary2 => GetText("Issue29122.Proj2.ClassLibrary2.vbproj");
                 public static string InvalidProjectReference => GetText("ProjectFiles.VisualBasic.InvalidProjectReference.vbproj");
                 public static string NonExistentProjectReference => GetText("ProjectFiles.VisualBasic.NonExistentProjectReference.vbproj");
                 public static string UnknownProjectExtension => GetText("ProjectFiles.VisualBasic.UnknownProjectExtension.vbproj");

--- a/src/Workspaces/CoreTestUtilities/TestFiles/Resources.cs
+++ b/src/Workspaces/CoreTestUtilities/TestFiles/Resources.cs
@@ -93,6 +93,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
             public static string MissingEndProject3 => GetText("SolutionFiles.MissingEndProject3.sln");
             public static string NetCoreMultiTFM_ProjectReferenceToFSharp = GetText("NetCoreMultiTFM_ProjectReferenceToFSharp.Solution.sln");
             public static string NonExistentProject => GetText("SolutionFiles.NonExistentProject.sln");
+            public static string ProjectLoadErrorOnMissingDebugType => GetText("SolutionFiles.ProjectLoadErrorOnMissingDebugType.sln");
             public static string SolutionFolder => GetText("SolutionFiles.SolutionFolder.sln");
             public static string VB_and_CSharp => GetText("SolutionFiles.VB_and_CSharp.sln");
         }
@@ -138,6 +139,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
                 public static string NetCoreMultiTFM_ProjectReferenceWithReversedTFMs_Library => GetText("NetCoreMultiTFM_ProjectReferenceWithReversedTFMs.Library.csproj");
                 public static string NetCoreMultiTFM_ProjectReferenceWithReversedTFMs_Project => GetText("NetCoreMultiTFM_ProjectReferenceWithReversedTFMs.Project.csproj");
                 public static string PortableProject => GetText("ProjectFiles.CSharp.PortableProject.csproj");
+                public static string ProjectLoadErrorOnMissingDebugType => GetText("ProjectFiles.CSharp.ProjectLoadErrorOnMissingDebugType.csproj");
                 public static string ProjectReference => GetText("ProjectFiles.CSharp.ProjectReference.csproj");
                 public static string ReferencesPortableProject => GetText("ProjectFiles.CSharp.ReferencesPortableProject.csproj");
                 public static string Wildcards => GetText("ProjectFiles.CSharp.Wildcards.csproj");

--- a/src/Workspaces/CoreTestUtilities/WorkspaceTestBase.cs
+++ b/src/Workspaces/CoreTestUtilities/WorkspaceTestBase.cs
@@ -87,6 +87,13 @@ namespace Microsoft.CodeAnalysis.UnitTests
             CreateFiles(GetSimpleCSharpSolutionFiles());
         }
 
+        protected FileSet GetBaseFiles()
+        {
+            return new FileSet(
+                (@"Directory.Build.props", Resources.Directory_Build_props),
+                (@"Directory.Build.targets", Resources.Directory_Build_targets));
+        }
+
         protected FileSet GetSimpleCSharpSolutionFiles()
         {
             return new FileSet(

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -3033,6 +3033,20 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        public async Task TestOpenProject_CSharp_WithMissingDebugType()
+        {
+            CreateFiles(new FileSet(
+                (@"ProjectLoadErrorOnMissingDebugType.sln", Resources.SolutionFiles.ProjectLoadErrorOnMissingDebugType),
+                (@"ProjectLoadErrorOnMissingDebugType\ProjectLoadErrorOnMissingDebugType.csproj", Resources.ProjectFiles.CSharp.ProjectLoadErrorOnMissingDebugType)));
+            var solutionFilePath = GetSolutionFileName(@"ProjectLoadErrorOnMissingDebugType.sln");
+
+            using (var workspace = CreateMSBuildWorkspace())
+            {
+                await workspace.OpenSolutionAsync(solutionFilePath);
+            }
+        }
+
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         [WorkItem(991528, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/991528")]
         public async Task MSBuildProjectShouldHandleCodePageProperty()
         {

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -3526,6 +3526,45 @@ class C { }";
             }
         }
 
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [WorkItem(29122, "https://github.com/dotnet/roslyn/issues/29122")]
+        public async Task TestOpenSolution_ProjectReferencesWithUnconventionalOutputPaths()
+        {
+            CreateFiles(GetBaseFiles()
+                .WithFile(@"TestVB2.sln", Resources.SolutionFiles.Issue29122_Solution)
+                .WithFile(@"Proj1\ClassLibrary1.vbproj", Resources.ProjectFiles.VisualBasic.Issue29122_ClassLibrary1)
+                .WithFile(@"Proj1\Class1.vb", Resources.SourceFiles.VisualBasic.VisualBasicClass)
+                .WithFile(@"Proj1\My Project\Application.Designer.vb", Resources.SourceFiles.VisualBasic.Application_Designer)
+                .WithFile(@"Proj1\My Project\Application.myapp", Resources.SourceFiles.VisualBasic.Application)
+                .WithFile(@"Proj1\My Project\AssemblyInfo.vb", Resources.SourceFiles.VisualBasic.AssemblyInfo)
+                .WithFile(@"Proj1\My Project\Resources.Designer.vb", Resources.SourceFiles.VisualBasic.Resources_Designer)
+                .WithFile(@"Proj1\My Project\Resources.resx", Resources.SourceFiles.VisualBasic.Resources)
+                .WithFile(@"Proj1\My Project\Settings.Designer.vb", Resources.SourceFiles.VisualBasic.Settings_Designer)
+                .WithFile(@"Proj1\My Project\Settings.settings", Resources.SourceFiles.VisualBasic.Settings)
+                .WithFile(@"Proj2\ClassLibrary2.vbproj", Resources.ProjectFiles.VisualBasic.Issue29122_ClassLibrary2)
+                .WithFile(@"Proj2\Class1.vb", Resources.SourceFiles.VisualBasic.VisualBasicClass)
+                .WithFile(@"Proj2\My Project\Application.Designer.vb", Resources.SourceFiles.VisualBasic.Application_Designer)
+                .WithFile(@"Proj2\My Project\Application.myapp", Resources.SourceFiles.VisualBasic.Application)
+                .WithFile(@"Proj2\My Project\AssemblyInfo.vb", Resources.SourceFiles.VisualBasic.AssemblyInfo)
+                .WithFile(@"Proj2\My Project\Resources.Designer.vb", Resources.SourceFiles.VisualBasic.Resources_Designer)
+                .WithFile(@"Proj2\My Project\Resources.resx", Resources.SourceFiles.VisualBasic.Resources)
+                .WithFile(@"Proj2\My Project\Settings.Designer.vb", Resources.SourceFiles.VisualBasic.Settings_Designer)
+                .WithFile(@"Proj2\My Project\Settings.settings", Resources.SourceFiles.VisualBasic.Settings));
+
+            var solutionFlePath = GetSolutionFileName(@"TestVB2.sln");
+
+            using (var workspace = CreateMSBuildWorkspace())
+            {
+                var solution = await workspace.OpenSolutionAsync(solutionFlePath);
+
+                // Neither project should contain any unresolved metadata references
+                foreach (var project in solution.Projects)
+                {
+                    Assert.DoesNotContain(project.MetadataReferences, mr => mr is UnresolvedMetadataReference);
+                }
+            }
+        }
+
         private class InMemoryAssemblyLoader : IAnalyzerAssemblyLoader
         {
             public void AddDependencyLocation(string fullPath)

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -1608,7 +1608,7 @@ class C1
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
-        public async Task TTestCompilationOptions_CSharp_DebugType_Full()
+        public async Task TestCompilationOptions_CSharp_DebugType_Full()
         {
             CreateCSharpFilesWith("DebugType", "full");
             await AssertCSParseOptionsAsync(0, options => options.Errors.Length);
@@ -3551,11 +3551,11 @@ class C { }";
                 .WithFile(@"Proj2\My Project\Settings.Designer.vb", Resources.SourceFiles.VisualBasic.Settings_Designer)
                 .WithFile(@"Proj2\My Project\Settings.settings", Resources.SourceFiles.VisualBasic.Settings));
 
-            var solutionFlePath = GetSolutionFileName(@"TestVB2.sln");
+            var solutionFilePath = GetSolutionFileName(@"TestVB2.sln");
 
             using (var workspace = CreateMSBuildWorkspace())
             {
-                var solution = await workspace.OpenSolutionAsync(solutionFlePath);
+                var solution = await workspace.OpenSolutionAsync(solutionFilePath);
 
                 // Neither project should contain any unresolved metadata references
                 foreach (var project in solution.Projects)


### PR DESCRIPTION
Fixes #29122

In MSBuildWorkspace, there's a fair amount of logic to resolve the metadata references that are passed to the compiler to project references that are defined on the project. This change adds a fallback in the case that a project reference can't be matched to one of the metadata references. This is primarily a situation where something is wrong with the project in it's current configuration. For these cases, MSBuildWorkspace will still attempt to add a project reference but also report a workspace diagnostic. In addtition, this change removes and reports diagnostics for any unresolved metadata references passed to the compiler after the reference resolution step occurs. In addition, this change exposed a small bug when ReferenceOutputAssembly is specified for a project reference, which was caught by an existing test and fixed.