### PR TITLE
Use IVsAsyncFileChangeEx throughout Roslyn

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -98,19 +98,18 @@
     <MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>15.8.27812-alpha</MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>
     <MicrosoftVisualStudioCodeAnalysisSdkUIVersion>15.8.27812-alpha</MicrosoftVisualStudioCodeAnalysisSdkUIVersion>
     <MicrosoftVisualStudioCodingConventionsVersion>1.1.20180503.2</MicrosoftVisualStudioCodingConventionsVersion>
-    <MicrosoftVisualStudioComponentModelHostVersion>15.7.27703</MicrosoftVisualStudioComponentModelHostVersion>
+    <MicrosoftVisualStudioComponentModelHostVersion>16.0.198-g52de9c2988</MicrosoftVisualStudioComponentModelHostVersion>
     <MicrosoftVisualStudioCompositionVersion>15.5.23</MicrosoftVisualStudioCompositionVersion>
     <MicrosoftVisualStudioCoreUtilityVersion>16.0.142-g25b7188c54</MicrosoftVisualStudioCoreUtilityVersion>
     <MicrosoftVisualStudioDebuggerUIInterfacesVersion>15.0.27309-vsucorediag</MicrosoftVisualStudioDebuggerUIInterfacesVersion>
     <MicrosoftVisualStudioDebuggerEngineimplementationVersion>15.7.2082401</MicrosoftVisualStudioDebuggerEngineimplementationVersion>
     <MicrosoftVisualStudioDebuggerMetadataimplementationVersion>15.7.2082401</MicrosoftVisualStudioDebuggerMetadataimplementationVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>1.1.4322</MicrosoftVisualStudioDesignerInterfacesVersion>
-    <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>15.8.27812-alpha</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>
+    <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>16.0.28226-alpha</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>
     <MicrosoftVisualStudioSDKEmbedInteropTypesVersion>15.0.17</MicrosoftVisualStudioSDKEmbedInteropTypesVersion>
     <MicrosoftVisualStudioEditorVersion>16.0.142-g25b7188c54</MicrosoftVisualStudioEditorVersion>
-    <MicrosoftVisualStudioGraphModelVersion>15.8.27812-alpha</MicrosoftVisualStudioGraphModelVersion>
-    <MicrosoftVisualStudioImageCatalogVersion>15.0.26730-alpha</MicrosoftVisualStudioImageCatalogVersion>
-    <MicrosoftVisualStudioImagingVersion>15.8.27828</MicrosoftVisualStudioImagingVersion>
+    <MicrosoftVisualStudioGraphModelVersion>16.0.28226-alpha</MicrosoftVisualStudioGraphModelVersion>
+    <MicrosoftVisualStudioImagingVersion>16.0.28226-pre</MicrosoftVisualStudioImagingVersion>
     <MicrosoftVisualStudioInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioInteractiveWindowVersion>
     <MicrosoftVisualStudioLanguageVersion>16.0.142-g25b7188c54</MicrosoftVisualStudioLanguageVersion>
     <MicrosoftVisualStudioLanguageCallHierarchyVersion>15.8.27812-alpha</MicrosoftVisualStudioLanguageCallHierarchyVersion>
@@ -127,8 +126,8 @@
     <MicrosoftVisualStudioRemoteControlVersion>14.0.249-master2E2DC10C</MicrosoftVisualStudioRemoteControlVersion>
     <MicrosoftVisualStudioSDKAnalyzersVersion>15.7.7</MicrosoftVisualStudioSDKAnalyzersVersion>
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>1.15.103</MicrosoftVisualStudioSetupConfigurationInteropVersion>
-    <MicrosoftVisualStudioShell150Version>15.8.27828</MicrosoftVisualStudioShell150Version>
-    <MicrosoftVisualStudioShellFrameworkVersion>15.8.27828</MicrosoftVisualStudioShellFrameworkVersion>
+    <MicrosoftVisualStudioShell150Version>16.0.28226-pre</MicrosoftVisualStudioShell150Version>
+    <MicrosoftVisualStudioShellFrameworkVersion>16.0.28226-pre</MicrosoftVisualStudioShellFrameworkVersion>
     <MicrosoftVisualStudioShellDesignVersion>15.7.27703</MicrosoftVisualStudioShellDesignVersion>
     <MicrosoftVisualStudioShellImmutable100Version>15.0.25415</MicrosoftVisualStudioShellImmutable100Version>
     <MicrosoftVisualStudioShellImmutable110Version>15.0.25415</MicrosoftVisualStudioShellImmutable110Version>

