### PR TITLE
Skip NullableWalker below #nullable disable

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -375,7 +375,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 walker.Free();
             }
 
-            if (member.NonNullTypes != null &&
+            if (member.NonNullTypes == true &&
                 compilation.LanguageVersion >= MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion())
             {
                 NullableWalker.Analyze(compilation, member, node, diagnostics);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -4155,6 +4155,7 @@ class C
                 );
         }
 
+        [WorkItem(30840, "https://github.com/dotnet/roslyn/issues/30840")]
         [Fact]
         public void NonNullTypesFalse_Foreach()
         {
@@ -4324,6 +4325,7 @@ class C
                 );
         }
 
+        [WorkItem(30840, "https://github.com/dotnet/roslyn/issues/30840")]
         [Fact]
         public void NonNullTypesFalse_OutVars()
         {
@@ -4487,6 +4489,7 @@ public class Base
                 );
         }
 
+        [WorkItem(30840, "https://github.com/dotnet/roslyn/issues/30840")]
         [Fact]
         public void NonNullTypesFalse_LocalDeclarations()
         {
@@ -28692,6 +28695,7 @@ partial class C
             c.VerifyDiagnostics(expected);
         }
 
+        [WorkItem(30840, "https://github.com/dotnet/roslyn/issues/30840")]
         [Fact]
         public void NonNullTypes_03()
         {
@@ -28865,6 +28869,7 @@ partial class C
             c.VerifyDiagnostics(expectedDiagnostics);
         }
 
+        [WorkItem(30840, "https://github.com/dotnet/roslyn/issues/30840")]
         [Fact]
         public void NonNullTypes_04()
         {
@@ -29003,6 +29008,7 @@ partial class C
             c.VerifyDiagnostics(expected);
         }
 
+        [WorkItem(30840, "https://github.com/dotnet/roslyn/issues/30840")]
         [Fact]
         public void NonNullTypes_05()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -326,8 +326,10 @@ partial class C9 { }
 @"#nullable enable
 class Program
 {
-    static void F(object o)
+    static void F(object x)
     {
+        object? y = null;
+        F(y); // warning
     }
 #nullable disable
     static void G()
@@ -336,7 +338,10 @@ class Program
     }
 }";
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (7,11): warning CS8604: Possible null reference argument for parameter 'x' in 'void Program.F(object x)'.
+                //         F(y); // warning
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y").WithArguments("x", "void Program.F(object x)").WithLocation(7, 11));
         }
 
         [WorkItem(30840, "https://github.com/dotnet/roslyn/issues/30840")]
@@ -352,12 +357,17 @@ class Program
         F(null);
     }
 #nullable enable
-    static void F(object o)
+    static void F(object x)
     {
+        object? y = null;
+        F(y); // warning
     }
 }";
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (12,11): warning CS8604: Possible null reference argument for parameter 'x' in 'void Program.F(object x)'.
+                //         F(y); // warning
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y").WithArguments("x", "void Program.F(object x)").WithLocation(12, 11));
         }
 
         [WorkItem(30840, "https://github.com/dotnet/roslyn/issues/30840")]
@@ -367,8 +377,10 @@ class Program
             var source =
 @"class Program
 {
-    static void F(object o)
+    static void F(object x)
     {
+        object? y = null;
+        F(y); // warning
     }
 #nullable disable
     static void G()
@@ -377,7 +389,10 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (6,11): warning CS8604: Possible null reference argument for parameter 'x' in 'void Program.F(object x)'.
+                //         F(y); // warning
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y").WithArguments("x", "void Program.F(object x)").WithLocation(6, 11));
         }
 
         [WorkItem(30840, "https://github.com/dotnet/roslyn/issues/30840")]
@@ -392,12 +407,17 @@ class Program
         F(null);
     }
 #nullable enable
-    static void F(object o)
+    static void F(object x)
     {
+        object? y = null;
+        F(y); // warning
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesFalse());
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (11,11): warning CS8604: Possible null reference argument for parameter 'x' in 'void Program.F(object x)'.
+                //         F(y); // warning
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y").WithArguments("x", "void Program.F(object x)").WithLocation(11, 11));
         }
 
         [Fact, WorkItem(29318, "https://github.com/dotnet/roslyn/issues/29318")]


### PR DESCRIPTION
### Customer scenario

`#nullable disable` does not disable nullability warnings on executable code. (Unannotated types are treated as null-oblivious within a method marked with `#nullable disable`. But for cases where the nullability is known, say `string?` or `null` or a reference to an annotated member, the nullability can result in warnings.)

### Bugs this fixes

#30840

### Workarounds, if any

Avoid using `#nullable` feature.

### Risk

Low.

### Performance impact

None.

### Is this a regression from a previous update?

The is a bug in the `#nullable` feature which is new for this update.

### How was the bug found?

Internal use.

VSO bug: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/721092