### PR TITLE
Improve syntax diffing of similar nodes

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
@@ -462,6 +462,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private protected override bool IsSimilarToCore(SyntaxNode other)
         {
+            int thisGroup = kindGroup(this);
+
+            return thisGroup != -1 && thisGroup == kindGroup(other);
+            
             int kindGroup(SyntaxNode node)
             {
                 switch (node.Kind())
@@ -474,10 +478,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return -1;
                 }
             }
-
-            int thisGroup = kindGroup(this);
-
-            return thisGroup != -1 && thisGroup == kindGroup(other);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
@@ -460,6 +460,26 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #region SyntaxNode members
 
+        internal override bool IsSimilarTo(SyntaxNode other)
+        {
+            int kindGroup(SyntaxNode node)
+            {
+                switch (node.Kind())
+                {
+                    case SyntaxKind.ClassDeclaration:
+                    case SyntaxKind.StructDeclaration:
+                    case SyntaxKind.InterfaceDeclaration:
+                        return 1;
+                    default:
+                        return -1;
+                }
+            }
+
+            int thisGroup = kindGroup(this);
+
+            return thisGroup != -1 && thisGroup == kindGroup(other);
+        }
+
         /// <summary>
         /// Determine if this node is structurally equivalent to another.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
@@ -460,7 +460,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #region SyntaxNode members
 
-        internal override bool IsSimilarTo(SyntaxNode other)
+        private protected override bool IsSimilarToCore(SyntaxNode other)
         {
             int kindGroup(SyntaxNode node)
             {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
@@ -270,6 +270,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(" ", changes[1].NewText);
         }
 
+        [Fact]
+        public void TestDiffMinusChangedToPlus()
+        {
+            var options = new CSharpParseOptions(kind: SourceCodeKind.Script);
+            // note: PostIncrementExpression and PostDecrementExpression are both PostfixUnaryExpressionSyntax
+            var oldTree = SyntaxFactory.ParseSyntaxTree("a.b++", options);
+            var newTree = SyntaxFactory.ParseSyntaxTree("c.b--", options);
+
+            var changes = newTree.GetChanges(oldTree);
+            Assert.NotNull(changes);
+            Assert.Equal(2, changes.Count);
+            Assert.Equal(new TextSpan(0, 1), changes[0].Span);
+            Assert.Equal("c", changes[0].NewText);
+            Assert.Equal(new TextSpan(3, 2), changes[1].Span);
+            Assert.Equal("--", changes[1].NewText);
+        }
+
         [Fact, WorkItem(463, "https://github.com/dotnet/roslyn/issues/463")]
         public void TestQualifyWithThis()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxDiffingTests.cs
@@ -254,6 +254,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("struct", changes[0].NewText);
         }
 
+        [Fact]
+        public void TestDiffClassChangedToStruct2()
+        {
+            var oldTree = SyntaxFactory.ParseSyntaxTree("class A { }");
+            // the trailing space is necessary, so that ReduceChanges doesn't help
+            var newTree = SyntaxFactory.ParseSyntaxTree("struct A { } ");
+
+            var changes = newTree.GetChanges(oldTree);
+            Assert.NotNull(changes);
+            Assert.Equal(2, changes.Count);
+            Assert.Equal(new TextSpan(0, 5), changes[0].Span);
+            Assert.Equal("struct", changes[0].NewText);
+            Assert.Equal(new TextSpan(11, 0), changes[1].Span);
+            Assert.Equal(" ", changes[1].NewText);
+        }
+
         [Fact, WorkItem(463, "https://github.com/dotnet/roslyn/issues/463")]
         public void TestQualifyWithThis()
         {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
@@ -502,7 +502,7 @@ namespace Microsoft.CodeAnalysis
 
         private static bool AreSimilar(in SyntaxNodeOrToken node1, in SyntaxNodeOrToken node2)
         {
-            return node1.RawKind == node2.RawKind;
+            return node1.IsSimilarTo(node2);
         }
 
         private struct ChangeRecord

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -1221,6 +1221,8 @@ namespace Microsoft.CodeAnalysis
 
         #endregion
 
+        internal virtual bool IsSimilarTo(SyntaxNode other) => false;
+
         /// <summary>
         /// Determines if two nodes are the same, disregarding trivia differences.
         /// </summary>

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -1221,7 +1221,28 @@ namespace Microsoft.CodeAnalysis
 
         #endregion
 
-        internal virtual bool IsSimilarTo(SyntaxNode other) => false;
+        internal bool IsSimilarTo(SyntaxNode other)
+        {
+            if (this.RawKind == other.RawKind)
+            {
+                return true;
+            }
+
+            if (this.GetType() == other.GetType())
+            {
+                return true;
+            }
+
+            if (this.IsSimilarToCore(other))
+            {
+                return true;
+            }
+
+            return false;
+
+        }
+
+        private protected virtual bool IsSimilarToCore(SyntaxNode other) => false;
 
         /// <summary>
         /// Determines if two nodes are the same, disregarding trivia differences.

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -1239,7 +1239,6 @@ namespace Microsoft.CodeAnalysis
             }
 
             return false;
