### PR TITLE
Make IMethodSymbol.IsStatic return false by default for local functions

### DIFF
--- a/docs/Language Feature Status.md
+++ b/docs/Language Feature Status.md
@@ -24,13 +24,14 @@ efforts behind them.
 | [Null-coalescing Assignment](https://github.com/dotnet/csharplang/issues/34) | master | [Merged to dev16 preview1](https://github.com/dotnet/roslyn/issues/29168) | [333fred](https://github.com/333fred) | [cston](https://github.com/cston) | [gafter](https://github.com/gafter)
 | [Alternative interpolated verbatim strings](https://github.com/dotnet/csharplang/issues/1630) | master | Merged to dev16 preview1 | [jcouv](https://github.com/jcouv) | [cston](https://github.com/cston) | [jcouv](https://github.com/jcouv)
 | [stackalloc in nested contexts](https://github.com/dotnet/csharplang/issues/1412) | [nested-stackalloc](https://github.com/dotnet/roslyn/tree/features/nested-stackalloc) | [In Progress](https://github.com/dotnet/roslyn/issues/28968) | [gafter](https://github.com/gafter) | - | [gafter](https://github.com/gafter)
+| [Static local functions](https://github.com/dotnet/csharplang/issues/1565) | Not yet made | In Progress | [333fred](https://github.com/333fred) | TDB | [gafter](https://github.com/gafter) |
 
 # VB 16.0
 
 | Feature | Branch | State | Developers | Reviewer | LDM Champ |
 | ------- | ------ | ----- | ---------- | -------- | --------- |
 | [Line continuation comments](https://github.com/dotnet/vblang/issues/65) | [continuation-comments](https://github.com/dotnet/roslyn/tree/features/continuation-comments) | Prototype | [paul1956](https://github.com/paul1956) | [AlekseyTs](https://github.com/AlekseyTs) | [gafter](https://github.com/gafter) |
-| [Relax null coalesing operator requirements](https://github.com/dotnet/vblang/issues/339) | [null-operator-enhancements](https://github.com/dotnet/roslyn/tree/features/null-operator-enhancements) | In Progress | [333fred](https://github.com/333fred) | [cston](https://github.com/cston) | [gafter](https://github.com/gafter) |
+| [Relax null coalesing operator requirements](https://github.com/dotnet/vblang/issues/339) | [null-operator-enhancements](https://github.com/dotnet/roslyn/tree/features/null-operator-enhancements) | [Merged to dev16 preview1](https://github.com/dotnet/roslyn/issues/29168) | [333fred](https://github.com/333fred) | [cston](https://github.com/cston) | [gafter](https://github.com/gafter) |
 
 # C# 7.3
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -45,7 +45,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             _declarationModifiers =
                 DeclarationModifiers.Private |
-                DeclarationModifiers.Static |
                 syntax.Modifiers.ToDeclarationModifiers(diagnostics: _declarationDiagnostics);
 
             this.CheckUnsafeModifier(_declarationModifiers, _declarationDiagnostics);
@@ -341,7 +340,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool IsAsync => (_declarationModifiers & DeclarationModifiers.Async) != 0;
 
-        public override bool IsStatic => (_declarationModifiers & DeclarationModifiers.Static) != 0;
+        public override bool IsStatic => true;
+
+        // LocalFunctions are always emitted as static, so the internal IsStatic property should always return IsTrue. The public
+        // ISymbol property, on the other hand, should only return true for local functions declared with the static modifier.
+        protected override bool PublicIsStatic => (_declarationModifiers & DeclarationModifiers.Static) != 0;
 
         public override bool IsVirtual => (_declarationModifiers & DeclarationModifiers.Virtual) != 0;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1289,8 +1289,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         bool ISymbol.IsStatic
         {
-            get { return this.IsStatic; }
+            get { return this.PublicIsStatic; }
         }
+
+        // LocalFunctionSymbol needs to be able to provide different functionality for ISymbol.IsStatic than for Symbol.IsStatic, without
+        // also overriding all other explicit implementations of ISymbol methods and properties. This provides a level of indirection for
+        // it to do so.
+        protected virtual bool PublicIsStatic => this.IsStatic;
 
         bool ISymbol.IsVirtual
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -3891,5 +3891,29 @@ var lambda = new System.Action(() =>
             CreateSubmission(source, previous: previous)
                 .VerifyEmitDiagnostics();
         }
+
+        [Fact]
+        public void LocalFunctionsAreNotStatic()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        void LocalFunc()
+        {
+        }
+    }
+}";
+
+            var comp = CreateCompilation(source);
+            var syntaxTree = comp.SyntaxTrees[0];
+            var semanticModel = comp.GetSemanticModel(syntaxTree);
+
+            var localFuncDecl = syntaxTree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single();
+            var localFuncSymbol = (IMethodSymbol)semanticModel.GetDeclaredSymbol(localFuncDecl);
+
+            Assert.False(localFuncSymbol.IsStatic);
+        }
     }
 }


### PR DESCRIPTION
First part of the work for static local functions. The `IsStatic` decision is currently under design review, when we decide this is the pattern we want I will tag reviewers.

Fixes https://github.com/dotnet/roslyn/issues/27719