### PR TITLE
Implement new interfaces for adding files

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Interop/IProjectSiteEx.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Interop/IProjectSiteEx.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Interop
+{
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("38B39ADD-D4D6-47E1-B996-7ED16D0295A5")]
+    internal interface IProjectSiteEx
+    {
+        void StartBatch();
+        void EndBatch();
+
+        void AddFileEx([MarshalAs(UnmanagedType.LPWStr)] string filePath, [MarshalAs(UnmanagedType.LPWStr)] string linkMetadata);
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_IProjectSiteEx.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_IProjectSiteEx.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Interop;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Legacy
+{
+    internal abstract partial class AbstractLegacyProject : IProjectSiteEx
+    {
+        private readonly Stack<VisualStudioProject.BatchScope> _batchScopes = new Stack<VisualStudioProject.BatchScope>();
+
+        public void StartBatch()
+        {
+            _batchScopes.Push(VisualStudioProject.CreateBatchScope());
+        }
+
+        public void EndBatch()
+        {
+            Contract.ThrowIfFalse(_batchScopes.Count > 0);
+            var scope = _batchScopes.Pop();
+            scope.Dispose();
+        }
+
+        public void AddFileEx([MarshalAs(UnmanagedType.LPWStr)] string filePath, [MarshalAs(UnmanagedType.LPWStr)] string linkMetadata)
+        {
+            // TODO: uncomment when fixing https://github.com/dotnet/roslyn/issues/5325
+            //var sourceCodeKind = extension.Equals(".csx", StringComparison.OrdinalIgnoreCase)
+            //    ? SourceCodeKind.Script
+            //    : SourceCodeKind.Regular;
+            AddFile(filePath, linkMetadata, SourceCodeKind.Regular);
+        }
+    }
+}


### PR DESCRIPTION
Implement a new set of interfaces to allow csproj/msvbprj to add files.
The existing `ICSharpProjecSite.OnSourceFileAdded` and
`IVbCompilerProject.AddFile` had to go back to the hierarchy to check if
the file had any `<Link>` metadata on it, effectively requiring that
these methods only be called on the main thread. However, this metadata
is readily available to csproj/msvbprj; the new
`OnSourceFileEx`\`AddFileEx` methods allow it to be passed in. This
should make it possible to call these methods on a background thread.