### PR TITLE
Fix symbol end action not completing for symbols with non-implicit me…

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1043,6 +1043,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Attempt to execute all analyzer actions.
                 var processedState = EventProcessedState.Processed;
                 var symbol = symbolEvent.Symbol;
+                Debug.Assert(symbol.HasSourceLocation());
                 var isGeneratedCodeSymbol = IsGeneratedCodeSymbol(symbol);
 
                 var skipSymbolAnalysis = AnalysisScope.ShouldSkipSymbolAnalysis(symbolEvent);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1043,7 +1043,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Attempt to execute all analyzer actions.
                 var processedState = EventProcessedState.Processed;
                 var symbol = symbolEvent.Symbol;
-                Debug.Assert(symbol.IsInSource());
                 var isGeneratedCodeSymbol = IsGeneratedCodeSymbol(symbol);
 
                 var skipSymbolAnalysis = AnalysisScope.ShouldSkipSymbolAnalysis(symbolEvent);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1043,7 +1043,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Attempt to execute all analyzer actions.
                 var processedState = EventProcessedState.Processed;
                 var symbol = symbolEvent.Symbol;
-                Debug.Assert(symbol.HasSourceLocation());
+                Debug.Assert(symbol.IsInSource());
                 var isGeneratedCodeSymbol = IsGeneratedCodeSymbol(symbol);
 
                 var skipSymbolAnalysis = AnalysisScope.ShouldSkipSymbolAnalysis(symbolEvent);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     {
                         foreach (var member in members)
                         {
-                            if (!member.IsImplicitlyDeclared && member.HasSourceLocation())
+                            if (!member.IsImplicitlyDeclared && member.IsInSource())
                             {
                                 memberSet = memberSet ?? new HashSet<ISymbol>();
                                 memberSet.Add(member);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
@@ -167,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     {
                         foreach (var member in members)
                         {
-                            if (!member.IsImplicitlyDeclared)
+                            if (!member.IsImplicitlyDeclared && member.HasSourceLocation())
                             {
                                 memberSet = memberSet ?? new HashSet<ISymbol>();
                                 memberSet.Add(member);
@@ -344,7 +343,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 lock (_gate)
                 {
-                    Debug.Assert(_lazyPendingSymbolEndActionsOpt == null || _lazyPendingSymbolEndActionsOpt.Count == 0);
+                    Debug.Assert(_lazyPendingMemberSymbolsMapOpt == null || _lazyPendingMemberSymbolsMapOpt.Count == 0);
                     Debug.Assert(_lazyPendingSymbolEndActionsOpt == null || _lazyPendingSymbolEndActionsOpt.Count == 0);
                 }
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -353,8 +353,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             GetAnalyzerExecutionContext(analyzer).MarkSymbolEndAnalysisComplete(symbol);
         }
 
-        // https://github.com/dotnet/roslyn/issues/30309 tracks enabling the below debug verification.
-        [Conditional("DEBUG_30309")]
+        [Conditional("DEBUG")]
         public void VerifyAllSymbolEndActionsExecuted()
         {
             foreach (var analyzerExecutionContext in _analyzerExecutionContextMap.Values)

--- a/src/Compilers/Core/Portable/Symbols/ISymbolExtensions.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbolExtensions.cs
@@ -96,5 +96,18 @@ namespace Microsoft.CodeAnalysis
 
         internal static bool IsNetModule(this IAssemblySymbol assembly) =>
             assembly is ISourceAssemblySymbol sourceAssembly && sourceAssembly.Compilation.Options.OutputKind.IsNetModule();
+
+        internal static bool HasSourceLocation(this ISymbol symbol)
+        {
+            foreach (var location in symbol.Locations)
+            {
+                if (location.IsInSource)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/ISymbolExtensions.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbolExtensions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis
         internal static bool IsNetModule(this IAssemblySymbol assembly) =>
             assembly is ISourceAssemblySymbol sourceAssembly && sourceAssembly.Compilation.Options.OutputKind.IsNetModule();
 
-        internal static bool HasSourceLocation(this ISymbol symbol)
+        internal static bool IsInSource(this ISymbol symbol)
         {
             foreach (var location in symbol.Locations)
             {

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1672,7 +1672,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Friend Function ShouldAddEvent(symbol As Symbol) As Boolean
-            Return EventQueue IsNot Nothing AndAlso symbol.HasSourceLocation()
+            Return EventQueue IsNot Nothing AndAlso symbol.IsInSource()
         End Function
 
         Friend Sub SymbolDeclaredEvent(symbol As Symbol)

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1672,18 +1672,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Friend Function ShouldAddEvent(symbol As Symbol) As Boolean
-            If EventQueue Is Nothing Then
-                Return False
-            End If
-
-            For Each location As Location In symbol.Locations
-                If location.SourceTree IsNot Nothing Then
-                    Debug.Assert(AllSyntaxTrees.Contains(location.SourceTree))
-                    Return True
-                End If
-            Next
-
-            Return False
+            Return EventQueue IsNot Nothing AndAlso symbol.HasSourceLocation()
         End Function
 
         Friend Sub SymbolDeclaredEvent(symbol As Symbol)


### PR DESCRIPTION
…mbers that have no source location.

In VB, MyApplication type has a Main method which is not marked as IsImplicitlyDeclared but has no source locations (it has a MyTemplateLocation). Due to the latter, VB never generates symbol declared events for such a Main method, causing the symbol end action to never run for it's container. This assert fires intermittently in an [integration test](http://source.roslyn.io/#Microsoft.VisualStudio.LanguageServices.IntegrationTests/VisualBasic/BasicAddMissingReference.cs,151), but does not repro when the project is manually opened. Verified the assert does not fire for multiple iterations of the same integration test after this fix.

 Fixes #30309 