### PR TITLE
Improved syntax diffing of unrelated trees

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
@@ -48,6 +47,24 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(1, changes.Count);
             Assert.Equal(new TextSpan(6, 1), changes[0].Span);
             Assert.Equal("B", changes[0].NewText);
+        }
+
+        [Fact]
+        public void TestDiffClassWithWhitespaceChanged()
+        {
+            var oldTree = SyntaxFactory.ParseSyntaxTree(" class A\r\n{\r\n} ");
+            // this approach ensures tokens are not interned
+            var newTree = SyntaxFactory.SyntaxTree(
+                SyntaxFactory.CompilationUnit().AddMembers(
+                    SyntaxFactory.ClassDeclaration("A")).NormalizeWhitespace());
+
+            var changes = newTree.GetChanges(oldTree);
+            Assert.NotNull(changes);
+            Assert.Equal(2, changes.Count);
+            Assert.Equal(new TextSpan(0, 1), changes[0].Span);
+            Assert.Equal("", changes[0].NewText);
+            Assert.Equal(new TextSpan(14, 1), changes[1].Span);
+            Assert.Equal("", changes[0].NewText);
         }
 
         [Fact]


### PR DESCRIPTION
Contributes to https://github.com/dotnet/roslyn/issues/17498.

Because `SyntaxDiffer` is primarily based on reference equality of green nodes, it doesn't work well for comparing trees that were created from different sources (except for the case when most tokens are interned).

This PR improves that by performing an expensive full string comparison between nodes, but only when there is a high chance that they are actually equal. Namely, they have to have the same full length and their similarity has to be high.

For example, for the newly added test `TestDiffClassWithWhitespaceChanged`, `GetChanges` would previously say that the whole input changed:

```
[0, 15) → "class A\r\n{\r\n}"
```

With this PR, it instead shows only what actually changed:

```
[0, 1) → ""
[14, 15) → ""
```

I believe this change should have acceptable performance, because:

* For related trees, when nodes are identical,  reference equality of green nodes is still used, so performance stays the same. For nodes that are not identical, the full string comparison should be performed only very rarely, because they should almost never have both high similarity and equal length.
* For unrelated trees, performance will become worse. At the same time, their diff results can become significantly better, and I think the performance decrease is worth that.

If this kind of vague performance analysis is not sufficient, what would be a good way of performing a proper benchmark?

cc: @CyrusNajmabadi, @tmat