### PR TITLE
Add NullableReferenceTypes msbuild property

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -143,6 +143,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return (string)_store[nameof(WarningsNotAsErrors)]; }
         }
 
+        public bool NullableReferenceTypes
+        {
+            set { _store[nameof(NullableReferenceTypes)] = value; }
+            get { return (bool)_store[nameof(NullableReferenceTypes)]; }
+        }
+
         #endregion
 
         #region Tool Members
@@ -198,6 +204,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             commandLine.AppendWhenTrue("/errorendlocation", _store, nameof(ErrorEndLocation));
             commandLine.AppendSwitchIfNotNull("/preferreduilang:", PreferredUILang);
             commandLine.AppendPlusOrMinusSwitch("/highentropyva", _store, nameof(HighEntropyVA));
+            commandLine.AppendPlusOrMinusSwitch("/nullable", _store, nameof(NullableReferenceTypes));
 
             // If not design time build and the globalSessionGuid property was set then add a -globalsessionguid:<guid>
             bool designTime = false;

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -88,6 +88,7 @@
          NoLogo="$(NoLogo)"
          NoStandardLib="$(NoCompilerStandardLib)"
          NoWin32Manifest="$(NoWin32Manifest)"
+         NullableReferenceTypes="$(NullableReferenceTypes)"
          Optimize="$(Optimize)"
          Deterministic="$(Deterministic)"
          PublicSign="$(PublicSign)"

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -333,6 +333,24 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         }
 
         [Fact]
+        public void NullableReferenceTypes_True()
+        {
+            var csc = new Csc();
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            csc.NullableReferenceTypes = true;
+            Assert.Equal("/nullable+ /out:test.exe test.cs", csc.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        public void NullableReferenceTypes_False()
+        {
+            var csc = new Csc();
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            csc.NullableReferenceTypes = false;
+            Assert.Equal("/nullable- /out:test.exe test.cs", csc.GenerateResponseFileContents());
+        }
+
+        [Fact]
         public void SharedCompilationId()
         {
             var csc = new Csc();


### PR DESCRIPTION
Aleksey recently added a `/nullable(+/-)` command-line option (https://github.com/dotnet/roslyn/pull/30479). We also need to surface that property via `Csc` task and our targets file.

FYI @rainersigwald @nguerrera @davkean 
We don't expect the property name "NullableReferenceTypes" would cause any conflicts.