### PR TITLE
Fixed documentation for SyntaxNode.Contains()

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -430,6 +430,7 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Determines if the specified node is a descendant of this node.
+        /// Returns true for current node.
         /// </summary>
         public bool Contains(SyntaxNode node)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/27055