### PR TITLE
Fix package dependencies

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -314,6 +314,7 @@
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Progression.Common"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Progression.Interfaces"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.RemoteControl"/>
+    <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Shell.15.0"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Shell.Design"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Shell.Framework"/>
@@ -325,6 +326,7 @@
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime"/>
+    <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Telemetry"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Text.Data"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Text.Logic"/>
@@ -334,6 +336,8 @@
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.TextManager.Interop.12.0"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime"/>
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Utilities"/>
+    <PrivateVisualStudioPackage Include="Microsoft.VSSDK.BuildTools"/>
+    <PrivateVisualStudioPackage Include="Newtonsoft.Json"/>
     <PrivateVisualStudioPackage Include="NuGet.VisualStudio"/>
     <PrivateVisualStudioPackage Include="StreamJsonRpc"/>
     <PrivateVisualStudioPackage Include="VSLangProj"/>

--- a/build/Targets/RepoToolset/Version.targets
+++ b/build/Targets/RepoToolset/Version.targets
@@ -37,21 +37,4 @@
       <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">42.42.42.42</AssemblyVersion>
     </PropertyGroup>
   </Target>
-
-  <!-- 
-    Append short commit SHA to PackageVersion.
-  -->
-  <Target Name="GetPackageVersion" 
-          BeforeTargets="GenerateNuSpec" 
-          DependsOnTargets="InitializeSourceControlInformation"
-          Condition="'$(DotNetFinalVersionKind)' != 'release'">
-    <PropertyGroup>
-      <_ShortSha>$(SourceRevisionId)</_ShortSha>
-      <_ShortSha Condition="$(SourceRevisionId.Length) &gt; 7">$(SourceRevisionId.Substring(0, 8))</_ShortSha>
-
-      <PackageVersion Condition="'$(SemanticVersioningV1)' != 'true'">$(Version)+$(_ShortSha)</PackageVersion>
-      <PackageVersion Condition="'$(SemanticVersioningV1)' == 'true'">$(Version)-$(_ShortSha)</PackageVersion>
-    </PropertyGroup>
-  </Target>
-
 </Project>

--- a/build/Targets/RepoToolset/Workarounds.targets
+++ b/build/Targets/RepoToolset/Workarounds.targets
@@ -67,7 +67,7 @@
   -->
   <Target Name="InitializeStandardNuspecProperties"
           BeforeTargets="GenerateNuspec"
-          DependsOnTargets="GetPackageVersion;_InitializeNuspecRepositoryInformationPropertiesWorkaround"
+          DependsOnTargets="_InitializeNuspecRepositoryInformationPropertiesWorkaround"
           Condition="'$(NuspecFile)' != '' and '$(NuspecProperties)' == ''">
     
     <PropertyGroup>

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -68,11 +68,11 @@
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
     <!-- PrivateAssets due to https://github.com/dotnet/roslyn/issues/29292 -->
     <ProjectReference Include="..\..\..\Workspaces\Core\Desktop\Microsoft.CodeAnalysis.Workspaces.Desktop.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\..\..\EditorFeatures\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj" />
-    <ProjectReference Include="..\..\..\EditorFeatures\Core.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj" />
+    <ProjectReference Include="..\..\..\EditorFeatures\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\..\EditorFeatures\Core.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\..\EditorFeatures\Text\Microsoft.CodeAnalysis.EditorFeatures.Text.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
     <ProjectReference Include="..\..\..\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj" />
-    <ProjectReference Include="..\..\..\EditorFeatures\Text\Microsoft.CodeAnalysis.EditorFeatures.Text.csproj" />
   </ItemGroup>
   <ItemGroup Label="File References">
     <Reference Include="System.ComponentModel.Composition" />
@@ -147,7 +147,7 @@
     <Reference Include="WindowsFormsIntegration" />
     <PackageReference Include="EnvDTE" Version="$(EnvDTEVersion)" />
     <PackageReference Include="EnvDTE80" Version="$(EnvDTE80Version)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Version="$(MicrosoftCodeAnalysisElfieVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Version="$(MicrosoftCodeAnalysisElfieVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.ServiceHub.Client" Version="$(MicrosoftServiceHubClientVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine" Version="$(MicrosoftVisualStudioDebuggerEngineVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.UI.Interfaces" Version="$(MicrosoftVisualStudioDebuggerUIInterfacesVersion)" />
@@ -179,11 +179,10 @@
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="$(MicrosoftVisualStudioTextManagerInterop100Version)" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="$(MicrosoftVisualStudioTextManagerInterop120Version)" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" Version="$(MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
+    <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.MSXML" Version="$(MicrosoftMSXMLVersion)" />
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageReference Include="VSLangProj" Version="$(VSLangProjVersion)" />
     <PackageReference Include="VSLangProj2" Version="$(VSLangProj2Version)" />

--- a/src/VisualStudio/Core/Impl/Microsoft.VisualStudio.LanguageServices.Implementation.csproj
+++ b/src/VisualStudio/Core/Impl/Microsoft.VisualStudio.LanguageServices.Implementation.csproj
@@ -59,7 +59,6 @@
     <Reference Include="WindowsFormsIntegration" />
     <PackageReference Include="EnvDTE" Version="$(EnvDTEVersion)" />
     <PackageReference Include="EnvDTE80" Version="$(EnvDTE80Version)" />
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
@@ -68,6 +67,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Options\GridOptionPreviewControl.xaml.cs">


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/30662 and https://github.com/dotnet/roslyn/issues/30256.

Reduces dependencies of Microsoft.VisualStudio.LanguageServices.nupkg to

```xml
<dependency id="Microsoft.CodeAnalysis.Common" version="2.11.0" exclude="Build,Analyzers" />
<dependency id="Microsoft.CodeAnalysis.Features" version="2.11.0" exclude="Build,Analyzers" />
<dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.11.0" exclude="Build,Analyzers" />
```