### PR TITLE
Increase available span for 'Convert to interpolated string' refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
@@ -544,42 +544,28 @@ public class C
 
         [WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
-        public async Task TestWithSelectionOnEntireToBeInterpolatedString()
+        public async Task TestMissingWithSelectionOnEntireToBeInterpolatedString()
         {
-            await TestInRegularAndScriptAsync(
+            await TestMissingInRegularAndScriptAsync(
 @"public class C
 {
     void M()
     {
         var v = [|""string"" + 1|];
     }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""string{1}"";
-    }
 }");
         }
 
         [WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
-        public async Task TestWithSelectionOnPartOfToBeInterpolatedString()
+        public async Task TestMissingWithSelectionOnPartOfToBeInterpolatedString()
         {
-            await TestInRegularAndScriptAsync(
+            await TestMissingInRegularAndScriptAsync(
 @"public class C
 {
     void M()
     {
         var v = [|""string"" + 1|] + ""string"";
-    }
-}",
-@"public class C
-{
-    void M()
-    {
-        var v = $""string{1}string"";
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
@@ -541,5 +541,187 @@ public class C
     }
 }");
         }
+
+        [WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithSelectionOnEntireToBeInterpolatedString()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        var v = [|""string"" + 1|];
+    }
+}",
+@"public class C
+{
+    void M()
+    {
+        var v = $""string{1}"";
+    }
+}");
+        }
+
+        [WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithSelectionOnPartOfToBeInterpolatedString()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        var v = [|""string"" + 1|] + ""string"";
+    }
+}",
+@"public class C
+{
+    void M()
+    {
+        var v = $""string{1}string"";
+    }
+}");
+        }
+
+        [WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestMissingWithSelectionExceedingToBeInterpolatedString()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        [|var v = ""string"" + 1|];
+    }
+}");
+        }
+
+        [WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithCaretBeforeNonStringToken()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        var v = [||]3 + ""string"" + 1 + ""string"";
+    }
+}",
+@"public class C
+{
+    void M()
+    {
+        var v = $""{3}string{1}string"";
+    }
+}");
+        }
+
+        [WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithCaretAfterNonStringToken()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        var v = 3[||] + ""string"" + 1 + ""string"";
+    }
+}",
+@"public class C
+{
+    void M()
+    {
+        var v = $""{3}string{1}string"";
+    }
+}");
+        }
+
+        [WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithCaretBeforePlusToken()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        var v = 3 [||]+ ""string"" + 1 + ""string"";
+    }
+}",
+@"public class C
+{
+    void M()
+    {
+        var v = $""{3}string{1}string"";
+    }
+}");
+        }
+
+        [WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithCaretAfterPlusToken()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        var v = 3 +[||] ""string"" + 1 + ""string"";
+    }
+}",
+@"public class C
+{
+    void M()
+    {
+        var v = $""{3}string{1}string"";
+    }
+}");
+        }
+
+        [WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithCaretBeforeLastPlusToken()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        var v = 3 + ""string"" + 1 [||]+ ""string"";
+    }
+}",
+@"public class C
+{
+    void M()
+    {
+        var v = $""{3}string{1}string"";
+    }
+}");
+        }
+
+        [WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithCaretAfterLastPlusToken()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        var v = 3 + ""string"" + 1 +[||] ""string"";
+    }
+}",
+@"public class C
+{
+    void M()
+    {
+        var v = $""{3}string{1}string"";
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.vb
@@ -320,5 +320,161 @@ Public Class C
     End Sub
 End Class")
         End Function
+
+        <WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestWithSelectionOnEntireToBeInterpolatedString() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        dim v = [|""string"" & 1|]
+    End Sub
+End Class",
+"
+Public Class C
+    Sub M()
+        dim v = $""string{1}""
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestWithSelectionOnPartOfToBeInterpolatedString() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        dim v = [|""string"" & 1|] & ""string""
+    End Sub
+End Class",
+"
+Public Class C
+    Sub M()
+        dim v = $""string{1}string""
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestMissingWithSelectionExceedingToBeInterpolatedString() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        [|dim v = ""string"" & 1|]
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestWithCaretBeforeNonStringToken() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        dim v = [||]3 & ""string"" & 1 & ""string""
+    End Sub
+End Class",
+"
+Public Class C
+    Sub M()
+        dim v = $""{3}string{1}string""
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestWithCaretAfterNonStringToken() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        dim v = 3[||] & ""string"" & 1 & ""string""
+    End Sub
+End Class",
+"
+Public Class C
+    Sub M()
+        dim v = $""{3}string{1}string""
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestWithCaretBeforeAmpersandToken() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        dim v = 3 [||]& ""string"" & 1 & ""string""
+    End Sub
+End Class",
+"
+Public Class C
+    Sub M()
+        dim v = $""{3}string{1}string""
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestWithCaretAfterAmpersandToken() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        dim v = 3 &[||] ""string"" & 1 & ""string""
+    End Sub
+End Class",
+"
+Public Class C
+    Sub M()
+        dim v = $""{3}string{1}string""
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestWithCaretBeforeLastAmpersandToken() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        dim v = 3 & ""string"" & 1 [||]& ""string""
+    End Sub
+End Class",
+"
+Public Class C
+    Sub M()
+        dim v = $""{3}string{1}string""
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestWithCaretAfterLastAmpersandToken() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        dim v = 3 & ""string"" & 1 &[||] ""string""
+    End Sub
+End Class",
+"
+Public Class C
+    Sub M()
+        dim v = $""{3}string{1}string""
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.vb
@@ -323,36 +323,24 @@ End Class")
 
         <WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
-        Public Async Function TestWithSelectionOnEntireToBeInterpolatedString() As Task
-            Await TestInRegularAndScriptAsync(
+        Public Async Function TestMissingWithSelectionOnEntireToBeInterpolatedString() As Task
+            Await TestMissingInRegularAndScriptAsync(
 "
 Public Class C
     Sub M()
         dim v = [|""string"" & 1|]
-    End Sub
-End Class",
-"
-Public Class C
-    Sub M()
-        dim v = $""string{1}""
     End Sub
 End Class")
         End Function
 
         <WorkItem(16981, "https://github.com/dotnet/roslyn/issues/16981")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
-        Public Async Function TestWithSelectionOnPartOfToBeInterpolatedString() As Task
-            Await TestInRegularAndScriptAsync(
+        Public Async Function TestMissingWithSelectionOnPartOfToBeInterpolatedString() As Task
+            Await TestMissingInRegularAndScriptAsync(
 "
 Public Class C
     Sub M()
         dim v = [|""string"" & 1|] & ""string""
-    End Sub
-End Class",
-"
-Public Class C
-    Sub M()
-        dim v = $""string{1}string""
     End Sub
 End Class")
         End Function

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -22,13 +22,6 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
     {
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
-            // Currently only supported if there is no selection.  We could consider relaxing
-            // this if the selection is of a string concatenation expression.
-            if (context.Span.Length > 0)
-            {
-                return;
-            }
-
             var cancellationToken = context.CancellationToken;
 
             var document = context.Document;
@@ -36,20 +29,12 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var token = root.FindToken(position);
 
-            // Cursor has to at least be touching a string token.
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
-            if (!token.Span.IntersectsWith(position) ||
-                !syntaxFacts.IsStringLiteral(token))
-            {
-                return;
-            }
-
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             // The string literal has to at least be contained in a concatenation of some form.
             // i.e.  "goo" + a      or     a + "goo".  However, those concats could be in larger
             // concats as well.  Walk to the top of that entire chain.
-
             var literalExpression = token.Parent;
             var top = literalExpression;
             while (IsStringConcat(syntaxFacts, top.Parent, semanticModel, cancellationToken))
@@ -57,7 +42,7 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
                 top = top.Parent;
             }
 
-            if (top == literalExpression)
+            if (top == literalExpression && !IsStringConcat(syntaxFacts, top, semanticModel, cancellationToken))
             {
                 // We weren't in a concatenation at all.
                 return;
@@ -78,9 +63,9 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
 
             // Make sure that all the string tokens we're concatenating are the same type
             // of string literal.  i.e. if we have an expression like: @" "" " + " \r\n "
-            // then we don't merge this.  We don't want to be munging differnet types of
+            // then we don't merge this.  We don't want to be munging different types of
             // escape sequences in these strings, so we only support combining the string
-            // tokens if they're all teh same type.
+            // tokens if they're all the same type.
             var firstStringToken = pieces.First(syntaxFacts.IsStringLiteralExpression).GetFirstToken();
             var isVerbatimStringLiteral = syntaxFacts.IsVerbatimStringLiteral(firstStringToken);
             if (pieces.Where(syntaxFacts.IsStringLiteralExpression).Any(

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -22,6 +22,13 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
     {
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
+            // Currently only supported if there is no selection, to prevent possible confusion when
+            // selecting part of what would become an interpolated string
+            if (context.Span.Length > 0)
+            {
+                return;
+            }
+
             var cancellationToken = context.CancellationToken;
 
             var document = context.Document;
@@ -32,8 +39,8 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-            // The string literal has to at least be contained in a concatenation of some form.
-            // i.e.  "goo" + a      or     a + "goo".  However, those concats could be in larger
+            // The token has to at least be contained in a concatenation of some form.
+            // i.e.  "goo" + a      or    3 + 1 + "goo".  However, those concats could be in larger
             // concats as well.  Walk to the top of that entire chain.
             var literalExpression = token.Parent;
             var top = literalExpression;

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -39,17 +39,17 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-            // The token has to at least be contained in a concatenation of some form.
+            // The selected token has to at least be contained in a concatenation of some form.
             // i.e.  "goo" + a      or    3 + 1 + "goo".  However, those concats could be in larger
             // concats as well.  Walk to the top of that entire chain.
-            var literalExpression = token.Parent;
-            var top = literalExpression;
+            var selectedExpression = token.Parent;
+            var top = selectedExpression;
             while (IsStringConcat(syntaxFacts, top.Parent, semanticModel, cancellationToken))
             {
                 top = top.Parent;
             }
 
-            if (top == literalExpression && !IsStringConcat(syntaxFacts, top, semanticModel, cancellationToken))
+            if (top == selectedExpression && !IsStringConcat(syntaxFacts, top, semanticModel, cancellationToken))
             {
                 // We weren't in a concatenation at all.
                 return;


### PR DESCRIPTION
Resolves #16981.

The available span where the 'Convert to interpolated string' refactoring offered is widened. The available span is now similar to the refactoring on a `string.Format()` statement.

For example (using the example from the referenced issue):
`Console.WriteLine(3 + "Hi" + 3 + "There");`


Before this change, the refactoring was only offered when the caret was touching the "Hi" or "There" strings (including quotation marks). Now, it is also offered on the non-string tokens (i.e. `3` and `5`) and the plus tokens (or ampersand in VB). Lastly, it is offered when having a selection of either part of or the entire to be interpolated string.