### PR TITLE
Skip M.CA.CS.Symbol.UnitTests on dev16.0.x

### DIFF
--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -24,7 +24,6 @@ if [[ "${runtime}" == "dotnet" ]]; then
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/${target_framework}/xunit.console.dll
 elif [[ "${runtime}" == "mono" ]]; then
     file_list=(
-        "${unittest_dir}/Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests/net46/Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.dll"
         "${unittest_dir}/Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests/net46/Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests.dll"
         )
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/net452/xunit.console.exe


### PR DESCRIPTION
Adapted from @jaredpar's comment at https://github.com/dotnet/roslyn/pull/30379#issuecomment-428022215