### PR TITLE
Add support for default namespace to workspace

### DIFF
--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -253,6 +253,23 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [Fact]
+        public async Task Project_DefaultNamespace_Change()
+        {
+            using (var workspace = new WorkCoordinatorWorkspace(SolutionCrawler))
+            {
+                var solutionInfo = GetInitialSolutionInfo_2Projects_10Documents(workspace);
+                workspace.OnSolutionAdded(solutionInfo);
+                await WaitWaiterAsync(workspace.ExportProvider);
+
+                var project = workspace.CurrentSolution.Projects.First(p => p.Name == "P1").WithDefaultNamespace("newNamespace");
+                var worker = await ExecuteOperation(workspace, w => w.ChangeProject(project.Id, project.Solution));
+
+                Assert.Equal(5, worker.SyntaxDocumentIds.Count);
+                Assert.Equal(5, worker.DocumentIds.Count);
+            }
+        }
+
+        [Fact]
         public async Task Project_AnalyzerOptions_Change()
         {
             using (var workspace = new WorkCoordinatorWorkspace(SolutionCrawler))

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -505,7 +505,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     !object.Equals(oldProject.CompilationOptions, newProject.CompilationOptions) ||
                     !object.Equals(oldProject.AssemblyName, newProject.AssemblyName) ||
                     !object.Equals(oldProject.Name, newProject.Name) ||
-                    !object.Equals(oldProject.AnalyzerOptions, newProject.AnalyzerOptions))
+                    !object.Equals(oldProject.AnalyzerOptions, newProject.AnalyzerOptions) ||
+                    !object.Equals(oldProject.DefaultNamespace, newProject.DefaultNamespace))
                 {
                     projectConfigurationChange = projectConfigurationChange.With(InvocationReasons.ProjectConfigurationChanged);
                 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -74,6 +74,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                     FilePath = projectFilePath,
                     Hierarchy = hierarchy,
                     ProjectGuid = GetProjectIDGuid(hierarchy),
+                    DefaultNamespace = GetDefaultNamespace(hierarchy, language)
                 });
 
             Hierarchy = hierarchy;
@@ -301,6 +302,48 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                     ComputeFolderNames(parentID, names, hierarchy);
                 }
             }
