### PR TITLE
Handle extension `ref this` usage via collection initializer

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -460,6 +460,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     return true;
 
+                case BoundKind.ImplicitReceiver:
+                    return true;
+
                 case BoundKind.Call:
                     var call = (BoundCall)expr;
                     return CheckCallValueKind(call, node, valueKind, checkingReceiver, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -461,7 +461,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
 
                 case BoundKind.ImplicitReceiver:
-                    return true;
+                    return (valueKind & BindValueKind.RefAssignable) != BindValueKind.RefAssignable;
 
                 case BoundKind.Call:
                     var call = (BoundCall)expr;

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -461,7 +461,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
 
                 case BoundKind.ImplicitReceiver:
-                    return (valueKind & BindValueKind.RefAssignable) != BindValueKind.RefAssignable;
+                    Debug.Assert(!RequiresRefAssignableVariable(valueKind));
+                    return true;
 
                 case BoundKind.Call:
                     var call = (BoundCall)expr;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -654,7 +654,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var receiverNamedType = invokedAsExtensionMethod ?
                                         ((MethodSymbol)methodOrIndexer).Parameters[0].Type.TypeSymbol as NamedTypeSymbol :
                                         methodOrIndexer.ContainingType;
-            isComReceiver = (object)receiverNamedType != null && receiverNamedType.IsComImport;
+                isComReceiver = (object)receiverNamedType != null && receiverNamedType.IsComImport;
+            }
+
+            var @params = methodOrIndexer.GetParameters();
+            if (!@params.IsDefaultOrEmpty)
+            {
+                var thisParam = @params[0];
+                var isRefParam = (thisParam.RefKind & RefKind.Ref) != RefKind.None;
+                if (isRefParam)
+                {
+                    return false;
+                }
             }
 
             return rewrittenArguments.Length == methodOrIndexer.GetParameterCount() &&

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -661,8 +661,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!@params.IsDefaultOrEmpty)
             {
                 var thisParam = @params[0];
-                var isRefParam = (thisParam.RefKind & RefKind.Ref) != RefKind.None;
-                if (isRefParam)
+                if (thisParam.RefKind == RefKind.Ref)
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -637,13 +637,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             isComReceiver = false;
 
+            var @params = methodOrIndexer.GetParameters();
+
             // An applicable "vararg" method could not possibly be applicable in its expanded
             // form, and cannot possibly have named arguments or used optional parameters, 
             // because the __arglist() argument has to be positional and in the last position. 
 
             if (methodOrIndexer.GetIsVararg())
             {
-                Debug.Assert(rewrittenArguments.Length == methodOrIndexer.GetParameterCount() + 1);
+                Debug.Assert(rewrittenArguments.Length == @params.Length + 1);
                 Debug.Assert(argsToParamsOpt.IsDefault);
                 Debug.Assert(!expanded);
                 return true;
@@ -652,12 +654,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!ignoreComReceiver)
             {
                 var receiverNamedType = invokedAsExtensionMethod ?
-                                        ((MethodSymbol)methodOrIndexer).Parameters[0].Type.TypeSymbol as NamedTypeSymbol :
+                                        @params[0].Type.TypeSymbol as NamedTypeSymbol :
                                         methodOrIndexer.ContainingType;
                 isComReceiver = (object)receiverNamedType != null && receiverNamedType.IsComImport;
             }
 
-            var @params = methodOrIndexer.GetParameters();
             if (!@params.IsDefaultOrEmpty)
             {
                 var thisParam = @params[0];
@@ -667,7 +668,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            return rewrittenArguments.Length == methodOrIndexer.GetParameterCount() &&
+            return rewrittenArguments.Length == @params.Length &&
                 argsToParamsOpt.IsDefault &&
                 !expanded &&
                 !isComReceiver;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -637,15 +637,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             isComReceiver = false;
 
-            var @params = methodOrIndexer.GetParameters();
-
             // An applicable "vararg" method could not possibly be applicable in its expanded
             // form, and cannot possibly have named arguments or used optional parameters, 
             // because the __arglist() argument has to be positional and in the last position. 
 
             if (methodOrIndexer.GetIsVararg())
             {
-                Debug.Assert(rewrittenArguments.Length == @params.Length + 1);
+                Debug.Assert(rewrittenArguments.Length == methodOrIndexer.GetParameterCount() + 1);
                 Debug.Assert(argsToParamsOpt.IsDefault);
                 Debug.Assert(!expanded);
                 return true;
@@ -654,21 +652,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!ignoreComReceiver)
             {
                 var receiverNamedType = invokedAsExtensionMethod ?
-                                        @params[0].Type.TypeSymbol as NamedTypeSymbol :
+                                        ((MethodSymbol)methodOrIndexer).Parameters[0].Type.TypeSymbol as NamedTypeSymbol :
                                         methodOrIndexer.ContainingType;
-                isComReceiver = (object)receiverNamedType != null && receiverNamedType.IsComImport;
+            isComReceiver = (object)receiverNamedType != null && receiverNamedType.IsComImport;
             }
 
-            if (!@params.IsDefaultOrEmpty)
-            {
-                var thisParam = @params[0];
-                if (thisParam.RefKind == RefKind.Ref)
-                {
-                    return false;
-                }
-            }
-
-            return rewrittenArguments.Length == @params.Length &&
+            return rewrittenArguments.Length == methodOrIndexer.GetParameterCount() &&
                 argsToParamsOpt.IsDefault &&
                 !expanded &&
                 !isComReceiver;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectOrCollectionInitializerExpression.cs
@@ -156,6 +156,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             // such as generating a params array, re-ordering arguments based on argsToParamsOpt map, inserting arguments for optional parameters, etc.
             ImmutableArray<LocalSymbol> temps;
             var argumentRefKindsOpt = default(ImmutableArray<RefKind>);
+            if (addMethod.Parameters[0].RefKind == RefKind.Ref)
+            {
+                // If the Add method is an extension which takes a `ref this` as the first parameter, implicitly add a `ref` to the argument
+                var builder = ArrayBuilder<RefKind>.GetInstance(addMethod.Parameters.Length, RefKind.None);
+                builder[0] = RefKind.Ref;
+                argumentRefKindsOpt = builder.ToImmutableAndFree();
+            }
+
             rewrittenArguments = MakeArguments(syntax, rewrittenArguments, addMethod, addMethod, initializer.Expanded, initializer.ArgsToParamsOpt, ref argumentRefKindsOpt, out temps, enableCallerInfo: ThreeState.True);
 
             if (initializer.InvokedAsExtensionMethod)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/DestructorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/DestructorTests.cs
@@ -416,7 +416,7 @@ public class Program
         }
 
         [WorkItem(542828, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542828")]
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
         public void GenericBaseTypeHasNonVirtualFinalize()
         {
             var text = @"
@@ -454,6 +454,7 @@ public class Program
     }
 }
 ";
+
             var validator = GetDestructorValidator("Derived");
             var compVerifier = CompileAndVerify(text,
                 sourceSymbolValidator: validator,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
@@ -39,6 +39,35 @@ public static class Program
         }
 
         [Fact]
+        public void ExtensionMethods_StructCollectionInitializer()
+        {
+            var code = @"
+public struct MyStruct : System.Collections.IEnumerable
+{
+    public int i;
+    public System.Collections.IEnumerator GetEnumerator() => throw new System.NotImplementedException();
+}
+
+public static class MyStructExtension
+{
+    public static void Add(ref this MyStruct s, int i)
+    {
+        s.i += i;
+    }
+}
+
+public static class Program
+{
+    public static void Main()
+    {
+        var s = new MyStruct { 1 };
+        System.Console.Write(s.i);
+    }
+}";
+            CompileAndVerify(code, expectedOutput: "1");
+        }
+
+        [Fact]
         public void ExtensionMethods_LValues_Ref_Allowed()
         {
             var code = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
@@ -39,6 +39,7 @@ public static class Program
         }
 
         [Fact]
+        [WorkItem(25862, "https://github.com/dotnet/roslyn/issues/25862")]
         public void ExtensionMethods_StructCollectionInitializer()
         {
             var code = @"
@@ -68,6 +69,7 @@ public static class Program
         }
 
         [Fact]
+        [WorkItem(25862, "https://github.com/dotnet/roslyn/issues/25862")]
         public void ExtensionMethods_StructCollectionInitializerInParam()
         {
             var code = @"
@@ -120,6 +122,7 @@ public static class Program
         }
 
         [Fact]
+        [WorkItem(25862, "https://github.com/dotnet/roslyn/issues/25862")]
         public void ExtensionMethods_StructCollectionInitializerInParamImplicitTempArg()
         {
             var code = @"
@@ -169,6 +172,7 @@ public static class Program
         }
 
         [Fact]
+        [WorkItem(25862, "https://github.com/dotnet/roslyn/issues/25862")]
         public void ExtensionMethods_StructCollectionInitializerRefThisRefElement()
         {
             var code = @"
@@ -201,6 +205,7 @@ public static class Program
         }
 
         [Fact]
+        [WorkItem(25862, "https://github.com/dotnet/roslyn/issues/25862")]
         public void ExtensionMethods_StructCollectionInitializerInThisRefElement()
         {
             var code = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
@@ -169,6 +169,69 @@ public static class Program
         }
 
         [Fact]
+        public void ExtensionMethods_StructCollectionInitializerRefThisRefElement()
+        {
+            var code = @"
+public struct MyStruct : System.Collections.IEnumerable
+{
+    public int i;
+    public System.Collections.IEnumerator GetEnumerator() => throw new System.NotImplementedException();
+}
+
+public static class MyStructExtension
+{
+    public static void Add(ref this MyStruct s, ref int i)
+    {
+        s.i += i;
+    }
+}
+
+public static class Program
+{
+    public static void Main()
+    {
+        var s = new MyStruct { 1 };
+        System.Console.Write(s.i);
+    }
+}";
+            CreateCompilation(code).VerifyDiagnostics(
+                Diagnostic(ErrorCode.ERR_InitializerAddHasParamModifiers, "1")
+                    .WithArguments("MyStructExtension.Add(ref MyStruct, ref int)")
+                    .WithLocation(20, 32));
+        }
+
+        [Fact]
+        public void ExtensionMethods_StructCollectionInitializerInThisRefElement()
+        {
+            var code = @"
+public struct MyStruct : System.Collections.IEnumerable
+{
+    public int i;
+    public System.Collections.IEnumerator GetEnumerator() => throw new System.NotImplementedException();
+}
+
+public static class MyStructExtension
+{
+    public static void Add(in this MyStruct s, ref int i)
+    {
+    }
+}
+
+public static class Program
+{
+    public static void Main()
+    {
+        var s = new MyStruct { 1 };
+        System.Console.Write(s.i);
+    }
+}";
+            CreateCompilation(code).VerifyDiagnostics(
+                Diagnostic(ErrorCode.ERR_InitializerAddHasParamModifiers, "1")
+                    .WithArguments("MyStructExtension.Add(in MyStruct, ref int)")
+                    .WithLocation(19, 32));
+        }
+
+        [Fact]
         public void ExtensionMethods_LValues_Ref_Allowed()
         {
             var code = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
@@ -198,10 +198,11 @@ public static class Program
         System.Console.Write(s.i);
     }
 }";
-            CreateCompilation(code).VerifyDiagnostics(
-                Diagnostic(ErrorCode.ERR_InitializerAddHasParamModifiers, "1")
-                    .WithArguments("MyStructExtension.Add(ref MyStruct, ref int)")
-                    .WithLocation(20, 32));
+
+            CreateCompilationWithMscorlib40AndSystemCore(code).VerifyDiagnostics(
+                // (20,32): error CS1954: The best overloaded method match 'MyStructExtension.Add(ref MyStruct, ref int)' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.
+                //         var s = new MyStruct { 1 };
+                Diagnostic(ErrorCode.ERR_InitializerAddHasParamModifiers, "1").WithArguments("MyStructExtension.Add(ref MyStruct, ref int)").WithLocation(20, 32));
         }
 
         [Fact]
