### PR TITLE
Add -shared and -keepalive compiler options

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -429,7 +429,7 @@ namespace Microsoft.CodeAnalysis
             {
                 bool hasValue;
                 string value;
-                if (IsClientArgsOption(arg, "/keepalive", out hasValue, out value))
+                if (isClientArgsOption(arg, "keepalive", out hasValue, out value))
                 {
                     if (string.IsNullOrEmpty(value))
                     {
@@ -455,7 +455,7 @@ namespace Microsoft.CodeAnalysis
                     continue;
                 }
 
-                if (IsClientArgsOption(arg, "/shared", out hasValue, out value))
+                if (isClientArgsOption(arg, "shared", out hasValue, out value))
                 {
                     if (hasValue)
                     {
@@ -485,30 +485,36 @@ namespace Microsoft.CodeAnalysis
                 parsedArgs = newArgs;
                 return true;
             }
-        }
 
-        internal static bool IsClientArgsOption(string arg, string optionName, out bool hasValue, out string optionValue)
-        {
-            hasValue = false;
-            optionValue = null;
-
-            if (!arg.StartsWith(optionName, StringComparison.OrdinalIgnoreCase))
+            bool isClientArgsOption(string arg, string optionName, out bool hasValue, out string optionValue)
             {
-                return false;
-            }
+                hasValue = false;
+                optionValue = null;
 
-            if (arg.Length > optionName.Length && !(arg[optionName.Length] == ':' || arg[optionName.Length] == '='))
-            {
-                return false;
-            }
+                if (arg.Length == 0 || !(arg[0] == '/' || arg[0] == '-'))
+                {
+                    return false;
+                } 
+                
+                arg = arg.Substring(1);
+                if (!arg.StartsWith(optionName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
 
-            if (arg.Length > optionName.Length)
-            {
-                hasValue = true;
-                optionValue = arg.Substring(optionName.Length + 1).Trim('"');
-            }
+                if (arg.Length > optionName.Length && !(arg[optionName.Length] == ':' || arg[optionName.Length] == '='))
+                {
+                    return false;
+                }
 
-            return true;
+                if (arg.Length > optionName.Length)
+                {
+                    hasValue = true;
+                    optionValue = arg.Substring(optionName.Length + 1).Trim('"');
+                }
+
+                return true;
+            }
         }
 
         internal static string MismatchedVersionErrorText => CodeAnalysisResources.MismatchedVersion;

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -502,13 +502,13 @@ namespace Microsoft.CodeAnalysis
                     return false;
                 }
 
-                if (arg.Length > optionName.Length && !(arg[optionName.Length] == ':' || arg[optionName.Length] == '='))
-                {
-                    return false;
-                }
-
                 if (arg.Length > optionName.Length)
                 {
+                    if (!(arg[optionName.Length] == ':' || arg[optionName.Length] == '='))
+                    {
+                        return false;
+                    }
+
                     hasValue = true;
                     optionValue = arg.Substring(optionName.Length + 1).Trim('"');
                 }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -388,6 +388,18 @@ End Module")
             }
         }
 
