### PR TITLE
Display documentation from associated property/event when showing QuickInfo for get/set and add/remove

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6172,5 +6172,33 @@ class X
 }",
                 MainDescription("void M<T>() where T : unmanaged"));
         }
+
+        [WorkItem(29703, "https://github.com/dotnet/roslyn/issues/29703")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestGetAccessorDocumentation()
+        {
+            await TestAsync(
+@"
+class X
+{
+    /// <summary>Summary for property Goo</summary>
+    int Goo { g$$et; set; }
+}",
+                Documentation("Summary for property Goo"));
+        }
+
+        [WorkItem(29703, "https://github.com/dotnet/roslyn/issues/29703")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestSetAccessorDocumentation()
+        {
+            await TestAsync(
+@"
+class X
+{
+    /// <summary>Summary for property Goo</summary>
+    int Goo { get; s$$et; }
+}",
+                Documentation("Summary for property Goo"));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6200,5 +6200,81 @@ class X
 }",
                 Documentation("Summary for property Goo"));
         }
+
+        [WorkItem(29703, "https://github.com/dotnet/roslyn/issues/29703")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestEventAddDocumentation1()
+        {
+            await TestAsync(
+@"
+using System;
+
+class X
+{
+    /// <summary>Summary for event Goo</summary>
+    event EventHandler<EventArgs> Goo
+    {
+        a$$dd => throw null;
+        remove => throw null;
+    }
+}",
+                Documentation("Summary for event Goo"));
+        }
+
+        [WorkItem(29703, "https://github.com/dotnet/roslyn/issues/29703")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestEventAddDocumentation2()
+        {
+            await TestAsync(
+@"
+using System;
+
+class X
+{
+    /// <summary>Summary for event Goo</summary>
+    event EventHandler<EventArgs> Goo;
+
+    void M() => Goo +$$= null;
+}",
+                Documentation("Summary for event Goo"));
+        }
+
+        [WorkItem(29703, "https://github.com/dotnet/roslyn/issues/29703")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestEventRemoveDocumentation1()
+        {
+            await TestAsync(
+@"
+using System;
+
+class X
+{
+    /// <summary>Summary for event Goo</summary>
+    event EventHandler<EventArgs> Goo
+    {
+        add => throw null;
+        r$$emove => throw null;
+    }
+}",
+                Documentation("Summary for event Goo"));
+        }
+
+        [WorkItem(29703, "https://github.com/dotnet/roslyn/issues/29703")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestEventRemoveDocumentation2()
+        {
+            await TestAsync(
+@"
+using System;
+
+class X
+{
+    /// <summary>Summary for event Goo</summary>
+    event EventHandler<EventArgs> Goo;
+
+    void M() => Goo -$$= null;
+}",
+                Documentation("Summary for event Goo"));
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -2369,5 +2369,39 @@ Class C3
 End Class",
             MainDescription("Function C2.ViewData() As C1"))
         End Function
+
+        <WorkItem(29703, "https://github.com/dotnet/roslyn/issues/29703")>
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        Public Async Function TestGetAccessorDocumentation() As Task
+            Await TestAsync("
+Class C
+    ''' <summary>Summary for property Goo</summary>
+    Property Goo As Integer
+        G$$et
+            Return 0
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class",
+            Documentation("Summary for property Goo"))
+        End Function
+
+        <WorkItem(29703, "https://github.com/dotnet/roslyn/issues/29703")>
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        Public Async Function TestSetAccessorDocumentation() As Task
+            Await TestAsync("
+Class C
+    ''' <summary>Summary for property Goo</summary>
+    Property Goo As Integer
+        Get
+            Return 0
+        End Get
+        S$$et(value As Integer)
+        End Set
+    End Property
+End Class",
+            Documentation("Summary for property Goo"))
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 case MethodKind.EventRemove:
                 case MethodKind.PropertyGet:
                 case MethodKind.PropertySet:
-                    return method.ContainingSymbol.GetDocumentationComment().SummaryText;
+                    return method.AssociatedSymbol.GetDocumentationComment().SummaryText;
                 default:
                     return method.GetDocumentationComment().SummaryText;
             }


### PR DESCRIPTION
Prior to this PR, the QuickInfo for property get/set accessors and event add/remove methods would display the documentation for the containing type rather than the property or event. This PR rectifies that so that the property/event documentation is displayed in the QuickInfo instead.

![image](https://user-images.githubusercontent.com/2829282/47125795-639aad80-d253-11e8-95c7-83acbc5a636e.png)

Fixes #29703.