+        }
+
+        /// <summary>
+        /// Get the default namespace of the project ("" if not defined, which means global namespace),
+        /// or null if it is unknown or not applicable. 
+        /// </summary>
+        private static string GetDefaultNamespace(IVsHierarchy hierarchy, string language)
+        {
+            // While both csproj and vbproj might define <rootnamespace> property in the project file, 
+            // they are very different things.
+            // 
+            // In C#, it's called default namespace (even though we got the value from rootnamespace property),
+            // and it doesn't affect the semantic of the code in anyway, just something used by VS.
+            // For example, when you create a new class, the namespace for the new class is based on it. 
+            // Therefore, we can't get this info from compiler.
+            // 
+            // However, in VB, it's actually called root namespace, and that info is part of the VB compilation 
+            // (parsed from arguments), because VB compiler needs it to determine the root of all the namespace 
+            // declared in the compilation.
+            // 
+            // Unfortunately, although being different concepts, default namespace and root namespace are almost
+            // used interchangebly in VS. For example, (1) the value is define in "rootnamespace" property in project 
+            // files and, (2) the property name we use to call into DTE project below to retrieve the value is 
+            // called "DefaultNamespace".
+
+            if (hierarchy != null && language == LanguageNames.CSharp)
+            {
+                if (hierarchy.TryGetProject(out var dteProject))
+                {
+                    try
+                    {
+                        return (string)dteProject.Properties.Item("DefaultNamespace").Value;
+                    }
+                    catch (ArgumentException)
+                    {
+                        // DefaultNamespace does not exist for this project.
+                        return string.Empty;
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -308,6 +308,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
         /// Get the default namespace of the project ("" if not defined, which means global namespace),
         /// or null if it is unknown or not applicable. 
         /// </summary>
+        /// <remarks>
+        /// This only has meaning in C# and is explicitly set to null in VB.
+        /// </remarks>>
         private static string GetDefaultNamespace(IVsHierarchy hierarchy, string language)
         {
             // While both csproj and vbproj might define <rootnamespace> property in the project file, 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectCreationInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectCreationInfo.cs
@@ -13,5 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public IVsHierarchy Hierarchy { get; set; }
         public Guid ProjectGuid { get; set; }
+
+        public string DefaultNamespace { get; set; }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectFactory.cs
@@ -51,7 +51,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         language: language,
                         filePath: creationInfo.FilePath,
                         compilationOptions: creationInfo.CompilationOptions,
-                        parseOptions: creationInfo.ParseOptions);
+                        parseOptions: creationInfo.ParseOptions)
+                        .WithDefaultNamespace(creationInfo.DefaultNamespace);
 
                 // HACK: update this since we're still on the UI thread. Note we can only update this if we don't have projects -- the workspace
                 // only lets us really do this with OnSolutionAdded for now.

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -178,6 +178,14 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
+        public async Task TestUpdateDefaultNamespace()
+        {
+            var code = @"class Test { void Method() { } }";
+
+            await VerifySolutionUpdate(code, s => s.WithProjectDefaultNamespace(s.ProjectIds[0], "TestClassLibrary"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
         public async Task TestUpdateDocumentInfo()
         {
             var code = @"class Test { void Method() { } }";

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
@@ -384,7 +384,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
                         analyzerReferences: analyzerReferences,
                         additionalDocuments: additionalDocuments,
                         isSubmission: false,
-                        hostObjectType: null);
+                        hostObjectType: null)
+                        .WithDefaultNamespace(projectFileInfo.DefaultNamespace);
                 });
             }
 

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFile.cs
@@ -119,6 +119,19 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 outputRefFilePath = GetAbsolutePathRelativeToProject(outputRefFilePath);
             }
 
+            // Get the default namespace for C# project, which is a C# only concept at the moment.
+            // We need the language check because "rootnamespace" property is also used in VB for
+            // completely different purpose.
+            string defaultNamespace = null;
+            if (Language == LanguageNames.CSharp)
+            {
+                defaultNamespace = project.ReadPropertyString(PropertyNames.RootNamespace);
+                if (string.IsNullOrWhiteSpace(defaultNamespace))
+                {
+                    defaultNamespace = string.Empty;
+                }
+            }
+
             var targetFramework = project.ReadPropertyString(PropertyNames.TargetFramework);
             if (string.IsNullOrWhiteSpace(targetFramework))
             {
@@ -139,6 +152,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 project.FullPath,
                 outputFilePath,
                 outputRefFilePath,
+                defaultNamespace,
                 targetFramework,
                 commandLineArgs,
                 docs,

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -39,6 +39,9 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// The default namespace of the project ("" if not defined, which means global namespace),
         /// or null if it is unknown or not applicable. 
         /// </summary>
+        /// <remarks>
+        /// This only has meaning in C# and is explicitly set to null in VB.
+        /// </remarks>>
         public string DefaultNamespace { get; }
 
         /// <summary>

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -36,6 +36,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public string OutputRefFilePath { get; }
 
         /// <summary>
+        /// The default namespace of the project ("" if not defined, which means global namespace),
+        /// or null if it is unknown or not applicable. 
+        /// </summary>
+        public string DefaultNamespace { get; }
+
+        /// <summary>
         /// The target framework of this project.
         /// This takes the form of the 'short name' form used by NuGet (e.g. net46, netcoreapp2.0, etc.)
         /// </summary>
@@ -78,6 +84,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             string filePath,
             string outputFilePath,
             string outputRefFilePath,
+            string defaultNamespace,
             string targetFramework,
             ImmutableArray<string> commandLineArgs,
             ImmutableArray<DocumentFileInfo> documents,
@@ -92,6 +99,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             this.FilePath = filePath;
             this.OutputFilePath = outputFilePath;
             this.OutputRefFilePath = outputRefFilePath;
+            this.DefaultNamespace = defaultNamespace;
             this.TargetFramework = targetFramework;
             this.CommandLineArgs = commandLineArgs;
             this.Documents = documents;
@@ -105,6 +113,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             string filePath,
             string outputFilePath,
             string outputRefFilePath,
+            string defaultNamespace,
             string targetFramework,
             ImmutableArray<string> commandLineArgs,
             ImmutableArray<DocumentFileInfo> documents,
@@ -117,6 +126,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 filePath,
                 outputFilePath,
                 outputRefFilePath,
+                defaultNamespace,
                 targetFramework,
                 commandLineArgs,
                 documents,
@@ -131,6 +141,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 filePath,
                 outputFilePath: null,
                 outputRefFilePath: null,
+                defaultNamespace: null,
                 targetFramework: null,
                 commandLineArgs: ImmutableArray<string>.Empty,
                 documents: ImmutableArray<DocumentFileInfo>.Empty,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -66,6 +66,9 @@ namespace Microsoft.CodeAnalysis
         /// The default namespace of the project ("" if not defined, which means global namespace),
         /// or null if it is unknown or not applicable. 
         /// </summary>
+        /// <remarks>
+        /// This only has meaning in C# and is explicitly set to null in VB.
+        /// </remarks>>
         internal string DefaultNamespace => _projectState.DefaultNamespace;
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -63,6 +63,12 @@ namespace Microsoft.CodeAnalysis
         public string OutputRefFilePath => _projectState.OutputRefFilePath;
 
         /// <summary>
+        /// The default namespace of the project ("" if not defined, which means global namespace),
+        /// or null if it is unknown or not applicable. 
+        /// </summary>
+        internal string DefaultNamespace => _projectState.DefaultNamespace;
+
+        /// <summary>
         /// <see langword="true"/> if this <see cref="Project"/> supports providing data through the
         /// <see cref="GetCompilationAsync(CancellationToken)"/> method.
         /// 
@@ -340,6 +346,14 @@ namespace Microsoft.CodeAnalysis
         public Project WithAssemblyName(string assemblyName)
         {
             return this.Solution.WithProjectAssemblyName(this.Id, assemblyName).GetProject(this.Id);
+        }
+
+        /// <summary>
+        /// Creates a new instance of this project updated to have the new default namespace.
+        /// </summary>
+        internal Project WithDefaultNamespace(string defaultNamespace)
+        {
+            return this.Solution.WithProjectDefaultNamespace(this.Id, defaultNamespace).GetProject(this.Id);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -59,6 +59,12 @@ namespace Microsoft.CodeAnalysis
         public string OutputRefFilePath => Attributes.OutputRefFilePath;
 
         /// <summary>
+        /// The default namespace of the project ("" if not defined, which means global namespace),
+        /// or null if it is unknown or not applicable. 
+        /// </summary>
+        internal string DefaultNamespace => Attributes.DefaultNamespace;
+
+        /// <summary>
         /// True if this is a submission project for interactive sessions.
         /// </summary>
         public bool IsSubmission => Attributes.IsSubmission;
@@ -144,6 +150,7 @@ namespace Microsoft.CodeAnalysis
             string filePath,
             string outputFilePath,
             string outputRefFilePath,
+            string defaultNamespace,
             CompilationOptions compilationOptions,
             ParseOptions parseOptions,
             IEnumerable<DocumentInfo> documents,
@@ -165,6 +172,7 @@ namespace Microsoft.CodeAnalysis
                     filePath,
                     outputFilePath,
                     outputRefFilePath,
+                    defaultNamespace,
                     isSubmission,
                     hasAllInformation),
                 compilationOptions,
@@ -201,7 +209,7 @@ namespace Microsoft.CodeAnalysis
         {
             return Create(
                 id, version, name, assemblyName, language,
-                filePath, outputFilePath, outputRefFilePath: null, compilationOptions, parseOptions,
+                filePath, outputFilePath, outputRefFilePath: null, defaultNamespace: null, compilationOptions, parseOptions,
                 documents, projectReferences, metadataReferences, analyzerReferences, additionalDocuments,
                 isSubmission, hostObjectType, hasAllInformation: true);
         }
@@ -230,7 +238,7 @@ namespace Microsoft.CodeAnalysis
         {
             return Create(
                 id, version, name, assemblyName, language,
-                filePath, outputFilePath, outputRefFilePath, compilationOptions, parseOptions,
+                filePath, outputFilePath, outputRefFilePath, defaultNamespace: null, compilationOptions, parseOptions,
                 documents, projectReferences, metadataReferences, analyzerReferences, additionalDocuments,
                 isSubmission, hostObjectType, hasAllInformation: true);
         }
@@ -321,6 +329,11 @@ namespace Microsoft.CodeAnalysis
             return With(attributes: Attributes.With(outputRefPath: outputRefFilePath));
         }
 
+        internal ProjectInfo WithDefaultNamespace(string defaultNamespace)
+        {
+            return With(attributes: Attributes.With(defaultNamespace: defaultNamespace));
+        }
+
         public ProjectInfo WithCompilationOptions(CompilationOptions compilationOptions)
         {
             return With(compilationOptions: compilationOptions);
@@ -403,6 +416,11 @@ namespace Microsoft.CodeAnalysis
             public string OutputRefFilePath { get; }
 
             /// <summary>
+            /// The default namespace of the project.
+            /// </summary>
+            public string DefaultNamespace { get; }
+
+            /// <summary>
             /// True if this is a submission project for interactive sessions.
             /// </summary>
             public bool IsSubmission { get; }
@@ -423,6 +441,7 @@ namespace Microsoft.CodeAnalysis
                 string filePath,
                 string outputFilePath,
                 string outputRefFilePath,
+                string defaultNamespace,
                 bool isSubmission,
                 bool hasAllInformation)
             {
@@ -435,6 +454,7 @@ namespace Microsoft.CodeAnalysis
                 FilePath = filePath;
                 OutputFilePath = outputFilePath;
                 OutputRefFilePath = outputRefFilePath;
+                DefaultNamespace = defaultNamespace;
                 IsSubmission = isSubmission;
                 HasAllInformation = hasAllInformation;
             }
@@ -447,6 +467,7 @@ namespace Microsoft.CodeAnalysis
                 Optional<string> filePath = default,
                 Optional<string> outputPath = default,
                 Optional<string> outputRefPath = default,
+                Optional<string> defaultNamespace = default,
                 Optional<bool> isSubmission = default,
                 Optional<bool> hasAllInformation = default)
             {
@@ -457,6 +478,7 @@ namespace Microsoft.CodeAnalysis
                 var newFilepath = filePath.HasValue ? filePath.Value : FilePath;
                 var newOutputPath = outputPath.HasValue ? outputPath.Value : OutputFilePath;
                 var newOutputRefPath = outputRefPath.HasValue ? outputRefPath.Value : OutputRefFilePath;
+                var newDefaultNamespace = defaultNamespace.HasValue ? defaultNamespace.Value : DefaultNamespace;
                 var newIsSubmission = isSubmission.HasValue ? isSubmission.Value : IsSubmission;
                 var newHasAllInformation = hasAllInformation.HasValue ? hasAllInformation.Value : HasAllInformation;
 
@@ -467,6 +489,7 @@ namespace Microsoft.CodeAnalysis
                     newFilepath == FilePath &&
                     newOutputPath == OutputFilePath &&
                     newOutputRefPath == OutputRefFilePath &&
+                    newDefaultNamespace == DefaultNamespace &&
                     newIsSubmission == IsSubmission &&
                     newHasAllInformation == HasAllInformation)
                 {
@@ -482,6 +505,7 @@ namespace Microsoft.CodeAnalysis
                     newFilepath,
                     newOutputPath,
                     newOutputRefPath,
+                    newDefaultNamespace,
                     newIsSubmission,
                     newHasAllInformation);
             }