+        [Fact]
+        [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
+        public async Task HelloWorldCSDashShared()
+        {
+            using (var serverData = ServerUtil.CreateServer())
+            {
+                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"-shared:{serverData.PipeName} /nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
+                VerifyResultAndOutput(result, _tempDirectory, "Hello, world.");
+                await serverData.Verify(connections: 1, completed: 1).ConfigureAwait(true);
+            }
+        }
+
         [ConditionalFact(typeof(DesktopOnly))]
         [WorkItem(946954, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/946954")]
         public void CompilerBinariesAreNotX86()

--- a/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
@@ -287,99 +287,115 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                     out _errorMessage);
             }
 
-            [Fact]
-            public void Shared()
+            [Theory]
+            [InlineData('-')]
+            [InlineData('/')]
+            public void Shared(char optionPrefix)
             {
-                Assert.True(Parse("/shared", "test.cs"));
+                Assert.True(Parse(optionPrefix + "shared", "test.cs"));
                 Assert.True(_hasShared);
                 Assert.Null(_sessionKey);
                 Assert.Equal(new[] { "test.cs" }, _parsedArgs);
             }
 
-            [Fact]
-            public void SharedWithSessionKey()
+            [Theory]
+            [InlineData('-')]
+            [InlineData('/')]
+            public void SharedWithSessionKey(char optionPrefix)
             {
-                Assert.True(Parse("/shared:pipe", "test.cs"));
+                Assert.True(Parse(optionPrefix + "shared:pipe", "test.cs"));
                 Assert.True(_hasShared);
                 Assert.Equal("pipe", _sessionKey);
                 Assert.Equal(new[] { "test.cs" }, _parsedArgs);
 
-                Assert.True(Parse("/shared:1:2", "test.cs"));
+                Assert.True(Parse(optionPrefix + "shared:1:2", "test.cs"));
                 Assert.True(_hasShared);
                 Assert.Equal("1:2", _sessionKey);
                 Assert.Equal(new[] { "test.cs" }, _parsedArgs);
 
-                Assert.True(Parse("/shared=1:2", "test.cs"));
+                Assert.True(Parse(optionPrefix + "shared=1:2", "test.cs"));
                 Assert.True(_hasShared);
                 Assert.Equal("1:2", _sessionKey);
                 Assert.Equal(new[] { "test.cs" }, _parsedArgs);
             }
 
-            [Fact]
-            public void SharedWithEmptySessionKey()
+            [Theory]
+            [InlineData('-')]
+            [InlineData('/')]
+            public void SharedWithEmptySessionKey(char optionPrefix)
             {
-                Assert.False(Parse("/shared:", "test.cs"));
+                Assert.False(Parse(optionPrefix + "shared:", "test.cs"));
                 Assert.False(_hasShared);
                 Assert.Equal(CodeAnalysisResources.SharedArgumentMissing, _errorMessage);
             }
 
-            [Fact]
-            public void SharedPrefix()
+            [Theory]
+            [InlineData('-')]
+            [InlineData('/')]
+            public void SharedPrefix(char optionPrefix)
             {
-                Assert.True(Parse("/sharedstart", "test.cs"));
+                Assert.True(Parse(optionPrefix + "sharedstart", "test.cs"));
                 Assert.False(_hasShared);
-                Assert.Equal(new[] { "/sharedstart", "test.cs" }, _parsedArgs);
+                Assert.Equal(new[] { optionPrefix + "sharedstart", "test.cs" }, _parsedArgs);
             }
 
-            [Fact]
-            public void Basic()
+            [Theory]
+            [InlineData('-')]
+            [InlineData('/')]
+            public void Basic(char optionPrefix)
             {
                 Assert.True(Parse("test.cs"));
                 Assert.False(_hasShared);
                 Assert.Null(_sessionKey);
                 Assert.Equal(new[] { "test.cs" }, _parsedArgs);
 
-                Assert.True(Parse("/keepalive:100", "/shared", "test.cs"));
+                Assert.True(Parse(optionPrefix + "keepalive:100", "/shared", "test.cs"));
                 Assert.True(_hasShared);
                 Assert.Null(_sessionKey);
                 Assert.Equal("100", _keepAlive);
                 Assert.Equal(new[] { "test.cs" }, _parsedArgs);
             }
 
-            [Fact]
-            public void KeepAliveBad()
+            [Theory]
+            [InlineData('-')]
+            [InlineData('/')]
+            public void KeepAliveBad(char optionPrefix)
             {
-                Assert.False(Parse("/keepalive", "test.cs"));
+                Assert.False(Parse(optionPrefix + "keepalive", "test.cs"));
                 Assert.Equal(CodeAnalysisResources.MissingKeepAlive, _errorMessage);
 
-                Assert.False(Parse("/keepalive:", "test.cs"));
+                Assert.False(Parse(optionPrefix + "keepalive:", "test.cs"));
                 Assert.Equal(CodeAnalysisResources.MissingKeepAlive, _errorMessage);
 
-                Assert.False(Parse("/keepalive:-100", "test.cs"));
+                Assert.False(Parse(optionPrefix + "keepalive:-100", "test.cs"));
                 Assert.Equal(CodeAnalysisResources.KeepAliveIsTooSmall, _errorMessage);
 
-                Assert.False(Parse("/keepalive:100", "test.cs"));
+                Assert.False(Parse(optionPrefix + "keepalive:100", "test.cs"));
                 Assert.Equal(CodeAnalysisResources.KeepAliveWithoutShared, _errorMessage);
             }
 
-            [Fact]
-            public void KeepAlivePrefix()
+            [Theory]
+            [InlineData('-')]
+            [InlineData('/')]
+            public void KeepAlivePrefix(char optionPrefix)
             {
-                Assert.True(Parse("/keepalivestart", "test.cs"));
+                Assert.True(Parse(optionPrefix + "keepalivestart", "test.cs"));
                 Assert.Null(_keepAlive);
-                Assert.Equal(new[] { "/keepalivestart", "test.cs" }, _parsedArgs);
+                Assert.Equal(new[] { optionPrefix + "keepalivestart", "test.cs" }, _parsedArgs);
             }
 
-            [Fact]
-            public void KeepAlive()
+            [Theory]
+            [InlineData('-')]
+            [InlineData('/')]
+            public void KeepAlive(char optionPrefix)
             {
-                Assert.True(Parse("/keepalive:100", "/shared", "test.cs"));
+                Assert.True(Parse(optionPrefix + "keepalive:100", optionPrefix + "shared", "test.cs"));
                 Assert.Equal("100", _keepAlive);
                 Assert.Equal(new[] { "test.cs" }, _parsedArgs);
                 Assert.True(_hasShared);
                 Assert.Null(_sessionKey);
 
-                Assert.True(Parse("/keepalive=100", "/shared", "test.cs"));
+                Assert.True(Parse(optionPrefix + "keepalive=100", optionPrefix + "shared", "test.cs"));
                 Assert.Equal("100", _keepAlive);
                 Assert.Equal(new[] { "test.cs" }, _parsedArgs);
                 Assert.True(_hasShared);


### PR DESCRIPTION
Right now we only recognize /shared and /keepalive for
these flags, but we allow '-' everywhere else as an option
prefix, so we should do the same here.