### PR TITLE
Ensure PinnedRemotableDataScope is disposed

### DIFF
--- a/src/Workspaces/Core/Portable/Remote/RemoteHostSessionHelpers.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostSessionHelpers.cs
@@ -40,10 +40,16 @@ namespace Microsoft.CodeAnalysis.Remote
             }
             catch
             {
-                // make sure disposable objects are disposed when
-                // exceptions are thrown
-                connection.Dispose();
-                scope?.Dispose();
+                // Make sure disposable objects are disposed when exceptions are thrown. The try/finally is used to
+                // ensure 'scope' is disposed even if an exception is thrown while disposing 'connection'.
+                try
+                {
+                    connection.Dispose();
+                }
+                finally
+                {
+                    scope?.Dispose();
+                }
 
                 // we only expect this to happen on cancellation. otherwise, rethrow
                 cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Fixes #30271

### Customer scenario

Under unknown situations, the IDE crashes due to a failure to clean up a database resource.

### Bugs this fixes

#30271 
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/671157

### Workarounds, if any

None.

### Risk

Low. This pull request cannot alter execution behavior except on a code path which was certain to crash the IDE.

### Performance impact

N/A

### Is this a regression from a previous update?

No.

### Root cause analysis

Found by Watson. The steps to reproduce this issue are unknown.

### How was the bug found?

Watson.

### Test documentation updated?

N/A

