### PR TITLE
Fix mis-translation of VB documentation comment marker

### DIFF
--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.de.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.de.xlf
@@ -84,7 +84,7 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_XML-Dokumentationskommentare generieren für "'"</target>
+        <target state="translated">_XML-Dokumentationskommentare generieren für '''</target>
         <note />
       </trans-unit>
       <trans-unit id="Highlighting">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.es.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.es.xlf
@@ -84,7 +84,7 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_Generar comentarios de documentación XML con """</target>
+        <target state="translated">_Generar comentarios de documentación XML con '''</target>
         <note />
       </trans-unit>
       <trans-unit id="Highlighting">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ru.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/BasicVSResources.ru.xlf
@@ -84,7 +84,7 @@
       </trans-unit>
       <trans-unit id="Generate_XML_documentation_comments_for">
         <source>_Generate XML documentation comments for '''</source>
-        <target state="translated">_Создавать комментарии XML-документации для """</target>
+        <target state="translated">_Создавать комментарии XML-документации для '''</target>
         <note />
       </trans-unit>
       <trans-unit id="Highlighting">


### PR DESCRIPTION
This fixes the translation mistake I've pointed out in my [comment](https://github.com/dotnet/roslyn/pull/30905#issuecomment-435122983) for PR #30905.

I've also fixed this for the Russian translation, seeing as it was already wrong there.

You can see in the attached screenshot that it looks very wrong. (On the left is 15.9 Preview 4 in English, on the right is 15.8 in Russian).

![ticks](https://user-images.githubusercontent.com/823398/47876257-2587b700-de19-11e8-9bc2-303cd061e9eb.png)