@@ -501,6 +525,7 @@ namespace Microsoft.CodeAnalysis
                 writer.WriteString(FilePath);
                 writer.WriteString(OutputFilePath);
                 writer.WriteString(OutputRefFilePath);
+                writer.WriteString(DefaultNamespace);
                 writer.WriteBoolean(IsSubmission);
                 writer.WriteBoolean(HasAllInformation);
 
@@ -519,10 +544,11 @@ namespace Microsoft.CodeAnalysis
                 var filePath = reader.ReadString();
                 var outputFilePath = reader.ReadString();
                 var outputRefFilePath = reader.ReadString();
+                var defaultNamespace = reader.ReadString();
                 var isSubmission = reader.ReadBoolean();
                 var hasAllInformation = reader.ReadBoolean();
 
-                return new ProjectAttributes(projectId, VersionStamp.Create(), name, assemblyName, language, filePath, outputFilePath, outputRefFilePath, isSubmission, hasAllInformation);
+                return new ProjectAttributes(projectId, VersionStamp.Create(), name, assemblyName, language, filePath, outputFilePath, outputRefFilePath, defaultNamespace, isSubmission, hasAllInformation);
             }
 
             private Checksum _lazyChecksum;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -62,6 +62,9 @@ namespace Microsoft.CodeAnalysis
         /// The default namespace of the project ("" if not defined, which means global namespace),
         /// or null if it is unknown or not applicable. 
         /// </summary>
