### PR TITLE
Fixes issue #30529 "object initializers and csharp_new_line_before_open_brace in editorconfig"

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.Parsers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.Parsers.cs
@@ -80,9 +80,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         private static NewLineOption? ConvertToNewLineOption(string value)
-            => s_newLineOptionsEditorConfigMap.TryGetValue(value, out var option)
-               ? option
-               : (NewLineOption?)null;
+        { 
+            if (s_newLineOptionsEditorConfigMap.TryGetValue(value, out var option)) {
+                return option;
+            }
+            if (s_legacyNewLineOptionsEditorConfigMap.TryGetValue(value, out var legacyOption))
+            {
+                return legacyOption;
+            }
+            return null;
+        }
 
         private static string GetNewLineOptionEditorConfigString(OptionSet optionSet)
         {

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
@@ -40,6 +40,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 KeyValuePairUtil.Create("no_change", LabelPositionOptions.NoIndent),
                 KeyValuePairUtil.Create("one_less_than_current", LabelPositionOptions.OneLess),
             });
+        private static readonly BidirectionalMap<string, NewLineOption> s_legacyNewLineOptionsEditorConfigMap =
+            new BidirectionalMap<string, NewLineOption>(new[]
+            {
+                KeyValuePairUtil.Create("object_collection_array_initalizers", NewLineOption.ObjectCollectionsArrayInitializers),
+            });
         private static readonly BidirectionalMap<string, NewLineOption> s_newLineOptionsEditorConfigMap =
             new BidirectionalMap<string, NewLineOption>(new[]
             {
@@ -52,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 KeyValuePairUtil.Create("anonymous_methods", NewLineOption.AnonymousMethods),
                 KeyValuePairUtil.Create("control_blocks", NewLineOption.ControlBlocks),
                 KeyValuePairUtil.Create("anonymous_types", NewLineOption.AnonymousTypes),
-                KeyValuePairUtil.Create("object_collection_array_initalizers", NewLineOption.ObjectCollectionsArrayInitializers),
+                KeyValuePairUtil.Create("object_collection_array_initializers", NewLineOption.ObjectCollectionsArrayInitializers),
                 KeyValuePairUtil.Create("lambdas", NewLineOption.Lambdas),
                 KeyValuePairUtil.Create("local_functions", NewLineOption.LocalFunction),
             });

--- a/src/Workspaces/CSharpTest/Formatting/EditorConfigOptionParserTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/EditorConfigOptionParserTests.cs
@@ -92,6 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
         InlineData("control_blocks", NewLineOption.ControlBlocks),
         InlineData("anonymous_types", NewLineOption.AnonymousTypes),
         InlineData("object_collection_array_initalizers", NewLineOption.ObjectCollectionsArrayInitializers),
+        InlineData("object_collection_array_initializers", NewLineOption.ObjectCollectionsArrayInitializers),
         InlineData("lambdas", NewLineOption.Lambdas),
         InlineData("local_functions", NewLineOption.LocalFunction)]
         static void TestParseNewLineOptionTrue(string value, NewLineOption option)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/30529

`csharp_new_line_before_open_brace = accessors, anonymous_methods, anonymous_types, control_blocks, events, indexers, lambdas, local_functions, methods, object_collection_array_initializers, properties, types`

does not include `NewLineOption.ObjectCollectionsArrayInitializers` because of misspelling of `object_collection_array_initalizers` in code:

(https://github.com/dotnet/roslyn/issues/30529#issuecomment-430063368) @sharwell 
> The underlying problems is the following setting is misspelled.
> 
> roslyn/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
> 
> Line 55 in 14e0068
>  KeyValuePairUtil.Create("object_collection_array_initalizers", NewLineOption.ObjectCollectionsArrayInitializers), 
> 
> roslyn/src/Workspaces/CSharpTest/Formatting/EditorConfigOptionParserTests.cs
> 
> Line 94 in 14e0068
>  InlineData("object_collection_array_initalizers", NewLineOption.ObjectCollectionsArrayInitializers), 
> 
> We need to update the code so the correct spelling is supported, and also preserve support for the original value.


Fixing this issue while supporting already misspelled option was not that easy, because the options are using a `BidirectionalMap` with unique Keys and Values.  I didn't like the idea of changing the BidirectionalMap, so I've introduced a new static map `s_legacyNewLineOptionsEditorConfigMap` complementing the existing `s_newLineOptionsEditorConfigMap`.
