### PR TITLE
Fix NullReferenceException for MakeFieldReadonlyCodeFixProvider in Visual Basic.NET

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/MakeFieldReadonly/MakeFieldReadonlyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MakeFieldReadonly/MakeFieldReadonlyTests.vb
@@ -894,5 +894,17 @@ End Class",
     End Sub
 End Class")
         End Function
+
+        <WorkItem(26850, "https://github.com/dotnet/roslyn/issues/26850")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeFieldReadonly)>
+        Public Async Function FieldNotAssigned_FieldPartiallyDeclaredWithDim() As Task
+            Await TestInRegularAndScriptAsync(
+"Class C
+    Dim [|_goo|]
+End Class",
+"Class C
+    ReadOnly _goo
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/MakeFieldReadonly/AbstractMakeFieldReadonlyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeFieldReadonly/AbstractMakeFieldReadonlyCodeFixProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.MakeFieldReadonly
                 var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-                declarators.Add(root.FindNode(diagnosticSpan).FirstAncestorOrSelf<TSymbolSyntax>());
+                declarators.Add(root.FindNode(diagnosticSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<TSymbolSyntax>());
             }
 
             await MakeFieldReadonlyAsync(document, editor, declarators).ConfigureAwait(false);


### PR DESCRIPTION
A `NullReferenceException` was being thrown by the `AbstractMakeFieldReadonlyCodeFixProvider` when iterating over the variable declarators.

This fix resolves the issue by ensuring that the `FindAncestorOrSelf()` call can find the necessary node. Without the `getInnermostNodeForTie` argument, `FindNode()` was returning a node that was a layer out from the `TSymbolSyntax`-type node, so the `FindAncestorOrSelf()` call was unable to find the correct node. `getInnermostNodeForTie` ensures that the inner node, which is of type `TSymbolSyntax`, is returned and subsequently found by `FindAncestorOrSelf()`.

Fixes #26850.