+        /// <remarks>
+        /// This only has meaning in C# and is explicitly set to null in VB.
+        /// </remarks>>
         internal string DefaultNamespace => Attributes.DefaultNamespace;
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -269,6 +269,9 @@ namespace Microsoft.CodeAnalysis
         public string OutputRefFilePath => this.ProjectInfo.OutputRefFilePath;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+        public string DefaultNamespace => this.ProjectInfo.DefaultNamespace;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
         public HostLanguageServices LanguageServices => _languageServices;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
@@ -422,6 +425,16 @@ namespace Microsoft.CodeAnalysis
             }
 
             return this.With(projectInfo: this.ProjectInfo.WithOutputRefFilePath(outputRefFilePath).WithVersion(this.Version.GetNewerVersion()));
+        }
+
+        public ProjectState UpdateDefaultNamespace(string defaultNamespace)
+        {
+            if (defaultNamespace == this.DefaultNamespace)
+            {
+                return this;
+            }
+
+            return this.With(projectInfo: this.ProjectInfo.WithDefaultNamespace(defaultNamespace).WithVersion(this.Version.GetNewerVersion()));
         }
 
         public ProjectState UpdateCompilationOptions(CompilationOptions options)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -305,6 +305,20 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Creates a new solution instance with the project specified updated to have the default namespace.
