### PR TITLE
Null check baseDirectory before adding to keyFileSearchPaths

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -46,6 +46,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <returns>a commandlinearguments object representing the parsed command line.</returns>
         public new CSharpCommandLineArguments Parse(IEnumerable<string> args, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories = null)
         {
+            Debug.Assert(baseDirectory == null || PathUtilities.IsAbsolute(baseDirectory));
+
             List<Diagnostic> diagnostics = new List<Diagnostic>();
             List<string> flattenedArgs = new List<string>();
             List<string> scriptArgs = IsScriptCommandLineParser ? new List<string>() : null;

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1225,8 +1225,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Dev11 searches for the key file in the current directory and assembly output directory.
             // We always look to base directory and then examine the search paths.
-            keyFileSearchPaths.Add(baseDirectory);
-            if (baseDirectory != outputDirectory)
+            if (!string.IsNullOrWhiteSpace(baseDirectory))
+            {
+                keyFileSearchPaths.Add(baseDirectory);
+            }
+
+            if (!string.IsNullOrWhiteSpace(outputDirectory) && baseDirectory != outputDirectory)
             {
                 keyFileSearchPaths.Add(outputDirectory);
             }

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1214,7 +1214,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // add additional reference paths if specified
-            if (!string.IsNullOrWhiteSpace(additionalReferenceDirectories))
+            if (!string.IsNullOrEmpty(additionalReferenceDirectories))
             {
                 ParseAndResolveReferencePaths(null, additionalReferenceDirectories, baseDirectory, libPaths, MessageID.IDS_LIB_ENV, diagnostics);
             }
@@ -1225,18 +1225,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Dev11 searches for the key file in the current directory and assembly output directory.
             // We always look to base directory and then examine the search paths.
-            if (!string.IsNullOrWhiteSpace(baseDirectory))
+            if (!string.IsNullOrEmpty(baseDirectory))
             {
                 keyFileSearchPaths.Add(baseDirectory);
             }
 
-            if (!string.IsNullOrWhiteSpace(outputDirectory) && baseDirectory != outputDirectory)
+            if (!string.IsNullOrEmpty(outputDirectory) && baseDirectory != outputDirectory)
             {
                 keyFileSearchPaths.Add(outputDirectory);
             }
 
             // Public sign doesn't use the legacy search path settings
-            if (publicSign && !string.IsNullOrWhiteSpace(keyFileSetting))
+            if (publicSign && !string.IsNullOrEmpty(keyFileSetting))
             {
                 keyFileSetting = ParseGenericPathToFile(keyFileSetting, diagnostics, baseDirectory);
             }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -250,6 +250,14 @@ d.cs
             AssertEx.Equal(ImmutableArray.Create<string>(), parser.KeyFileSearchPaths);
         }
 
+        [Fact]
+        public void WhiteSpaceBaseDirectoryAddedToKeyFileSearchPaths()
+        {
+            var baseDir = "\u200A";
+            var parser = CSharpCommandLineParser.Default.Parse(new string[0], baseDir, SdkDirectory);
+            AssertEx.Equal(ImmutableArray.Create(baseDir), parser.KeyFileSearchPaths);
+        }
+
         [ConditionalFact(typeof(WindowsOnly))]
         public void SourceFiles_Patterns()
         {

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -250,14 +250,6 @@ d.cs
             AssertEx.Equal(ImmutableArray.Create<string>(), parser.KeyFileSearchPaths);
         }
 
-        [Fact]
-        public void WhiteSpaceBaseDirectoryAddedToKeyFileSearchPaths()
-        {
-            var baseDir = "\u200A";
-            var parser = CSharpCommandLineParser.Default.Parse(new string[0], baseDir, SdkDirectory);
-            AssertEx.Equal(ImmutableArray.Create(baseDir), parser.KeyFileSearchPaths);
-        }
-
         [ConditionalFact(typeof(WindowsOnly))]
         public void SourceFiles_Patterns()
         {

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -243,6 +243,13 @@ d.cs
             Assert.Equal(basePath, args.BaseDirectory);
         }
 
