### PR TITLE
Update ITextBufferCloneService

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -618,7 +618,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                 foreach (var replacement in relevantReplacements)
                 {
-                    var buffer = snapshotSpanToClone.HasValue ? textBufferCloneService.Clone(snapshotSpanToClone.Value) : _textBufferFactoryService.CreateTextBuffer(preMergeDocumentTextString, contentType);
+                    var buffer = snapshotSpanToClone.HasValue ? textBufferCloneService.CloneWithUnknownContentType(snapshotSpanToClone.Value) : _textBufferFactoryService.CreateTextBuffer(preMergeDocumentTextString, contentType);
                     var trackingSpan = buffer.CurrentSnapshot.CreateTrackingSpan(replacement.NewSpan.ToSpan(), SpanTrackingMode.EdgeExclusive, TrackingFidelityMode.Forward);
 
                     using (var edit = _subjectBuffer.CreateEdit(EditOptions.None, null, s_calculateMergedSpansEditTag))

--- a/src/EditorFeatures/Core/ContentTypeNames.cs
+++ b/src/EditorFeatures/Core/ContentTypeNames.cs
@@ -1,16 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-namespace Microsoft.CodeAnalysis.Editor
-{
-    internal static class ContentTypeNames
-    {
-        public const string CSharpContentType = "CSharp";
-        public const string CSharpSignatureHelpContentType = "CSharp Signature Help";
-        public const string RoslynContentType = "Roslyn Languages";
-        public const string VisualBasicContentType = "Basic";
-        public const string VisualBasicSignatureHelpContentType = "Basic Signature Help";
-        public const string XamlContentType = "XAML";
-        public const string JavaScriptContentTypeName = "JavaScript";
-        public const string TypeScriptContentTypeName = "TypeScript";
-    }
-}
+using System.Runtime.CompilerServices;
+
+// Microsoft.CodeAnalysis.Editor.ContentTypeNames has been moved to Microsoft.CodeAnalysis.Editor.Text.dll
+[assembly: TypeForwardedTo(typeof(Microsoft.CodeAnalysis.Editor.ContentTypeNames))]

--- a/src/EditorFeatures/Test/Extensions/SourceTextContainerExtensionsTests.cs
+++ b/src/EditorFeatures/Test/Extensions/SourceTextContainerExtensionsTests.cs
@@ -28,9 +28,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
             bufferMock.SetupGet(x => x.CurrentSnapshot).Returns(textSnapshotMock.Object);
             bufferMock.SetupGet(x => x.Properties).Returns(new VisualStudio.Utilities.PropertyCollection());
 
-            var textContainer = Text.Extensions.TextBufferContainer.From(bufferMock.Object);
+            var textContainer = CodeAnalysis.Text.Extensions.TextBufferContainer.From(bufferMock.Object);
 
-            Text.Extensions.GetTextBuffer(textContainer);
+            CodeAnalysis.Text.Extensions.GetTextBuffer(textContainer);
         }
     }
 }

--- a/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
@@ -143,6 +143,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             public ITextBuffer CloneWithUnknownContentType(SnapshotSpan span) => throw new NotImplementedException();
 
             public ITextBuffer CloneWithUnknownContentType(ITextImage textImage) => throw new NotImplementedException();
+
+            public ITextBuffer CloneWithRoslynContentType(SourceText sourceText) => throw new NotImplementedException();
+
+            public ITextBuffer Clone(SourceText sourceText, IContentType contentType) => throw new NotImplementedException();
+
         }
     }
 }

--- a/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
@@ -140,9 +140,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         private class FakeTextBufferCloneService : ITextBufferCloneService
         {
-            public ITextBuffer Clone(SnapshotSpan span) => throw new NotImplementedException();
+            public ITextBuffer CloneWithUnknownContentType(SnapshotSpan span) => throw new NotImplementedException();
 
-            public ITextBuffer Clone(ITextImage textImage) => throw new NotImplementedException();
+            public ITextBuffer CloneWithUnknownContentType(ITextImage textImage) => throw new NotImplementedException();
         }
     }
 }

