### PR TITLE
MSBuildWorkspace needs to set a property to ensure that project references are built with the correct configuration

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
@@ -39,7 +39,13 @@ namespace Microsoft.CodeAnalysis.MSBuild.Build
             // don't actually run the compiler
             { PropertyNames.SkipCompilerExecution, bool.TrueString },
 
-            { PropertyNames.ContinueOnError, PropertyValues.ErrorAndContinue }
+            { PropertyNames.ContinueOnError, PropertyValues.ErrorAndContinue },
+
+            // this ensures that the parent project's configuration and platform will be used for
+            // referenced projects. So, setting Configuration=Release will also cause any project
+            // references to also be built with Configuration=Release. This is necessary for getting
+            // the correct output path from project references.
+            { PropertyNames.ShouldUnsetParentConfigurationAndPlatform, bool.FalseString }
         }.ToImmutableDictionary();
 
         private readonly ImmutableDictionary<string, string> _additionalGlobalProperties;

--- a/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.Build
             // this ensures that the parent project's configuration and platform will be used for
             // referenced projects. So, setting Configuration=Release will also cause any project
             // references to also be built with Configuration=Release. This is necessary for getting
-            // the correct output path from project references.
+            // a more-likely-to-be-correct output path from project references.
             { PropertyNames.ShouldUnsetParentConfigurationAndPlatform, bool.FalseString }
         }.ToImmutableDictionary();
 

--- a/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.Build
             _additionalGlobalProperties = additionalGlobalProperties ?? ImmutableDictionary<string, string>.Empty;
         }
 
-        private ImmutableDictionary<string, string> AllGlobalProperties()
+        private ImmutableDictionary<string, string> AllGlobalProperties
             => s_defaultGlobalProperties.AddRange(_additionalGlobalProperties);
 
         private static async Task<(MSB.Evaluation.Project project, DiagnosticLog log)> LoadProjectAsync(
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.Build
             }
             else
             {
-                var projectCollection = new MSB.Evaluation.ProjectCollection(AllGlobalProperties());
+                var projectCollection = new MSB.Evaluation.ProjectCollection(AllGlobalProperties);
                 try
                 {
                     return LoadProjectAsync(path, projectCollection, cancellationToken);

--- a/src/Workspaces/Core/MSBuild/MSBuild/Constants/PropertyNames.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/Constants/PropertyNames.cs
@@ -49,6 +49,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public const string RemoveIntegerChecks = nameof(RemoveIntegerChecks);
         public const string ResolvedCodeAnalysisRuleSet = nameof(ResolvedCodeAnalysisRuleSet);
         public const string RootNamespace = nameof(RootNamespace);
+        public const string ShouldUnsetParentConfigurationAndPlatform = nameof(ShouldUnsetParentConfigurationAndPlatform);
         public const string SignAssembly = nameof(SignAssembly);
         public const string SkipCompilerExecution = nameof(SkipCompilerExecution);
         public const string StartupObject = nameof(StartupObject);

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 var results = ImmutableArray.CreateBuilder<ProjectInfo>();
                 var processedPaths = new HashSet<string>(PathUtilities.Comparer);
 
-                _buildManager.Start(_globalProperties);
+                _buildManager.StartBatchBuild(_globalProperties);
                 try
                 {
                     foreach (var projectPath in _requestedProjectPaths)
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 }
                 finally
                 {
-                    _buildManager.Stop();
+                    _buildManager.EndBatchBuild();
                 }
             }
 

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 var results = ImmutableArray.CreateBuilder<ProjectInfo>();
                 var processedPaths = new HashSet<string>(PathUtilities.Comparer);
 
-                _buildManager.Start();
+                _buildManager.Start(_globalProperties);
                 try
                 {
                     foreach (var projectPath in _requestedProjectPaths)
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                     ProjectLoadOperation.Evaluate,
                     projectPath,
                     targetFramework: null,
-                    () => loader.LoadProjectFileAsync(projectPath, _globalProperties, _buildManager, cancellationToken)
+                    () => loader.LoadProjectFileAsync(projectPath, _buildManager, cancellationToken)
                 ).ConfigureAwait(false);
 
                 // If there were any failures during load, we won't be able to build the project. So, bail early with an empty project.

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker_ResolveReferences.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker_ResolveReferences.cs
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
             private async Task<bool> VerifyUnloadableProjectOutputExistsAsync(string projectPath, ResolvedReferencesBuilder builder, CancellationToken cancellationToken)
             {
-                var outputFilePath = await _buildManager.TryGetOutputFilePathAsync(projectPath, _globalProperties, cancellationToken).ConfigureAwait(false);
+                var outputFilePath = await _buildManager.TryGetOutputFilePathAsync(projectPath, cancellationToken).ConfigureAwait(false);
                 return builder.Contains(outputFilePath)
                     && File.Exists(outputFilePath);
             }

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.cs
@@ -27,8 +27,6 @@ namespace Microsoft.CodeAnalysis.MSBuild
         private readonly NonReentrantLock _dataGuard = new NonReentrantLock();
         private ImmutableDictionary<string, string> _properties;
 
-        internal readonly ProjectBuildManager BuildManager;
-
         internal MSBuildProjectLoader(
             Workspace workspace,
             DiagnosticReporter diagnosticReporter,
@@ -46,8 +44,6 @@ namespace Microsoft.CodeAnalysis.MSBuild
             {
                 _properties = _properties.AddRange(properties);
             }
-
-            BuildManager = new ProjectBuildManager();
         }
 
         /// <summary>
@@ -183,12 +179,14 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 }
             }
 
