### PR TITLE
Fix bug in 'yield return await'

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -589,6 +589,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return UpdateStatement(builder, node.Update(node.RefKind, expression), substituteTemps: true);
         }
 
+        public override BoundNode VisitYieldReturnStatement(BoundYieldReturnStatement node)
+        {
+            EnterStatement(node);
+
+            BoundSpillSequenceBuilder builder = null;
+            var expression = VisitExpression(ref builder, node.Expression);
+            return UpdateStatement(builder, node.Update(expression), substituteTemps: true);
+        }
+
 #if DEBUG
         public override BoundNode DefaultVisit(BoundNode node)
         {


### PR DESCRIPTION
The await expression spiller did not handle the case of a `yield return
await` statement, which it should handle by lowering the await into a spill sequence, then removing the await expression from the `yield return` statement. This is a simple fix that mostly delegates to the existing infrastructure.

Fixes #30566 

VSO bug: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/721089