--- a/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
+++ b/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
@@ -98,6 +98,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="$(MicrosoftVisualStudioShellInterop80Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="$(MicrosoftVisualStudioShellInterop100Version)" />
+    <!-- Work around https://devdiv.visualstudio.com/DevDiv/_workitems/edit/725508 by referencing Microsoft.VisualStudio.Text.Data -->
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />

--- a/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
+++ b/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
@@ -82,6 +82,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="$(MicrosoftVisualStudioSDKAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
+    <!-- Work around https://devdiv.visualstudio.com/DevDiv/_workitems/edit/725508 by referencing Microsoft.VisualStudio.Text.Data -->
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
@@ -6,16 +6,17 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using IVsAsyncFileChangeEx = Microsoft.VisualStudio.Shell.IVsAsyncFileChangeEx;
 using Microsoft.VisualStudio.Shell.Interop;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
-    internal sealed class FileChangeTracker : IVsFileChangeEvents, IDisposable
+    internal sealed class FileChangeTracker : IVsFreeThreadedFileChangeEvents2, IDisposable
     {
-        private const uint FileChangeFlags = (uint)(_VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Add | _VSFILECHANGEFLAGS.VSFILECHG_Del | _VSFILECHANGEFLAGS.VSFILECHG_Size);
+        private const _VSFILECHANGEFLAGS FileChangeFlags = _VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Add | _VSFILECHANGEFLAGS.VSFILECHG_Del | _VSFILECHANGEFLAGS.VSFILECHG_Size;
 
-        private static readonly Lazy<uint?> s_none = new Lazy<uint?>(() => null, LazyThreadSafetyMode.ExecutionAndPublication);
+        private static readonly AsyncLazy<uint?> s_none = new AsyncLazy<uint?>(ct => null, cacheResult: true);
 
         private readonly IVsFileChangeEx _fileChangeService;
         private readonly string _filePath;
@@ -26,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// this file. This field may never be null, but might be a Lazy that has a value of null if
         /// we either failed to subscribe over never have tried to subscribe.
         /// </summary>
-        private Lazy<uint?> _fileChangeCookie;
+        private AsyncLazy<uint?> _fileChangeCookie;
 
         public event EventHandler UpdatedOnDisk;
 
@@ -75,7 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             get
             {
                 var cookie = _fileChangeCookie;
-                return cookie != s_none && cookie.IsValueCreated;
+                return cookie != s_none && cookie.TryGetValue(out _);
             }
         }
 
@@ -88,7 +89,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         public void EnsureSubscription()
         {
             // make sure we have file notification subscribed
-            var unused = _fileChangeCookie.Value;
+            var unused = _fileChangeCookie.GetValue(CancellationToken.None);
         }
 
         public void StartFileChangeListeningAsync()
@@ -100,23 +101,33 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             Contract.ThrowIfTrue(_fileChangeCookie != s_none);
 
-            _fileChangeCookie = new Lazy<uint?>(() =>
+            _fileChangeCookie = new AsyncLazy<uint?>(async cancellationToken =>
+            {
+                try
+                {
+                    return await ((IVsAsyncFileChangeEx)_fileChangeService).AdviseFileChangeAsync(_filePath, FileChangeFlags, this).ConfigureAwait(false);
+                }
+                catch (Exception e) when (ReportException(e))
+                {
+                    return null;
+                }
+            }, cancellationToken =>
             {
                 try
                 {
                     Marshal.ThrowExceptionForHR(
-                        _fileChangeService.AdviseFileChange(_filePath, FileChangeFlags, this, out var newCookie));
+                        _fileChangeService.AdviseFileChange(_filePath, (uint)FileChangeFlags, this, out var newCookie));
                     return newCookie;
                 }
                 catch (Exception e) when (ReportException(e))
                 {
                     return null;
                 }
-            }, LazyThreadSafetyMode.ExecutionAndPublication);
+            }, cacheResult: true);
 
             lock (s_lastBackgroundTaskGate)
             {
-                s_lastBackgroundTask = s_lastBackgroundTask.ContinueWith(_ => _fileChangeCookie.Value, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+                s_lastBackgroundTask = s_lastBackgroundTask.ContinueWith(_ => _fileChangeCookie.GetValueAsync(CancellationToken.None), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default).Unwrap();
             }
         }
 
