### PR TITLE
Gracefully handle project systems not giving us a file path

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
@@ -95,10 +95,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return VSConstants.VSITEMID_NIL;
         }
 
-        public static string GetProjectFilePath(this IVsHierarchy hierarchy)
+        public static string TryGetProjectFilePath(this IVsHierarchy hierarchy)
         {
-            Marshal.ThrowExceptionForHR(((IVsProject3)hierarchy).GetMkDocument((uint)VSConstants.VSITEMID.Root, out var projectFilePath));
-            return projectFilePath;
+            if (ErrorHandler.Succeeded(((IVsProject3)hierarchy).GetMkDocument((uint)VSConstants.VSITEMID.Root, out var projectFilePath)) && !string.IsNullOrEmpty(projectFilePath))
+            {
+                return projectFilePath;
+            }
+
+            return null;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             var componentModel = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
             Workspace = componentModel.GetService<VisualStudioWorkspace>();
 
-            var projectFilePath = hierarchy.GetProjectFilePath();
+            var projectFilePath = hierarchy.TryGetProjectFilePath();
 
             if (projectFilePath != null && !File.Exists(projectFilePath))
             {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_IVsHierarchyEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_IVsHierarchyEvents.cs
@@ -67,9 +67,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                  propid == (int)__VSHPROPID.VSHPROPID_Name) &&
                 itemid == (uint)VSConstants.VSITEMID.Root)
             {
-                var filePath = Hierarchy.GetProjectFilePath();
+                var filePath = Hierarchy.TryGetProjectFilePath();
 
-                if (File.Exists(filePath))
+                if (filePath != null && File.Exists(filePath))
                 {
                     VisualStudioProject.FilePath = filePath;
                 }


### PR DESCRIPTION
We previously didn't throw if a project system refused to give us a file path for the project file itself. In my refactoring, this accidentally switched over to a Marshal.ThrowExceptionForHR, which is now causing us to crash on at least Visual Studio Tools for Office projects. Put this back for now.

Ultimately, after this "fix" we're back to the behavior described in dotnet/rosyn#30429: we won't crash, but we won't have a project file for the project.