+            var buildManager = new ProjectBuildManager(_properties);
+
             var worker = new Worker(
                 _workspace,
                 _diagnosticReporter,
                 _pathResolver,
                 _projectFileLoaderRegistry,
-                BuildManager,
+                buildManager,
                 projectPaths.ToImmutable(),
                 baseDirectory: Path.GetDirectoryName(absoluteSolutionPath),
                 _properties,
@@ -237,12 +235,14 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 onPathFailure: reportingMode,
                 onLoaderFailure: reportingMode);
 
+            var buildManager = new ProjectBuildManager(_properties);
+
             var worker = new Worker(
                 _workspace,
                 _diagnosticReporter,
                 _pathResolver,
                 _projectFileLoaderRegistry,
-                BuildManager,
+                buildManager,
                 requestedProjectPaths: ImmutableArray.Create(projectFilePath),
                 baseDirectory: Directory.GetCurrentDirectory(),
                 globalProperties: _properties,

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.MSBuild.Build;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -281,11 +282,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 if (this.HasProjectFileChanges(projectChanges))
                 {
                     var projectPath = project.FilePath;
-                    if (_projectFileLoaderRegistry.TryGetLoaderFromProjectPath(projectPath, out var loader))
+                    if (_projectFileLoaderRegistry.TryGetLoaderFromProjectPath(projectPath, out var fileLoader))
                     {
                         try
                         {
-                            _applyChangesProjectFile = loader.LoadProjectFileAsync(projectPath, _loader.Properties, _loader.BuildManager, CancellationToken.None).Result;
+                            var buildManager = new ProjectBuildManager(_loader.Properties);
+                            _applyChangesProjectFile = fileLoader.LoadProjectFileAsync(projectPath, buildManager, CancellationToken.None).Result;
                         }
                         catch (IOException exception)
                         {

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/IProjectFileLoader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/IProjectFileLoader.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -13,7 +12,6 @@ namespace Microsoft.CodeAnalysis.MSBuild
         string Language { get; }
         Task<IProjectFile> LoadProjectFileAsync(
             string path,
-            IDictionary<string, string> globalProperties,
             ProjectBuildManager buildManager,
             CancellationToken cancellationToken);
     }

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFileLoader.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFileLoader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,7 +18,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
         protected abstract ProjectFile CreateProjectFile(MSB.Evaluation.Project project, ProjectBuildManager buildManager, DiagnosticLog log);
 
-        public async Task<IProjectFile> LoadProjectFileAsync(string path, IDictionary<string, string> globalProperties, ProjectBuildManager buildManager, CancellationToken cancellationToken)
+        public async Task<IProjectFile> LoadProjectFileAsync(string path, ProjectBuildManager buildManager, CancellationToken cancellationToken)
         {
             if (path == null)
             {
@@ -27,7 +26,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             }
 
             // load project file async
-            var (project, log) = await buildManager.LoadProjectAsync(path, globalProperties, cancellationToken).ConfigureAwait(false);
+            var (project, log) = await buildManager.LoadProjectAsync(path, cancellationToken).ConfigureAwait(false);
 
             return this.CreateProjectFile(project, buildManager, log);
         }

--- a/src/Workspaces/CoreTestUtilities/Resources/Issue30174/InspectedLibrary/InspectedClass.cs
+++ b/src/Workspaces/CoreTestUtilities/Resources/Issue30174/InspectedLibrary/InspectedClass.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Threading.Tasks;
+using ReferencedLibrary;
+
+namespace InspectedLibrary
+{
+    [SomeMetadata]
+    public class InspectedClass
+    {
+        public Task DoAsync()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Workspaces/CoreTestUtilities/Resources/Issue30174/InspectedLibrary/InspectedLibrary.csproj
+++ b/src/Workspaces/CoreTestUtilities/Resources/Issue30174/InspectedLibrary/InspectedLibrary.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReferencedLibrary\ReferencedLibrary.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Workspaces/CoreTestUtilities/Resources/Issue30174/ReferencedLibrary/ReferencedLibrary.csproj
+++ b/src/Workspaces/CoreTestUtilities/Resources/Issue30174/ReferencedLibrary/ReferencedLibrary.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Workspaces/CoreTestUtilities/Resources/Issue30174/ReferencedLibrary/SomeMetadataAttribute.cs
+++ b/src/Workspaces/CoreTestUtilities/Resources/Issue30174/ReferencedLibrary/SomeMetadataAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ReferencedLibrary
+{
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    public sealed class SomeMetadataAttribute : Attribute
+    {
+    }
+}

--- a/src/Workspaces/CoreTestUtilities/Resources/Issue30174/Solution.sln
+++ b/src/Workspaces/CoreTestUtilities/Resources/Issue30174/Solution.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferencedLibrary", "ReferencedLibrary\ReferencedLibrary.csproj", "{A5800480-7965-4BA3-95F5-4830B831163D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InspectedLibrary", "InspectedLibrary\InspectedLibrary.csproj", "{86B44D47-6E01-4385-AFDB-C82695AFD2DA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Debug|x64.Build.0 = Debug|Any CPU
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Debug|x86.Build.0 = Debug|Any CPU
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Release|x64.ActiveCfg = Release|Any CPU
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Release|x64.Build.0 = Release|Any CPU
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Release|x86.ActiveCfg = Release|Any CPU
+		{A5800480-7965-4BA3-95F5-4830B831163D}.Release|x86.Build.0 = Release|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Debug|x64.Build.0 = Debug|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Debug|x86.Build.0 = Debug|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Release|x64.ActiveCfg = Release|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Release|x64.Build.0 = Release|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Release|x86.ActiveCfg = Release|Any CPU
+		{86B44D47-6E01-4385-AFDB-C82695AFD2DA}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/Workspaces/CoreTestUtilities/TestFiles/Resources.cs
+++ b/src/Workspaces/CoreTestUtilities/TestFiles/Resources.cs
@@ -87,6 +87,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
             public static string DuplicatedGuidsBecomeCircularReferential => GetText("SolutionFiles.DuplicatedGuidsBecomeCircularReferential.sln");
             public static string EmptyLineBetweenProjectBlock => GetText("SolutionFiles.EmptyLineBetweenProjectBlock.sln");
             public static string Issue29122_Solution => GetText("Issue29122.TestVB2.sln");
+            public static string Issue30174_Solution => GetText("Issue30174.Solution.sln");
             public static string InvalidProjectPath => GetText("SolutionFiles.InvalidProjectPath.sln");
             public static string MissingEndProject1 => GetText("SolutionFiles.MissingEndProject1.sln");
             public static string MissingEndProject2 => GetText("SolutionFiles.MissingEndProject2.sln");
@@ -125,6 +126,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
                 public static string ExternAlias => GetText("ProjectFiles.CSharp.ExternAlias.csproj");
                 public static string ExternAlias2 => GetText("ProjectFiles.CSharp.ExternAlias2.csproj");
                 public static string ForEmittedOutput => GetText("ProjectFiles.CSharp.ForEmittedOutput.csproj");
+                public static string Issue30174_InspectedLibrary => GetText("Issue30174.InspectedLibrary.InspectedLibrary.csproj");
+                public static string Issue30174_ReferencedLibrary => GetText("Issue30174.ReferencedLibrary.ReferencedLibrary.csproj");
                 public static string MsbuildError => GetText("ProjectFiles.CSharp.MsbuildError.csproj");
                 public static string MallformedAdditionalFilePath => GetText("ProjectFiles.CSharp.MallformedAdditionalFilePath.csproj");
                 public static string NetCoreApp2_Project => GetText("NetCoreApp2.Project.csproj");
@@ -186,6 +189,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
                 public static string CSharpClass_WithConditionalAttributes => GetText("SourceFiles.CSharp.CSharpClass_WithConditionalAttributes.cs");
                 public static string CSharpConsole => GetText("SourceFiles.CSharp.CSharpConsole.cs");
                 public static string CSharpExternAlias => GetText("SourceFiles.CSharp.CSharpExternAlias.cs");
+                public static string Issue30174_InspectedClass => GetText("Issue30174.InspectedLibrary.InspectedClass.cs");
+                public static string Issue30174_SomeMetadataAttribute => GetText("Issue30174.ReferencedLibrary.SomeMetadataAttribute.cs");
                 public static string NetCoreApp2_Program => GetText("NetCoreApp2.Program.cs");
                 public static string NetCoreApp2AndLibrary_Class1 => GetText("NetCoreApp2AndLibrary.Class1.cs");
                 public static string NetCoreApp2AndLibrary_Program => GetText("NetCoreApp2AndLibrary.Program.cs");

--- a/src/Workspaces/CoreTestUtilities/WorkspaceTestBase.cs
+++ b/src/Workspaces/CoreTestUtilities/WorkspaceTestBase.cs
@@ -90,6 +90,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         protected FileSet GetBaseFiles()
         {
             return new FileSet(
+                (@"NuGet.Config", Resources.NuGet_Config),
                 (@"Directory.Build.props", Resources.Directory_Build_props),
                 (@"Directory.Build.targets", Resources.Directory_Build_targets));
         }

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -3518,11 +3518,11 @@ class C { }";
                 var projectFilePath = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
 
                 var buildManager = new ProjectBuildManager(ImmutableDictionary<string, string>.Empty);
-                buildManager.Start();
+                buildManager.StartBatchBuild();
 
                 var projectFile = await loader.LoadProjectFileAsync(projectFilePath, buildManager, CancellationToken.None);
                 var projectFileInfo = (await projectFile.GetProjectFileInfosAsync(CancellationToken.None)).Single();
-                buildManager.Stop();
+                buildManager.EndBatchBuild();
 
                 var commandLineParser = workspace.Services
                     .GetLanguageServices(loader.Language)

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -3517,7 +3517,7 @@ class C { }";
 
                 var projectFilePath = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
 
-                var buildManager = new ProjectBuildManager();
+                var buildManager = new ProjectBuildManager(ImmutableDictionary<string, string>.Empty);
                 buildManager.Start();
 
                 var projectFile = await loader.LoadProjectFileAsync(projectFilePath, buildManager, CancellationToken.None);

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -3517,11 +3517,10 @@ class C { }";
 
                 var projectFilePath = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
 
-                var properties = ImmutableDictionary<string, string>.Empty;
                 var buildManager = new ProjectBuildManager();
                 buildManager.Start();
 
-                var projectFile = await loader.LoadProjectFileAsync(projectFilePath, properties, buildManager, CancellationToken.None);
+                var projectFile = await loader.LoadProjectFileAsync(projectFilePath, buildManager, CancellationToken.None);
                 var projectFileInfo = (await projectFile.GetProjectFileInfosAsync(CancellationToken.None)).Single();
                 buildManager.Stop();
 

--- a/src/Workspaces/MSBuildTest/NetCoreTests.cs
+++ b/src/Workspaces/MSBuildTest/NetCoreTests.cs
@@ -369,7 +369,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled), typeof(DotNetCoreSdk.IsAvailable))]
         [Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         [Trait(Traits.Feature, Traits.Features.NetCore)]
-        public async Task TestOpenSolution_ReferenceConfigurationSpecificMetadata()
+        public async Task TestOpenProject_ReferenceConfigurationSpecificMetadata()
         {
             var files = GetBaseFiles()
                 .WithFile(@"Solution.sln", Resources.SolutionFiles.Issue30174_Solution)

--- a/src/Workspaces/MSBuildTest/NetCoreTests.cs
+++ b/src/Workspaces/MSBuildTest/NetCoreTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
 
         private void DotNetBuild(string solutionOrProjectFileName, string configuration = null)
         {
-            var arguments = $@"msbuild ""{solutionOrProjectFileName}"" /bl:{Path.Combine(SolutionDirectory.Path, "restore.binlog")}";
+            var arguments = $@"msbuild ""{solutionOrProjectFileName}"" /bl:{Path.Combine(SolutionDirectory.Path, "build.binlog")}";
 
             if (configuration != null)
             {

--- a/src/Workspaces/MSBuildTest/NetCoreTests.cs
+++ b/src/Workspaces/MSBuildTest/NetCoreTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.UnitTests;
+using Microsoft.CodeAnalysis.UnitTests.TestFiles;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
             _nugetCacheDir = SolutionDirectory.CreateDirectory(".packages");
         }
 
-        private void DotNetRestore(string solutionOrProjectFileName)
+        private void RunDotNet(string arguments)
         {
             Assert.NotNull(DotNetCoreSdk.ExePath);
 
@@ -32,12 +33,29 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
             };
 
             var restoreResult = ProcessUtilities.Run(
-                fileName: DotNetCoreSdk.ExePath,
-                arguments: $@"msbuild ""{solutionOrProjectFileName}"" /t:restore /bl:{Path.Combine(SolutionDirectory.Path, "restore.binlog")}",
+                DotNetCoreSdk.ExePath, arguments,
                 workingDirectory: SolutionDirectory.Path,
                 additionalEnvironmentVars: environmentVariables);
 
-            Assert.True(restoreResult.ExitCode == 0, $"Restore failed with exit code {restoreResult.ExitCode}: {restoreResult.Output}");
+            Assert.True(restoreResult.ExitCode == 0, $"{DotNetCoreSdk.ExePath} failed with exit code {restoreResult.ExitCode}: {restoreResult.Output}");
+        }
+
+        private void DotNetRestore(string solutionOrProjectFileName)
+        {
+            var arguments = $@"msbuild ""{solutionOrProjectFileName}"" /t:restore /bl:{Path.Combine(SolutionDirectory.Path, "restore.binlog")}";
+            RunDotNet(arguments);
+        }
+
+        private void DotNetBuild(string solutionOrProjectFileName, string configuration = null)
+        {
+            var arguments = $@"msbuild ""{solutionOrProjectFileName}"" /bl:{Path.Combine(SolutionDirectory.Path, "restore.binlog")}";
+
+            if (configuration != null)
+            {
+                arguments += $" /p:Configuration={configuration}";
+            }
+
+            RunDotNet(arguments);
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled), typeof(DotNetCoreSdk.IsAvailable))]
@@ -345,6 +363,38 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
                     Assert.Empty(project.ProjectReferences);
                     Assert.Single(project.AllProjectReferences);
                 }
+            }
+        }
+
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled), typeof(DotNetCoreSdk.IsAvailable))]
+        [Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [Trait(Traits.Feature, Traits.Features.NetCore)]
+        public async Task TestOpenSolution_ReferenceConfigurationSpecificMetadata()
+        {
+            var files = GetBaseFiles()
+                .WithFile(@"Solution.sln", Resources.SolutionFiles.Issue30174_Solution)
+                .WithFile(@"InspectedLibrary\InspectedLibrary.csproj", Resources.ProjectFiles.CSharp.Issue30174_InspectedLibrary)
+                .WithFile(@"InspectedLibrary\InspectedClass.cs", Resources.SourceFiles.CSharp.Issue30174_InspectedClass)
+                .WithFile(@"ReferencedLibrary\ReferencedLibrary.csproj", Resources.ProjectFiles.CSharp.Issue30174_ReferencedLibrary)
+                .WithFile(@"ReferencedLibrary\SomeMetadataAttribute.cs", Resources.SourceFiles.CSharp.Issue30174_SomeMetadataAttribute);
+
+            CreateFiles(files);
+
+            DotNetRestore("Solution.sln");
+            DotNetBuild("Solution.sln", configuration: "Release");
+
+            var projectFilePath = GetSolutionFileName(@"InspectedLibrary\InspectedLibrary.csproj");
+
+            using (var workspace = CreateMSBuildWorkspace(("Configuration", "Release")))
+            {
+                workspace.LoadMetadataForReferencedProjects = true;
+
+                var project = await workspace.OpenProjectAsync(projectFilePath);
+
+                Assert.Empty(project.ProjectReferences);
+                Assert.Empty(workspace.Diagnostics);
+
+                var compilation = await project.GetCompilationAsync();
             }
         }
     }


