### PR TITLE
Dispose pattern refactor

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -623,7 +623,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     outVars.Add(variable);
                 }
 
-                const string methodName = "Deconstruct";
+                const string methodName = WellKnownMemberNames.DeconstructMethodName;
                 var memberAccess = BindInstanceMemberAccess(
                                         rightSyntax, receiverSyntax, receiver, methodName, rightArity: 0,
                                         typeArgumentsSyntax: default(SeparatedSyntaxList<TypeSyntax>), typeArguments: default(ImmutableArray<TypeSymbol>),

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -675,6 +675,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundLocalDeclaration declaration = declarations[0];
             TypeSymbol declType = declaration.DeclaredType.Type;
+            BoundLocal declarationLocal = new BoundLocal(declaration.Syntax, declaration.LocalSymbol, null, declType);
 
             if (declType.IsDynamic())
             {
@@ -689,7 +690,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!iDisposableConversion.IsImplicit)
                 {
-                   disposeMethod = TryFindDisposePatternMethod(declaration.InitializerOpt, declarationSyntax, diagnostics);
+                   disposeMethod = TryFindDisposePatternMethod(declarationLocal, declarationSyntax, diagnostics);
                    if (disposeMethod is null)
                    {
                        if (!declType.IsErrorType())

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -675,7 +675,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundLocalDeclaration declaration = declarations[0];
             TypeSymbol declType = declaration.DeclaredType.Type;
-            BoundLocal declarationLocal = new BoundLocal(declaration.Syntax, declaration.LocalSymbol, null, declType);
 
             if (declType.IsDynamic())
             {
@@ -690,15 +689,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!iDisposableConversion.IsImplicit)
                 {
-                   disposeMethod = TryFindDisposePatternMethod(declarationLocal, declarationSyntax, diagnostics);
-                   if (disposeMethod is null)
-                   {
-                       if (!declType.IsErrorType())
-                       {
-                           Error(diagnostics, ErrorCode.ERR_NoConvToIDisp, declarationSyntax, declType);
-                       }
-                       hasErrors = true;
-                   }
+                    var declarationLocal = new BoundLocal(declaration.Syntax, declaration.LocalSymbol, null, declType);
+
+                    disposeMethod = TryFindDisposePatternMethod(declarationLocal, declarationSyntax, diagnostics);
+                    if (disposeMethod is null)
+                    {
+                        if (!declType.IsErrorType())
+                        {
+                            Error(diagnostics, ErrorCode.ERR_NoConvToIDisp, declarationSyntax, declType);
+                        }
+                        hasErrors = true;
+                    }
                 }
             }
             return declarations;
@@ -713,7 +714,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <returns>The <see cref="MethodSymbol"/> of the Dispose method if one is found, otherwise null.</returns>
         internal MethodSymbol TryFindDisposePatternMethod(BoundExpression expr, SyntaxNode syntaxNode, DiagnosticBag diagnostics)
         {
-            if(expr?.Type is null)
+            Debug.Assert(!(expr is null));
+            if(expr.Type is null)
             {
                 return null;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3277,7 +3277,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return PatternLookupResult.NoResults;
                 }
 
-                // we have succeeded or almost succeded to bind the method
+                // we have succeeded or almost succeeded to bind the method
                 // report additional binding diagnostics that we have seen so far
                 diagnostics.AddRange(bindingDiagnostics);
 

--- a/src/Compilers/CSharp/Portable/Binder/PatternMethodLookupResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternMethodLookupResult.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         Success,
 
         /// <summary>
-        /// A member was looked up, but it was not a method
+        /// A member was found, but it was not a method
         /// </summary>
         NotAMethod,
 

--- a/src/Compilers/CSharp/Portable/Binder/PatternMethodLookupResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternMethodLookupResult.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         NotAMethod,
 
         /// <summary>
-        /// A member was looked up, but it was not callable
+        /// A member was found, but it was not callable
         /// </summary>
         NotCallable,
 

--- a/src/Compilers/CSharp/Portable/Binder/PatternMethodLookupResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternMethodLookupResult.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+using System;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal enum PatternLookupResult
+    {
+        /// <summary>
+        /// The Lookup was successful
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// A member was looked up, but it was not a method
+        /// </summary>
+        NotAMethod,
+
+        /// <summary>
+        /// A member was looked up, but it was not callable
+        /// </summary>
+        NotCallable,
+
+        /// <summary>
+        /// The lookup failed to find anything
+        /// </summary>
+        NoResults,
+
+        /// <summary>
+        /// One or more errors occured while performing the lookup
+        /// </summary>
+        ResultHasErrors
+    }
+
+}
+

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -135,9 +135,9 @@ class C2
                 // (6,17): error CS0111: Type 'C1' already defines a member called 'Dispose' with the same parameter types
                 //     public void Dispose() { }
                 Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dispose").WithArguments("Dispose", "C1").WithLocation(6, 17),
-                // (13,16): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is ambiguous with 'C1.Dispose()'.
+                // (13,16): error CS0121: The call is ambiguous between the following methods or properties: 'C1.Dispose()' and 'C1.Dispose()'
                 //         using (C1 c = new C1())
-                Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "C1 c = new C1()").WithArguments("C1", "disposable", "C1.Dispose()", "C1.Dispose()").WithLocation(13, 16),
+                Diagnostic(ErrorCode.ERR_AmbigCall, "C1 c = new C1()").WithArguments("C1.Dispose()", "C1.Dispose()").WithLocation(13, 16),
                 // (13,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(13, 16)
@@ -170,16 +170,16 @@ class C2
                 // (6,17): error CS0111: Type 'C1' already defines a member called 'Dispose' with the same parameter types
                 //     public bool Dispose() { return false; }
                 Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dispose").WithArguments("Dispose", "C1").WithLocation(6, 17),
-                // (13,16): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is ambiguous with 'C1.Dispose()'.
+                // (13,16): error CS0121: The call is ambiguous between the following methods or properties: 'C1.Dispose()' and 'C1.Dispose()'
                 //         using (C1 c = new C1())
-                Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "C1 c = new C1()").WithArguments("C1", "disposable", "C1.Dispose()", "C1.Dispose()").WithLocation(13, 16),
-                // (13,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
+                Diagnostic(ErrorCode.ERR_AmbigCall, "C1 c = new C1()").WithArguments("C1.Dispose()", "C1.Dispose()").WithLocation(13, 16),
+                // (13,16): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(13, 16),
-                // (17,16): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is ambiguous with 'C1.Dispose()'.
+                // (17,16): error CS0121: The call is ambiguous between the following methods or properties: 'C1.Dispose()' and 'C1.Dispose()'
                 //         using (c1b) { }
