### PR TITLE
Rearranged query to avoid unnecessary allocations

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                   from typeDefHandle in module.MetadataReader.TypeDefinitions
                                   let typeDef = module.MetadataReader.GetTypeDefinition(typeDefHandle)
                                   let supportedLanguages = GetSupportedLanguages(typeDef, module.Module, attributePredicate)
-                                  where supportedLanguages != null && supportedLanguages.Any()
+                                  where supportedLanguages.Any()
                                   let typeName = GetFullyQualifiedTypeName(typeDef, module.Module)
                                   from supportedLanguage in supportedLanguages
                                   group typeName by supportedLanguage;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -159,15 +159,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <exception cref="BadImageFormatException">The PE image format is invalid.</exception>
         /// <exception cref="IOException">IO error reading the metadata.</exception>
+        [PerformanceSensitive( "https://github.com/dotnet/roslyn/issues/30449" )]
         private static ImmutableDictionary<string, ImmutableHashSet<string>> GetAnalyzerTypeNameMap(string fullPath, AttributePredicate attributePredicate)
         {
             using (var assembly = AssemblyMetadata.CreateFromFile(fullPath))
             {
+                // This is longer than strictly necessary to avoid thrashing the GC with string allocations
+                // in the call to GetFullyQualifiedTypeNames. Specifically, this checks for the presence of
+                // supported languages prior to creating the type names.
                 var typeNameMap = from module in assembly.GetModules()
                                   from typeDefHandle in module.MetadataReader.TypeDefinitions
-                                  let typeDef = module.MetadataReader.GetTypeDefinition(typeDefHandle)
-                                  let typeName = GetFullyQualifiedTypeName(typeDef, module.Module)
-                                  from supportedLanguage in GetSupportedLanguages(typeDef, module.Module, attributePredicate)
+                                  let typeDef = module.MetadataReader.GetTypeDefinition( typeDefHandle )
+                                  let supportedLanguages = GetSupportedLanguages( typeDef, module.Module, attributePredicate )
+                                  where supportedLanguages != null && supportedLanguages.Any()
+                                  let typeName = GetFullyQualifiedTypeName( typeDef, module.Module )
+                                  from supportedLanguage in supportedLanguages
                                   group typeName by supportedLanguage;
 
                 return typeNameMap.ToImmutableDictionary(g => g.Key, g => g.ToImmutableHashSet());

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         /// <exception cref="BadImageFormatException">The PE image format is invalid.</exception>
         /// <exception cref="IOException">IO error reading the metadata.</exception>
-        [PerformanceSensitive( "https://github.com/dotnet/roslyn/issues/30449" )]
+        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/30449")]
         private static ImmutableDictionary<string, ImmutableHashSet<string>> GetAnalyzerTypeNameMap(string fullPath, AttributePredicate attributePredicate)
         {
             using (var assembly = AssemblyMetadata.CreateFromFile(fullPath))

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -169,10 +169,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // supported languages prior to creating the type names.
                 var typeNameMap = from module in assembly.GetModules()
                                   from typeDefHandle in module.MetadataReader.TypeDefinitions
-                                  let typeDef = module.MetadataReader.GetTypeDefinition( typeDefHandle )
-                                  let supportedLanguages = GetSupportedLanguages( typeDef, module.Module, attributePredicate )
+                                  let typeDef = module.MetadataReader.GetTypeDefinition(typeDefHandle)
+                                  let supportedLanguages = GetSupportedLanguages(typeDef, module.Module, attributePredicate)
                                   where supportedLanguages != null && supportedLanguages.Any()
-                                  let typeName = GetFullyQualifiedTypeName( typeDef, module.Module )
+                                  let typeName = GetFullyQualifiedTypeName(typeDef, module.Module)
                                   from supportedLanguage in supportedLanguages
                                   group typeName by supportedLanguage;
 


### PR DESCRIPTION
Moved the typeName assignment after checking for supported languages per:

Fixes #30449