@@ -148,7 +159,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return;
             }
 
-            var fileChangeCookie = _fileChangeCookie.Value;
+            var fileChangeCookie = _fileChangeCookie.GetValue(CancellationToken.None);
             _fileChangeCookie = s_none;
 
             // We may have tried to subscribe but failed, so have to check a second time
@@ -184,6 +195,45 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             UpdatedOnDisk?.Invoke(this, EventArgs.Empty);
 
             return VSConstants.S_OK;
+        }
+
+        int IVsFreeThreadedFileChangeEvents2.FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
+        {
+            UpdatedOnDisk?.Invoke(this, EventArgs.Empty);
+
+            return VSConstants.S_OK;
+        }
+
+        int IVsFreeThreadedFileChangeEvents2.DirectoryChanged(string pszDirectory)
+        {
+            throw new Exception("We only watch files; we should never be seeing directory changes!");
+        }
+
+        int IVsFreeThreadedFileChangeEvents2.DirectoryChangedEx(string pszDirectory, string pszFile)
+        {
+            throw new Exception("We only watch files; we should never be seeing directory changes!");
+        }
+
+        int IVsFreeThreadedFileChangeEvents2.DirectoryChangedEx2(string pszDirectory, uint cChanges, string[] rgpszFile, uint[] rggrfChange)
+        {
+            throw new Exception("We only watch files; we should never be seeing directory changes!");
+        }
+
+        int IVsFreeThreadedFileChangeEvents.FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
+        {
+            UpdatedOnDisk?.Invoke(this, EventArgs.Empty);
+
+            return VSConstants.S_OK;
+        }
+
+        int IVsFreeThreadedFileChangeEvents.DirectoryChanged(string pszDirectory)
+        {
+            throw new Exception("We only watch files; we should never be seeing directory changes!");
+        }
+
+        int IVsFreeThreadedFileChangeEvents.DirectoryChangedEx(string pszDirectory, string pszFile)
+        {
+            throw new Exception("We only watch files; we should never be seeing directory changes!");
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeWatcherProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeWatcherProvider.cs
@@ -2,13 +2,14 @@
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell.Interop;
+using IVsAsyncFileChangeEx = Microsoft.VisualStudio.Shell.IVsAsyncFileChangeEx;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
     [Export(typeof(FileChangeWatcherProvider))]
     internal sealed class FileChangeWatcherProvider
     {
-        private readonly TaskCompletionSource<IVsFileChangeEx> _fileChangeService = new TaskCompletionSource<IVsFileChangeEx>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<IVsAsyncFileChangeEx> _fileChangeService = new TaskCompletionSource<IVsAsyncFileChangeEx>(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly Lazy<FileChangeWatcher> _fileChangeWatcher;
 
         public FileChangeWatcherProvider()
@@ -18,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public FileChangeWatcher Watcher => _fileChangeWatcher.Value;
 
-        internal void SetFileChangeService(IVsFileChangeEx fileChangeService)
+        internal void SetFileChangeService(IVsAsyncFileChangeEx fileChangeService)
         {
             _fileChangeService.TrySetResult(fileChangeService);
         }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -99,11 +99,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var fileChangeWatcherProvider = exportProvider.GetExportedValue<FileChangeWatcherProvider>();
 
             FileChangeWatcher = fileChangeWatcherProvider.Watcher;
-            System.Threading.Tasks.Task.Run(async () =>
+            _threadingContext.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                    var fileChangeService = (IVsFileChangeEx)ServiceProvider.GlobalProvider.GetService(typeof(SVsFileChangeEx));
+                    var fileChangeService = (IVsAsyncFileChangeEx)await asyncServiceProvider.GetServiceAsync(typeof(SVsFileChangeEx));
+                    
                     fileChangeWatcherProvider.SetFileChangeService(fileChangeService);
                 });
         }

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioRuleSetTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioRuleSetTests.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
+Imports IVsAsyncFileChangeEx = Microsoft.VisualStudio.Shell.IVsAsyncFileChangeEx
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Roslyn.Test.Utilities
 
@@ -43,7 +44,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             File.WriteAllText(ruleSetPath, ruleSetSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsFileChangeEx)(fileChangeService))
+            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsAsyncFileChangeEx)(fileChangeService))
             Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeWatcher, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
             Using visualStudioRuleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
