### PR TITLE
Fix crash when applying code fixes that modify additional files

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspace.cs
@@ -85,7 +85,9 @@ namespace Microsoft.VisualStudio.LanguageServices
 
         public virtual string GetFilePath(DocumentId documentId)
         {
-            return CurrentSolution.GetDocument(documentId)?.FilePath;
+            var solution = CurrentSolution;
+
+            return (solution.GetDocument(documentId) ?? solution.GetAdditionalDocument(documentId))?.FilePath;
         }
 
         /// <summary>

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -267,7 +267,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
 
             // first make sure we can edit the document we will be updating (check them out from source control, etc)
-            var changedDocs = projectChanges.SelectMany(pd => pd.GetChangedDocuments(true)).ToList();
+            var changedDocs = projectChanges.SelectMany(pd => pd.GetChangedDocuments(true).Concat(pd.GetChangedAdditionalDocuments())).ToList();
             if (changedDocs.Count > 0)
             {
                 this.EnsureEditableDocuments(changedDocs);


### PR DESCRIPTION
An oversight in my refactorings of the project system means that applying code fixes that modify additional files will crash. We shouldn't do that.

**Note:** additional commentary is in the commit messages themselves.

### Customer scenario

User has an analyzer or code fix that modifies "additional files", which are extra inputs to analyzers. A good example is Roslyn's "public API" analyzer, which has a list of approved surface area that you can't modify without also modifying this extra file. If you have a codefix that tries to change the file, and you apply the change, Visual Studio crashes.

Analyzers with code fixes that modify this are rare, but are used heavily in Roslyn development itself. This will definitely be hit in dogfooding.

### Bugs this fixes

[no bug yet filed, this was fixed once discovered]

### Workarounds, if any

Just don't apply the fix, and manually do whatever the fix would do.

### Risk

Very low -- fixing a method that needed to consider both regular files and these additional files. The additional file path will only be taken when the regular one isn't.

### Performance impact

None.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

A helper function was rewritten as a part of a larger rewrite, and it was unclear the function needed to deal with both regular documents and additional documents. What previously worked by accident now needed to be explicit.

### How was the bug found?

Ad-hoc testing as we were working on the project shim rewrite.

</details>