--- a/src/EditorFeatures/Text/ContentTypeNames.cs
+++ b/src/EditorFeatures/Text/ContentTypeNames.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Editor
+{
+    internal static class ContentTypeNames
+    {
+        public const string CSharpContentType = "CSharp";
+        public const string CSharpSignatureHelpContentType = "CSharp Signature Help";
+        public const string RoslynContentType = "Roslyn Languages";
+        public const string VisualBasicContentType = "Basic";
+        public const string VisualBasicSignatureHelpContentType = "Basic Signature Help";
+        public const string XamlContentType = "XAML";
+        public const string JavaScriptContentTypeName = "JavaScript";
+        public const string TypeScriptContentTypeName = "TypeScript";
+    }
+}

--- a/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
+++ b/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.Text
                 }
 
                 // otherwise, create a new cloned snapshot
-                var buffer = factory.Clone(TextImage);
+                var buffer = factory.CloneWithUnknownContentType(TextImage);
                 var baseSnapshot = buffer.CurrentSnapshot;
 
                 // apply the change to the buffer

--- a/src/EditorFeatures/Text/Implementation/TextBufferFactoryService/ITextBufferCloneService.cs
+++ b/src/EditorFeatures/Text/Implementation/TextBufferFactoryService/ITextBufferCloneService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
@@ -21,5 +22,15 @@ namespace Microsoft.CodeAnalysis.Text
         /// it is explicitly marked with unknown content type so that it can't be used with editor directly
         /// </summary>
         ITextBuffer CloneWithUnknownContentType(ITextImage textImage);
+
+        /// <summary>
+        /// get new <see cref="ITextBuffer"/> from <see cref="SourceText"/> with <see cref="ContentTypeNames.RoslynContentType"/>
+        /// </summary>
+        ITextBuffer CloneWithRoslynContentType(SourceText sourceText);
+
+        /// <summary>
+        /// get new <see cref="ITextBuffer"/> from <see cref="SourceText"/> with <see cref="IContentType"/>
+        /// </summary>
+        ITextBuffer Clone(SourceText sourceText, IContentType contentType);
     }
 }

--- a/src/EditorFeatures/Text/Implementation/TextBufferFactoryService/ITextBufferCloneService.cs
+++ b/src/EditorFeatures/Text/Implementation/TextBufferFactoryService/ITextBufferCloneService.cs
@@ -2,12 +2,24 @@
 
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Text
 {
     internal interface ITextBufferCloneService : IWorkspaceService
     {
-        ITextBuffer Clone(SnapshotSpan span);
-        ITextBuffer Clone(ITextImage textImage);
+        /// <summary>
+        /// get new <see cref="ITextBuffer"/> from <see cref="SnapshotSpan"/> with <see cref="IContentTypeRegistryService.UnknownContentType"/>
+        /// 
+        /// it is explicitly marked with unknown content type so that it can't be used with editor directly
+        /// </summary>
+        ITextBuffer CloneWithUnknownContentType(SnapshotSpan span);
+
+        /// <summary>
+        /// get new <see cref="ITextBuffer"/> from <see cref="ITextImage"/> with <see cref="IContentTypeRegistryService.UnknownContentType"/>
+        /// 
+        /// it is explicitly marked with unknown content type so that it can't be used with editor directly
+        /// </summary>
+        ITextBuffer CloneWithUnknownContentType(ITextImage textImage);
     }
 }

--- a/src/EditorFeatures/Text/Implementation/TextBufferFactoryService/TextBufferCloneServiceFactory.cs
+++ b/src/EditorFeatures/Text/Implementation/TextBufferFactoryService/TextBufferCloneServiceFactory.cs
@@ -39,11 +39,14 @@ namespace Microsoft.CodeAnalysis.Text.Implementation.TextBufferFactoryService
                 _unknownContentType = contentTypeRegistryService.UnknownContentType;
             }
 
-            public ITextBuffer Clone(SnapshotSpan span)
+            public ITextBuffer CloneWithUnknownContentType(SnapshotSpan span)
                 => _textBufferFactoryService.CreateTextBuffer(span, _unknownContentType);
 
