### PR TITLE
Handle failures during integration test remoting cleanup

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -185,12 +185,22 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         {
             if (!IsRunning)
             {
+                CloseRemotingService(allowInProcCalls: false);
                 return;
             }
 
-            CleanUp();
+            try
+            {
+                CleanUp();
+            }
+            catch
+            {
+                // A cleanup failure occurred, but we still need to close the communication channel from this side
+                CloseRemotingService(allowInProcCalls: false);
+                throw;
+            }
 
-            CloseRemotingService();
+            CloseRemotingService(allowInProcCalls: true);
 
             if (exitHostProcess)
             {
@@ -204,11 +214,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             IntegrationHelper.KillProcess(HostProcess);
         }
 
-        private void CloseRemotingService()
+        private void CloseRemotingService(bool allowInProcCalls)
         {
             try
             {
-                StopRemoteIntegrationService();
+                if (allowInProcCalls)
+                {
+                    StopRemoteIntegrationService();
+                }
             }
             finally
             {


### PR DESCRIPTION
In the event of the following exception:

> System.Runtime.Remoting.RemotingException: Failed to write to an IPC Port: The pipe is being closed.

<details><summary>Stack trace</summary>

```text
System.Runtime.Remoting.RemotingException: Failed to write to an IPC Port: The pipe is being closed.


Server stack trace: 
   at System.Runtime.Remoting.Channels.Ipc.IpcPort.Write(Byte[] data, Int32 offset, Int32 size)
   at System.Runtime.Remoting.Channels.Ipc.PipeStream.Write(Byte[] buffer, Int32 offset, Int32 count)
   at System.Runtime.Remoting.Channels.ChunkedMemoryStream.WriteTo(Stream stream)
   at System.Runtime.Remoting.Channels.Ipc.IpcClientHandler.SendRequest(IMessage msg, ITransportHeaders headers, Stream contentStream)
   at System.Runtime.Remoting.Channels.Ipc.IpcClientTransportSink.ProcessMessage(IMessage msg, ITransportHeaders requestHeaders, Stream requestStream, ITransportHeaders& responseHeaders, Stream& responseStream)
   at System.Runtime.Remoting.Channels.BinaryClientFormatterSink.SyncProcessMessage(IMessage msg)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess.VisualStudioWorkspace_InProc.CleanUpWaitingService()
   at Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess.VisualStudioWorkspace_OutOfProc.CleanUpWaitingService() in /_/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs:line 59
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstance.CleanUp() in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs:line 172
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstance.Close(Boolean exitHostProcess) in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs:line 191
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstanceFactory.NotifyCurrentInstanceContextDisposed(Boolean canReuse) in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs:line 130
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstanceFactory.<GetNewOrUsedInstanceAsync>d__9.MoveNext() in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs:line 121
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Roslyn.VisualStudio.IntegrationTests.AbstractIntegrationTest.<InitializeAsync>d__8.MoveNext() in /_/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs:line 54
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Roslyn.VisualStudio.IntegrationTests.AbstractEditorTest.<InitializeAsync>d__7.MoveNext() in /_/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs:line 40
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Xunit.Sdk.TestInvoker`1.<<RunAsync>b__47_0>d.MoveNext() in C:\projects\xunit\src\xunit.execution\Sdk\Frameworks\Runners\TestInvoker.cs:line 199
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task).GetType().Name

Server stack trace: 
   at System.Runtime.Remoting.Channels.Ipc.IpcPort.Write(Byte[] data, Int32 offset, Int32 size)
   at System.Runtime.Remoting.Channels.Ipc.PipeStream.Write(Byte[] buffer, Int32 offset, Int32 count)
   at System.Runtime.Remoting.Channels.ChunkedMemoryStream.WriteTo(Stream stream)
   at System.Runtime.Remoting.Channels.Ipc.IpcClientHandler.SendRequest(IMessage msg, ITransportHeaders headers, Stream contentStream)
   at System.Runtime.Remoting.Channels.Ipc.IpcClientTransportSink.ProcessMessage(IMessage msg, ITransportHeaders requestHeaders, Stream requestStream, ITransportHeaders& responseHeaders, Stream& responseStream)
   at System.Runtime.Remoting.Channels.BinaryClientFormatterSink.SyncProcessMessage(IMessage msg)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess.VisualStudioWorkspace_InProc.CleanUpWaitingService()
   at Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess.VisualStudioWorkspace_OutOfProc.CleanUpWaitingService() in /_/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs:line 59
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstance.CleanUp() in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs:line 172
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstance.Close(Boolean exitHostProcess) in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs:line 191
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstanceFactory.NotifyCurrentInstanceContextDisposed(Boolean canReuse) in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs:line 130
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstanceFactory.<GetNewOrUsedInstanceAsync>d__9.MoveNext() in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs:line 121
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Roslyn.VisualStudio.IntegrationTests.AbstractIntegrationTest.<InitializeAsync>d__8.MoveNext() in /_/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs:line 54
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Roslyn.VisualStudio.IntegrationTests.AbstractEditorTest.<InitializeAsync>d__7.MoveNext() in /_/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs:line 40
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Xunit.Sdk.TestInvoker`1.<<RunAsync>b__47_0>d.MoveNext() in C:\projects\xunit\src\xunit.execution\Sdk\Frameworks\Runners\TestInvoker.cs:line 199
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
```

</details>

This pull request avoids cascading to the following exceptions:

> System.Runtime.Remoting.RemotingException: The channel 'IPC channel client for 5108' is already registered.

<details><summary>Stack trace</summary>

```text
System.Runtime.Remoting.RemotingException: The channel 'IPC channel client for 5108' is already registered.
   at System.Runtime.Remoting.Channels.ChannelServices.RegisterChannelInternal(IChannel chnl, Boolean ensureSecurity)
   at System.Runtime.Remoting.Channels.ChannelServices.RegisterChannel(IChannel chnl, Boolean ensureSecurity)
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstance..ctor(Process hostProcess, DTE dte, ImmutableHashSet`1 supportedPackageIds, String installationPath) in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs:line 88
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstanceFactory.<UpdateCurrentlyRunningInstanceAsync>d__12.MoveNext() in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs:line 196
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstanceFactory.<GetNewOrUsedInstanceAsync>d__9.MoveNext() in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs:line 122
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Roslyn.VisualStudio.IntegrationTests.AbstractIntegrationTest.<InitializeAsync>d__8.MoveNext() in /_/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs:line 54
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Roslyn.VisualStudio.IntegrationTests.AbstractEditorTest.<InitializeAsync>d__7.MoveNext() in /_/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs:line 40
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Xunit.Sdk.TestInvoker`1.<<RunAsync>b__47_0>d.MoveNext() in C:\projects\xunit\src\xunit.execution\Sdk\Frameworks\Runners\TestInvoker.cs:line 199
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task).GetType().Name
   at System.Runtime.Remoting.Channels.ChannelServices.RegisterChannelInternal(IChannel chnl, Boolean ensureSecurity)
   at System.Runtime.Remoting.Channels.ChannelServices.RegisterChannel(IChannel chnl, Boolean ensureSecurity)
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstance..ctor(Process hostProcess, DTE dte, ImmutableHashSet`1 supportedPackageIds, String installationPath) in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs:line 88
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstanceFactory.<UpdateCurrentlyRunningInstanceAsync>d__12.MoveNext() in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs:line 196
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.VisualStudio.IntegrationTest.Utilities.VisualStudioInstanceFactory.<GetNewOrUsedInstanceAsync>d__9.MoveNext() in /_/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs:line 122
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Roslyn.VisualStudio.IntegrationTests.AbstractIntegrationTest.<InitializeAsync>d__8.MoveNext() in /_/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs:line 54
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Roslyn.VisualStudio.IntegrationTests.AbstractEditorTest.<InitializeAsync>d__7.MoveNext() in /_/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs:line 40
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Xunit.Sdk.TestInvoker`1.<<RunAsync>b__47_0>d.MoveNext() in C:\projects\xunit\src\xunit.execution\Sdk\Frameworks\Runners\TestInvoker.cs:line 199
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
```

</details>