### PR TITLE
Fix paste tracking

### DIFF
--- a/src/EditorFeatures/Core/Implementation/PasteTracking/PasteTrackingPasteCommandHandlercs.cs
+++ b/src/EditorFeatures/Core/Implementation/PasteTracking/PasteTrackingPasteCommandHandlercs.cs
@@ -17,6 +17,10 @@ namespace Microsoft.CodeAnalysis.PasteTracking
     [Export(typeof(VSCommanding.ICommandHandler))]
     [ContentType(ContentTypeNames.RoslynContentType)]
     [Name(PredefinedCommandHandlerNames.PasteTrackingPaste)]
+    // By registering to run prior to FormatDocument and deferring until it has completed we
+    // will be able to register the pasted text span after any formatting changes have been
+    // applied. This is important because the PasteTrackingService will dismiss the registered
+    // textspan when the textbuffer is changed.
     [Order(Before = PredefinedCommandHandlerNames.FormatDocument)]
     internal class PasteTrackingPasteCommandHandler : IChainedCommandHandler<PasteCommandArgs>
     {
@@ -40,7 +44,7 @@ namespace Microsoft.CodeAnalysis.PasteTracking
             // Capture the pre-paste caret position
             var caretPosition = args.TextView.GetCaretPoint(args.SubjectBuffer);
 
-            // Allow the pasted text to be inserted.
+            // Allow the pasted text to be inserted and formatted.
             nextCommandHandler();
 
             if (!args.SubjectBuffer.CanApplyChangeDocumentToWorkspace())

--- a/src/EditorFeatures/Core/Implementation/PasteTracking/PasteTrackingPasteCommandHandlercs.cs
+++ b/src/EditorFeatures/Core/Implementation/PasteTracking/PasteTrackingPasteCommandHandlercs.cs
@@ -17,8 +17,7 @@ namespace Microsoft.CodeAnalysis.PasteTracking
     [Export(typeof(VSCommanding.ICommandHandler))]
     [ContentType(ContentTypeNames.RoslynContentType)]
     [Name(PredefinedCommandHandlerNames.PasteTrackingPaste)]
-    [Order(After = PredefinedCommandHandlerNames.FormatDocument)]
-    [Order(Before = PredefinedCommandHandlerNames.Completion)]
+    [Order(Before = PredefinedCommandHandlerNames.FormatDocument)]
     internal class PasteTrackingPasteCommandHandler : IChainedCommandHandler<PasteCommandArgs>
     {
         public string DisplayName => EditorFeaturesResources.Paste_Tracking;

--- a/src/EditorFeatures/Test2/PasteTracking/PasteTrackingServiceTests.vb
+++ b/src/EditorFeatures/Test2/PasteTracking/PasteTrackingServiceTests.vb
@@ -11,6 +11,11 @@ Namespace Microsoft.CodeAnalysis.PasteTracking
         Private Const Class2Name = "Class2.cs"
 
         Private Const PastedCode As String = "
+    public void Main(string[] args)
+    {
+    }"
+
+        Private Const UnformattedPastedCode As String = "
 public void Main(string[] args)
 {
 }"
@@ -19,10 +24,10 @@ public void Main(string[] args)
             <Workspace>
                 <Project Language="C#" CommonReferences="True" AssemblyName="Proj1">
                     <Document FilePath="Class1.cs">
-                        public class Class1
-                        {
-                        $$
-                        }
+public class Class1
+{
+$$
+}
                     </Document>
                 </Project>
             </Workspace>
@@ -31,18 +36,18 @@ public void Main(string[] args)
             <Workspace>
                 <Project Language="C#" CommonReferences="True" AssemblyName=<%= Project1Name %>>
                     <Document FilePath=<%= Class1Name %>>
-                        public class Class1
-                        {
-                        $$
-                        }
+public class Class1
+{
+$$
+}
                     </Document>
                     <Document FilePath=<%= Class2Name %>>
-                        public class Class2
-                        {
-                            public const string Greeting = "Hello";
+public class Class2
+{
+    public const string Greeting = "Hello";
 
-                        $$
-                        }
+$$
+}
                     </Document>
                 </Project>
                 <Project Language="C#" CommonReferences="True" AssemblyName=<%= Project2Name %>>
@@ -72,6 +77,17 @@ public void Main(string[] args)
             End Using
         End Function
 
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.PasteTracking)>
+        Public Async Function PasteTracking_HasTextSpan_AfterFormattingPaste() As Task
+            Using testState = New PasteTrackingTestState(SingleFileCode)
+                Dim class1Document = testState.OpenDocument(Project1Name, Class1Name)
+
+                Dim expectedTextSpan = testState.SendPaste(class1Document, UnformattedPastedCode)
+
+                Await testState.AssertHasPastedTextSpanAsync(class1Document, expectedTextSpan)
+            End Using
+        End Function
 
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.PasteTracking)>


### PR DESCRIPTION
This fixes an issue with paste tracking where the format command handler would apply text changes that dismissed the pasted span we were tracking.

### Customer scenario
Pasting a improperly formatted code snippet will not show the new "Add missing imports" code refactoring

### Bugs this fixes
N/A 

### Workarounds, if any
Only paste properly formatted code snippets into the editor.

### Risk
Low

### Performance impact
None.

### Is this a regression from a previous update?
Add missing import code refactoring is a new feature

### Root cause analysis
A test gap. A unit-test is added.

### How was the bug found?
Demo preparation for the sprint showcase