### PR TITLE
Fix for perf issues in CompilationWithAnalyzers found from perf traces

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -480,6 +480,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             // Remove the event from event map.
+            // Note: We do not pass in the cancellationToken to DisposableWait to ensure the state is updated.
             using (_gate.DisposableWait())
             {
                 UpdateEventsMap_NoLock(compilationEvent, add: false);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -135,7 +135,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalyzerDriver driver,
             CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
             using (_gate.DisposableWait(cancellationToken))
             {
                 if (_treesWithGeneratedSourceEvents.Contains(tree))


### PR DESCRIPTION
1. Check cancellation at multiple places.
2. Run partial tree completion logic sequentially when `AnalysisOptions.ConcurrentAnalysis = false`