### PR TITLE
fix for PerfWatsonHang: microsoft.visualstudio.languageservices.dll!Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue.VsENCRebuildableProjectImpl.GetProjectAnalysisSummary

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioActiveStatementProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioActiveStatementProvider.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 
                 // No exception should be thrown in case of errors on the debugger side. 
                 // The debugger is responsible to provide telemetry for error cases.
+                // The callback should not be called, but it's there to guarantee that the task completes and a hang is avoided.
                 var workList = DkmWorkList.Create(_ => { completion.TrySetResult(ImmutableArray<ActiveStatementDebugInfo>.Empty); });
 
                 void CancelWork()

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioActiveStatementProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioActiveStatementProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 
                 // No exception should be thrown in case of errors on the debugger side. 
                 // The debugger is responsible to provide telemetry for error cases.
-                var workList = DkmWorkList.Create(null); 
+                var workList = DkmWorkList.Create(_ => { completion.TrySetResult(ImmutableArray<ActiveStatementDebugInfo>.Empty); });
 
                 void CancelWork()
                 {
@@ -66,92 +66,112 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 
                             clrRuntimeInstance.GetActiveStatements(workList, activeStatementsResult =>
                             {
-                                if (cancellationToken.IsCancellationRequested)
+                                try
                                 {
-                                    CancelWork();
-                                    return;
-                                }
-
-                                if (activeStatementsResult.ErrorCode != 0)
-                                {
-                                    builders[runtimeIndex] = ArrayBuilder<ActiveStatementDebugInfo>.GetInstance(0);
-
-                                    // the last active statement of the last runtime has been processed:
-                                    if (Interlocked.Decrement(ref pendingRuntimes) == 0)
+                                    if (cancellationToken.IsCancellationRequested)
                                     {
-                                        completion.TrySetResult(builders.ToFlattenedImmutableArrayAndFree());
+                                        CancelWork();
+                                        return;
                                     }
 
-                                    return;
-                                }
-
-                                // group active statement by instruction and aggregate flags and threads:
-                                var instructionMap = PooledDictionary<ActiveInstructionId, (DkmInstructionSymbol Symbol, ArrayBuilder<Guid> Threads, int Index, ActiveStatementFlags Flags)>.GetInstance();
-
-                                GroupActiveStatementsByInstructionId(instructionMap, activeStatementsResult.ActiveStatements);
-
-                                int pendingStatements = instructionMap.Count;
-                                builders[runtimeIndex] = ArrayBuilder<ActiveStatementDebugInfo>.GetInstance(pendingStatements);
-                                builders[runtimeIndex].Count = pendingStatements;
-
-                                if (instructionMap.Count == 0)
-                                {
-                                    if (Interlocked.Decrement(ref pendingRuntimes) == 0)
+                                    var localBuilders = builders;
+                                    if (localBuilders == null) // e.g. cancelled
                                     {
-                                        completion.TrySetResult(builders.ToFlattenedImmutableArrayAndFree());
+                                        return;
                                     }
 
-                                    return;
-                                }
-
-                                foreach (var (instructionId, (symbol, threads, index, flags)) in instructionMap)
-                                {
-                                    var immutableThreads = threads.ToImmutableAndFree();
-
-                                    symbol.GetSourcePosition(workList, DkmSourcePositionFlags.None, InspectionSession: null, sourcePositionResult =>
+                                    if (activeStatementsResult.ErrorCode != 0)
                                     {
-                                        if (cancellationToken.IsCancellationRequested)
+                                        localBuilders[runtimeIndex] = ArrayBuilder<ActiveStatementDebugInfo>.GetInstance(0);
+
+                                        // the last active statement of the last runtime has been processed:
+                                        if (Interlocked.Decrement(ref pendingRuntimes) == 0)
                                         {
-                                            CancelWork();
-                                            return;
+                                            completion.TrySetResult(localBuilders.ToFlattenedImmutableArrayAndFree());
                                         }
 
-                                        DkmSourcePosition position;
-                                        string documentNameOpt;
-                                        LinePositionSpan span;
-                                        if (sourcePositionResult.ErrorCode == 0 && (position = sourcePositionResult.SourcePosition) != null)
+                                        return;
+                                    }
+
+                                    // group active statement by instruction and aggregate flags and threads:
+                                    var instructionMap = PooledDictionary<ActiveInstructionId, (DkmInstructionSymbol Symbol, ArrayBuilder<Guid> Threads, int Index, ActiveStatementFlags Flags)>.GetInstance();
+
+                                    GroupActiveStatementsByInstructionId(instructionMap, activeStatementsResult.ActiveStatements);
+
+                                    int pendingStatements = instructionMap.Count;
+                                    localBuilders[runtimeIndex] = ArrayBuilder<ActiveStatementDebugInfo>.GetInstance(pendingStatements);
+                                    localBuilders[runtimeIndex].Count = pendingStatements;
+
+                                    if (instructionMap.Count == 0)
+                                    {
+                                        if (Interlocked.Decrement(ref pendingRuntimes) == 0)
                                         {
-                                            documentNameOpt = position.DocumentName;
-                                            span = ToLinePositionSpan(position.TextSpan);
-                                        }
-                                        else
-                                        {
-                                            // The debugger can't determine source location for the active statement.
-                                            // The PDB might not be available or the statement is in a method that doesn't have debug information.
-                                            documentNameOpt = null;
-                                            span = default;
+                                            completion.TrySetResult(localBuilders.ToFlattenedImmutableArrayAndFree());
                                         }
 
-                                        builders[runtimeIndex][index] = new ActiveStatementDebugInfo(
-                                            instructionId,
-                                            documentNameOpt,
-                                            span,
-                                            immutableThreads,
-                                            flags);
+                                        return;
+                                    }
 
-                                        // the last active statement of the current runtime has been processed:
-                                        if (Interlocked.Decrement(ref pendingStatements) == 0)
+                                    foreach (var (instructionId, (symbol, threads, index, flags)) in instructionMap)
+                                    {
+                                        var immutableThreads = threads.ToImmutableAndFree();
+
+                                        symbol.GetSourcePosition(workList, DkmSourcePositionFlags.None, InspectionSession: null, sourcePositionResult =>
                                         {
-                                            // the last active statement of the last runtime has been processed:
-                                            if (Interlocked.Decrement(ref pendingRuntimes) == 0)
+                                            try
                                             {
-                                                completion.TrySetResult(builders.ToFlattenedImmutableArrayAndFree());
-                                            }
-                                        }
-                                    });
-                                }
+                                                if (cancellationToken.IsCancellationRequested)
+                                                {
+                                                    CancelWork();
+                                                    return;
+                                                }
 
-                                instructionMap.Free();
+                                                DkmSourcePosition position;
+                                                string documentNameOpt;
+                                                LinePositionSpan span;
+                                                if (sourcePositionResult.ErrorCode == 0 && (position = sourcePositionResult.SourcePosition) != null)
+                                                {
+                                                    documentNameOpt = position.DocumentName;
+                                                    span = ToLinePositionSpan(position.TextSpan);
+                                                }
+                                                else
+                                                {
+                                                    // The debugger can't determine source location for the active statement.
+                                                    // The PDB might not be available or the statement is in a method that doesn't have debug information.
+                                                    documentNameOpt = null;
+                                                    span = default;
+                                                }
+
+                                                localBuilders[runtimeIndex][index] = new ActiveStatementDebugInfo(
+                                                    instructionId,
+                                                    documentNameOpt,
+                                                    span,
+                                                    immutableThreads,
+                                                    flags);
+
+                                                // the last active statement of the current runtime has been processed:
+                                                if (Interlocked.Decrement(ref pendingStatements) == 0)
+                                                {
+                                                    // the last active statement of the last runtime has been processed:
+                                                    if (Interlocked.Decrement(ref pendingRuntimes) == 0)
+                                                    {
+                                                        completion.TrySetResult(localBuilders.ToFlattenedImmutableArrayAndFree());
+                                                    }
+                                                }
+                                            }
+                                            catch (Exception e)
+                                            {
+                                                completion.TrySetException(e);
+                                            }
+                                        });
+                                    }
+
+                                    instructionMap.Free();
+                                }
+                                catch (Exception e)
+                                {
+                                    completion.TrySetException(e);
+                                }
                             });
                         }
                     }


