### PR TITLE
Show nullable types in operator QuickInfo tool tips

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -3401,9 +3401,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert((object)unaryOperator.MethodOpt == null && unaryOperator.OriginalUserDefinedOperatorsOpt.IsDefaultOrEmpty);
                 UnaryOperatorKind op = unaryOperator.OperatorKind.Operator();
-                symbols = ImmutableArray.Create<Symbol>(new SynthesizedIntrinsicOperatorSymbol(unaryOperator.Operand.Type.StrippedType(),
+                symbols = ImmutableArray.Create<Symbol>(new SynthesizedIntrinsicOperatorSymbol(unaryOperator.Operand.Type,
                                                                                                  OperatorFacts.UnaryOperatorNameFromOperatorKind(op),
-                                                                                                 unaryOperator.Type.StrippedType(),
+                                                                                                 unaryOperator.Type,
                                                                                                  unaryOperator.OperatorKind.IsChecked()));
                 resultKind = unaryOperator.ResultKind;
             }
@@ -3425,9 +3425,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert((object)increment.MethodOpt == null && increment.OriginalUserDefinedOperatorsOpt.IsDefaultOrEmpty);
                 UnaryOperatorKind op = increment.OperatorKind.Operator();
-                symbols = ImmutableArray.Create<Symbol>(new SynthesizedIntrinsicOperatorSymbol(increment.Operand.Type.StrippedType(),
+                symbols = ImmutableArray.Create<Symbol>(new SynthesizedIntrinsicOperatorSymbol(increment.Operand.Type,
                                                                                                  OperatorFacts.UnaryOperatorNameFromOperatorKind(op),
-                                                                                                 increment.Type.StrippedType(),
+                                                                                                 increment.Type,
                                                                                                  increment.OperatorKind.IsChecked()));
                 resultKind = increment.ResultKind;
             }
@@ -3480,13 +3480,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static Symbol GetIntrinsicOperatorSymbol(BinaryOperatorKind op, bool isDynamic, TypeSymbol leftType, TypeSymbol rightType, TypeSymbol returnType, bool isChecked)
         {
-            if (!isDynamic)
-            {
-                leftType = leftType.StrippedType();
-                rightType = rightType.StrippedType();
-                returnType = returnType.StrippedType();
-            }
-            else
+            if (isDynamic)
             {
                 Debug.Assert(returnType.IsDynamic());
 
@@ -3501,6 +3495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     rightType = leftType;
                 }
             }
+
             return new SynthesizedIntrinsicOperatorSymbol(leftType,
                                                           OperatorFacts.BinaryOperatorNameFromOperatorKind(op),
                                                           rightType,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -7076,7 +7076,6 @@ public class RubyTime
 
             if (type.IsValueType && !type.IsPointerType())
             {
-                Assert.Equal(symbol1, symbol2);
                 return;
             }
 
@@ -7867,9 +7866,6 @@ class Module1
             {
                 if (rightType.IsValueType && !rightType.IsPointerType())
                 {
-                    Assert.Equal(symbol1, symbol2);
-                    Assert.Equal(symbol1, symbol3);
-                    Assert.Equal(symbol1, symbol4);
                     return;
                 }
                 else
@@ -8124,10 +8120,10 @@ struct TestStr
                         Assert.Equal("System.Boolean System.Object.op_Inequality(System.Object left, System.Object right)", info1.Symbol.ToTestDisplayString());
                         break;
                     case 8:
-                        Assert.Equal("System.Boolean System.Int32.op_Equality(System.Int32 left, System.Int32 right)", info1.Symbol.ToTestDisplayString());
+                        Assert.Equal("System.Boolean System.Int32?.op_Equality(System.Int32? left, System.Int32? right)", info1.Symbol.ToTestDisplayString());
                         break;
                     case 9:
-                        Assert.Equal("System.Boolean System.Int32.op_Inequality(System.Int32 left, System.Int32 right)", info1.Symbol.ToTestDisplayString());
+                        Assert.Equal("System.Boolean System.Int32?.op_Inequality(System.Int32? left, System.Int32? right)", info1.Symbol.ToTestDisplayString());
                         break;
                     case 10:
                     case 11:

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -2015,7 +2015,7 @@ public class Test
             Assert.Equal(TypeKind.Struct, semanticInfo.ConvertedType.TypeKind);
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
-            Assert.Equal("ulong.operator +(ulong, ulong)", semanticInfo.Symbol.ToString());
+            Assert.Equal("ulong?.operator +(ulong?, ulong?)", semanticInfo.Symbol.ToString());
             Assert.Equal(0, semanticInfo.CandidateSymbols.Length);
 
             Assert.Equal(0, semanticInfo.MethodGroup.Length);

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6135,5 +6135,29 @@ class X
 }",
                 MainDescription("int? int?.operator -(int? value)"));
         }
+
+        [WorkItem(21494, "https://github.com/dotnet/roslyn/issues/21494")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestNullableOfIntDecrementOperator()
+        {
+            await TestAsync(
+@"class C
+{
+    int? M(int? value) => value-$$-;
+}",
+                MainDescription("int? int?.operator --(int? value)"));
+        }
+
+        [WorkItem(21494, "https://github.com/dotnet/roslyn/issues/21494")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestNullableOfIntCompoundAssignmentOperator()
+        {
+            await TestAsync(
+@"class C
+{
+    void M(ref int? value) => value *$$= 2;
+}",
+                MainDescription("int? int?.operator *(int? left, int? right)"));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6114,7 +6114,7 @@ class X
 
         [WorkItem(21494, "https://github.com/dotnet/roslyn/issues/21494")]
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
-        public async Task TestNullableOfIntOperator()
+        public async Task TestNullableOfIntBinaryOperator()
         {
             await TestAsync(
 @"class C
@@ -6122,6 +6122,18 @@ class X
     bool M(int? value) => value $$> 0;
 }",
                 MainDescription("bool int?.operator >(int? left, int? right)"));
+        }
+
+        [WorkItem(21494, "https://github.com/dotnet/roslyn/issues/21494")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestNullableOfIntUnaryOperator()
+        {
+            await TestAsync(
+@"class C
+{
+    int? M(int? value) => $$-value;
+}",
+                MainDescription("int? int?.operator -(int? value)"));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6111,5 +6111,17 @@ class X
 }",
                 MainDescription("void M<T>() where T : unmanaged"));
         }
+
+        [WorkItem(21494, "https://github.com/dotnet/roslyn/issues/21494")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestNullableOfIntOperator()
+        {
+            await TestAsync(
+@"class C
+{
+    bool M(int? value) => value $$> 0;
+}",
+                MainDescription("bool int?.operator >(int? left, int? right)"));
+        }
     }
 }


### PR DESCRIPTION
Prior to this PR, QuickInfo tool tips for operators on nullable types would only reference the underlying type instead of the nullable type. For example, the QuickInfo for the `>` in `a > b` where `a` and `b` are `int?` would read `bool int.operator >(int left, int right)`.

This affects compound assignments, increments/decrements, binary operators, and unary operators.

After this PR:
![image](https://user-images.githubusercontent.com/2829282/46920151-01724c00-cfb8-11e8-9c97-47074209b12f.png)
![image](https://user-images.githubusercontent.com/2829282/46920164-3b435280-cfb8-11e8-9f52-818608979725.png)
![image](https://user-images.githubusercontent.com/2829282/46920171-4f874f80-cfb8-11e8-9767-d4bc2beead27.png)
![image](https://user-images.githubusercontent.com/2829282/46920177-69289700-cfb8-11e8-8366-a2ff3cf3e75c.png)

Fixes #21494.