### PR TITLE
Revert "Add a SetProperty API for CPS to passing msbuild properties"

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
@@ -22,9 +24,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
 
         // Options.
         void SetOptions(string commandLineForOptions);
-
-        // Other project properties.
-        void SetProperty(string name, object value);
 
         // References.
         void AddMetadataReference(string referencePath, MetadataReferenceProperties properties);

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -123,11 +123,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             }
         }
 
-        public void SetProperty(string name, object value)
-        {
-            // TODO
-        }
-
         public void AddMetadataReference(string referencePath, MetadataReferenceProperties properties)
         {
             referencePath = FileUtilities.NormalizeAbsolutePath(referencePath);


### PR DESCRIPTION
Reverts dotnet/roslyn#30748

Turns out this is a breaking change for [project system](https://github.com/dotnet/project-system/blob/d8de8cd390ab04474f8e88ec68b785757b14d350/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.ForegroundWorkspaceProjectContext.cs)
(default interface method would come in handy here)

FYI @jinujoseph @Pilchie @jasonmalinowski @davkean 