@@ -85,7 +86,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             File.WriteAllText(includePath, includeSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsFileChangeEx)(fileChangeService))
+            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsAsyncFileChangeEx)(fileChangeService))
             Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeWatcher, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
             Using visualStudioRuleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
@@ -127,7 +128,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             File.WriteAllText(includePath, includeSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsFileChangeEx)(fileChangeService))
+            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsAsyncFileChangeEx)(fileChangeService))
             Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeWatcher, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
             Using ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
                 Dim handlerCalled As Boolean = False
@@ -159,7 +160,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             File.WriteAllText(ruleSetPath, ruleSetSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsFileChangeEx)(fileChangeService))
+            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsAsyncFileChangeEx)(fileChangeService))
             Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeWatcher, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
             Using ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
@@ -200,7 +201,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             File.WriteAllText(ruleSetPath, ruleSetSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsFileChangeEx)(fileChangeService))
+            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsAsyncFileChangeEx)(fileChangeService))
             Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeWatcher, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
             Using ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
@@ -236,7 +237,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             File.WriteAllText(ruleSetPath, ruleSetSource)
 
             Dim fileChangeService = New MockVsFileChangeEx
-            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsFileChangeEx)(fileChangeService))
+            Dim fileChangeWatcher = New FileChangeWatcher(Task.FromResult(Of IVsAsyncFileChangeEx)(fileChangeService))
             Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeWatcher, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
             Using ruleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 

--- a/src/VisualStudio/RemoteHostClientMock/Roslyn.VisualStudio.RemoteHostClientMock.csproj
+++ b/src/VisualStudio/RemoteHostClientMock/Roslyn.VisualStudio.RemoteHostClientMock.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="$(MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="$(MicrosoftVisualStudioSDKAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
   </ItemGroup>

--- a/src/VisualStudio/Setup.Dependencies/Roslyn.VisualStudio.Setup.Dependencies.csproj
+++ b/src/VisualStudio/Setup.Dependencies/Roslyn.VisualStudio.Setup.Dependencies.csproj
@@ -43,6 +43,8 @@
   <ItemGroup>
     <!-- Needed to use RegistrationAttribute -->
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
+    <!-- Work around https://devdiv.visualstudio.com/DevDiv/_workitems/edit/725508 -->
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataVersion)" />
     <!-- All packages that we depend on, either as facades or implementations -->
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)" />

--- a/src/VisualStudio/TestUtilities2/Microsoft.VisualStudio.LanguageServices.Test.Utilities2.vbproj
+++ b/src/VisualStudio/TestUtilities2/Microsoft.VisualStudio.LanguageServices.Test.Utilities2.vbproj
@@ -82,11 +82,11 @@
     <PackageReference Include="Microsoft.VisualStudio.GraphModel" Version="$(MicrosoftVisualStudioGraphModelVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="$(MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion)" />
-    <!-- Microsoft.VisualStudio.Platform.VSEditor references Microsoft.VisualStudio.Text.Internal since it's needed at runtime; we want to insure we are using
-         it _only_ for runtime dependencies and not anything compile time -->
     <PackageReference Include="Microsoft.VisualStudio.Language.CallHierarchy" Version="$(MicrosoftVisualStudioLanguageCallHierarchyVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(MicrosoftVisualStudioTextLogicVersion)" />
+    <!-- Microsoft.VisualStudio.Platform.VSEditor references Microsoft.VisualStudio.Text.Internal since it's needed at runtime; we want to insure we are using
+         it _only_ for runtime dependencies and not anything compile time -->
     <PackageReference Include="Microsoft.VisualStudio.Text.Internal" Version="$(MicrosoftVisualStudioTextInternalVersion)" IncludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />

