### PR TITLE
Validate generic arguments in `using static` directives

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -576,14 +576,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 alias.Alias.CheckConstraints(semanticDiagnostics);
             }
 
+            var corLibrary = _compilation.SourceAssembly.CorLibrary;
+            var conversions = new TypeConversions(corLibrary);
             foreach (var @using in Usings)
             {
                 // Check if `using static` directives meet constraints.
                 if (@using.NamespaceOrType.IsType)
                 {
                     var typeSymbol = (TypeSymbol)@using.NamespaceOrType;
-                    var corLibrary = _compilation.SourceAssembly.CorLibrary;
-                    var conversions = new TypeConversions(corLibrary);
                     var location = @using.UsingDirective?.Name.Location ?? NoLocation.Singleton;
                     typeSymbol.CheckAllConstraints(conversions, location, semanticDiagnostics);
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -584,7 +584,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var typeSymbol = (TypeSymbol)@using.NamespaceOrType;
                     var corLibrary = _compilation.SourceAssembly.CorLibrary;
                     var conversions = new TypeConversions(corLibrary);
-                    typeSymbol.CheckAllConstraints(conversions, @using.UsingDirective.Name.Location, semanticDiagnostics);
+                    var location = @using.UsingDirective?.Name.Location ?? NoLocation.Singleton;
+                    typeSymbol.CheckAllConstraints(conversions, location, semanticDiagnostics);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -582,7 +582,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (@using.NamespaceOrType.IsType)
                 {
                     var typeSymbol = (TypeSymbol)@using.NamespaceOrType;
-                    var corLibrary = typeSymbol.ContainingAssembly.CorLibrary;
+                    var corLibrary = _compilation.SourceAssembly.CorLibrary;
                     var conversions = new TypeConversions(corLibrary);
                     typeSymbol.CheckAllConstraints(conversions, @using.UsingDirective.Name.Location, semanticDiagnostics);
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -576,6 +576,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 alias.Alias.CheckConstraints(semanticDiagnostics);
             }
 
+            foreach (var @using in Usings)
+            {
+                // Check if `using static` directives meet constraints.
+                if (@using.NamespaceOrType.IsType)
+                {
+                    var typeSymbol = (TypeSymbol)@using.NamespaceOrType;
+                    var corLibrary = typeSymbol.ContainingAssembly.CorLibrary;
+                    var conversions = new TypeConversions(corLibrary);
+                    typeSymbol.CheckAllConstraints(conversions, @using.UsingDirective.Name.Location, semanticDiagnostics);
+                }
+            }
+
             // Force resolution of extern aliases.
             foreach (var alias in ExternAliases)
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3401,6 +3401,25 @@ class A<T> where T : class
                 Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "A<A<int>[]>.B").WithArguments("A<T>", "T", "int").WithLocation(2, 14));
         }
 
+        [Fact, WorkItem(30726, "https://github.com/dotnet/roslyn/issues/30726")]
+        public void UsingStaticMultipleGenericConstraints()
+        {
+            var code = @"
+using static A<int, string>;
+static class A<T, U> where T : class where U : struct { }
+";
+            CreateCompilationWithMscorlib45(code).VerifyDiagnostics(
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static A<int, string>;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static A<int, string>;").WithLocation(2, 1),
+                // (2,14): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'T' in the generic type or method 'A<T, U>'
+                // using static A<int, string>;
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "A<int, string>").WithArguments("A<T, U>", "T", "int").WithLocation(2, 14),
+                // (2,14): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'U' in the generic type or method 'A<T, U>'
+                // using static A<int, string>;
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "A<int, string>").WithArguments("A<T, U>", "U", "string").WithLocation(2, 14));
+        }
+
         [Fact, WorkItem(8234, "https://github.com/dotnet/roslyn/issues/8234")]
         public void EventAccessInTypeNameContext()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3370,10 +3370,7 @@ static class Extension2
             var code = @"
 using static Test<System.String>;
 
-public static class Test<T> where T : struct
-{
-    public static void Run( T item ) { }
-}
+public static class Test<T> where T : struct { }
 ";
             CreateCompilationWithMscorlib45(code).VerifyDiagnostics(
                 // (2,1): hidden CS8019: Unnecessary using directive.
@@ -3382,6 +3379,26 @@ public static class Test<T> where T : struct
                 // (2,14): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Test<T>'
                 // using static Test<System.String>;
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test<System.String>").WithArguments("Test<T>", "T", "string").WithLocation(2, 14));
+        }
+
+        [Fact, WorkItem(30726, "https://github.com/dotnet/roslyn/issues/30726")]
+        public void UsingStaticGenericConstraintNestedType()
+        {
+            var code = @"
+using static A<A<int>[]>.B;
+
+class A<T> where T : class
+{
+    internal static class B { }
+}
+";
+            CreateCompilationWithMscorlib45(code).VerifyDiagnostics(
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static A<A<int>[]>.B;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static A<A<int>[]>.B;").WithLocation(2, 1),
+                // (2,14): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'T' in the generic type or method 'A<T>'
+                // using static A<A<int>[]>.B;
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "A<A<int>[]>.B").WithArguments("A<T>", "T", "int").WithLocation(2, 14));
         }
 
         [Fact, WorkItem(8234, "https://github.com/dotnet/roslyn/issues/8234")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
@@ -2070,8 +2070,11 @@ namespace CrashTest
 }";
             var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
+    // (2,14): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'Crash<T>'. There is no implicit reference conversion from 'object' to 'CrashTest.Crash<object>.AbstractClass'.
+    // using static CrashTest.Crash<object>;
+    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "CrashTest.Crash<object>").WithArguments("CrashTest.Crash<T>", "CrashTest.Crash<object>.AbstractClass", "T", "object").WithLocation(2, 14),
     // (6,11): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'Crash<T>'. There is no implicit reference conversion from 'object' to 'CrashTest.Crash<object>.AbstractClass'.
-    //     class Class2 : AbstractClass 
+    //     class Class2 : AbstractClass
     Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "Class2").WithArguments("CrashTest.Crash<T>", "CrashTest.Crash<object>.AbstractClass", "T", "object").WithLocation(6, 11),
     // (21,23): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'Crash<T>'. There is no implicit reference conversion from 'object' to 'CrashTest.Crash<object>.AbstractClass'.
     //         AbstractClass Test()


### PR DESCRIPTION
Resolves #30726

Looks like there is a separate Validate() phase in Imports which takes place after binding, probably because attempting certain validations during binding can result in a stack overflow.

This PR adds to the Imports.Validate method to validate constraints on `using static`. It was already validating constraints on using aliases which explains what we were seeing before @AlekseyTs.