-
         }
 
         private protected virtual bool IsSimilarToCore(SyntaxNode other) => false;

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
@@ -658,6 +658,21 @@ namespace Microsoft.CodeAnalysis
 
         #endregion
 
+        internal bool IsSimilarTo(SyntaxNodeOrToken other)
+        {
+            if (this.RawKind == other.RawKind)
+            {
+                return true;
+            }
+
+            if (this.IsToken || other.IsToken)
+            {
+                return false;
+            }
+
+            return this._nodeOrParent.IsSimilarTo(other._nodeOrParent);
+        }
+
         /// <summary>
         /// Determines whether the supplied <see cref="SyntaxNodeOrToken"/> is equal to this
         /// <see cref="SyntaxNodeOrToken"/>.

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
@@ -474,7 +474,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return SyntaxTree.GetDiagnostics(Me)
         End Function
 
-        Friend Overrides Function IsSimilarTo(other As SyntaxNode) As Boolean
+        Private Protected Overrides Function IsSimilarToCore(other As SyntaxNode) As Boolean
             Dim kindGroup =
                 Function(node As SyntaxNode) As Integer
                     Select Case node.Kind()

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
@@ -474,6 +474,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return SyntaxTree.GetDiagnostics(Me)
         End Function
 
+        Friend Overrides Function IsSimilarTo(other As SyntaxNode) As Boolean
+            Dim kindGroup =
+                Function(node As SyntaxNode) As Integer
+                    Select Case node.Kind()
+                        Case SyntaxKind.ClassBlock, SyntaxKind.StructureBlock, SyntaxKind.InterfaceBlock, SyntaxKind.ModuleBlock
+                            Return 1
+                        Case SyntaxKind.FunctionBlock, SyntaxKind.SubBlock
+                            Return 2
+                        Case Else
+                            Return -1
+                    End Select
+                End Function
+
+            Dim meGroup = kindGroup(Me)
+
+            Return meGroup <> -1 AndAlso meGroup = kindGroup(other)
+        End Function
+
         Protected Overrides Function IsEquivalentToCore(node As SyntaxNode, Optional topLevel As Boolean = False) As Boolean
             Return SyntaxFactory.AreEquivalent(Me, DirectCast(node, VisualBasicSyntaxNode), topLevel)
         End Function

--- a/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
@@ -2797,6 +2797,28 @@ End Module
         End Sub
 
         <Fact>
