### PR TITLE
Fix race condition in symbol start action execution

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             [Conditional("DEBUG")]
-            void VerifyNewEntryForPendingMemberSymbolsMap(ISymbol symbol, HashSet<ISymbol> dependentSymbols)
+            private void VerifyNewEntryForPendingMemberSymbolsMap(ISymbol symbol, HashSet<ISymbol> dependentSymbols)
             {
                 if (_lazyPendingMemberSymbolsMapOpt.TryGetValue(symbol, out var existingDependentSymbols))
                 {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -139,7 +139,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                             lock (_gate)
                             {
                                 _lazyPendingMemberSymbolsMapOpt = _lazyPendingMemberSymbolsMapOpt ?? new Dictionary<ISymbol, HashSet<ISymbol>>();
-                                _lazyPendingMemberSymbolsMapOpt.Add(symbol, dependentSymbols);
+
+                                // Guard against entry added from another thread.
+                                if (!_lazyPendingMemberSymbolsMapOpt.ContainsKey(symbol))
+                                {
+                                    _lazyPendingMemberSymbolsMapOpt.Add(symbol, dependentSymbols);
+                                }
+                                else
+                                {
+                                    Debug.Assert(dependentSymbols.SetEquals(_lazyPendingMemberSymbolsMapOpt[symbol]));
+                                }
                             }
                         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -141,14 +141,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                 _lazyPendingMemberSymbolsMapOpt = _lazyPendingMemberSymbolsMapOpt ?? new Dictionary<ISymbol, HashSet<ISymbol>>();
 
                                 // Guard against entry added from another thread.
-                                if (!_lazyPendingMemberSymbolsMapOpt.ContainsKey(symbol))
-                                {
-                                    _lazyPendingMemberSymbolsMapOpt.Add(symbol, dependentSymbols);
-                                }
-                                else
-                                {
-                                    Debug.Assert(dependentSymbols.SetEquals(_lazyPendingMemberSymbolsMapOpt[symbol]));
-                                }
+                                Debug.Assert(!_lazyPendingMemberSymbolsMapOpt.TryGetValue(symbol, out var existingDependentSymbols) ||
+                                    dependentSymbols.SetEquals(existingDependentSymbols));
+                                _lazyPendingMemberSymbolsMapOpt[symbol] = dependentSymbols;
                             }
                         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -141,8 +141,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                 _lazyPendingMemberSymbolsMapOpt = _lazyPendingMemberSymbolsMapOpt ?? new Dictionary<ISymbol, HashSet<ISymbol>>();
 
                                 // Guard against entry added from another thread.
-                                Debug.Assert(!_lazyPendingMemberSymbolsMapOpt.TryGetValue(symbol, out var existingDependentSymbols) ||
-                                    dependentSymbols.SetEquals(existingDependentSymbols));
+                                VerifyNewEntryForPendingMemberSymbolsMap(symbol, dependentSymbols);
                                 _lazyPendingMemberSymbolsMapOpt[symbol] = dependentSymbols;
                             }
                         }
@@ -183,6 +182,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                 processMembers(typeMember.GetMembers());
                             }
                         }
+                    }
+                }
+            }
+
+            [Conditional("DEBUG")]
+            void VerifyNewEntryForPendingMemberSymbolsMap(ISymbol symbol, HashSet<ISymbol> dependentSymbols)
+            {
+                if (_lazyPendingMemberSymbolsMapOpt.TryGetValue(symbol, out var existingDependentSymbols))
+                {
+                    if (existingDependentSymbols == null)
+                    {
+                        Debug.Assert(dependentSymbols == null);
+                    }
+                    else
+                    {
+                        Debug.Assert(dependentSymbols != null);
+                        Debug.Assert(dependentSymbols.SetEquals(existingDependentSymbols));
                     }
                 }
             }


### PR DESCRIPTION
Guard against entry added from another thread.

Fixes internal VSO bug [#700302](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/700302)