@@ -230,10 +231,10 @@ public static class Program
         System.Console.Write(s.i);
     }
 }";
-            CreateCompilation(code).VerifyDiagnostics(
-                Diagnostic(ErrorCode.ERR_InitializerAddHasParamModifiers, "1")
-                    .WithArguments("MyStructExtension.Add(in MyStruct, ref int)")
-                    .WithLocation(19, 32));
+            CreateCompilationWithMscorlib40AndSystemCore(code).VerifyDiagnostics(
+                // (19,32): error CS1954: The best overloaded method match 'MyStructExtension.Add(in MyStruct, ref int)' for the collection initializer element cannot be used. Collection initializer 'Add' methods cannot have ref or out parameters.
+                //         var s = new MyStruct { 1 };
+                Diagnostic(ErrorCode.ERR_InitializerAddHasParamModifiers, "1").WithArguments("MyStructExtension.Add(in MyStruct, ref int)").WithLocation(19, 32));
         }
 
         [Fact]


### PR DESCRIPTION
Resolves #25862 

Questions:
- How should it be decided in `Binder.ValueChecks.CheckValueKind()` if the ImplicitReceiver is compatible with a given BindValueKind? Can't think of an example where CheckValueKind returns false, but I might not know about all the places where an ImplicitReceiver comes about.
- What other test coverage is needed?