### PR TITLE
Add missing binding redirects to csc.exe.config

### DIFF
--- a/build/Targets/GenerateCompilerExecutableBindingRedirects.targets
+++ b/build/Targets/GenerateCompilerExecutableBindingRedirects.targets
@@ -33,6 +33,15 @@
       <SuggestedBindingRedirects Include="System.Reflection.Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
         <MaxVersion>1.4.3.0</MaxVersion>
       </SuggestedBindingRedirects>
+      <SuggestedBindingRedirects Include="System.Runtime.CompilerServices.Unsafe, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <MaxVersion>4.0.4.0</MaxVersion>
+      </SuggestedBindingRedirects>
+      <SuggestedBindingRedirects Include="System.Text.Encoding.CodePages, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <MaxVersion>4.1.1.0</MaxVersion>
+      </SuggestedBindingRedirects>
+      <SuggestedBindingRedirects Include="System.Threading.Tasks.Extensions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+        <MaxVersion>4.2.0.0</MaxVersion>
+      </SuggestedBindingRedirects>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9864,7 +9864,7 @@ class C
                 result.Output.Trim());
         }
 
-        [ConditionalFact(typeof(IsEnglishLocal), AlwaysSkip = "TODO")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), typeof(IsEnglishLocal), Reason = "https://github.com/dotnet/roslyn/issues/30321")]
         public void LoadingAnalyzerNetStandard13()
         {
             var analyzerFileName = "AnalyzerNS13.dll";


### PR DESCRIPTION
Analyzers compiled against netstandard1.3 won't work without these redirects.