### PR DESCRIPTION
Fixes #30174

This change fixes an issue with MSBuildWorkspace's design to resolve project references by matching the output path of a referenced project with the reference path that is passed in the compiler command-line args. That approach works fine until the user tries to call `OpenProjectAsync(...)` on an `MSBuildWorkspace` that was created with the `Configuration` property set to `Release`. In that scenario, the `Configuration` property that was set globally doesn't get used for project references. Instead, referenced projects are built with their default `Configuration` and `Platform` values, which results in the output paths of those referenced projects being different (e.g. `bin\Debug` instead of `bin\Release`). So, project references aren't resolved properly.

The reason that the referenced projects don't use the globally set `Configuration` property is due to the following condition in [`Microsoft.Common.CurrentVersion.targets`](https://github.com/Microsoft/msbuild/blob/d1af34332573aab3de6482ac1d0b35e1d7951564/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1473):

```XML
<ShouldUnsetParentConfigurationAndPlatform Condition="'$(ShouldUnsetParentConfigurationAndPlatform)' == '' and ('$(BuildingInsideVisualStudio)' == 'true' or '$(BuildingSolutionFile)' == 'true')">true</ShouldUnsetParentConfigurationAndPlatform>
```

That condition causes `ShouldUnsetParentConfigurationAndPlatform` to be set to true because `MSBuildWorkspace` sets `BuildingInsideVisualStudio` to true. And, when set to true, this property causes the global configuration not to be used for project references. So, my fix is to set the property to false in `MSBuildWorkspace`, which addresses the problem. In addition, there were situations in `MSBuildWorkspace` where the property would not flow properly to the build and most of the additional changes are about addressing that.

I'm cc'ing @rainersigwald here to verify that this is a reasonable fix and throw an exception if there's a better way to handle this situation.

cc @jinujoseph and @ManishJayaswal 