### PR TITLE
Infer return type of bool when generating methods in when clauses

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -7932,5 +7932,45 @@ class Class
     }
 }");
         }
+
+        [WorkItem(24138, "https://github.com/dotnet/roslyn/issues/24138")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestInCaseWhenClause()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class Class
+{
+    void M(object goo)
+    {
+        switch (goo)
+        {
+            case int i when [|GreaterThanZero(i)|]:
+                break;
+        }
+    }
+}",
+@"
+using System;
+
+class Class
+{
+    void M(object goo)
+    {
+        switch (goo)
+        {
+            case int i when GreaterThanZero(i):
+                break;
+        }
+    }
+
+    private bool GreaterThanZero(int i)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -168,6 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case ThrowExpressionSyntax throwExpression: return InferTypeInThrowExpression(throwExpression);
                     case ThrowStatementSyntax throwStatement: return InferTypeInThrowStatement(throwStatement);
                     case UsingStatementSyntax usingStatement: return InferTypeInUsingStatement(usingStatement);
+                    case WhenClauseSyntax whenClause: return InferTypeInWhenClause(whenClause);
                     case WhileStatementSyntax whileStatement: return InferTypeInWhileStatement(whileStatement);
                     case YieldStatementSyntax yieldStatement: return InferTypeInYieldStatement(yieldStatement);
                     default: return SpecializedCollections.EmptyEnumerable<TypeInferenceInfo>();
@@ -238,6 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case SwitchStatementSyntax switchStatement: return InferTypeInSwitchStatement(switchStatement, token);
                     case ThrowStatementSyntax throwStatement: return InferTypeInThrowStatement(throwStatement, token);
                     case UsingStatementSyntax usingStatement: return InferTypeInUsingStatement(usingStatement, token);
+                    case WhenClauseSyntax whenClause: return InferTypeInWhenClause(whenClause, token);
                     case WhileStatementSyntax whileStatement: return InferTypeInWhileStatement(whileStatement, token);
                     case YieldStatementSyntax yieldStatement: return InferTypeInYieldStatement(yieldStatement, token);
                     default: return SpecializedCollections.EmptyEnumerable<TypeInferenceInfo>();
@@ -2148,6 +2150,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var tupleType = GetTupleType(tuple);
                 elementTypesBuilder.Add(tupleType);
                 elementNamesBuilder.Add(null);
+            }
+
+            private IEnumerable<TypeInferenceInfo> InferTypeInWhenClause(WhenClauseSyntax whenClause, SyntaxToken? previousToken = null)
+            {
+                // If we have a position, we have to be after the "when"
+                if (previousToken.HasValue && previousToken.Value != whenClause.WhenKeyword)
+                {
+                    return SpecializedCollections.EmptyEnumerable<TypeInferenceInfo>();
+                }
+
+                return SpecializedCollections.SingletonEnumerable(new TypeInferenceInfo(Compilation.GetSpecialType(SpecialType.System_Boolean)));
             }
 
             private IEnumerable<TypeInferenceInfo> InferTypeInWhileStatement(WhileStatementSyntax whileStatement, SyntaxToken? previousToken = null)


### PR DESCRIPTION
Prior to this PR, the Generate Method code fix would infer a return type of `object` when generating methods in `when` clauses. This PR modifies that behavior so that a return type of `bool` is inferred instead.

![image](https://user-images.githubusercontent.com/2829282/46986670-a9723d00-d0be-11e8-9664-717d56d5ed38.png)

Fixes #24138.