### PR TITLE
Allow VisualStudioExperimentationService to initialize on a background thread

### DIFF
--- a/src/VisualStudio/Core/Def/Experimentation/VisualStudioExperimentationService.cs
+++ b/src/VisualStudio/Core/Def/Experimentation/VisualStudioExperimentationService.cs
@@ -27,11 +27,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Experimentation
 
             threadingContext.JoinableTaskFactory.Run(async () =>
             {
-                await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
-
                 try
                 {
-                    experimentationServiceOpt = serviceProvider.GetService(typeof(SVsExperimentationService));
+                    experimentationServiceOpt = await ((IAsyncServiceProvider)serviceProvider).GetServiceAsync(typeof(SVsExperimentationService));
                     if (experimentationServiceOpt != null)
                     {
                         isCachedFlightEnabledInfo = experimentationServiceOpt.GetType().GetMethod(


### PR DESCRIPTION
Fixes #30892 

### Customer scenario

When the first Roslyn document opened in the editor is opened via the Navigate To feature, the Roslyn package fails to load and its IDE features are missing substantial functionality.

### Bugs this fixes

#30892
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/725190

### Workarounds, if any

Open a source document before using Navigate To.

### Risk

Low. In the event other initialization code has bugs (fails to follow required threading rules of the host application), the IDE could hang (deadlock) during the test scenario. However, this is unlikely to result in loss of data because changes cannot be made to most source documents prior to opening the first source document.

### Performance impact

Code paths are not altered outside of the broken scenario.

### Is this a regression from a previous update?

Unknown.

### Root cause analysis

Manual testing scenarios should be updated to cover this case.

### How was the bug found?

Internal report.

### Test documentation updated?

Not yet.