-                Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "c1b").WithArguments("C1", "disposable", "C1.Dispose()", "C1.Dispose()").WithLocation(17, 16),
-                // (17,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
+                Diagnostic(ErrorCode.ERR_AmbigCall, "c1b").WithArguments("C1.Dispose()", "C1.Dispose()").WithLocation(17, 16),
+                // (17,16): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
                 //         using (c1b) { }
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "c1b").WithArguments("C1").WithLocation(17, 16)
                 );
@@ -237,15 +237,15 @@ class C2
                 // (6,19): error CS0111: Type 'C1' already defines a member called 'Dispose' with the same parameter types
                 //     internal void Dispose() { }
                 Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dispose").WithArguments("Dispose", "C1").WithLocation(6, 19),
-                // (13,16): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is ambiguous with 'C1.Dispose()'.
+                // (13,16): error CS0121: The call is ambiguous between the following methods or properties: 'C1.Dispose()' and 'C1.Dispose()'
                 //         using (C1 c = new C1())
-                Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "C1 c = new C1()").WithArguments("C1", "disposable", "C1.Dispose()", "C1.Dispose()").WithLocation(13, 16),
+                Diagnostic(ErrorCode.ERR_AmbigCall, "C1 c = new C1()").WithArguments("C1.Dispose()", "C1.Dispose()").WithLocation(13, 16),
                 // (13,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(13, 16),
-                // (17,16): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is ambiguous with 'C1.Dispose()'.
+                // (17,16): error CS0121: The call is ambiguous between the following methods or properties: 'C1.Dispose()' and 'C1.Dispose()'
                 //         using (c1b) { }
