### PR TITLE
Fix for Incorrect IDE0052 (assigned but never read)

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.RemoveUnusedMembers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 using static Roslyn.Test.Utilities.TestHelpers;
 
@@ -1076,6 +1077,7 @@ class MyClass
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(30397, "https://github.com/dotnet/roslyn/issues/30397")]
         public async Task FieldIsIncrementedAndValueUsed()
         {
             await TestDiagnosticMissingAsync(
@@ -1087,6 +1089,7 @@ class MyClass
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(30397, "https://github.com/dotnet/roslyn/issues/30397")]
         public async Task FieldIsIncrementedAndValueUsed_02()
         {
             await TestDiagnosticMissingAsync(

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -16,6 +16,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedMembers
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
             => (new CSharpRemoveUnusedMembersDiagnosticAnalyzer(), new CSharpRemoveUnusedMembersCodeFixProvider());
 
+        // Ensure that we explicitly test missing IDE0052, which has no corresponding code fix (non-fixable diagnostic).
+        private Task TestDiagnosticMissingAsync(string initialMarkup)
+            => TestDiagnosticMissingAsync(initialMarkup, fixableDiagnosticsOnly: false);
+
         [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         [InlineData("public")]
         [InlineData("internal")]
@@ -24,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedMembers
         [InlineData("private protected")]
         public async Task NonPrivateField(string accessibility)
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 $@"class MyClass
 {{
     {accessibility} int [|_goo|];
@@ -39,7 +43,7 @@ $@"class MyClass
         [InlineData("private protected")]
         public async Task NonPrivateFieldWithConstantInitializer(string accessibility)
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 $@"class MyClass
 {{
     {accessibility} int [|_goo|] = 0;
@@ -54,7 +58,7 @@ $@"class MyClass
         [InlineData("private protected")]
         public async Task NonPrivateFieldWithNonConstantInitializer(string accessibility)
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 $@"class MyClass
 {{
     {accessibility} int [|_goo|] = _goo2;
@@ -70,7 +74,7 @@ $@"class MyClass
         [InlineData("private protected")]
         public async Task NonPrivateMethod(string accessibility)
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 $@"class MyClass
 {{
     {accessibility} void [|M|]() {{ }}
@@ -85,7 +89,7 @@ $@"class MyClass
         [InlineData("private protected")]
         public async Task NonPrivateProperty(string accessibility)
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 $@"class MyClass
 {{
     {accessibility} int [|P|] {{ get; }}
@@ -100,7 +104,7 @@ $@"class MyClass
         [InlineData("private protected")]
         public async Task NonPrivateIndexer(string accessibility)
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 $@"class MyClass
 {{
     {accessibility} int [|this|] {{ get {{ return 0; }} set {{ }} }}
@@ -115,7 +119,7 @@ $@"class MyClass
         [InlineData("private protected")]
         public async Task NonPrivateEvent(string accessibility)
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 $@"using System;
 
 class MyClass
@@ -180,7 +184,7 @@ class MyClass
         public async Task InstanceConstructorIsUnused_NoArguments()
         {
             // We only flag constructors with arguments.
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private [|MyClass()|] { }
@@ -203,7 +207,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task StaticConstructorIsNotFlagged()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     static [|MyClass()|] { }
@@ -213,7 +217,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task DestructorIsNotFlagged()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     ~[|MyClass()|] { }
@@ -262,7 +266,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task EntryPointMethodNotFlagged()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private static void [|Main|]() { }
@@ -272,7 +276,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task EntryPointMethodNotFlagged_02()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"using System.Threading.Tasks;
 
 class MyClass
@@ -284,7 +288,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task EntryPointMethodNotFlagged_03()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"using System.Threading.Tasks;
 
 class MyClass
@@ -296,7 +300,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task EntryPointMethodNotFlagged_04()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"using System.Threading.Tasks;
 
 class MyClass
@@ -412,7 +416,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MethodIsUnused_Extern()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"using System.Runtime.InteropServices;
 
 class C
@@ -425,7 +429,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MethodIsUnused_Abstract()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class C
 {
     private abstract void [|M|]();
@@ -435,7 +439,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MethodIsUnused_InterfaceMethod()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"interface I
 {
     void [|M|]();
@@ -445,7 +449,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MethodIsUnused_ExplicitInterfaceImplementation()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"interface I
 {
     void M();
@@ -460,7 +464,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task PropertyIsUnused_ExplicitInterfaceImplementation()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"interface I
 {
     int P { get; set; }
@@ -488,7 +492,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_ExpressionBody()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -499,7 +503,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_BlockBody()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -510,7 +514,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_ExpressionLambda()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -524,7 +528,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_BlockLambda()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -538,7 +542,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_Delegate()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -552,7 +556,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_ExpressionBodyLocalFunction()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -567,7 +571,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_BlockBodyLocalFunction()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -582,7 +586,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_Accessor()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -599,7 +603,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_Deconstruction()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -613,7 +617,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_DifferentInstance()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -624,7 +628,7 @@ class C : I
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_ObjectInitializer()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"
 class C
 {
@@ -640,7 +644,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_ThisInstance()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -651,7 +655,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_Attribute()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private const string [|_goo|] = """";
@@ -664,7 +668,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MethodIsInvoked()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|M1|] => 0
@@ -675,7 +679,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MethodIsAddressTaken()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|M1|] => 0
@@ -689,7 +693,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task GenericMethodIsInvoked_ExplicitTypeArguments()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|M1|]<T>() => 0;
@@ -700,7 +704,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task GenericMethodIsInvoked_ImplicitTypeArguments()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private T [|M1|]<T>(T t) => t;
@@ -711,7 +715,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MethodInGenericTypeIsInvoked_NoTypeArguments()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass<T>
 {
     private int [|M1|]() => 0;
@@ -722,7 +726,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MethodInGenericTypeIsInvoked_NonConstructedType()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass<T>
 {
     private int [|M1|]() => 0;
@@ -733,7 +737,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MethodInGenericTypeIsInvoked_ConstructedType()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass<T>
 {
     private int [|M1|]() => 0;
@@ -744,7 +748,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task InstanceConstructorIsUsed_NoArguments()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private [|MyClass()|] { }
@@ -755,7 +759,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task InstanceConstructorIsUsed_WithArguments()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private [|MyClass(int i)|] { }
@@ -766,7 +770,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task PropertyIsRead()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|P|] => 0;
@@ -777,7 +781,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task IndexerIsRead()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|this|][int x] { get { return 0; } set { } }
@@ -788,7 +792,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task EventIsRead()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"using System;
 
 class MyClass
@@ -801,7 +805,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task EventIsSubscribed()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"using System;
 
 class MyClass
@@ -821,7 +825,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task EventIsRaised()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"using System;
 
 class MyClass
@@ -942,7 +946,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task EventIsOnlyWritten()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private event System.EventHandler [|e|] { add { } remove { } }
@@ -1014,7 +1018,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsReadAndWritten()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -1029,7 +1033,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task PropertyIsReadAndWritten()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|P|] { get; set; }
@@ -1044,7 +1048,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task IndexerIsReadAndWritten()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|this|][int x] { get { return 0; } set { } }
@@ -1059,7 +1063,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsReadAndWritten_InProperty()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -1074,7 +1078,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsIncrementedAndValueUsed()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -1085,7 +1089,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsIncrementedAndValueUsed_02()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -1120,7 +1124,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task PropertyIsIncrementedAndValueUsed()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|P|] { get; set; }
@@ -1143,7 +1147,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task IndexerIsIncrementedAndValueUsed()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|this|][int x] { get { return 0; } set { } }
@@ -1166,7 +1170,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsTargetOfCompoundAssignmentAndValueUsed()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -1177,7 +1181,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsTargetOfCompoundAssignmentAndValueUsed_02()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -1212,7 +1216,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task PropertyIsTargetOfCompoundAssignmentAndValueUsed()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|P|] { get; set; }
@@ -1235,7 +1239,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task IndexerIsTargetOfCompoundAssignmentAndValueUsed()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|this|][int x] { get { return 0; } set { } }
@@ -1283,7 +1287,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsArg()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -1295,7 +1299,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsInArg()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -1307,7 +1311,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRefArg()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -1332,7 +1336,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MethodIsArg()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|M|]() => 0;
@@ -1344,7 +1348,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task PropertyIsArg()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|P|] => 0;
@@ -1356,7 +1360,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task IndexerIsArg()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|this|][int x] { get { return 0; } set { } }
@@ -1368,7 +1372,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task EventIsArg()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"using System;
 
 class MyClass
@@ -1426,7 +1430,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MultipleFields_SomeUnused_02()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|] = 0, _bar = 0;
@@ -1437,7 +1441,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_InNestedType()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -1452,7 +1456,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task MethodIsInvoked_InNestedType()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|M1|]() => 0;
@@ -1486,7 +1490,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldOfNestedTypeIsRead()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     class NestedType
@@ -1514,7 +1518,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_PartialClass()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"partial class MyClass
 {
     private int [|_goo|];
@@ -1528,7 +1532,7 @@ partial class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_PartialClass_DifferentFile()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
@@ -1571,7 +1575,7 @@ partial class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_InParens()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
@@ -1606,7 +1610,7 @@ partial class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsRead_InDeconstruction_InParens()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class C
 {
     private int [|i|];
@@ -1647,7 +1651,7 @@ partial class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsGeneratedCode()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class C
 {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("""", """")]
@@ -1662,7 +1666,7 @@ partial class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldUsedInGeneratedCode()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class C
 {
     private int [|i|];
@@ -1675,7 +1679,7 @@ partial class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsUnusedInType_SyntaxError()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class C
 {
     private int [|i|];
@@ -1687,7 +1691,7 @@ partial class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsUnusedInType_SemanticError()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class C
 {
     private int [|i|];
@@ -1725,7 +1729,7 @@ class C2
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task StructLayoutAttribute_ExplicitLayout()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"using System.Runtime.InteropServices;
 
 [StructLayoutAttribute(LayoutKind.Explicit)]
@@ -1742,7 +1746,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task StructLayoutAttribute_SequentialLayout()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"using System.Runtime.InteropServices;
 
 [StructLayoutAttribute(LayoutKind.Sequential)]
@@ -1756,7 +1760,7 @@ struct S
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task DebuggerDisplayAttribute_OnType_ReferencesField()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"[System.Diagnostics.DebuggerDisplayAttribute(""{s}"")]
 class C
 {
@@ -1767,7 +1771,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task DebuggerDisplayAttribute_OnType_ReferencesMethod()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"[System.Diagnostics.DebuggerDisplayAttribute(""{GetString()}"")]
 class C
 {
@@ -1778,7 +1782,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task DebuggerDisplayAttribute_OnType_ReferencesProperty()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"[System.Diagnostics.DebuggerDisplayAttribute(""{MyString}"")]
 class C
 {
@@ -1789,7 +1793,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task DebuggerDisplayAttribute_OnField_ReferencesField()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class C
 {
     private string [|s|];
@@ -1802,7 +1806,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task DebuggerDisplayAttribute_OnProperty_ReferencesMethod()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class C
 {
     private string [|GetString|]() => """";
@@ -1815,7 +1819,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task DebuggerDisplayAttribute_OnProperty_ReferencesProperty()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class C
 {
     private string [|MyString|] { get { return """"; } }
@@ -1828,7 +1832,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task DebuggerDisplayAttribute_OnNestedTypeMember_ReferencesField()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestDiagnosticMissingAsync(
 @"class C
 {
     private static string [|s|];

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -106,11 +106,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
         }
 
         protected async Task TestDiagnosticMissingAsync(
-            string initialMarkup, TestParameters parameters = default)
+            string initialMarkup, TestParameters parameters = default, bool fixableDiagnosticsOnly = true)
         {
             using (var workspace = CreateWorkspaceFromOptions(initialMarkup, parameters))
             {
-                var diagnostics = await GetDiagnosticsWorkerAsync(workspace, parameters);
+                var diagnostics = await GetDiagnosticsWorkerAsync(workspace, parameters, fixableDiagnosticsOnly);
                 Assert.Equal(0, diagnostics.Length);
             }
         }
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             TestWorkspace workspace, TestParameters parameters);
 
         protected abstract Task<ImmutableArray<Diagnostic>> GetDiagnosticsWorkerAsync(
-            TestWorkspace workspace, TestParameters parameters);
+            TestWorkspace workspace, TestParameters parameters, bool fixableDiagnosticsOnly);
 
         protected Task TestSmartTagTextAsync(string initialMarkup, string displayText, int index)
             => TestSmartTagTextAsync(initialMarkup, displayText, new TestParameters(index: index));

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             return (actions, actions.IsDefaultOrEmpty ? null : actions[parameters.index]);
         }
 
-        protected override Task<ImmutableArray<Diagnostic>> GetDiagnosticsWorkerAsync(TestWorkspace workspace, TestParameters parameters)
+        protected override Task<ImmutableArray<Diagnostic>> GetDiagnosticsWorkerAsync(TestWorkspace workspace, TestParameters parameters, bool fixableDiagnosticsOnly)
         {
             return SpecializedTasks.EmptyImmutableArray<Diagnostic>();
         }

--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         }
 
         internal override async Task<(ImmutableArray<Diagnostic>, ImmutableArray<CodeAction>, CodeAction actionToInvoke)> GetDiagnosticAndFixesAsync(
-            TestWorkspace workspace, TestParameters parameters)
+            TestWorkspace workspace, TestParameters parameters, bool fixableDiagnosticsOnly)
         {
             var providerAndFixer = GetOrCreateDiagnosticProviderAndFixer(workspace, parameters);
 
@@ -143,8 +143,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
             var ids = new HashSet<string>(fixer.FixableDiagnosticIds);
             var dxs = diagnostics.Where(d => ids.Contains(d.Id)).ToList();
-            return await GetDiagnosticAndFixesAsync(
+            var (resultDiagnostics, codeActions, actionToInvoke) = await GetDiagnosticAndFixesAsync(
                 dxs, provider, fixer, testDriver, document, span, annotation, parameters.index);
+            if (!fixableDiagnosticsOnly)
+            {
+                resultDiagnostics = diagnostics;
+            }
+
+            return (resultDiagnostics, codeActions, actionToInvoke);
         }
 
         protected async Task TestDiagnosticInfoAsync(

--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractSuppressionDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractSuppressionDiagnosticTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         }
 
         internal override async Task<(ImmutableArray<Diagnostic>, ImmutableArray<CodeAction>, CodeAction actionToInvoke)> GetDiagnosticAndFixesAsync(
-            TestWorkspace workspace, TestParameters parameters)
+            TestWorkspace workspace, TestParameters parameters, bool fixableDiagnosticsOnly)
         {
             var providerAndFixer = CreateDiagnosticProviderAndFixer(workspace);
 

--- a/src/EditorFeatures/VisualBasicTest/SimplifyTypeNames/SimplifyTypeNamesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SimplifyTypeNames/SimplifyTypeNamesTests.vb
@@ -1861,7 +1861,7 @@ End Module
             Await TestInRegularAndScriptAsync(source.Value, expected.Value)
 
             Using workspace = TestWorkspace.CreateVisualBasic(source.Value)
-                Dim diagnosticAndFixes = Await GetDiagnosticAndFixesAsync(workspace, New TestParameters())
+                Dim diagnosticAndFixes = Await GetDiagnosticAndFixesAsync(workspace, New TestParameters(), fixableDiagnosticsOnly:=True)
                 Dim span = diagnosticAndFixes.Item1.First().Location.SourceSpan
                 Assert.NotEqual(span.Start, 0)
                 Assert.NotEqual(span.End, 0)
@@ -1910,7 +1910,7 @@ End Namespace
             Await TestInRegularAndScriptAsync(source.Value, expected.Value)
 
             Using workspace = TestWorkspace.CreateVisualBasic(source.Value)
-                Dim diagnosticAndFixes = Await GetDiagnosticAndFixesAsync(workspace, New TestParameters())
+                Dim diagnosticAndFixes = Await GetDiagnosticAndFixesAsync(workspace, New TestParameters(), fixableDiagnosticsOnly:=True)
                 Dim span = diagnosticAndFixes.Item1.First().Location.SourceSpan
                 Assert.Equal(span.Start, expected.Value.ToString.Replace(vbLf, vbCrLf).IndexOf("new C", StringComparison.Ordinal) + 4)
                 Assert.Equal(span.Length, "A.B".Length)
@@ -1945,7 +1945,7 @@ End Module
             Await TestInRegularAndScriptAsync(source.Value, expected.Value)
 
             Using workspace = TestWorkspace.CreateVisualBasic(source.Value)
-                Dim diagnosticAndFixes = Await GetDiagnosticAndFixesAsync(workspace, New TestParameters())
+                Dim diagnosticAndFixes = Await GetDiagnosticAndFixesAsync(workspace, New TestParameters(), fixableDiagnosticsOnly:=True)
                 Dim span = diagnosticAndFixes.Item1.First().Location.SourceSpan
                 Assert.Equal(span.Start, expected.Value.ToString.Replace(vbLf, vbCrLf).IndexOf("Console.WriteLine(""goo"")", StringComparison.Ordinal))
                 Assert.Equal(span.Length, "System".Length)

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                             compoundAssignment.Target == memberReference ||
                             memberReference.Parent is IIncrementOrDecrementOperation);
 
-                        // Compound assignment or increment whose value is being dropped (parent has null type)
+                        // Compound assignment or increment whose value is being dropped (parent is an expression statement)
                         // is treated as a Write as the value was never actually 'read' in a way that is observable.
                         //
                         // Consider the following example:
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                         // while the increment operation '_f2++' is child of a return statement, which uses the result of the increment.
                         // For the above test, '_f1' can be safely removed without affecting the semantics of the program, while '_f2' cannot be removed.
 
-                        if (memberReference.Parent.Parent?.Type == null)
+                        if (memberReference.Parent.Parent is IExpressionStatementOperation)
                         {
                             valueUsageInfo = ValueUsageInfo.Write;
                         }


### PR DESCRIPTION
Fixes #30397

1. Commit https://github.com/dotnet/roslyn/commit/a80c765db2974f898bbb6d0af731e2e6bb63f9c9: Ensure that we can test for missing non-fixable diagnostics in the test framework.
2. Commit https://github.com/dotnet/roslyn/commit/c606a541895b7cfb672e5cc1be3312797829d744: Fix the core issue causing incorrect report in #30397.