### PR TITLE
Remove TokenStream._tokenToIndexMap and replace with binary search

### DIFF
--- a/src/Workspaces/Core/Portable/Formatting/Engine/TokenData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TokenData.cs
@@ -17,9 +17,9 @@ namespace Microsoft.CodeAnalysis.Formatting
     /// this object is supposed to be live very short but created a lot of time. that is why it is struct. 
     /// (same reason why SyntaxToken is struct - to reduce heap allocation)
     /// </summary>
-    internal struct TokenData : IEqualityComparer<TokenData>, IEquatable<TokenData>, IComparable<TokenData>, IComparer<TokenData>
+    internal readonly struct TokenData : IEqualityComparer<TokenData>, IEquatable<TokenData>, IComparable<TokenData>, IComparer<TokenData>
     {
-        public TokenData(TokenStream tokenStream, int indexInStream, SyntaxToken token) : this()
+        public TokenData(TokenStream tokenStream, int indexInStream, SyntaxToken token)
         {
             Contract.ThrowIfNull(tokenStream);
             Contract.ThrowIfFalse((indexInStream == -1) || (0 <= indexInStream && indexInStream < tokenStream.TokenCount));


### PR DESCRIPTION
Fixes one RPS regression resulting from the new implementation of FormattingDiagnosticAnalyzer. The analyzer continues to be quite expensive.

A modification of #30819 was used to verify the performance impact of this change.

> $(SolutionDir)Binaries\\$(Configuration)\\Exes\\AnalyzerRunner $(SolutionDir)..\\perfview\\PerfView.sln /concurrent /iter:10 /stats /a FormattingDiagnosticAnalyzer

| Scenario | Total analysis time |
| --- | --- |
| Baseline (e7608094aaa6dda6a92272080cf134e2a9bab4f7) | 66762ms |
| Remove token to index map (72e2a2a) | 69788ms |
| Mark TokenData readonly (00d164f) | 70262ms |
| ~~Remove trivia data cache~~ (eliminated due to performance impact) | ~~95599ms~~ |

Most of the performance overhead (increased elapsed time when the token to index map is removed) is evaluations of `SyntaxToken.FullSpan` in the comparer. It's possible that NGEN/inlining would eliminate some of this overhead.

### Customer scenario

After installing Visual Studio 16.0 Preview 1, the new Formatting Analyzer performs allocations in the large object heap which could negatively impact overall performance.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/711165

### Workarounds, if any

Disable FormattingDiagnosticAnalyzer.

### Risk

Low. The performance was measured at scale and showed at most a 5% performance impact due to the change. Based on profiling results, the change is unlikely to observably impact a user scenario. NGEN and/or inlining is likely to close the performance gap in practice.

The performance regression risk is limited to the Format Document behavior, which prior to version 16.0 could only be applied to one document at a time. Even a 5% impact in this explicitly-triggered scenario would not be observable.

### Performance impact

This change improves performance by eliminating a large object heap allocation without replacement (e.g. no object pool or initialization is required as part of the allocation reduction).

### Is this a regression from a previous update?

This is a consumption metric regression caused by a new analyzer.

### Root cause analysis

The bug was caught during an RPS run for a Roslyn insertion, but the insertion was allowed to proceed with this fix as a follow-up item.

### How was the bug found?

RPS

### Test documentation updated?

No.

