### PR TITLE
Add regression test for attribute with async delegate parameter

### DIFF
--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -4618,5 +4618,39 @@ End Class
             Assert.NotNull(compilation2.GetTypeByMetadataName("TestReference2"))
         End Sub
 
+        <Fact>
+        Public Sub AttributeWithTaskDelegateParameter()
+            Dim code = "
+Imports System
+Imports System.Threading.Tasks
+
+Namespace a
+    Public Class Class1
+        <AttributeUsage(AttributeTargets.Class, AllowMultiple:=True)>
+        Public Class CommandAttribute
+            Inherits Attribute
+
+            Public Delegate Function FxCommand() As Task
+
+            Public Sub New(Fx As FxCommand)
+                Me.Fx = Fx
+            End Sub
+
+            Public Property Fx As FxCommand
+        End Class
+
+        <Command(AddressOf UserInfo)>
+        Public Shared Async Function UserInfo() As Task
+            Await New Task(
+                Sub()
+                End Sub)
+        End Function
+    End Class
+End Namespace
+"
+            CreateCompilationWithMscorlib45(code).VerifyDiagnostics(
+                Diagnostic(ERRID.ERR_BadAttributeConstructor1, "Command").WithArguments("a.Class1.CommandAttribute.FxCommand").WithLocation(20, 10),
+                Diagnostic(ERRID.ERR_RequiredConstExpr, "AddressOf UserInfo").WithLocation(20, 18))
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Resolves #30833 

This test should prevent the error described in #30833 from recurring. It **passes on master** but on the **15.9 branch** it produces the following error:

```
Microsoft.CodeAnalysis.CSharp.UnitTests.AttributeTests.AttributeWithTaskDelegateParameter [FAIL]
    System.AggregateException : One or more errors occurred.
    ---- System.AggregateException : One or more errors occurred.
    -------- System.NullReferenceException : Object reference not set to an instance of an object.
    Stack Trace:
        at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
        at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
        at System.Threading.Tasks.Parallel.ForWorker[TLocal](Int32 fromInclusive, Int32 toExclusive, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Func`4 bodyWithLocal, Func`1 localInit, Action`1 localFinally)
        at System.Threading.Tasks.Parallel.For(Int32 fromInclusive, Int32 toExclusive, ParallelOptions parallelOptions, Action`1 body)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceNamespaceSymbol_Completion.cs(53,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamespaceSymbol.ForceComplete(SourceLocation locationOpt, CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceModuleSymbol.cs(258,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceModuleSymbol.ForceComplete(SourceLocation locationOpt, CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceAssemblySymbol.cs(908,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceAssemblySymbol.ForceComplete(SourceLocation locationOpt, CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Compilation\CSharpCompilation.cs(2308,0): at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetSourceDeclarationDiagnostics(SyntaxTree syntaxTree, Nullable`1 filterSpanWithinTree, Func`4 locationFilterOpt, CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Compilation\CSharpCompilation.cs(2195,0): at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetDiagnostics(CompilationStage stage, Boolean includeEarlierStages, DiagnosticBag diagnostics, CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Compilation\CSharpCompilation.cs(2131,0): at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetDiagnostics(CompilationStage stage, Boolean includeEarlierStages, CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Compilation\CSharpCompilation.cs(2125,0): at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetDiagnostics(CancellationToken cancellationToken)
    src\Test\Utilities\Portable\Diagnostics\DiagnosticExtensions.cs(98,0): at Microsoft.CodeAnalysis.DiagnosticExtensions.VerifyDiagnostics[TCompilation](TCompilation c, DiagnosticDescription[] expected)
    src\Compilers\CSharp\Test\Emit\Attributes\AttributeTests.cs(8948,0): at Microsoft.CodeAnalysis.CSharp.UnitTests.AttributeTests.AttributeWithTaskDelegateParameter()
    ----- Inner Stack Trace -----
        at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
        at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
        at System.Threading.Tasks.Parallel.ForWorker[TLocal](Int32 fromInclusive, Int32 toExclusive, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Func`4 bodyWithLocal, Func`1 localInit, Action`1 localFinally)
        at System.Threading.Tasks.Parallel.For(Int32 fromInclusive, Int32 toExclusive, ParallelOptions parallelOptions, Action`1 body)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceNamespaceSymbol_Completion.cs(53,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamespaceSymbol.ForceComplete(SourceLocation locationOpt, CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Symbols\Symbol.cs(712,0): at Microsoft.CodeAnalysis.CSharp.Symbol.ForceCompleteMemberByLocation(SourceLocation locationOpt, Symbol member, CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceNamespaceSymbol_Completion.cs(56,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamespaceSymbol.<>c__DisplayClass47_1.<ForceComplete>b__0(Int32 i)
    src\Compilers\Core\Portable\InternalUtilities\UICultureUtilities.cs(166,0): at Roslyn.Utilities.UICultureUtilities.<>c__DisplayClass6_0`1.<WithCurrentUICulture>b__0(T param)
        at System.Threading.Tasks.Parallel.<>c__DisplayClass17_0`1.<ForWorker>b__1()
        at System.Threading.Tasks.Task.InnerInvokeWithArg(Task childTask)
        at System.Threading.Tasks.Task.<>c__DisplayClass176_0.<ExecuteSelfReplicating>b__0(Object )
    ----- Inner Stack Trace -----
    src\Compilers\CSharp\Portable\Symbols\Source\SourceOrdinaryMethodSymbol.cs(686,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceOrdinaryMethodSymbol.get_ReturnTypeCustomModifiers()
    src\Compilers\CSharp\Portable\Symbols\SymbolExtensions.cs(381,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SymbolExtensions.GetTypeOrReturnType(Symbol symbol, RefKind& refKind, TypeSymbol& returnType, ImmutableArray`1& returnTypeCustomModifiers, ImmutableArray`1& refCustomModifiers)
    src\Compilers\CSharp\Portable\Symbols\SymbolExtensions.cs(360,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SymbolExtensions.GetTypeOrReturnType(Symbol symbol)
    src\Compilers\CSharp\Portable\Binder\Binder_Conversions.cs(653,0): at Microsoft.CodeAnalysis.CSharp.Binder.MemberGroupFinalValidationAccessibilityChecks(BoundExpression receiverOpt, Symbol memberSymbol, SyntaxNode node, DiagnosticBag diagnostics, Boolean invokedAsExtensionMethod)
    src\Compilers\CSharp\Portable\Binder\Binder_Conversions.cs(499,0): at Microsoft.CodeAnalysis.CSharp.Binder.MemberGroupFinalValidation(BoundExpression receiverOpt, MethodSymbol methodSymbol, SyntaxNode node, DiagnosticBag diagnostics, Boolean invokedAsExtensionMethod)
    src\Compilers\CSharp\Portable\Binder\Binder_Conversions.cs(812,0): at Microsoft.CodeAnalysis.CSharp.Binder.MethodGroupConversionHasErrors(SyntaxNode syntax, Conversion conversion, BoundExpression receiverOpt, Boolean isExtensionMethod, NamedTypeSymbol delegateType, DiagnosticBag diagnostics)
    src\Compilers\CSharp\Portable\Binder\Binder_Conversions.cs(314,0): at Microsoft.CodeAnalysis.CSharp.Binder.CreateMethodGroupConversion(SyntaxNode syntax, BoundExpression source, Conversion conversion, Boolean isCast, TypeSymbol destination, DiagnosticBag diagnostics)
    src\Compilers\CSharp\Portable\Binder\Binder_Conversions.cs(90,0): at Microsoft.CodeAnalysis.CSharp.Binder.CreateConversion(SyntaxNode syntax, BoundExpression source, Conversion conversion, Boolean isCast, Boolean wasCompilerGenerated, TypeSymbol destination, DiagnosticBag diagnostics)
    src\Compilers\CSharp\Portable\Binder\Binder_Conversions.cs(46,0): at Microsoft.CodeAnalysis.CSharp.Binder.CreateConversion(SyntaxNode syntax, BoundExpression source, Conversion conversion, Boolean isCast, TypeSymbol destination, DiagnosticBag diagnostics)
    src\Compilers\CSharp\Portable\Binder\Binder_Expressions.cs(2539,0): at Microsoft.CodeAnalysis.CSharp.Binder.CoerceArguments[TMember](MemberResolutionResult`1 methodResult, ArrayBuilder`1 arguments, DiagnosticBag diagnostics)
    src\Compilers\CSharp\Portable\Binder\Binder_Expressions.cs(4983,0): at Microsoft.CodeAnalysis.CSharp.Binder.TryPerformConstructorOverloadResolution(NamedTypeSymbol typeContainingConstructors, AnalyzedArguments analyzedArguments, String errorName, Location errorLocation, Boolean suppressResultDiagnostics, DiagnosticBag diagnostics, MemberResolutionResult`1& memberResolutionResult, ImmutableArray`1& candidateConstructors, Boolean allowProtectedConstructorsOfBaseType)
    src\Compilers\CSharp\Portable\Binder\Binder_Attributes.cs(498,0): at Microsoft.CodeAnalysis.CSharp.Binder.BindAttributeConstructor(AttributeSyntax node, NamedTypeSymbol attributeType, AnalyzedArguments boundConstructorArguments, DiagnosticBag diagnostics, LookupResultKind& resultKind, Boolean suppressErrors, HashSet`1& useSiteDiagnostics)
    src\Compilers\CSharp\Portable\Binder\Binder_Attributes.cs(152,0): at Microsoft.CodeAnalysis.CSharp.Binder.BindAttributeCore(AttributeSyntax node, NamedTypeSymbol attributeType, DiagnosticBag diagnostics)
    src\Compilers\CSharp\Portable\Binder\Binder_Attributes.cs(105,0): at Microsoft.CodeAnalysis.CSharp.Binder.BindAttribute(AttributeSyntax node, NamedTypeSymbol attributeType, DiagnosticBag diagnostics)
    src\Compilers\CSharp\Portable\Binder\Binder_Attributes.cs(98,0): at Microsoft.CodeAnalysis.CSharp.Binder.GetAttribute(AttributeSyntax node, NamedTypeSymbol boundAttributeType, DiagnosticBag diagnostics)
    src\Compilers\CSharp\Portable\Binder\Binder_Attributes.cs(74,0): at Microsoft.CodeAnalysis.CSharp.Binder.GetAttributes(ImmutableArray`1 binders, ImmutableArray`1 attributesToBind, ImmutableArray`1 boundAttributeTypes, CSharpAttributeData[] attributesBuilder, DiagnosticBag diagnostics)
    src\Compilers\CSharp\Portable\Symbols\Symbol_Attributes.cs(317,0): at Microsoft.CodeAnalysis.CSharp.Symbol.LoadAndValidateAttributes(OneOrMany`1 attributesSyntaxLists, CustomAttributesBag`1& lazyCustomAttributesBag, AttributeLocation symbolPart, Boolean earlyDecodingOnly, Binder binderOpt, Func`2 attributeMatchesOpt)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceMemberMethodSymbol.cs(1010,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol.GetAttributesBag(CustomAttributesBag`1& lazyCustomAttributesBag, Boolean forReturnType)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceMemberMethodSymbol.cs(968,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol.GetAttributesBag()
    src\Compilers\CSharp\Portable\Symbols\Source\SourceMemberMethodSymbol.cs(931,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol.GetDecodedWellKnownAttributeData()
    src\Compilers\CSharp\Portable\Symbols\Source\SourceMemberMethodSymbol.cs(1597,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol.get_ImplementationAttributes()
    src\Compilers\CSharp\Portable\Symbols\Source\SourceOrdinaryMethodSymbol.cs(434,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceOrdinaryMethodSymbol.LazyAsyncMethodChecks(CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceOrdinaryMethodSymbol.cs(292,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceOrdinaryMethodSymbol.MethodChecks(MethodDeclarationSyntax syntax, Binder withTypeParamsBinder, DiagnosticBag diagnostics)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceOrdinaryMethodSymbol.cs(472,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceOrdinaryMethodSymbol.MethodChecks(DiagnosticBag diagnostics)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceMemberMethodSymbol.cs(293,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol.LazyMethodChecks()
    src\Compilers\CSharp\Portable\Symbols\Source\SourceMemberMethodSymbol.cs(743,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol.get_OverriddenOrHiddenMembers()
    src\Compilers\CSharp\Portable\Symbols\Source\SourceMemberContainerSymbol_ImplementationChecks.cs(392,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.CheckMembersAgainstBaseType(DiagnosticBag diagnostics, CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceMemberContainerSymbol_ImplementationChecks.cs(31,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.GetSynthesizedExplicitImplementations(CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceMemberContainerSymbol.cs(499,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.ForceComplete(SourceLocation locationOpt, CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Symbols\Symbol.cs(712,0): at Microsoft.CodeAnalysis.CSharp.Symbol.ForceCompleteMemberByLocation(SourceLocation locationOpt, Symbol member, CancellationToken cancellationToken)
    src\Compilers\CSharp\Portable\Symbols\Source\SourceNamespaceSymbol_Completion.cs(56,0): at Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamespaceSymbol.<>c__DisplayClass47_1.<ForceComplete>b__0(Int32 i)
    src\Compilers\Core\Portable\InternalUtilities\UICultureUtilities.cs(166,0): at Roslyn.Utilities.UICultureUtilities.<>c__DisplayClass6_0`1.<WithCurrentUICulture>b__0(T param)
        at System.Threading.Tasks.Parallel.<>c__DisplayClass17_0`1.<ForWorker>b__1()
        at System.Threading.Tasks.Task.InnerInvokeWithArg(Task childTask)
        at System.Threading.Tasks.Task.<>c__DisplayClass176_0.<ExecuteSelfReplicating>b__0(Object )
```

Note that this doesn't actually test emit because attributes can't actually take delegate arguments. This is kind of an attribute test, though, and it seems independent from the GetSymbolInfo API. Where should this actually go?