--- a/src/VisualStudio/TestUtilities2/Microsoft.VisualStudio.LanguageServices.Test.Utilities2.vbproj
+++ b/src/VisualStudio/TestUtilities2/Microsoft.VisualStudio.LanguageServices.Test.Utilities2.vbproj
@@ -73,6 +73,7 @@
     <PackageReference Include="Microsoft.VisualStudio.RemoteControl" Version="$(MicrosoftVisualStudioRemoteControlVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="$(MicrosoftVisualStudioShellInterop121DesignTimeVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime" Version="$(MicrosoftVisualStudioShellInterop157DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime" Version="$(MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion)" />

--- a/src/VisualStudio/TestUtilities2/MockComponentModel.vb
+++ b/src/VisualStudio/TestUtilities2/MockComponentModel.vb
@@ -16,11 +16,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
             _exportProvider = exportProvider
         End Sub
 
+#Disable Warning BC40000 ' Type or member is obsolete
         Public ReadOnly Property DefaultCatalog As ComposablePartCatalog Implements IComponentModel.DefaultCatalog
             Get
                 Throw New NotImplementedException
             End Get
         End Property
+#Enable Warning BC40000 ' Type or member is obsolete
 
         Public ReadOnly Property DefaultCompositionService As ICompositionService Implements IComponentModel.DefaultCompositionService
             Get

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/MockVsFileChangeEx.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/MockVsFileChangeEx.vb
@@ -1,13 +1,18 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Runtime.InteropServices
+Imports System.Threading
+Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
+Imports Task = System.Threading.Tasks.Task
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
     Friend Class MockVsFileChangeEx
         Implements IVsFileChangeEx
+        Implements IVsAsyncFileChangeEx
 
         Private ReadOnly _lock As New Object
-        Private ReadOnly _watchedFiles As List(Of Tuple(Of UInteger, String, IVsFileChangeEvents)) = New List(Of Tuple(Of UInteger, String, IVsFileChangeEvents))
+        Private ReadOnly _watchedFiles As List(Of Tuple(Of UInteger, String, IVsFreeThreadedFileChangeEvents2)) = New List(Of Tuple(Of UInteger, String, IVsFreeThreadedFileChangeEvents2))
         Private _nextCookie As UInteger = 0UI
 
         Public Function AdviseDirChange(pszDir As String, fWatchSubDir As Integer, pFCE As IVsFileChangeEvents, ByRef pvsCookie As UInteger) As Integer Implements IVsFileChangeEx.AdviseDirChange
@@ -21,7 +26,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
 
             SyncLock _lock
                 pvsCookie = _nextCookie
-                _watchedFiles.Add(Tuple.Create(pvsCookie, pszMkDocument, pFCE))
+                _watchedFiles.Add(Tuple.Create(pvsCookie, pszMkDocument, DirectCast(pFCE, IVsFreeThreadedFileChangeEvents2)))
                 _nextCookie += 1UI
 
                 Return VSConstants.S_OK
@@ -50,18 +55,55 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
         End Function
 
         Public Sub FireUpdate(filename As String)
-            Dim subscription As Tuple(Of UInteger, String, IVsFileChangeEvents) = Nothing
+            Dim subscription As Tuple(Of UInteger, String, IVsFreeThreadedFileChangeEvents2) = Nothing
 
             SyncLock _lock
                 subscription = _watchedFiles.First(Function(t) String.Equals(t.Item2, filename, StringComparison.OrdinalIgnoreCase))
             End SyncLock
 
             If subscription IsNot Nothing Then
+
                 subscription.Item3.FilesChanged(1, {subscription.Item2}, {CType(_VSFILECHANGEFLAGS.VSFILECHG_Time, UInteger)})
             Else
                 Throw New InvalidOperationException("There is no subscription for file " + filename)
             End If
         End Sub
+
+        Public Function AdviseFileChangeAsync(filename As String, filter As _VSFILECHANGEFLAGS, sink As IVsFreeThreadedFileChangeEvents2, Optional cancellationToken As CancellationToken = Nothing) As Task(Of UInteger) Implements IVsAsyncFileChangeEx.AdviseFileChangeAsync
+            Dim cookie As UInteger
+            Marshal.ThrowExceptionForHR(AdviseFileChange(filename, CType(filter, UInteger), sink, cookie))
+            Return Task.FromResult(cookie)
+        End Function
+
+        Public Function UnadviseFileChangeAsync(cookie As UInteger, Optional cancellationToken As CancellationToken = Nothing) As Task(Of String) Implements IVsAsyncFileChangeEx.UnadviseFileChangeAsync
+            SyncLock _lock
+                Dim path = _watchedFiles.FirstOrDefault(Function(t) t.Item1 = cookie).Item2
+
+                Marshal.ThrowExceptionForHR(UnadviseFileChange(cookie))
+
+                Return Task.FromResult(path)
+            End SyncLock
+        End Function
+
+        Public Function AdviseDirChangeAsync(directory As String, watchSubdirectories As Boolean, sink As IVsFreeThreadedFileChangeEvents2, Optional cancellationToken As CancellationToken = Nothing) As Task(Of UInteger) Implements IVsAsyncFileChangeEx.AdviseDirChangeAsync
+            Throw New NotImplementedException()
+        End Function
+
+        Public Function UnadviseDirChangeAsync(cookie As UInteger, Optional cancellationToken As CancellationToken = Nothing) As Task(Of String) Implements IVsAsyncFileChangeEx.UnadviseDirChangeAsync
+            Throw New NotImplementedException()
+        End Function
+
+        Public Function SyncFileAsync(filename As String, Optional cancellationToken As CancellationToken = Nothing) As Tasks.Task Implements IVsAsyncFileChangeEx.SyncFileAsync
+            Throw New NotImplementedException()
+        End Function
+
+        Public Function IgnoreFileAsync(cookie As UInteger, filename As String, ignore As Boolean, Optional cancellationToken As CancellationToken = Nothing) As Tasks.Task Implements IVsAsyncFileChangeEx.IgnoreFileAsync
+            Throw New NotImplementedException()
+        End Function
+
+        Public Function IgnoreDirAsync(directory As String, ignore As Boolean, Optional cancellationToken As CancellationToken = Nothing) As Tasks.Task Implements IVsAsyncFileChangeEx.IgnoreDirAsync
+            Throw New NotImplementedException()
+        End Function
 
         Public ReadOnly Property WatchedFileCount As Integer
             Get

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -5,12 +5,10 @@ Imports System.ComponentModel.Composition.Hosting
 Imports System.IO
 Imports System.Runtime.InteropServices
 Imports System.Threading
-Imports EnvDTE
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.FindSymbols
-Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.ComponentModelHost
@@ -24,7 +22,6 @@ Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Leg
 Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Moq
-Imports Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
 
@@ -64,7 +61,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
             ServiceProvider = mockServiceProvider
 
             Dim ruleSetFileProvider = New VisualStudioRuleSetManager(
-                New FileChangeWatcher(System.Threading.Tasks.Task.FromResult(DirectCast(ServiceProvider.GetService(GetType(SVsFileChangeEx)), IVsFileChangeEx))),
+                New FileChangeWatcher(System.Threading.Tasks.Task.FromResult(DirectCast(ServiceProvider.GetService(GetType(SVsFileChangeEx)), IVsAsyncFileChangeEx))),
                 New TestForegroundNotificationService(),
                 AsynchronousOperationListenerProvider.NullListener)
 

--- a/src/VisualStudio/Xaml/Impl/Microsoft.VisualStudio.LanguageServices.Xaml.csproj
+++ b/src/VisualStudio/Xaml/Impl/Microsoft.VisualStudio.LanguageServices.Xaml.csproj
@@ -9,7 +9,6 @@
     <DeployExtension>false</DeployExtension>
     <TargetFramework>net472</TargetFramework>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />


### PR DESCRIPTION
This change is a fairly mechanical change to move over to IVsAsyncFileChangeEx, without making larger changes to Roslyn. Notably, Roslyn has always called the file watching service with one request at time, to avoid starving off the thread pool. Since the entrypoints are now async, we could start doing more in parallel to to allow the underlying service to implement things more efficiently.

Also, the implementation for FileChangeTracker is decidedly not great and still uses synchronous entrypoints in a few places. Since that part of the code is actively going away once we move the remaining uses too FileChangeWatcher, we'll just do a cheap approach now.