### PR TITLE
[WIP] ensure the variable `$(VsixVersion)` is set when building the VS insertion components

### DIFF
--- a/build/Targets/RepoToolset/AfterSigning.proj
+++ b/build/Targets/RepoToolset/AfterSigning.proj
@@ -1,6 +1,7 @@
 ﻿<!-- All Rights Reserved. Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
   <Import Project="BuildStep.props" />
+  <Import Project="VisualStudio.props" />
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
   <Target Name="Clean" />


### PR DESCRIPTION
Versioning the `*.vsman` files requires the `$(VsixVersion)` variable to be set, which requires that `VisualStudio.props` is included.

**Running a full build to verify the package manifests are created appropriately.** - Full build complete; the expected value is present.  Currently running a test insertion to validate that doesn't break.