-                Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "c1b").WithArguments("C1", "disposable", "C1.Dispose()", "C1.Dispose()").WithLocation(17, 16),
+                Diagnostic(ErrorCode.ERR_AmbigCall, "c1b").WithArguments("C1.Dispose()", "C1.Dispose()").WithLocation(17, 16),
                 // (17,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
                 //         using (c1b) { }
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "c1b").WithArguments("C1").WithLocation(17, 16)
@@ -370,9 +370,6 @@ class C3
                 // (17,16): warning CS0280: 'C2' does not implement the 'disposable' pattern. 'C1.Dispose()' has the wrong signature.
                 //         using (C2 c = new C2())
                 Diagnostic(ErrorCode.WRN_PatternBadSignature, "C2 c = new C2()").WithArguments("C2", "disposable", "C1.Dispose()").WithLocation(17, 16),
-                // (17,16): warning CS0280: 'C2' does not implement the 'disposable' pattern. 'C2.Dispose' has the wrong signature.
-                //         using (C2 c = new C2())
-                Diagnostic(ErrorCode.WRN_PatternBadSignature, "C2 c = new C2()").WithArguments("C2", "disposable", "C2.Dispose").WithLocation(17, 16),
                 // (17,16): error CS1674: 'C2': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
                 //         using (C2 c = new C2())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C2 c = new C2()").WithArguments("C2").WithLocation(17, 16)
@@ -500,7 +497,14 @@ class C4
         }
     }
 }";
-            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics(
+                // (22,16): warning CS0280: 'C2' does not implement the 'disposable' pattern. 'C1.Dispose()' has the wrong signature.
+                //         using (C2 c = new C2())
+                Diagnostic(ErrorCode.WRN_PatternBadSignature, "C2 c = new C2()").WithArguments("C2", "disposable", "C1.Dispose()").WithLocation(22, 16),
+                // (22,16): error CS1674: 'C2': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
+                //         using (C2 c = new C2())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C2 c = new C2()").WithArguments("C2").WithLocation(22, 16)
+                );
         }
 
         [Fact]
@@ -533,16 +537,10 @@ class C4
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (22,16): warning CS0280: 'C2' does not implement the 'disposable' pattern. 'C4.Dispose(C1)' has the wrong signature.
-                //         using (C2 c = new C2())
-                Diagnostic(ErrorCode.WRN_PatternBadSignature, "C2 c = new C2()").WithArguments("C2", "disposable", "C3.Dispose(C1)").WithLocation(22, 16),
-                // (17,16): warning CS0280: 'C2' does not implement the 'disposable' pattern. 'C1.Dispose()' has the wrong signature.
+                // (22,16): warning CS0280: 'C2' does not implement the 'disposable' pattern. 'C1.Dispose()' has the wrong signature.
                 //         using (C2 c = new C2())
                 Diagnostic(ErrorCode.WRN_PatternBadSignature, "C2 c = new C2()").WithArguments("C2", "disposable", "C1.Dispose()").WithLocation(22, 16),
-                // (17,16): warning CS0280: 'C2' does not implement the 'disposable' pattern. 'C2.Dispose' has the wrong signature.
-                //         using (C2 c = new C2())
-                Diagnostic(ErrorCode.WRN_PatternBadSignature, "C2 c = new C2()").WithArguments("C2", "disposable", "C2.Dispose").WithLocation(22, 16),
-                // (17,16): error CS1674: 'C2': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
+                // (22,16): error CS1674: 'C2': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
                 //         using (C2 c = new C2())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C2 c = new C2()").WithArguments("C2").WithLocation(22, 16)
                 );
@@ -577,9 +575,9 @@ class C4
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (21,16): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C2.Dispose(C1)' is ambiguous with 'C3.Dispose(C1)'.
+                // (21,16): error CS0121: The call is ambiguous between the following methods or properties: 'C2.Dispose(C1)' and 'C3.Dispose(C1)'
                 //         using (C1 c = new C1())
-                Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "C1 c = new C1()").WithArguments("C1", "disposable", "C2.Dispose(C1)", "C3.Dispose(C1)").WithLocation(21, 16),
+                Diagnostic(ErrorCode.ERR_AmbigCall, "C1 c = new C1()").WithArguments("C2.Dispose(C1)", "C3.Dispose(C1)").WithLocation(21, 16),
                 // (21,16): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(21, 16)