### PR DESCRIPTION
### Customer scenario
Hangs happens sometimes during Edit-and-continue scenarios

### Bugs this fixes
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/705591

### Workarounds, if any
None

### Risk
Low

### Performance impact
Should improve: remove hangs

### Is this a regression from a previous update?
Not exactly, we try to fix issues with asynchronous interaction between Debugger and Roslyn. There were NFW, crashes, etc. Now we see hangs could happens as well.

### Root cause analysis
@AArnott  wrote:

> 
> !dumpasync turned up several potentially relevant async return stacks:
> 
> 0:000> !dumpasync
> 7f23a3ec <0> Microsoft.CodeAnalysis.Diagnostics.EngineV2.DiagnosticIncrementalAnalyzer+Executor+<ComputeDocumentDiagnosticAnalyzerDiagnosticsAsync>d__14
> .7f23a4ac <0> Microsoft.CodeAnalysis.Diagnostics.EngineV2.DiagnosticIncrementalAnalyzer+Executor+<ComputeDiagnosticsAsync>d__7
> ..7f23a58c <1> Microsoft.CodeAnalysis.Diagnostics.EngineV2.DiagnosticIncrementalAnalyzer+Executor+<GetDocumentAnalysisDataAsync>d__4
> ...7f012334 <1> Microsoft.CodeAnalysis.Diagnostics.EngineV2.DiagnosticIncrementalAnalyzer+<AnalyzeDocumentForKindAsync>d__86
> ....7f012404 <0> Microsoft.CodeAnalysis.SolutionCrawler.SolutionCrawlerRegistrationService+WorkCoordinator+IncrementalAnalyzerProcessor+<>c__DisplayClass32_1+<<RunAnalyzersAsync>b__0>d<Microsoft.CodeAnalysis.Document>
> .....7f0124b8 <0> Microsoft.CodeAnalysis.SolutionCrawler.SolutionCrawlerRegistrationService+WorkCoordinator+IncrementalAnalyzerProcessor+<GetOrDefaultAsync>d__34<Microsoft.CodeAnalysis.Document,System.Object>
> ......7f01256c <0> Microsoft.CodeAnalysis.SolutionCrawler.SolutionCrawlerRegistrationService+WorkCoordinator+IncrementalAnalyzerProcessor+<RunAnalyzersAsync>d__32<Microsoft.CodeAnalysis.Document>
> .......7ef3d83c <1> Microsoft.CodeAnalysis.SolutionCrawler.SolutionCrawlerRegistrationService+WorkCoordinator+IncrementalAnalyzerProcessor+<ProcessDocumentAnalyzersAsync>d__31
> ........7ef3d914 <0> Microsoft.CodeAnalysis.SolutionCrawler.SolutionCrawlerRegistrationService+WorkCoordinator+IncrementalAnalyzerProcessor+HighPriorityProcessor+<ProcessDocumentAsync>d__15
> .........7ef3d9fc <0> Microsoft.CodeAnalysis.SolutionCrawler.SolutionCrawlerRegistrationService+WorkCoordinator+IncrementalAnalyzerProcessor+HighPriorityProcessor+<ExecuteAsync>d__13
> ..........04f2f288 <2> Microsoft.CodeAnalysis.SolutionCrawler.IdleProcessor+<ProcessAsync>d__12
> 
> 7f23a17c <0> Microsoft.CodeAnalysis.EditAndContinue.EditSession+<>c__DisplayClass35_0+<<GetDocumentAnalysisNoLock>b__0>d
> 7f23a32c <1> Microsoft.CodeAnalysis.EditAndContinue.RudeEditDiagnosticAnalyzer+<AnalyzeSemanticsAsync>d__4
> 
> The UI thread is blocked on:
> 17 012fedc8 1e84724b Microsoft_VisualStudio_LanguageServices_ni!Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue.VsENCRebuildableProjectImpl.GetProjectAnalysisSummary(Microsoft.CodeAnalysis.Project)+0x5a
> Which is synchronously blocking on the result of an async method with .ConfigureAwait(false) on its only await, so it has to be that the awaited Task didn’t complete. This Task came from a Roslyn-style AsyncLazy<T> that was initialized with an anonymous delegate defined within GetDocumentAnalysisNoLock. So that anonymous delegate must not have finished executing, and sure enough, we see its async state machine in the !dumpasync results above. Its state field is 0, so it’s the first await in that anonymous delegate that didn’t resume. The fact that that state machine isn’t shown as a continuation of another means that the await is on a method that doesn’t have an async modifier, and sure enough: its call to AsyncLazy.GetValueAsync is a method that merely returns a Task. But that AsyncLazy appears to be initialized with GetBaseActiveStatementsAsync as its value factory, and that method does use the async modifier. Since (if we assume AsyncLazy<T> is not faulty) that value factory hasn’t completed, I expect to find an async state machine in the !dumpasync output for that method. But I don’t see one. It certainly started, because we’re awaiting its result, so it must have already completed and the problem is elsewhere – maybe in a continuation, perhaps within AsyncLazy<T> itself?
> 
> So I drill more into that state machine that I do have:
> 
> 7f23a17c <0> Microsoft.CodeAnalysis.EditAndContinue.EditSession+<>c__DisplayClass35_0+<<GetDocumentAnalysisNoLock>b__0>d
> 
> And I find the local that is holding the TaskAwaiter that was awaited on:
> 
> 0:000> !DumpVC /d 20c96ebc 7f23a198
> Name:        System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[[Microsoft.CodeAnalysis.EditAndContinue.ActiveStatementsMap, Microsoft.CodeAnalysis.Features]]
> MethodTable: 20c96ebc
> EEClass:     206ce750
> Size:        16(0x10) bytes
> File:        C:\WINDOWS\Microsoft.Net\assembly\GAC_32\mscorlib\v4.0_4.0.0.0__b77a5c561934e089\mscorlib.dll
> Fields:
>       MT    Field   Offset                 Type VT     Attr    Value Name
> 20cb310c  4003725        0 ...alysis.Features]]  0 instance 7f239fdc m_task
> 71e4216c  4003726        4       System.Boolean  1 instance        0 m_continueOnCapturedContext
> 
> The task itself has state flags of (integer) 33555520, which is WaitingForActivation. So, the task being awaited is not complete. Not really any surprise there. But why isn’t it? 
> Looking at the AsyncLazy whose value is being awaited for (92ffce20), I can see it’s active, that it wants to cache the result, but it hasn’t got one yet. It’s a fairly complicated class that I’m not familiar with, so I’m going to hold off digging deeper till someone more familiar with the class has a chance to inspect it to see if they can quickly surmise what might have malfunctioned here.
> 
> My only other question is about the really tall return stack in the !dumpasync output. It has to do with analyzers, which at least sounds possibly related to the GetDocumentAnalysisNoLock method. Is it possibly that there is some odd dependency between these two? 
> 
> 7f23a3ec <0> Microsoft.CodeAnalysis.Diagnostics.EngineV2.DiagnosticIncrementalAnalyzer+Executor+<ComputeDocumentDiagnosticAnalyzerDiagnosticsAsync>d__14
> 
> If there is, that method is waiting on some semantic analysis from DiagnosticIncrementalAnalyzer+Executor.



### How was the bug found?
Watson