+        /// </summary>
+        internal Solution WithProjectDefaultNamespace(ProjectId projectId, string defaultNamespace)
+        {
+            var newState = _state.WithProjectDefaultNamespace(projectId, defaultNamespace);
+            if (newState == _state)
+            {
+                return this;
+            }
+
+            return new Solution(newState);
+        }
+
+        /// <summary>
         /// Creates a new solution instance with the project specified updated to have the name.
         /// </summary>
         public Solution WithProjectName(ProjectId projectId, string name)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -657,6 +657,29 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Creates a new solution instance with the project specified updated to have the default namespace.
+        /// </summary>
+        public SolutionState WithProjectDefaultNamespace(ProjectId projectId, string defaultNamespace)
+        {
+            if (projectId == null)
+            {
+                throw new ArgumentNullException(nameof(projectId));
+            }
+
+            CheckContainsProject(projectId);
+
+            var oldProjectState = this.GetProjectState(projectId);
+            var newProjectState = oldProjectState.UpdateDefaultNamespace(defaultNamespace);
+
+            if (oldProjectState == newProjectState)
+            {
+                return this;
+            }
+
+            return this.ForkProject(newProjectState);
+        }
+
+        /// <summary>
         /// Creates a new solution instance with the project specified updated to have the name.
         /// </summary>
         public SolutionState WithProjectName(ProjectId projectId, string name)

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1445,7 +1445,8 @@ namespace Microsoft.CodeAnalysis
                 project.AdditionalDocuments.Select(d => CreateDocumentInfoWithText(d)),
                 project.IsSubmission,
                 project.State.HostObjectType,
-                project.OutputRefFilePath);
+                project.OutputRefFilePath)
+                .WithDefaultNamespace(project.DefaultNamespace);
         }
 
         private DocumentInfo CreateDocumentInfoWithText(TextDocument doc)

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -267,6 +267,11 @@ namespace Microsoft.CodeAnalysis.Remote
                 project = project.Solution.WithProjectOutputRefFilePath(project.Id, newProjectInfo.OutputRefFilePath).GetProject(project.Id);
             }
 
+            if (project.State.ProjectInfo.Attributes.DefaultNamespace != newProjectInfo.DefaultNamespace)
+            {
+                project = project.Solution.WithProjectDefaultNamespace(project.Id, newProjectInfo.DefaultNamespace).GetProject(project.Id);
+            }
+
             if (project.State.ProjectInfo.Attributes.HasAllInformation != newProjectInfo.HasAllInformation)
             {
                 project = project.Solution.WithHasAllInformation(project.Id, newProjectInfo.HasAllInformation).GetProject(project.Id);
@@ -516,7 +521,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 projectInfo.Id, projectInfo.Version, projectInfo.Name, projectInfo.AssemblyName,
                 projectInfo.Language, projectInfo.FilePath, projectInfo.OutputFilePath,
                 compilationOptions, parseOptions,
-                documents, p2p, metadata, analyzers, additionals, projectInfo.IsSubmission).WithHasAllInformation(projectInfo.HasAllInformation);
+                documents, p2p, metadata, analyzers, additionals, projectInfo.IsSubmission)
+                .WithHasAllInformation(projectInfo.HasAllInformation)
+                .WithDefaultNamespace(projectInfo.DefaultNamespace);
         }
 
         private async Task<List<T>> CreateCollectionAsync<T>(ChecksumCollection collections)


### PR DESCRIPTION
I'm separating this independent part from #30156, which provides the basic support in workspace for the refactoring. All the changes are intentionally made `internal`, so we don't have to worry about public API design until we are ready to do so.

@CyrusNajmabadi @heejaechang @jasonmalinowski You have already reviewed and signed off on this in the other PR. This is just an exact port. Could you please review and sign-off again?