### PR TITLE
Don't attempt to set up pipe security on Mono as it is not implemented

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
@@ -63,21 +63,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             throw new Exception("Insufficient resources to process new connection.");
         }
 
-        // HACK to identify whether we are running on mono, see https://github.com/dotnet/roslyn/pull/30810
-        private static bool IsRunningOnMono {
-            get {
-                try
-                {
-                    return !(Type.GetType("Mono.Runtime") is null);
-                }
-                catch
-                {
-                    // Arbitrarily assume we're not running on Mono.
-                    return false;
-                }
-            }
-        }
-
         /// <summary>
         /// Create an instance of the pipe. This might be the first instance, or a subsequent instance.
         /// There always needs to be an instance of the pipe created to listen for a new client connection.
@@ -90,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 #if NET46
             PipeSecurity security;
 
-            if (!IsRunningOnMono) {
+            if (!PlatformInformation.IsRunningOnMono) {
                 security = new PipeSecurity();
                 SecurityIdentifier identifier = WindowsIdentity.GetCurrent().Owner;
 
@@ -99,8 +84,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 security.AddAccessRule(rule);
                 security.SetOwner(identifier);
             } else {
-                // HACK: Pipe security and additional access rights are not supported by Mono 
+                // Pipe security and additional access rights constructor arguments
+                //  are not supported by Mono 
                 // https://github.com/dotnet/roslyn/pull/30810
+                // https://github.com/mono/mono/issues/11406
                 security = null;
             }
 

--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
@@ -74,6 +74,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
 #if NET46
             PipeSecurity security;
+            PipeOptions pipeOptions = PipeOptions.Asynchronous | PipeOptions.WriteThrough;
 
             if (!PlatformInformation.IsRunningOnMono) {
                 security = new PipeSecurity();
@@ -89,6 +90,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 // https://github.com/dotnet/roslyn/pull/30810
                 // https://github.com/mono/mono/issues/11406
                 security = null;
+                // This enum value is implemented by Mono to restrict pipe access to
+                //  the current user
+                const int CurrentUserOnly = unchecked((int)0x20000000);
+                pipeOptions |= (PipeOptions)CurrentUserOnly;
             }
 
             NamedPipeServerStream pipeStream = new NamedPipeServerStream(
@@ -96,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 PipeDirection.InOut,
                 NamedPipeServerStream.MaxAllowedServerInstances, // Maximum connections.
                 PipeTransmissionMode.Byte,
-                PipeOptions.Asynchronous | PipeOptions.WriteThrough,
+                pipeOptions,
                 PipeBufferSize, // Default input buffer
                 PipeBufferSize, // Default output buffer
                 security,

--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             throw new Exception("Insufficient resources to process new connection.");
         }
 
-        // HACK
+        // HACK to identify whether we are running on mono, see https://github.com/dotnet/roslyn/pull/30810
         private static bool IsRunningOnMono {
             get {
                 try
@@ -100,6 +100,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 security.SetOwner(identifier);
             } else {
                 // HACK: Pipe security and additional access rights are not supported by Mono 
+                // https://github.com/dotnet/roslyn/pull/30810
                 security = null;
             }
 

--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
@@ -76,7 +76,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             PipeSecurity security;
             PipeOptions pipeOptions = PipeOptions.Asynchronous | PipeOptions.WriteThrough;
 
-            if (!PlatformInformation.IsRunningOnMono) {
+            if (!PlatformInformation.IsRunningOnMono) 
+            {
                 security = new PipeSecurity();
                 SecurityIdentifier identifier = WindowsIdentity.GetCurrent().Owner;
 
@@ -84,7 +85,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 PipeAccessRule rule = new PipeAccessRule(identifier, PipeAccessRights.ReadWrite | PipeAccessRights.CreateNewInstance, AccessControlType.Allow);
                 security.AddAccessRule(rule);
                 security.SetOwner(identifier);
-            } else {
+            } 
+            else 
+            {
                 // Pipe security and additional access rights constructor arguments
                 //  are not supported by Mono 
                 // https://github.com/dotnet/roslyn/pull/30810


### PR DESCRIPTION
Currently roslyn attempts to apply security settings to the named pipe for vbcscompiler, but Mono does not implement the relevant overload or APIs so there's no point in trying. This PR disables the relevant code.

I'll update the code with a link to this PR ID#. Is IsRunningOnMono accessible in some other form in the tree already that VBCS has access to? I didn't see one but I didn't look exhaustively