### PR TITLE
Split the 'move declaration near reference' feature into a feature and *service*

### DIFF
--- a/src/Features/CSharp/Portable/MoveDeclarationNearReference/CSharpMoveDeclarationNearReferenceService.cs
+++ b/src/Features/CSharp/Portable/MoveDeclarationNearReference/CSharpMoveDeclarationNearReferenceService.cs
@@ -1,21 +1,19 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MoveDeclarationNearReference;
 
 namespace Microsoft.CodeAnalysis.CSharp.MoveDeclarationNearReference
 {
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.MoveDeclarationNearReference), Shared]
-    [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.InlineTemporary)]
-    internal partial class CSharpMoveDeclarationNearReferenceCodeRefactoringProvider :
-        AbstractMoveDeclarationNearReferenceCodeRefactoringProvider<
-            CSharpMoveDeclarationNearReferenceCodeRefactoringProvider,
+    [ExportLanguageService(typeof(IMoveDeclarationNearReferenceService), LanguageNames.CSharp), Shared]
+    internal partial class CSharpMoveDeclarationNearReferenceService :
+        AbstractMoveDeclarationNearReferenceService<
+            CSharpMoveDeclarationNearReferenceService,
             StatementSyntax,
             LocalDeclarationStatementSyntax,
             VariableDeclaratorSyntax>

--- a/src/Features/Core/Portable/MoveDeclarationNearReference/AbstractMoveDeclarationNearReferenceCodeRefactoringProvider.State.cs
+++ b/src/Features/Core/Portable/MoveDeclarationNearReference/AbstractMoveDeclarationNearReferenceCodeRefactoringProvider.State.cs
@@ -12,7 +12,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.MoveDeclarationNearReference
 {
-    internal partial class AbstractMoveDeclarationNearReferenceCodeRefactoringProvider<
+    internal partial class AbstractMoveDeclarationNearReferenceService<
         TService,
         TStatementSyntax,
         TLocalDeclarationStatementSyntax,

--- a/src/Features/Core/Portable/MoveDeclarationNearReference/IMoveDeclarationNearReferenceService.cs
+++ b/src/Features/Core/Portable/MoveDeclarationNearReference/IMoveDeclarationNearReferenceService.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.MoveDeclarationNearReference
+{
+    internal interface IMoveDeclarationNearReferenceService : ILanguageService
+    {
+        /// <summary>
+        /// Returns true if <paramref name="localDeclarationStatement"/> is local declaration statement
+        /// that can be moved forward to be closer to its first reference.
+        /// </summary>
+        Task<bool> CanMoveDeclarationNearReferenceAsync(Document document, SyntaxNode localDeclarationStatement, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Moves true if <paramref name="localDeclarationStatement"/> closer to its first
+        /// reference. Only applicable if <see cref="CanMoveDeclarationNearReferenceAsync"/>
+        /// returned <code>true</code>.
+        /// </summary>
+        Task<Document> MoveDeclarationNearReferenceAsync(Document document, SyntaxNode localDeclarationStatement, CancellationToken cancellationToken);
+    }
+}

--- a/src/Features/Core/Portable/MoveDeclarationNearReference/MoveDeclarationNearReferenceCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/MoveDeclarationNearReference/MoveDeclarationNearReferenceCodeRefactoringProvider.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.MoveDeclarationNearReference
+{
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, Name = PredefinedCodeRefactoringProviderNames.MoveDeclarationNearReference), Shared]
+    [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.InlineTemporary)]
+    internal sealed class MoveDeclarationNearReferenceCodeRefactoringProvider : CodeRefactoringProvider
+    {
+        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var document = context.Document;
+            var textSpan = context.Span;
+            var cancellationToken = context.CancellationToken;
+
+            if (!textSpan.IsEmpty)
+            {
+                return;
+            }
+
+            var statement = await GetLocalDeclarationStatementAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
+            if (statement == null)
+            {
+                return;
+            }
+
+            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            var variables = syntaxFacts.GetVariablesOfLocalDeclarationStatement(statement);
+            if (variables.Count != 1)
+            {
+                return;
+            }
+
+            // Don't offer the refactoring inside the initializer for the variable.
+            var initializer = syntaxFacts.GetInitializerOfVariableDeclarator(variables[0]);
+            var applicableSpan = initializer == null
+                ? statement.Span
+                : TextSpan.FromBounds(statement.SpanStart, initializer.SpanStart);
+
+            if (!applicableSpan.IntersectsWith(textSpan.Start))
+            {
+                return;
+            }
+
+            var service = document.GetLanguageService<IMoveDeclarationNearReferenceService>();
+            if (!await service.CanMoveDeclarationNearReferenceAsync(
+                    document, statement, cancellationToken))
+            {
+                return;
+            }
+
+            context.RegisterRefactoring(
+                new MyCodeAction(c => MoveDeclarationNearReferenceAsync(document, textSpan, c)));
+        }
+
+        private async Task<SyntaxNode> GetLocalDeclarationStatementAsync(
+            Document document, TextSpan textSpan, CancellationToken cancellationToken)
+        {
+            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+
+            var position = textSpan.Start;
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var statement = root.FindToken(position).Parent.Ancestors().FirstOrDefault(n => syntaxFacts.IsLocalDeclarationStatement(n));
+            return statement;
+        }
+
+        private async Task<Document> MoveDeclarationNearReferenceAsync(
+            Document document, TextSpan span, CancellationToken cancellationToken)
+        {
+            var statement = await GetLocalDeclarationStatementAsync(document, span, cancellationToken).ConfigureAwait(false);
+            var service = document.GetLanguageService<IMoveDeclarationNearReferenceService>();
+
+            return await service.MoveDeclarationNearReferenceAsync(document, statement, cancellationToken);
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(FeaturesResources.Move_declaration_near_reference, createChangedDocument)
+            {
+            }
+
+            internal override CodeActionPriority Priority => CodeActionPriority.Low;
+        }
+    }
+}

--- a/src/Features/VisualBasic/Portable/MoveDeclarationNearReference/VisualBasicMoveDeclarationNearReferenceService.vb
+++ b/src/Features/VisualBasic/Portable/MoveDeclarationNearReference/VisualBasicMoveDeclarationNearReferenceService.vb
@@ -2,16 +2,15 @@
 
 Imports System.Composition
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.MoveDeclarationNearReference
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.MoveDeclarationNearReference
-    <ExportCodeRefactoringProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeRefactoringProviderNames.MoveDeclarationNearReference), [Shared]>
-    <ExtensionOrder(After:=PredefinedCodeRefactoringProviderNames.InlineTemporary)>
-    Friend Class VisualBasicMoveDeclarationNearReferenceCodeRefactoringProvider
-        Inherits AbstractMoveDeclarationNearReferenceCodeRefactoringProvider(Of
-            VisualBasicMoveDeclarationNearReferenceCodeRefactoringProvider,
+    <ExportLanguageService(GetType(IMoveDeclarationNearReferenceService), LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicMoveDeclarationNearReferenceService
+        Inherits AbstractMoveDeclarationNearReferenceService(Of
+            VisualBasicMoveDeclarationNearReferenceService,
             StatementSyntax,
             LocalDeclarationStatementSyntax,
             VariableDeclaratorSyntax)


### PR DESCRIPTION
That way other features can leverage the service portion.

Helps with this PR: https://github.com/dotnet/roslyn/pull/30777