### PR TITLE
[WIP] Don't Debug.Assert in ChangedText.GetTextChanges

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -797,14 +797,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 .WithChanges(new TextChange(new TextSpan(5, 1), "_")) // "Hello_World"
                 .WithChanges(new TextChange(new TextSpan(6, 0), "+")); // "Hello_+World"
 
-            var changedText2 = sourceText.WithChanges(
-                new TextChange(new TextSpan(5, 1), "_"), // "Hello_World"
-                new TextChange(new TextSpan(6, 0), "+")); // "Hello_+World"
-
-            var changedText1 = sourceText
-                .WithChanges(new TextChange(new TextSpan(6, 0), "+"))
-                .WithChanges(new TextChange(new TextSpan(5, 1), "_"));
-
             var changeList = changedText.GetTextChanges(sourceText);
             Assert.Equal(1, changeList.Count);
             Assert.Equal(new TextSpan(5, 1), changeList[0].Span);
@@ -846,25 +838,7 @@ namespace ConsoleApp22
             var text8 = text7.WithChanges(new TextChange(TextSpan.FromBounds(233, 233), "E"));
             var text9 = text8.WithChanges(new TextChange(TextSpan.FromBounds(231, 232), ""));
 
-            var textb = text0
-                .WithChanges(new TextChange(TextSpan.FromBounds(228, 229), ""))
-                .WithChanges(new TextChange(TextSpan.FromBounds(228, 228), "."))
-                .WithChanges(new TextChange(TextSpan.FromBounds(229, 229), "w"));
-
-            var changesb = textb
-                .GetTextChanges(text0)
-                .ToList();
-
-            var textc = text0.WithChanges(
-                new TextChange(TextSpan.FromBounds(228, 229), ""),
-                new TextChange(TextSpan.FromBounds(228, 228), "."),
-                new TextChange(TextSpan.FromBounds(229, 229), "w"));
-
-            var changesc = textc
-                .GetTextChanges(text0)
-                .ToList();
-
-            var changes = text4.GetTextChanges(text2).ToList();
+            var changes = text9.GetTextChanges(text0).ToList();
         }
     }
 }

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -299,7 +299,6 @@ namespace Microsoft.CodeAnalysis.Text
                         AddRange(list, new TextChangeRange(oldChange.Span, oldChangeLeadingInsertion));
                         oldDelta = oldDelta - oldChange.Span.Length + oldChangeLeadingInsertion;
                         oldChange = new TextChangeRange(new TextSpan(oldChange.Span.Start, 0), oldChange.NewLength - oldChangeLeadingInsertion);
-                        //newChange = new TextChangeRange(new TextSpan(oldChange.Span.Start + oldDelta, newChange.Span.Length), newChange.NewLength);
                         goto tryAgain;
                     }
                     else if (newChange.Span.Start == oldChange.Span.Start + oldDelta)

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.Text
                         AddRange(list, new TextChangeRange(oldChange.Span, oldChangeLeadingInsertion));
                         oldDelta = oldDelta - oldChange.Span.Length + oldChangeLeadingInsertion;
                         oldChange = new TextChangeRange(new TextSpan(oldChange.Span.Start, 0), oldChange.NewLength - oldChangeLeadingInsertion);
-                        newChange = new TextChangeRange(new TextSpan(oldChange.Span.Start + oldDelta, newChange.Span.Length), newChange.NewLength);
+                        //newChange = new TextChangeRange(new TextSpan(oldChange.Span.Start + oldDelta, newChange.Span.Length), newChange.NewLength);
                         goto tryAgain;
                     }
                     else if (newChange.Span.Start == oldChange.Span.Start + oldDelta)


### PR DESCRIPTION
Resolves #26305 

This solution is pretty naive but is intended to follow @heejaechang's suggestion. The changes that result from running the `WithChanges` test don't match what I predicted, as someone who has only started to touch this API in the last week or so. Specifically, there's no list entry that matches the deletion of the `"Console"` substring in the source text.

I'd greatly appreciate the chance to go over what ChangedText.Merge is really doing with someone who's familiar with it. :)