### PR TITLE
set content type for AbstractDebuggerIntelliSenseContext to the original content type

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -202,9 +202,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             return true;
         }
 
-        internal void SetContentType(int install)
+        internal void SetContentType(bool install)
         {
-            var contentType = install == 0 ? _originalContentType : _contentType;
+            var contentType = install ? _contentType :_originalContentType;
             _textView.TextBuffer.ChangeContentType(contentType, null);
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -25,6 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
     {
         private readonly IWpfTextView _textView;
         private readonly IContentType _contentType;
+        private readonly IContentType _originalContentType;
         protected readonly IProjectionBufferFactoryService ProjectionBufferFactoryService;
         protected readonly Microsoft.VisualStudio.TextManager.Interop.TextSpan CurrentStatementSpan;
         private readonly IVsTextLines _debuggerTextLines;
@@ -58,6 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             this.ContextBuffer = contextBuffer;
             this.CurrentStatementSpan = currentStatementSpan[0];
             _contentType = contentType;
+            _originalContentType = _textView.TextBuffer.ContentType;
             this.ProjectionBufferFactoryService = componentModel.GetService<IProjectionBufferFactoryService>();
             _bufferGraphFactoryService = componentModel.GetService<IBufferGraphFactoryService>();
             _isImmediateWindow = IsImmediateWindow((IVsUIShell)serviceProvider.GetService(typeof(SVsUIShell)), vsTextView);
@@ -198,6 +200,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
 
             _debuggerTextView = new DebuggerTextView(_textView, bufferGraph, _debuggerTextLines, InImmediateWindow);
             return true;
+        }
+
+        internal void SetContentType(int install)
+        {
+            var contentType = install == 0 ? _originalContentType : _contentType;
+            _textView.TextBuffer.ChangeContentType(contentType, null);
         }
 
         private ITrackingSpan CreateImmediateWindowProjectionMapping(Document document, out ImmediateWindowContext immediateWindowContext)

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
@@ -194,6 +194,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             _context = null;
         }
 
+        internal void SetContentType(int install)
+            => _context.SetContentType(install);
+
         public void Dispose()
         {
             if (_context != null)

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
@@ -194,8 +194,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             _context = null;
         }
 
-        internal void SetContentType(int install)
-            => _context.SetContentType(install);
+        internal void SetContentType(bool install)
+            => _context?.SetContentType(install);
 
         public void Dispose()
         {

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
@@ -40,12 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             if (install != 0)
             {
                 DebuggerIntelliSenseFilter<TPackage, TLanguageService> filter;
-                if (this.filters.ContainsKey(textView))
-                {
-                    // We already have a filter in this textview. Return.
-                    return VSConstants.S_OK;
-                }
-                else
+                if (!this.filters.ContainsKey(textView))
                 {
                     filter = new DebuggerIntelliSenseFilter<TPackage, TLanguageService>(this,
                         this.EditorAdaptersFactoryService.GetWpfTextView(textView),
@@ -55,10 +50,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                     Marshal.ThrowExceptionForHR(textView.AddCommandFilter(filter, out var nextFilter));
                     filter.SetNextFilter(nextFilter);
                 }
+
+                this.filters[textView].SetContentType(install);
             }
             else
             {
                 Marshal.ThrowExceptionForHR(textView.RemoveCommandFilter(this.filters[textView]));
+                this.filters[textView].SetContentType(install);
                 this.filters[textView].Dispose();
                 this.filters.Remove(textView);
             }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
@@ -51,12 +51,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                     filter.SetNextFilter(nextFilter);
                 }
 
-                this.filters[textView].SetContentType(install);
+                this.filters[textView].SetContentType(install: true);
             }
             else
             {
                 Marshal.ThrowExceptionForHR(textView.RemoveCommandFilter(this.filters[textView]));
-                this.filters[textView].SetContentType(install);
+                this.filters[textView].SetContentType(install: false);
                 this.filters[textView].Dispose();
                 this.filters.Remove(textView);
             }


### PR DESCRIPTION
Fixes the following issue:

> AbstractDebuggerIntelliSenseContext is overwriting the content type of the text buffer in the Immediate Window. I suppose this is relatively harmless while using it with C#, but if I then load a project of a different type that buffer continues to have a content type of “CSharp”, as opposed to “Command”.


<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario


### Bugs this fixes



### Workarounds, if any



### Risk


### Performance impact


### Is this a regression from a previous update?



### Root cause analysis


### How was the bug found?



</details>