### PR TITLE
Add support for ??= compound operator to the UseCompound fix

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseCompoundAssignment/UseCompoundAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseCompoundAssignment/UseCompoundAssignmentTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.UseCompoundAssignment;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
@@ -213,6 +214,40 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseCompoundAssignment
         a >>= 10;
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
+        public async Task TestCoalesceExpressionCSharp8OrGreater()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M(int? a)
+    {
+        a [||]= a ?? 10;
+    }
+}",
+@"public class C
+{
+    void M(int? a)
+    {
+        a ??= 10;
+    }
+}", parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
+        public async Task TestCoalesceExpressionCSharp7()
+        {
+            await TestMissingAsync(
+@"public class C
+{
+    void M(int? a)
+    {
+        a [||]= a ?? 10;
+    }
+}",
+    new TestParameters(parseOptions: new CSharpParseOptions(LanguageVersion.CSharp7_3)));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]

--- a/src/Features/CSharp/Portable/UseCompoundAssignment/CSharpUseCompoundAssignmentDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseCompoundAssignment/CSharpUseCompoundAssignmentDiagnosticAnalyzer.cs
@@ -20,5 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCompoundAssignment
 
         protected override SyntaxKind GetAnalysisKind()
             => SyntaxKind.SimpleAssignmentExpression;
+
+        protected override bool IsSupported(SyntaxKind assignmentKind, ParseOptions options)
+            => assignmentKind != SyntaxKind.CoalesceExpression ||
+            ((CSharpParseOptions)options).LanguageVersion >= LanguageVersion.CSharp8;
     }
 }

--- a/src/Features/CSharp/Portable/UseCompoundAssignment/Utilities.cs
+++ b/src/Features/CSharp/Portable/UseCompoundAssignment/Utilities.cs
@@ -19,7 +19,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCompoundAssignment
                 (SyntaxKind.ExclusiveOrExpression, SyntaxKind.ExclusiveOrAssignmentExpression),
                 (SyntaxKind.BitwiseOrExpression, SyntaxKind.OrAssignmentExpression),
                 (SyntaxKind.LeftShiftExpression, SyntaxKind.LeftShiftAssignmentExpression),
-                (SyntaxKind.RightShiftExpression, SyntaxKind.RightShiftAssignmentExpression)).SelectAsArray(
+                (SyntaxKind.RightShiftExpression, SyntaxKind.RightShiftAssignmentExpression),
+                (SyntaxKind.CoalesceExpression, SyntaxKind.CoalesceAssignmentExpression)).SelectAsArray(
                     tuple => (tuple.Item1, tuple.Item2, FindOperatorToken(tuple.Item2)));
 
         private static SyntaxKind FindOperatorToken(SyntaxKind assignmentExpressionKind)

--- a/src/Features/Core/Portable/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCompoundAssignment/AbstractUseCompoundAssignmentDiagnosticAnalyzer.cs
@@ -46,6 +46,7 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
 
         protected abstract TSyntaxKind GetKind(int rawKind);
         protected abstract TSyntaxKind GetAnalysisKind();
+        protected abstract bool IsSupported(TSyntaxKind assignmentKind, ParseOptions options);
 
         public override bool OpenFileOnly(Workspace workspace)
             => false;
@@ -87,6 +88,12 @@ namespace Microsoft.CodeAnalysis.UseCompoundAssignment
 
             var binaryKind = GetKind(binaryExpression.RawKind);
             if (!_binaryToAssignmentMap.ContainsKey(binaryKind))
+            {
+                return;
+            }
+
+            // Requires at least C# 8 for Coalesce compound expression
+            if (!IsSupported(binaryKind, syntaxTree.Options))
             {
                 return;
             }

--- a/src/Features/VisualBasic/Portable/UseCompoundAssignment/VisualBasicUseCompoundAssignmentDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseCompoundAssignment/VisualBasicUseCompoundAssignmentDiagnosticAnalyzer.vb
@@ -20,5 +20,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCompoundAssignment
         Protected Overrides Function GetAnalysisKind() As SyntaxKind
             Return SyntaxKind.SimpleAssignmentStatement
         End Function
+
+        Protected Overrides Function IsSupported(assignmentKind As SyntaxKind, options As ParseOptions) As Boolean
+            Return True
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Only enabled for C#8 or above to avoid suggesting fixes that
break compilation.
See #30009 for info.