### PR TITLE
Include GetAwaiter() extension method namespace in AddImport suggestions

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -4852,10 +4852,10 @@ namespace A
 
 namespace B
 {
-    using A;
     using System;
     using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
+    using A;
 
     static class Extensions
     {
@@ -4874,6 +4874,9 @@ namespace B
 @"
 namespace A
 {
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
     using B;
 
     class C
@@ -4886,6 +4889,9 @@ namespace A
 
 namespace B
 {
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
     using A;
 
     static class Extensions

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -4832,7 +4832,7 @@ class C
 
         [WorkItem(29313, "https://github.com/dotnet/roslyn/issues/29313")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-        public async Task TestGetAwaiterExtensionMethod()
+        public async Task TestGetAwaiterExtensionMethod1()
         {
             await TestAsync(
 @"
@@ -4884,6 +4884,86 @@ namespace A
         async Task M() => await Goo;
 
         C Goo { get; set; }
+    }
+}
+
+namespace B
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+    using A;
+
+    static class Extensions
+    {
+        public static Awaitable GetAwaiter(this C scheduler) => null;
+
+        public class Awaitable : INotifyCompletion
+        {
+            public object GetResult() => null;
+
+            public void OnCompleted(Action continuation) { }
+
+            public bool IsCompleted => true;
+        }
+    }
+}");
+        }
+
+        [WorkItem(29313, "https://github.com/dotnet/roslyn/issues/29313")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestGetAwaiterExtensionMethod2()
+        {
+            await TestAsync(
+@"
+namespace A
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+
+    class C
+    {
+        async Task M() => await [|GetC|]();
+
+        C GetC() => null;
+    }
+}
+
+namespace B
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+    using A;
+
+    static class Extensions
+    {
+        public static Awaitable GetAwaiter(this C scheduler) => null;
+
+        public class Awaitable : INotifyCompletion
+        {
+            public object GetResult() => null;
+
+            public void OnCompleted(Action continuation) { }
+
+            public bool IsCompleted => true;
+        }
+    }
+}",
+@"
+namespace A
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+    using B;
+
+    class C
+    {
+        async Task M() => await GetC();
+
+        C GetC() => null;
     }
 }
 

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -4859,9 +4859,9 @@ namespace B
 
     static class Extensions
     {
-        public static Awaitable GetAwaiter(this C scheduler) => null;
+        public static Awaiter GetAwaiter(this C scheduler) => null;
 
-        public class Awaitable : INotifyCompletion
+        public class Awaiter : INotifyCompletion
         {
             public object GetResult() => null;
 
@@ -4896,9 +4896,9 @@ namespace B
 
     static class Extensions
     {
-        public static Awaitable GetAwaiter(this C scheduler) => null;
+        public static Awaiter GetAwaiter(this C scheduler) => null;
 
-        public class Awaitable : INotifyCompletion
+        public class Awaiter : INotifyCompletion
         {
             public object GetResult() => null;
 
@@ -4939,9 +4939,9 @@ namespace B
 
     static class Extensions
     {
-        public static Awaitable GetAwaiter(this C scheduler) => null;
+        public static Awaiter GetAwaiter(this C scheduler) => null;
 
-        public class Awaitable : INotifyCompletion
+        public class Awaiter : INotifyCompletion
         {
             public object GetResult() => null;
 
@@ -4976,9 +4976,9 @@ namespace B
 
     static class Extensions
     {
-        public static Awaitable GetAwaiter(this C scheduler) => null;
+        public static Awaiter GetAwaiter(this C scheduler) => null;
 
-        public class Awaitable : INotifyCompletion
+        public class Awaiter : INotifyCompletion
         {
             public object GetResult() => null;
 

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -4829,5 +4829,72 @@ class C
 }
 ", WellKnownTagArrays.Namespace);
         }
+
+        [WorkItem(541730, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541730")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestGetAwaiterExtensionMethod()
+        {
+            await TestAsync(
+@"
+namespace A
+{
+    class C
+    {
+        async Task M() => await [|Goo|];
+
+        C Goo { get; set; }
+    }
+}
+
+namespace B
+{
+    using A;
+
+    static class Extensions
+    {
+        public static Awaitable GetAwaiter(this C scheduler) => default;
+
+        public class Awaitable : INotifyCompletion
+        {
+            public object GetResult() => default;
+
+            public void OnCompleted(Action continuation) { }
+
+            public bool IsCompleted => true;
+        }
+    }
+}",
+@"
+namespace A
+{
+    using B;
+
+    class C
+    {
+        async Task M() => await Goo;
+
+        C Goo { get; set; }
+    }
+}
+
+namespace B
+{
+    using A;
+
+    static class Extensions
+    {
+        public static Awaitable GetAwaiter(this C scheduler) => default;
+
+        public class Awaitable : INotifyCompletion
+        {
+            public object GetResult() => default;
+
+            public void OnCompleted(Action continuation) { }
+
+            public bool IsCompleted => true;
+        }
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -4830,7 +4830,7 @@ class C
 ", WellKnownTagArrays.Namespace);
         }
 
-        [WorkItem(541730, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541730")]
+        [WorkItem(29313, "https://github.com/dotnet/roslyn/issues/29313")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
         public async Task TestGetAwaiterExtensionMethod()
         {
@@ -4838,6 +4838,10 @@ class C
 @"
 namespace A
 {
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+
     class C
     {
         async Task M() => await [|Goo|];
@@ -4849,14 +4853,17 @@ namespace A
 namespace B
 {
     using A;
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
 
     static class Extensions
     {
-        public static Awaitable GetAwaiter(this C scheduler) => default;
+        public static Awaitable GetAwaiter(this C scheduler) => null;
 
         public class Awaitable : INotifyCompletion
         {
-            public object GetResult() => default;
+            public object GetResult() => null;
 
             public void OnCompleted(Action continuation) { }
 

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -4896,11 +4896,11 @@ namespace B
 
     static class Extensions
     {
-        public static Awaitable GetAwaiter(this C scheduler) => default;
+        public static Awaitable GetAwaiter(this C scheduler) => null;
 
         public class Awaitable : INotifyCompletion
         {
-            public object GetResult() => default;
+            public object GetResult() => null;
 
             public void OnCompleted(Action continuation) { }
 

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -132,6 +132,10 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
         protected override bool CanAddImportForDeconstruct(string diagnosticId, SyntaxNode node)
             => diagnosticId == CS8129;
 
+        protected override bool CanAddImportForGetAwaiter(string diagnosticId, SyntaxNode node) =>
+            diagnosticId == CS1061 &&
+            node.AncestorsAndSelf().Any(n => n is AwaitExpressionSyntax);
+
         protected override bool CanAddImportForNamespace(string diagnosticId, SyntaxNode node, out SimpleNameSyntax nameNode)
         {
             nameNode = null;
@@ -223,6 +227,16 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
             SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
         {
             return semanticModel.GetTypeInfo(node).Type;
+        }
+
+        protected override ITypeSymbol GetAwaitInfo(
+            SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
+        {
+            var @await = node.AncestorsAndSelf().OfType<AwaitExpressionSyntax>().First();
+
+            var expression = @await.Expression;
+
+            return semanticModel.GetTypeInfo(expression).Type;
         }
 
         protected override ITypeSymbol GetQueryClauseInfo(

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -132,9 +132,9 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
         protected override bool CanAddImportForDeconstruct(string diagnosticId, SyntaxNode node)
             => diagnosticId == CS8129;
 
-        protected override bool CanAddImportForGetAwaiter(string diagnosticId, SyntaxNode node, ISyntaxFactsService syntaxFactsService)
+        protected override bool CanAddImportForGetAwaiter(string diagnosticId, ISyntaxFactsService syntaxFactsService, SyntaxNode node)
             => diagnosticId == CS1061 &&
-            AncestorOrSelfIsAwaitExpression(node, syntaxFactsService);
+            AncestorOrSelfIsAwaitExpression(syntaxFactsService, node);
 
         protected override bool CanAddImportForNamespace(string diagnosticId, SyntaxNode node, out SimpleNameSyntax nameNode)
         {

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -132,9 +132,9 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
         protected override bool CanAddImportForDeconstruct(string diagnosticId, SyntaxNode node)
             => diagnosticId == CS8129;
 
-        protected override bool CanAddImportForGetAwaiter(string diagnosticId, SyntaxNode node) =>
-            diagnosticId == CS1061 &&
-            node.AncestorsAndSelf().Any(n => n is AwaitExpressionSyntax);
+        protected override bool CanAddImportForGetAwaiter(string diagnosticId, SyntaxNode node, ISyntaxFactsService syntaxFactsService)
+            => diagnosticId == CS1061 &&
+            AncestorOrSelfIsAwaitExpression(node, syntaxFactsService);
 
         protected override bool CanAddImportForNamespace(string diagnosticId, SyntaxNode node, out SimpleNameSyntax nameNode)
         {
@@ -227,16 +227,6 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
             SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
         {
             return semanticModel.GetTypeInfo(node).Type;
-        }
-
-        protected override ITypeSymbol GetAwaitInfo(
-            SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
-        {
-            var @await = node.AncestorsAndSelf().OfType<AwaitExpressionSyntax>().First();
-
-            var expression = @await.Expression;
-
-            return semanticModel.GetTypeInfo(expression).Type;
         }
 
         protected override ITypeSymbol GetQueryClauseInfo(

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         protected abstract bool CanAddImportForMethod(string diagnosticId, ISyntaxFactsService syntaxFacts, SyntaxNode node, out TSimpleNameSyntax nameNode);
         protected abstract bool CanAddImportForNamespace(string diagnosticId, SyntaxNode node, out TSimpleNameSyntax nameNode);
         protected abstract bool CanAddImportForDeconstruct(string diagnosticId, SyntaxNode node);
-        protected abstract bool CanAddImportForGetAwaiter(string diagnosticId, SyntaxNode node, ISyntaxFactsService syntaxFactsService);
+        protected abstract bool CanAddImportForGetAwaiter(string diagnosticId, ISyntaxFactsService syntaxFactsService, SyntaxNode node);
         protected abstract bool CanAddImportForQuery(string diagnosticId, SyntaxNode node);
         protected abstract bool CanAddImportForType(string diagnosticId, SyntaxNode node, out TSimpleNameSyntax nameNode);
 
@@ -542,19 +542,19 @@ namespace Microsoft.CodeAnalysis.AddImport
             throw ExceptionUtilities.Unreachable;
         }
 
-        protected ITypeSymbol GetAwaitInfo(SemanticModel semanticModel, SyntaxNode node, ISyntaxFactsService syntaxFactsService, CancellationToken cancellationToken)
+        private ITypeSymbol GetAwaitInfo(SemanticModel semanticModel, ISyntaxFactsService syntaxFactsService, SyntaxNode node, CancellationToken cancellationToken)
         {
-            var awaitExpression = FirstAwaitExpressionAncestor(node, syntaxFactsService);
+            var awaitExpression = FirstAwaitExpressionAncestor(syntaxFactsService, node);
 
             var innerExpression = syntaxFactsService.GetExpressionOfAwaitExpression(node);
 
             return semanticModel.GetTypeInfo(innerExpression).Type;
         }
 
-        protected bool AncestorOrSelfIsAwaitExpression(SyntaxNode node, ISyntaxFactsService syntaxFactsService)
-            => FirstAwaitExpressionAncestor(node, syntaxFactsService) != null;
+        protected bool AncestorOrSelfIsAwaitExpression(ISyntaxFactsService syntaxFactsService, SyntaxNode node)
+            => FirstAwaitExpressionAncestor(syntaxFactsService, node) != null;
 
-        private SyntaxNode FirstAwaitExpressionAncestor(SyntaxNode node, ISyntaxFactsService syntaxFactsService)
+        private SyntaxNode FirstAwaitExpressionAncestor(ISyntaxFactsService syntaxFactsService, SyntaxNode node)
             => node.FirstAncestorOrSelf<SyntaxNode>(n => syntaxFactsService.IsAwaitExpression(n));
     }
 }

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -30,11 +30,13 @@ namespace Microsoft.CodeAnalysis.AddImport
         protected abstract bool CanAddImportForMethod(string diagnosticId, ISyntaxFactsService syntaxFacts, SyntaxNode node, out TSimpleNameSyntax nameNode);
         protected abstract bool CanAddImportForNamespace(string diagnosticId, SyntaxNode node, out TSimpleNameSyntax nameNode);
         protected abstract bool CanAddImportForDeconstruct(string diagnosticId, SyntaxNode node);
+        protected abstract bool CanAddImportForGetAwaiter(string diagnosticId, SyntaxNode node);
         protected abstract bool CanAddImportForQuery(string diagnosticId, SyntaxNode node);
         protected abstract bool CanAddImportForType(string diagnosticId, SyntaxNode node, out TSimpleNameSyntax nameNode);
 
         protected abstract ISet<INamespaceSymbol> GetImportNamespacesInScope(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken);
         protected abstract ITypeSymbol GetDeconstructInfo(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken);
+        protected abstract ITypeSymbol GetAwaitInfo(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken);
         protected abstract ITypeSymbol GetQueryClauseInfo(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken);
         protected abstract bool IsViableExtensionMethod(IMethodSymbol method, SyntaxNode expression, SemanticModel semanticModel, ISyntaxFactsService syntaxFacts, CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -473,9 +473,9 @@ namespace Microsoft.CodeAnalysis.AddImport
             {
                 searchScope.CancellationToken.ThrowIfCancellationRequested();
 
-                if (_owner.CanAddImportForGetAwaiter(_diagnosticId, _node, _syntaxFacts))
+                if (_owner.CanAddImportForGetAwaiter(_diagnosticId, _syntaxFacts, _node))
                 {
-                    var type = _owner.GetAwaitInfo(_semanticModel, _node, _syntaxFacts, searchScope.CancellationToken);
+                    var type = _owner.GetAwaitInfo(_semanticModel, _syntaxFacts, _node, searchScope.CancellationToken);
                     if (type != null)
                     {
                         return await GetReferencesForExtensionMethodAsync(searchScope, WellKnownMemberNames.GetAwaiter, type,

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -140,6 +140,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                     tasks.Add(this.GetReferencesForCollectionInitializerMethodsAsync(searchScope));
                     tasks.Add(this.GetReferencesForQueryPatternsAsync(searchScope));
                     tasks.Add(this.GetReferencesForDeconstructAsync(searchScope));
+                    tasks.Add(this.GetReferencesForGetAwaiterAsync(searchScope));
                 }
 
                 await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -457,6 +458,28 @@ namespace Microsoft.CodeAnalysis.AddImport
                         // find extension methods named "Select"
                         return await GetReferencesForExtensionMethodAsync(
                             searchScope, nameof(Enumerable.Select), type).ConfigureAwait(false);
+                    }
+                }
+
+                return ImmutableArray<SymbolReference>.Empty;
+            }
+
+            /// <summary>
+            /// Searches for extension methods exactly called 'GetAwaiter'.  Returns
+            /// <see cref="SymbolReference"/>s to the <see cref="INamespaceSymbol"/>s that contain
+            /// the static classes that those extension methods are contained in.
+            /// </summary>
+            private async Task<ImmutableArray<SymbolReference>> GetReferencesForGetAwaiterAsync(SearchScope searchScope)
+            {
+                searchScope.CancellationToken.ThrowIfCancellationRequested();
+
+                if (_owner.CanAddImportForGetAwaiter(_diagnosticId, _node))
+                {
+                    var type = _owner.GetAwaitInfo(_semanticModel, _node, searchScope.CancellationToken);
+                    if (type != null)
+                    {
+                        return await GetReferencesForExtensionMethodAsync(searchScope, "GetAwaiter", type,
+                            m => m.IsValidGetAwaiter()).ConfigureAwait(false); 
                     }
                 }
 

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -473,12 +473,12 @@ namespace Microsoft.CodeAnalysis.AddImport
             {
                 searchScope.CancellationToken.ThrowIfCancellationRequested();
 
-                if (_owner.CanAddImportForGetAwaiter(_diagnosticId, _node))
+                if (_owner.CanAddImportForGetAwaiter(_diagnosticId, _node, _syntaxFacts))
                 {
-                    var type = _owner.GetAwaitInfo(_semanticModel, _node, searchScope.CancellationToken);
+                    var type = _owner.GetAwaitInfo(_semanticModel, _node, _syntaxFacts, searchScope.CancellationToken);
                     if (type != null)
                     {
-                        return await GetReferencesForExtensionMethodAsync(searchScope, "GetAwaiter", type,
+                        return await GetReferencesForExtensionMethodAsync(searchScope, WellKnownMemberNames.GetAwaiter, type,
                             m => m.IsValidGetAwaiter()).ConfigureAwait(false); 
                     }
                 }

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -104,9 +104,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
             Return False
         End Function
 
-        Protected Overrides Function CanAddImportForGetAwaiter(diagnosticId As String, node As SyntaxNode) As Boolean
+        Protected Overrides Function CanAddImportForGetAwaiter(diagnosticId As String, node As SyntaxNode, syntaxFactsService As ISyntaxFactsService) As Boolean
             Return diagnosticId = BC36610 And
-                node.AncestorsAndSelf().Any(Function(n) TypeOf n Is AwaitExpressionSyntax)
+                AncestorOrSelfIsAwaitExpression(node, syntaxFactsService)
         End Function
 
         Protected Overrides Function CanAddImportForQuery(diagnosticId As String, node As SyntaxNode) As Boolean
@@ -211,14 +211,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
 
         Protected Overrides Function GetDeconstructInfo(semanticModel As SemanticModel, node As SyntaxNode, cancellationToken As CancellationToken) As ITypeSymbol
             Return Nothing
-        End Function
-
-        Protected Overrides Function GetAwaitInfo(semanticModel As SemanticModel, node As SyntaxNode, cancellationToken As CancellationToken) As ITypeSymbol
-            Dim await = node.AncestorsAndSelf().OfType(Of AwaitExpressionSyntax)().First()
-
-            Dim expression = await.Expression
-
-            Return semanticModel.GetTypeInfo(expression).Type
         End Function
 
         Protected Overrides Function GetQueryClauseInfo(

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -104,9 +104,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
             Return False
         End Function
 
-        Protected Overrides Function CanAddImportForGetAwaiter(diagnosticId As String, node As SyntaxNode, syntaxFactsService As ISyntaxFactsService) As Boolean
+        Protected Overrides Function CanAddImportForGetAwaiter(diagnosticId As String, syntaxFactsService As ISyntaxFactsService, node As SyntaxNode) As Boolean
             Return diagnosticId = BC36610 And
-                AncestorOrSelfIsAwaitExpression(node, syntaxFactsService)
+                AncestorOrSelfIsAwaitExpression(syntaxFactsService, node)
         End Function
 
         Protected Overrides Function CanAddImportForQuery(diagnosticId As String, node As SyntaxNode) As Boolean

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -104,6 +104,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
             Return False
         End Function
 
+        Protected Overrides Function CanAddImportForGetAwaiter(diagnosticId As String, node As SyntaxNode) As Boolean
+            Return diagnosticId = BC36610 And
+                node.AncestorsAndSelf().Any(Function(n) TypeOf n Is AwaitExpressionSyntax)
+        End Function
+
         Protected Overrides Function CanAddImportForQuery(diagnosticId As String, node As SyntaxNode) As Boolean
             If diagnosticId <> AddImportDiagnosticIds.BC36593 Then
                 Return False
@@ -206,6 +211,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
 
         Protected Overrides Function GetDeconstructInfo(semanticModel As SemanticModel, node As SyntaxNode, cancellationToken As CancellationToken) As ITypeSymbol
             Return Nothing
+        End Function
+
+        Protected Overrides Function GetAwaitInfo(semanticModel As SemanticModel, node As SyntaxNode, cancellationToken As CancellationToken) As ITypeSymbol
+            Dim await = node.AncestorsAndSelf().OfType(Of AwaitExpressionSyntax)().First()
+
+            Dim expression = await.Expression
+
+            Return semanticModel.GetTypeInfo(expression).Type
         End Function
 
         Protected Overrides Function GetQueryClauseInfo(

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -915,6 +915,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return getAwaiters.Any(VerifyGetAwaiter);
         }
 
+        public static bool IsValidGetAwaiter(this IMethodSymbol symbol) => VerifyGetAwaiter(symbol);
+
         private static bool VerifyGetAwaiter(IMethodSymbol getAwaiter)
         {
             var returnType = getAwaiter.ReturnType;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -915,7 +915,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return getAwaiters.Any(VerifyGetAwaiter);
         }
 
-        public static bool IsValidGetAwaiter(this IMethodSymbol symbol) => VerifyGetAwaiter(symbol);
+        public static bool IsValidGetAwaiter(this IMethodSymbol symbol)
+            => symbol.Name == WellKnownMemberNames.GetAwaiter &&
+            VerifyGetAwaiter(symbol);
 
         private static bool VerifyGetAwaiter(IMethodSymbol getAwaiter)
         {


### PR DESCRIPTION
This PR expands the Add Import feature to include addition of a namespace that contains a `GetAwaiter()` extension method for an awaited expression.

![image](https://user-images.githubusercontent.com/2829282/47195595-94014b00-d32a-11e8-91e9-ec38f6c18965.png)

Fixes #29313.