+        Public Sub TestSyntaxTree_GetChangesWhenSubChangedToFunction()
+            Dim oldTree = SyntaxFactory.ParseSyntaxTree("Module M
+  Sub M()
+    Console.WriteLine(42)
+  End Sub
+End Module")
+            Dim newTree = SyntaxFactory.ParseSyntaxTree("Module M
+  Async Function M() of Task
+    Console.WriteLine(42)
+  End Function
+End Module")
+
+            Dim changes = newTree.GetChanges(oldTree)
+            Assert.NotNull(changes)
+            Assert.Equal(2, changes.Count)
+            Assert.Equal(new TextSpan(12, 7), changes(0).Span)
+            Assert.Equal("Async Function M() of Task", changes(0).NewText)
+            Assert.Equal(new TextSpan(54, 3), changes(1).Span)
+            Assert.Equal("Function", changes(1).NewText)
+        End Sub
+
+        <Fact>
         Public Sub TestSyntaxList_Failures()
             'Validate the exceptions being generated when Invalid arguments are used for a TextSpan Constructor           
 

--- a/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
@@ -2798,16 +2798,11 @@ End Module
 
         <Fact>
         Public Sub TestSyntaxTree_GetChangesWhenSubChangedToFunction()
-            Dim oldTree = SyntaxFactory.ParseSyntaxTree("Module M
-  Sub M()
-    Console.WriteLine(42)
-  End Sub
-End Module")
-            Dim newTree = SyntaxFactory.ParseSyntaxTree("Module M
-  Async Function M() of Task
-    Console.WriteLine(42)
-  End Function
-End Module")
+            Dim parseLines = 
+                Function(lines As String()) SyntaxFactory.ParseSyntaxTree(String.Join(vbCrLf, lines))
+
+            Dim oldTree = parseLines({ "Module M", "  Sub M()", "    Console.WriteLine(42)", "  End Sub", "End Module"})
+            Dim newTree = parseLines({ "Module M", "  Async Function M() of Task", "    Console.WriteLine(42)", "  End Function", "End Module"})
 
             Dim changes = newTree.GetChanges(oldTree)
             Assert.NotNull(changes)

--- a/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
@@ -2811,11 +2811,13 @@ End Module")
 
             Dim changes = newTree.GetChanges(oldTree)
             Assert.NotNull(changes)
-            Assert.Equal(2, changes.Count)
-            Assert.Equal(new TextSpan(12, 7), changes(0).Span)
-            Assert.Equal("Async Function M() of Task", changes(0).NewText)
-            Assert.Equal(new TextSpan(54, 3), changes(1).Span)
-            Assert.Equal("Function", changes(1).NewText)
+            Assert.Equal(3, changes.Count)
+            Assert.Equal(new TextSpan(12, 3), changes(0).Span)
+            Assert.Equal("Async Function", changes(0).NewText)
+            Assert.Equal(new TextSpan(19, 0), changes(1).Span)
+            Assert.Equal(" of Task", changes(1).NewText)
+            Assert.Equal(new TextSpan(54, 3), changes(2).Span)
+            Assert.Equal("Function", changes(2).NewText)
         End Sub
 
         <Fact>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/roslyn/issues/17498.

When `SyntaxDiffer` considers whether to look at two non-identical nodes more carefully by "reducing" them, it only considers nodes that have the same `RawKind`. But this means the diff does not work well when a node changes its kind, but otherwise stays mostly the same. This can happen for example when a `class` is changed to a `struct` or when a `Sub` is changed to a `Function`.

This PR improves that by considering each node kind within the same "group" (mathematically, they could be considered to be equivalence classes) to be similar. As a result of this, the code will investigate such pairs more closely, by computing their similarity and then possibly by reducing them together.

It's not completely clear to me which node kinds should form these groups. For example, a constructor could be changed to a factory method with mostly the same code. Or a property could be changed to a method. Does this mean they all should be considered similar?

What I did for now is to only consider the cases where I think there is a reasonably high chance of kind change with few other changes:

* `class`, `struct` and `interface` in C#; `Class`, `Structure`, `Interface` and `Module` in VB
* `Function` and `Sub` in VB

Specifically, for the newly added `TestSyntaxTree_GetChangesWhenSubChangedToFunction`, previously the reported changes were:

```
[12, 57) → "Async Function M() of Task\r\n    Console.WriteLine(42)\r\n  End Function"
```

With this PR, they are instead:

```
[12, 19) → "Async Function M() of Task"
[54, 57) → "Function"
```

As for performance, this PR does mean that similarity will be computed for more pairs of nodes. But since similarity is already computed for example for all pairs of functions (if they are within `MaxSearchLength`), I think this should not make it significantly worse.

cc: @CyrusNajmabadi, @tmat