+        [Fact]
+        public void NullBaseDirectoryNotAddedToKeyFileSearchPaths()
+        {
+            var parser = CSharpCommandLineParser.Default.Parse(new string[0], null, SdkDirectory);
+            AssertEx.Equal(ImmutableArray.Create<string>(), parser.KeyFileSearchPaths);
+        }
+
         [ConditionalFact(typeof(WindowsOnly))]
         public void SourceFiles_Patterns()
         {

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -73,6 +73,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="additionalReferenceDirectories">A string representing additional reference paths.</param>
         ''' <returns>A CommandLineArguments object representing the parsed command line.</returns>
         Public Shadows Function Parse(args As IEnumerable(Of String), baseDirectory As String, sdkDirectory As String, Optional additionalReferenceDirectories As String = Nothing) As VisualBasicCommandLineArguments
+            Debug.Assert(baseDirectory Is Nothing OrElse PathUtilities.IsAbsolute(baseDirectory))
+
             Const GenerateFileNameForDocComment As String = "USE-OUTPUT-NAME"
 
             Dim diagnostics As List(Of Diagnostic) = New List(Of Diagnostic)()

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1252,7 +1252,7 @@ lVbRuntimePlus:
             End If
 
             ' add additional reference paths if specified
-            If Not String.IsNullOrWhiteSpace(additionalReferenceDirectories) Then
+            If Not String.IsNullOrEmpty(additionalReferenceDirectories) Then
                 libPaths.AddRange(ParseSeparatedPaths(additionalReferenceDirectories))
             End If
 
@@ -1260,7 +1260,7 @@ lVbRuntimePlus:
             Dim searchPaths As ImmutableArray(Of String) = BuildSearchPaths(baseDirectory, sdkPaths, responsePaths, libPaths)
 
             ' Public sign doesn't use legacy search path settings
-            If publicSign AndAlso Not String.IsNullOrWhiteSpace(keyFileSetting) Then
+            If publicSign AndAlso Not String.IsNullOrEmpty(keyFileSetting) Then
                 keyFileSetting = ParseGenericPathToFile(keyFileSetting, diagnostics, baseDirectory)
             End If
 
@@ -1291,11 +1291,11 @@ lVbRuntimePlus:
 
             ' Dev10 searches for the keyfile in the current directory and assembly output directory.
             ' We always look to base directory and then examine the search paths.
-            If Not String.IsNullOrWhiteSpace(baseDirectory) Then
+            If Not String.IsNullOrEmpty(baseDirectory) Then
                 keyFileSearchPaths.Add(baseDirectory)
             End If
 
-            If Not String.IsNullOrWhiteSpace(outputDirectory) AndAlso baseDirectory <> outputDirectory Then
+            If Not String.IsNullOrEmpty(outputDirectory) AndAlso baseDirectory <> outputDirectory Then
                 keyFileSearchPaths.Add(outputDirectory)
             End If
 

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1291,8 +1291,11 @@ lVbRuntimePlus:
 
             ' Dev10 searches for the keyfile in the current directory and assembly output directory.
             ' We always look to base directory and then examine the search paths.
-            keyFileSearchPaths.Add(baseDirectory)
-            If baseDirectory <> outputDirectory Then
+            If Not String.IsNullOrWhiteSpace(baseDirectory) Then
+                keyFileSearchPaths.Add(baseDirectory)
+            End If
+
+            If Not String.IsNullOrWhiteSpace(outputDirectory) AndAlso baseDirectory <> outputDirectory Then
                 keyFileSearchPaths.Add(outputDirectory)
             End If
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -3185,6 +3185,13 @@ print Goodbye, World"
             AssertEx.Equal(ImmutableArray.Create(Of String)(), args.KeyFileSearchPaths)
         End Sub
 
+        <Fact>
+        Public Sub WhiteSpaceBaseDirectoryAddedToKeyFileSearchPaths()
+            Dim baseDir = "\u200A"
+            Dim args = VisualBasicCommandLineParser.Default.Parse(New String() {}, baseDir, RuntimeEnvironment.GetRuntimeDirectory())
+            AssertEx.Equal(ImmutableArray.Create(baseDir), args.KeyFileSearchPaths)
+        End Sub
+
         <CompilerTrait(CompilerFeature.Determinism)>
         <Fact>
         Public Sub PathMapPdbDeterminism()

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -3179,6 +3179,12 @@ print Goodbye, World"
             Assert.Equal(New KeyValuePair(Of String, String)("/temp/", "/bar/"), doublemap(1))
         End Sub
 
+        <Fact>
+        Public Sub NothingBaseDirectoryNotAddedToKeyFileSearchPaths()
+            Dim args As VisualBasicCommandLineArguments = VisualBasicCommandLineParser.Default.Parse(New String() {}, Nothing, RuntimeEnvironment.GetRuntimeDirectory())
+            AssertEx.Equal(ImmutableArray.Create(Of String)(), args.KeyFileSearchPaths)
+        End Sub
+
         <CompilerTrait(CompilerFeature.Determinism)>
         <Fact>
         Public Sub PathMapPdbDeterminism()

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -3185,13 +3185,6 @@ print Goodbye, World"
             AssertEx.Equal(ImmutableArray.Create(Of String)(), args.KeyFileSearchPaths)
         End Sub
 
-        <Fact>
-        Public Sub WhiteSpaceBaseDirectoryAddedToKeyFileSearchPaths()
-            Dim baseDir = "\u200A"
-            Dim args = VisualBasicCommandLineParser.Default.Parse(New String() {}, baseDir, RuntimeEnvironment.GetRuntimeDirectory())
-            AssertEx.Equal(ImmutableArray.Create(baseDir), args.KeyFileSearchPaths)
-        End Sub
-
         <CompilerTrait(CompilerFeature.Determinism)>
         <Fact>
         Public Sub PathMapPdbDeterminism()

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectOptionsHelper.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectOptionsHelper.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
         Private Shared s_conditionalCompilationSymbolsCache As Dictionary(Of KeyValuePair(Of String, OutputKind), ImmutableArray(Of KeyValuePair(Of String, Object))) =
             New Dictionary(Of KeyValuePair(Of String, OutputKind), ImmutableArray(Of KeyValuePair(Of String, Object)))
 
-        Private Shared ReadOnly s_EmptyCommandLineArguments As VisualBasicCommandLineArguments = VisualBasicCommandLineParser.Default.Parse(SpecializedCollections.EmptyEnumerable(Of String)(), baseDirectory:="", sdkDirectory:=Nothing)
+        Private Shared ReadOnly s_EmptyCommandLineArguments As VisualBasicCommandLineArguments = VisualBasicCommandLineParser.Default.Parse(SpecializedCollections.EmptyEnumerable(Of String)(), baseDirectory:=Nothing, sdkDirectory:=Nothing)
 
         Public Shared Function CreateCompilationOptions(baseCompilationOptionsOpt As VisualBasicCompilationOptions,
                                                      newParseOptions As VisualBasicParseOptions,


### PR DESCRIPTION
Resolves #30349 

Seems like the decision is that usages of the baseDirectory parameter should be null-resilient. This null checks the baseDirectory before adding to keyFileSearchPaths so that down the line it doesn't attempt to search a `null` for the key file.