### PR TITLE
Restore `CreateSignatureHelpItems` overload that an extension was relying on

### DIFF
--- a/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
+++ b/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
@@ -34,6 +34,15 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
 
         protected abstract Task<SignatureHelpItems> GetItemsWorkerAsync(Document document, int position, SignatureHelpTriggerInfo triggerInfo, CancellationToken cancellationToken);
 
+        /// <remarks>
+        /// This overload is required for compatibility with existing extensions.
+        /// </remarks>
+        protected static SignatureHelpItems CreateSignatureHelpItems(
+            IList<SignatureHelpItem> items, TextSpan applicableSpan, SignatureHelpState state)
+        {
+            return CreateSignatureHelpItems(items, applicableSpan, state, selectedItem: null);
+        }
+
         protected static SignatureHelpItems CreateSignatureHelpItems(
             IList<SignatureHelpItem> items, TextSpan applicableSpan, SignatureHelpState state, int? selectedItem)
         {


### PR DESCRIPTION
Fixes #30829

Consumers of this API should consider their scenario and decide if they should provide a `selectedItem` to take advantage of this new ability, but we also shouldn't break them. 

This PR has been validated by the partner team as fixing their crash.

**Customer scenario**
A crash when I use Signature Help in IntelliCode.

**Bugs this fixes**
#30829 

**Workarounds, if any**
The extension author could call the new alternative overload and ship an update, but existing installations of their extension would keep crashing.

**Risk**
Very low. This restores an internal overload with no known call sites other than the one we're fixing this for, and this restored overload simply forwards to a new version of that method that takes an `int?` for which it already handles null.

**Performance impact**
None.

**Is this a regression from a previous update?**
No.

**Root cause analysis**
IntelliCode depends on internal API's and we did not validate this scenario when the method signature was changed.

**How was the bug found?**
Partner team testing

**Test documentation updated?**
N/A