@@ -712,9 +710,9 @@ namespace N4
                 // (64,20): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
                 //             using (C1 c = new C1()) // error 2: C4.Dispose does not match pattern
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(64, 20),
-                // (78,20): warning CS0278: 'C1' does not implement the 'disposable' pattern. 'C2.Dispose(C1)' is ambiguous with 'C4.Dispose(C1)'.
+                // (78,20): error CS0121: The call is ambiguous between the following methods or properties: 'N1.C2.Dispose(C1)' and 'N3.C4.Dispose(C1)'
                 //             using (C1 c = new C1())  // error 3: C2.Dispose and C4.Dispose are ambiguous
-                Diagnostic(ErrorCode.WRN_PatternIsAmbiguous, "C1 c = new C1()").WithArguments("C1", "disposable", "N1.C2.Dispose(C1)", "N3.C4.Dispose(C1)").WithLocation(78, 20),
+                Diagnostic(ErrorCode.ERR_AmbigCall, "C1 c = new C1()").WithArguments("N1.C2.Dispose(C1)", "N3.C4.Dispose(C1)").WithLocation(78, 20),
                 // (78,20): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
                 //             using (C1 c = new C1())  // error 3: C2.Dispose and C4.Dispose are ambiguous
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(78, 20),
@@ -1105,14 +1103,31 @@ class C2
         using (c1b) { }
     }
 }";
-            CreateCompilation(source).VerifyDiagnostics(
-                // (12,16): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
-                //         using (C1 c = new C1())
-                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(12, 16),
-                // (16,16): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
-                //         using (c1b) { }
-                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "c1b").WithArguments("C1").WithLocation(16, 16)
-                );
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void UsingPatternWithDefaultParametersTest()
+        {
+            var source = @"
+class C1
+{
+    public C1() { }
+    public void Dispose(int a = 4){ }
+}
+
+class C2
+{
+    static void Main()
+    {
+        using (C1 c = new C1())
+        {
+        }
+        C1 c1b = new C1();
+        using (c1b) { }
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [Fact]
@@ -1159,7 +1174,7 @@ class C2
 class C1
 {
     public C1() { }
-    internal void Dispose() { }
+    private void Dispose() { }
 }
 
 class C2
@@ -1174,19 +1189,43 @@ class C2
     }
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (12,16): warning CS0279: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is either static or not public.
+                // (12,16): error CS0122: 'C1.Dispose()' is inaccessible due to its protection level
                 //         using (C1 c = new C1())
-                Diagnostic(ErrorCode.WRN_PatternStaticOrInaccessible, "C1 c = new C1()").WithArguments("C1", "disposable", "C1.Dispose()").WithLocation(12, 16),
-                // (12,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
+                Diagnostic(ErrorCode.ERR_BadAccess, "C1 c = new C1()").WithArguments("C1.Dispose()").WithLocation(12, 16),
+                // (12,16): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
                 //         using (C1 c = new C1())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(12, 16),
-                // (16,16): warning CS0279: 'C1' does not implement the 'disposable' pattern. 'C1.Dispose()' is either static or not public.
+                // (16,16): error CS0122: 'C1.Dispose()' is inaccessible due to its protection level
                 //         using (c1b) { }
-                Diagnostic(ErrorCode.WRN_PatternStaticOrInaccessible, "c1b").WithArguments("C1", "disposable", "C1.Dispose()").WithLocation(16, 16),
-                // (16,16): error CS1674: 'C1': type used in a using statement must have a public void-returning Dispose() instance method.
+                Diagnostic(ErrorCode.ERR_BadAccess, "c1b").WithArguments("C1.Dispose()").WithLocation(16, 16),
+                // (16,16): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
                 //         using (c1b) { }
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "c1b").WithArguments("C1").WithLocation(16, 16)
-            );
+                );
+        }
+
+        [Fact]
+        public void UsingPatternNonPublicAccessibilityTest()
+        {
+            var source = @"
+class C1
+{
+    public C1() { }
+    internal void Dispose() { }
+}
+
+class C2
+{
+    static void Main()
+    {
+        using (C1 c = new C1())
+        {
+        }
+        C1 c1b = new C1();
+        using (c1b) { }
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -469,6 +469,37 @@ class C3
         }
 
         [Fact]
+        public void UsingPatternStaticMethodTest()
+        {
+            var source = @"
+class C1
+{
+    public C1() { }
+
+    public static void Dispose() { }
+}
+
+class C2
+{
+    static void Main()
+    {
+        using (C1 c = new C1())
+        {
+        }
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (14,16): error CS0176: Member 'C1.Dispose()' cannot be accessed with an instance reference; qualify it with a type name instead
+                //         using (C1 c = new C1())
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "C1 c = new C1()").WithArguments("C1.Dispose()").WithLocation(13, 16),
+                // (14,16): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
+                //         using (C1 c = new C1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(13, 16)
+                );
+        }
+
+
+        [Fact]
         public void UsingPatternHidingInvalidInheritedWithPropertyAndValidExtensionMethodTest()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -1402,6 +1402,57 @@ class C2
         }
 
         [Fact]
+        public void UsingPatternGenericMethodTest()
+        {
+            var source = @"
+class C1
+{
+    public C1() { }
+    public void Dispose<T>() { }
+}
+
+class C2
+{
+    static void Main()
+    {
+        using (C1 c = new C1())
+        {
+        }
+    }
+}";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (12,16): error CS0411: The type arguments for method 'C1.Dispose<T>()' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         using (C1 c = new C1())
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "C1 c = new C1()").WithArguments("C1.Dispose<T>()").WithLocation(12, 16),
+                // (12,16): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
+                //         using (C1 c = new C1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c = new C1()").WithArguments("C1").WithLocation(12, 16)
+                );
+        }
+
+        [Fact]
+        public void UsingPatternDynamicArgument()
+        {
+            var source = @"
+class C1
+{
+    public void Dispose(dynamic x = null) { }
+}
+
+class C2
+{
+    static void Main()
+    {
+        using (C1 c1 = new C1())
+        {
+        }
+    }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact]
         public void Lambda()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -1373,6 +1373,35 @@ class C2
         }
 
         [Fact]
