### PR TITLE
Do not inject attribute types into .Net modules.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -537,6 +537,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public void AddInjectedSymbols(NamespaceSymbol containingNamespace)
             {
+                if (containingNamespace.DeclaringCompilation.Options.OutputKind.IsNetModule())
+                {
+                    return;
+                }
+
                 const string codeAnalysis = "CodeAnalysis";
                 const string system = "System";
                 const string microsoft = "Microsoft";

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/StructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/StructTests.cs
@@ -407,6 +407,42 @@ public struct Struct
                 );
         }
 
+        [Fact]
+        [WorkItem(30756, "https://github.com/dotnet/roslyn/issues/30756")]
+        public void IgnoreEffectivelyInternalStructFieldsOfReferenceTypeFromAddedModule_PlusNullable()
+        {
+            var source = @"
+internal class C1
+{
+    public struct S
+    {
+        public string data;
+    }
+}
+public struct Struct
+{
+    internal C1.S data;
+}
+";
+            var comp1 = CreateCompilation(source, options: WithNonNullTypesTrue(TestOptions.DebugModule));
+            var moduleReference = comp1.EmitToImageReference();
+
+            var source2 =
+@"class Program
+{
+    public static void Main()
+    {
+        Struct r1;
+        var r2 = r1;
+    }
+}";
+            CreateCompilation(source2, references: new MetadataReference[] { moduleReference }, options: WithNonNullTypesTrue()).VerifyDiagnostics(
+                // (6,18): error CS0165: Use of unassigned local variable 'r1'
+                //         var r2 = r1;
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "r1").WithArguments("r1").WithLocation(6, 18)
+                );
+        }
+
         [Fact, WorkItem(1072447, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072447")]
         public void IgnorePrivateStructFieldsOfReferenceTypeFromAddedModule02()
         {


### PR DESCRIPTION
### Customer scenario

An attempt to emit a .Net module while using Nullable feature causes a crash in C# compiler.

### Bugs this fixes

Fixes #30756.

### Workarounds, if any

Do not use Nullable feature in .Net modules.

### Risk

Low 

### Performance impact

None.

### Is this a regression from a previous update?

Nullable is a new feature.

### Root cause analysis

A test gap. A unit-test is added.

### How was the bug found?

Ran all C# unit-tests targeting language version 8 with nullable feature enabled and analyzed failures.

VSO Bug: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/718198