-            public ITextBuffer Clone(ITextImage textImage)
-                => _textBufferFactoryService.CreateTextBuffer(textImage, _unknownContentType);
+            public ITextBuffer CloneWithUnknownContentType(ITextImage textImage)
+                => Clone(textImage, _unknownContentType);
+
+            private ITextBuffer Clone(ITextImage textImage, IContentType contentType)
+                => _textBufferFactoryService.CreateTextBuffer(textImage, contentType);
         }
     }
 }

--- a/src/EditorFeatures/Text/Implementation/TextBufferFactoryService/TextBufferCloneServiceFactory.cs
+++ b/src/EditorFeatures/Text/Implementation/TextBufferFactoryService/TextBufferCloneServiceFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Composition;
+using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Text;
@@ -30,12 +31,15 @@ namespace Microsoft.CodeAnalysis.Text.Implementation.TextBufferFactoryService
         private class TextBufferCloneService : ITextBufferCloneService
         {
             private readonly ITextBufferFactoryService3 _textBufferFactoryService;
+            private readonly IContentType _roslynContentType;
             private readonly IContentType _unknownContentType;
 
             [ImportingConstructor]
             public TextBufferCloneService(ITextBufferFactoryService3 textBufferFactoryService, IContentTypeRegistryService contentTypeRegistryService)
             {
                 _textBufferFactoryService = textBufferFactoryService;
+
+                _roslynContentType = contentTypeRegistryService.GetContentType(ContentTypeNames.RoslynContentType);
                 _unknownContentType = contentTypeRegistryService.UnknownContentType;
             }
 
@@ -44,6 +48,22 @@ namespace Microsoft.CodeAnalysis.Text.Implementation.TextBufferFactoryService
 
             public ITextBuffer CloneWithUnknownContentType(ITextImage textImage)
                 => Clone(textImage, _unknownContentType);
+
+            public ITextBuffer CloneWithRoslynContentType(SourceText sourceText)
+                => Clone(sourceText, _roslynContentType);
+
+            public ITextBuffer Clone(SourceText sourceText, IContentType contentType)
+            {
+                // see whether we can do it cheaply
+                var textImage = sourceText.TryFindCorrespondingEditorTextImage();
+                if (textImage != null)
+                {
+                    return Clone(textImage, contentType);
+                }
+
+                // we can't, so do it more expensive way
+                return _textBufferFactoryService.CreateTextBuffer(sourceText.ToString(), contentType);
+            }
 
             private ITextBuffer Clone(ITextImage textImage, IContentType contentType)
                 => _textBufferFactoryService.CreateTextBuffer(textImage, contentType);

--- a/src/EditorFeatures/Text/Microsoft.CodeAnalysis.EditorFeatures.Text.csproj
+++ b/src/EditorFeatures/Text/Microsoft.CodeAnalysis.EditorFeatures.Text.csproj
@@ -33,6 +33,8 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Wpf" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.CSharp.Repl" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.InteractiveServices" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CSharp" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.VisualBasic" />
@@ -41,6 +43,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.InteractiveEditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.InteractiveEditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.TypeScript.EditorFeatures" Key="$(TypeScriptKey)" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Implementation" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.TypeScript" Key="$(TypeScriptKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Remote" Key="$(RemoteLanguageServiceKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Remote.15.7" Key="$(RemoteLanguageServiceKey)" />
@@ -48,6 +51,8 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Remote.CSharp" Key="$(RemoteLanguageServiceKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Remote.CSharp.15.7" Key="$(RemoteLanguageServiceKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Remote.CSharp.15.8" Key="$(RemoteLanguageServiceKey)" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Xaml" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.VisualBasic.Repl" />
     <InternalsVisibleTo Include="FSharp.Editor" Key="$(FSharpKey)" />
     <InternalsVisibleTo Include="FSharp.LanguageService" Key="$(FSharpKey)" />
     <!-- The rest are for test purposes only. -->


### PR DESCRIPTION
* Rename ITextBufferCloneService methods to clarify content type behavior 
* Support cloning a SourceText with a specified content type 

📝 The first two commits are intentionally shared with #30866 to avoid merge conflicts.

📝 Extracted from #30733 