+        public void UsingPatternStaticMethod()
+        {
+            var source = @"
+class C1
+{
+    public static void Dispose() { }
+}
+
+class C2
+{
+    static void Main()
+    {
+        using (C1 c1 = new C1())
+        {
+        }
+    }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (11,16): error CS0176: Member 'C1.Dispose()' cannot be accessed with an instance reference; qualify it with a type name instead
+                //         using (C1 c1 = new C1())
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "C1 c1 = new C1()").WithArguments("C1.Dispose()").WithLocation(11, 16),
+                // (11,16): error CS1674: 'C1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or have a public void-returning Dispose() instance method.
+                //         using (C1 c1 = new C1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "C1 c1 = new C1()").WithArguments("C1").WithLocation(11, 16)
+                );
+        }
+
+        [Fact]
         public void Lambda()
         {
             var source = @"
@@ -1993,6 +2022,7 @@ class C1 : IDisposable
                 Diagnostic(ErrorCode.ERR_UsingVarInSwitchCase, "using C1 o1 = new C1();").WithLocation(15, 21)
             );
         }
+
 
         #region help method
 


### PR DESCRIPTION
Refactor pattern lookup logic:

- Use BindMethodGroupInvocation to perform lookup, rather than manually iterating with LookupMembersInType
- Share the pattern logic with GetPinnableReference lookup
- Update tests to match new logic

This change aims to reduce the duplication we have for looking up pattern based methods, and attempt to set a path for future lookups. It makes the dispose lookup work in the same way we currently lookup GetPinnableReference, meaning we support any candidate that would be equivalent to writing ```c.Dispose()``` in code: essentially we attempt to perform binding on what we'll eventually lower to and report the results.

Previously we gave warnings about e.g. ambiguous candidates, or inaccessible methods; because we're actually doing an invocation binding these are now reported as errors as if the user had actually invoked it. This is actually consistent with the behavior we see when looking up Deconstruct and GetPinnableReference, so while different (and possibly not as nice?) it's at least consistent with what we do in other pattern lookups. 

We'll still report a warning (and an overall error) when binding succeeded but the thing that was bound doesn't fit the pattern.



