### PR TITLE
Show beta label in UpgradeProject code action

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -470,9 +470,10 @@ class C
     </Project>
 </Workspace>",
                 new[] {
-                    string.Format(CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0, "8.0"),
-                    string.Format(CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0, "8.0")
+                    string.Format(CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0, "8.0 *beta*"),
+                    string.Format(CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0, "8.0 *beta*")
     });
+            // https://github.com/dotnet/roslyn/issues/29819 Remove beta label once C# 8.0 is RTM
         }
 
         [Fact]
@@ -575,7 +576,7 @@ class C
     </Project>
 </Workspace>",
                 new[] {
-                    string.Format(CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0, "8.0"),
+                    string.Format(CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0, "8.0 *beta*"),
                     });
         }
 

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -41,6 +41,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
             return RequiredVersion(diagnostics).ToDisplayString();
         }
 
+        public override string AddBetaIfNeeded(string version)
+        {
+            if (version == "8.0")
+            {
+                // https://github.com/dotnet/roslyn/issues/29819 Remove once C# 8.0 is RTM
+                return "8.0 *beta*";
+            }
+            return version;
+        }
+
         private static LanguageVersion RequiredVersion(ImmutableArray<Diagnostic> diagnostics)
         {
             LanguageVersion max = 0;

--- a/src/Features/Core/Portable/UpgradeProject/AbstractUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UpgradeProject/AbstractUpgradeProjectCodeFixProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.UpgradeProject
         public abstract bool IsUpgrade(ParseOptions projectOptions, string newVersion);
         public abstract string UpgradeThisProjectResource { get; }
         public abstract string UpgradeAllProjectsResource { get; }
+        public abstract string AddBetaIfNeeded(string version);
 
         public override FixAllProvider GetFixAllProvider()
         {
@@ -42,7 +43,7 @@ namespace Microsoft.CodeAnalysis.UpgradeProject
             var result = new List<CodeAction>();
             var language = project.Language;
 
-            var fixOneProjectTitle = string.Format(UpgradeThisProjectResource, newVersion);
+            var fixOneProjectTitle = string.Format(UpgradeThisProjectResource, AddBetaIfNeeded(newVersion));
             var fixOneProject = new ParseOptionsChangeAction(fixOneProjectTitle,
                 _ => Task.FromResult(UpgradeProject(project, newVersion)));
 

--- a/src/Features/Core/Portable/UpgradeProject/AbstractUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UpgradeProject/AbstractUpgradeProjectCodeFixProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.UpgradeProject
             result.Add(fixOneProject);
             if (solution.Projects.Count(p => CanUpgrade(p, language, newVersion)) > 1)
             {
-                var fixAllProjectsTitle = string.Format(UpgradeAllProjectsResource, newVersion);
+                var fixAllProjectsTitle = string.Format(UpgradeAllProjectsResource, AddBetaIfNeeded(newVersion));
 
                 var fixAllProjects = new ParseOptionsChangeAction(fixAllProjectsTitle,
                     ct => Task.FromResult(UpgradeAllProjects(solution, language, newVersion, ct)));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12466233/46895742-89c4e580-ce2e-11e8-8556-adc4863dd556.png)

This is to match what we're showing on command-line and in language version drop-down:

![image](https://user-images.githubusercontent.com/12466233/45459186-00de5100-b6ac-11e8-885e-70675d9b6043.png)


![image](https://user-images.githubusercontent.com/12466233/46556077-5f0ce700-c89a-11e8-960c-23c1fa935f0e.png)


Notes: 
- the "*beta*" label is intentionally not localized. Let me know if that's a concern.
- the "*beta*" label is displayed within the quotes `'8.0 *beta*'`, which is slightly odd, but I think it's acceptable.
- the language version remains `8.0`:
![image](https://user-images.githubusercontent.com/12466233/46556452-87491580-c89b-11e8-8bdf-df1e015d645e.png)