### PR TITLE
Fix gold-bar when an analyzer starts up, but not all references are restored/found

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseIndexOrRangeOperator/UseIndexOperatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseIndexOrRangeOperator/UseIndexOperatorTests.cs
@@ -37,6 +37,27 @@ class C
     parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7)));
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseRangeOperator)]
+        public async Task TestWithMissingReference()
+        {
+            // We are explicitly *not* passing: CommonReferences="true" here.  We want to 
+            // validate we don't crash with missing references.
+            await TestMissingAsync(
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"">
+        <Document>
+class C
+{
+    void Goo(string s)
+    {
+        var v = s[[||]s.Length - 1];
+    }
+}
+        </Document>
+    </Project>
+</Workspace>");
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIndexOperator)]
         public async Task TestSimple()
         {

--- a/src/EditorFeatures/CSharpTest/UseIndexOrRangeOperator/UseRangeOperatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseIndexOrRangeOperator/UseRangeOperatorTests.cs
@@ -38,6 +38,27 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseRangeOperator)]
+        public async Task TestWithMissingReference()
+        {
+            // We are explicitly *not* passing: CommonReferences="true" here.  We want to 
+            // validate we don't crash with missing references.
+            await TestMissingAsync(
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"">
+        <Document>
+class C
+{
+    void Goo(string s)
+    {
+        var v = s.Substring([||]1, s.Length - 1);
+    }
+}
+        </Document>
+    </Project>
+</Workspace>");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseRangeOperator)]
         public async Task TestSimple()
         {
             await TestAsync(

--- a/src/Features/CSharp/Portable/ExtractMethod/Extensions.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/Extensions.cs
@@ -263,11 +263,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             return node is ExpressionSyntax;
         }
 
-        public static bool IsErrorType(this ITypeSymbol type)
-        {
-            return type == null || type.Kind == SymbolKind.ErrorType;
-        }
-
         public static bool IsObjectType(this ITypeSymbol type)
         {
             return type == null || type.SpecialType == SpecialType.System_Object;

--- a/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.InfoCache.cs
+++ b/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.InfoCache.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
 {
-    using System.Diagnostics;
-    using Microsoft.CodeAnalysis.Shared.Extensions;
     using static Helpers;
 
     internal partial class CSharpUseRangeOperatorDiagnosticAnalyzer

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -166,9 +166,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         public static bool IsErrorType(this ISymbol symbol)
-        {
-            return (symbol as ITypeSymbol)?.IsErrorType() == true;
-        }
+            => (symbol as ITypeSymbol)?.TypeKind == TypeKind.Error;
 
         public static bool IsModuleType(this ISymbol symbol)
         {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -49,11 +49,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static bool IsNullable(this ITypeSymbol symbol)
             => symbol?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
 
-        public static bool IsErrorType(this ITypeSymbol symbol)
-        {
-            return symbol?.TypeKind == TypeKind.Error;
-        }
-
         public static bool IsModuleType(this ITypeSymbol symbol)
         {
             return symbol?.TypeKind == TypeKind.Module;


### PR DESCRIPTION
Found while dogfooding.  I didn't take into account that even built-in types like System.String might come back as an error-type during VSLoading.