### PR TITLE
Reorder 'extract method' and 'introduce variable'

### DIFF
--- a/src/Features/Core/Portable/CodeRefactorings/ExtractMethod/AbstractExtractMethodCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ExtractMethod/AbstractExtractMethodCodeRefactoringProvider.cs
@@ -11,6 +11,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeRefactorings.ExtractMethod
 {
+    [ExtensionOrder(Before = PredefinedCodeRefactoringProviderNames.IntroduceVariable)]
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, LanguageNames.VisualBasic,
         Name = PredefinedCodeRefactoringProviderNames.ExtractMethod), Shared]
     internal class ExtractMethodCodeRefactoringProvider : CodeRefactoringProvider

--- a/src/Features/Core/Portable/IntroduceVariable/IntroduceVariableCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/IntroduceVariableCodeRefactoringProvider.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
 {
     [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.ConvertTupleToStruct)]
     [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.ConvertAnonymousTypeToClass)]
+    [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.ExtractMethod)]
     [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.InvertConditional)]
     [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.InvertLogical)]
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, LanguageNames.VisualBasic,

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -392,11 +392,12 @@ class Program
             var generateImplicitTitle = "Generate implicit conversion operator in 'C'";
             var expectedItems = new[]
             {
+                "Extract Method",
+                "Introduce constant",
                 "Introduce constant for '2'",
                 "Introduce constant for all occurrences of '2'",
                 "Introduce local constant for '2'",
                 "Introduce local constant for all occurrences of '2'",
-                "Extract Method",
                 generateImplicitTitle,
                 "Suppress CS0612",
                 "in Source",


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/30475.

Telemetry shows us that ExtractMethod is used far more than IntroVar.  It's also a nice single item versus the 2-4 you can get with IntroVar. Reordering just makes things nicer and more efficient for users.