### PR TITLE
Workaround in RemoveUnusedMembersDiagnosticAnalyzer for VB handles cl…

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
@@ -932,6 +932,71 @@ End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        <WorkItem(30895, "https://github.com/dotnet/roslyn/issues/30895")>
+        Public Async Function MethodWithHandlesClause() As Task
+            Await TestDiagnosticMissingAsync(
+"Public Interface I
+    Event M()
+End Interface
+
+Public Class C
+    Private WithEvents _field1 As I
+
+    Private Sub [|M|]() Handles _field1.M
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        <WorkItem(30895, "https://github.com/dotnet/roslyn/issues/30895")>
+        Public Async Function FieldReferencedInHandlesClause() As Task
+            Await TestDiagnosticMissingAsync(
+"Public Interface I
+    Event M()
+End Interface
+
+Public Class C
+    Private WithEvents [|_field1|] As I
+
+    Private Sub M() Handles _field1.M
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        <WorkItem(30895, "https://github.com/dotnet/roslyn/issues/30895")>
+        Public Async Function FieldReferencedInHandlesClause_02() As Task
+            Await TestDiagnosticMissingAsync(
+"Public Interface I
+    Event M()
+End Interface
+
+Public Class C
+    Private WithEvents _field1 As I
+    Private WithEvents [|_field2|] As I
+
+    Private Sub M() Handles _field1.M, _field2.M
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        <WorkItem(30895, "https://github.com/dotnet/roslyn/issues/30895")>
+        Public Async Function EventReferencedInHandlesClause() As Task
+            Await TestDiagnosticMissingAsync(
+"Public Class B
+    Private Event [|M|]()
+
+    Public Class C
+        Private WithEvents _field1 As B
+
+        Private Sub M() Handles _field1.M
+        End Sub
+    End Class
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
         Public Async Function PropertyIsArg() As Task
             Await TestDiagnosticMissingAsync(
 "Class C

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
         /// <summary>
         /// Override this method to register custom language specific actions to find symbol usages.
         /// </summary>
-        protected virtual void RegisterCustomSymbolReferenceActions(SymbolStartAnalysisContext context, Action<ISymbol, ValueUsageInfo> onSymbolUsageFound)
+        protected virtual void HandleNamedTypeSymbolStart(SymbolStartAnalysisContext context, Action<ISymbol, ValueUsageInfo> onSymbolUsageFound)
         {
         }
 
@@ -103,6 +103,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
 
                 compilationStartContext.RegisterSymbolAction(AnalyzeSymbolDeclaration, SymbolKind.Method, SymbolKind.Field, SymbolKind.Property, SymbolKind.Event);
 
+                Action<ISymbol, ValueUsageInfo> onSymbolUsageFound = OnSymbolUsage;
                 compilationStartContext.RegisterSymbolStartAction(symbolStartContext =>
                 {
                     if (symbolStartContext.Symbol.GetAttributes().Any(a => a.AttributeClass == _structLayoutAttributeType))
@@ -121,7 +122,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                     symbolStartContext.RegisterSymbolEndAction(symbolEndContext => OnSymbolEnd(symbolEndContext, hasInvalidOperation));
 
                     // Register custom language-specific actions, if any.
-                    _analyzer.RegisterCustomSymbolReferenceActions(symbolStartContext, OnSymbolUsage);
+                    _analyzer.HandleNamedTypeSymbolStart(symbolStartContext, onSymbolUsageFound);
                 }, SymbolKind.NamedType);
             }
 

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -49,17 +50,28 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
 
         protected sealed override void InitializeWorker(AnalysisContext context)
             => context.RegisterCompilationStartAction(compilationStartContext
-                => CompilationAnalyzer.CreateAndRegisterActions(compilationStartContext));
+                => CompilationAnalyzer.CreateAndRegisterActions(compilationStartContext, this));
+
+        /// <summary>
+        /// Override this method to register custom language specific actions to find symbol usages.
+        /// </summary>
+        protected virtual void RegisterCustomSymbolReferenceActions(SymbolStartAnalysisContext context, Action<ISymbol, ValueUsageInfo> onSymbolUsageFound)
+        {
+        }
 
         private sealed class CompilationAnalyzer
         {
             private readonly object _gate;
             private readonly Dictionary<ISymbol, ValueUsageInfo> _symbolValueUsageStateMap;
             private readonly INamedTypeSymbol _taskType, _genericTaskType, _debuggerDisplayAttributeType, _structLayoutAttributeType;
+            private readonly AbstractRemoveUnusedMembersDiagnosticAnalyzer<TDocumentationCommentTriviaSyntax, TIdentifierNameSyntax> _analyzer;
 
-            private CompilationAnalyzer(Compilation compilation)
+            private CompilationAnalyzer(
+                Compilation compilation,
+                AbstractRemoveUnusedMembersDiagnosticAnalyzer<TDocumentationCommentTriviaSyntax, TIdentifierNameSyntax> analyzer)
             {
                 _gate = new object();
+                _analyzer = analyzer;
 
                 // State map for candidate member symbols, with the value indicating how each symbol is used in executable code.
                 _symbolValueUsageStateMap = new Dictionary<ISymbol, ValueUsageInfo>();
@@ -70,9 +82,11 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 _structLayoutAttributeType = compilation.StructLayoutAttributeType();
             }
 
-            public static void CreateAndRegisterActions(CompilationStartAnalysisContext compilationStartContext)
+            public static void CreateAndRegisterActions(
+                CompilationStartAnalysisContext compilationStartContext,
+                AbstractRemoveUnusedMembersDiagnosticAnalyzer<TDocumentationCommentTriviaSyntax, TIdentifierNameSyntax> analyzer)
             {
-                var compilationAnalyzer = new CompilationAnalyzer(compilationStartContext.Compilation);
+                var compilationAnalyzer = new CompilationAnalyzer(compilationStartContext.Compilation, analyzer);
                 compilationAnalyzer.RegisterActions(compilationStartContext);
             }
 
@@ -105,6 +119,9 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                     symbolStartContext.RegisterOperationAction(AnalyzeObjectCreationOperation, OperationKind.ObjectCreation);
                     symbolStartContext.RegisterOperationAction(_ => hasInvalidOperation = true, OperationKind.Invalid);
                     symbolStartContext.RegisterSymbolEndAction(symbolEndContext => OnSymbolEnd(symbolEndContext, hasInvalidOperation));
+
+                    // Register custom language-specific actions, if any.
+                    _analyzer.RegisterCustomSymbolReferenceActions(symbolStartContext, OnSymbolUsage);
                 }, SymbolKind.NamedType);
             }
 
@@ -141,17 +158,17 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 {
                     foreach (var field in initializer.InitializedFields)
                     {
-                        if (IsCandidateSymbol(field))
-                        {
-                            OnSymbolUsage(field, ValueUsageInfo.Write);
-                        }
+                        OnSymbolUsage(field, ValueUsageInfo.Write);
                     }
                 }
             }
 
             private void OnSymbolUsage(ISymbol memberSymbol, ValueUsageInfo usageInfo)
             {
-                Debug.Assert(IsCandidateSymbol(memberSymbol));
+                if (!IsCandidateSymbol(memberSymbol))
+                {
+                    return;
+                }
 
                 lock (_gate)
                 {
@@ -222,23 +239,19 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
             private void AnalyzeInvocationOperation(OperationAnalysisContext operationContext)
             {
                 var targetMethod = ((IInvocationOperation)operationContext.Operation).TargetMethod.OriginalDefinition;
-                if (IsCandidateSymbol(targetMethod))
-                {
-                    // A method invocation is considered as a read reference to the symbol
-                    // to ensure that we consider the method as "used".
-                    OnSymbolUsage(targetMethod, ValueUsageInfo.Read);
-                }
+                
+                // A method invocation is considered as a read reference to the symbol
+                // to ensure that we consider the method as "used".
+                OnSymbolUsage(targetMethod, ValueUsageInfo.Read);
             }
 
             private void AnalyzeObjectCreationOperation(OperationAnalysisContext operationContext)
             {
                 var constructor = ((IObjectCreationOperation)operationContext.Operation).Constructor.OriginalDefinition;
-                if (IsCandidateSymbol(constructor))
-                {
-                    // An object creation is considered as a read reference to the constructor
-                    // to ensure that we consider the constructor as "used".
-                    OnSymbolUsage(constructor, ValueUsageInfo.Read);
-                }
+                
+                // An object creation is considered as a read reference to the constructor
+                // to ensure that we consider the constructor as "used".
+                OnSymbolUsage(constructor, ValueUsageInfo.Read);
             }
 
             private void OnSymbolEnd(SymbolAnalysisContext symbolEndContext, bool hasInvalidOperation)

--- a/src/Features/VisualBasic/Portable/RemoveUnusedMembers/VisualBasicRemoveUnusedMembersDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/RemoveUnusedMembers/VisualBasicRemoveUnusedMembersDiagnosticAnalyzer.vb
@@ -10,9 +10,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedMembers
     Friend NotInheritable Class VisualBasicRemoveUnusedMembersDiagnosticAnalyzer
         Inherits AbstractRemoveUnusedMembersDiagnosticAnalyzer(Of DocumentationCommentTriviaSyntax, IdentifierNameSyntax)
 
-        Protected Overrides Sub RegisterCustomSymbolReferenceActions(context As SymbolStartAnalysisContext, onSymbolUsageFound As Action(Of ISymbol, ValueUsageInfo))
+        Protected Overrides Sub HandleNamedTypeSymbolStart(context As SymbolStartAnalysisContext, onSymbolUsageFound As Action(Of ISymbol, ValueUsageInfo))
             ' Mark all methods with handles clause as having a read reference
             ' to ensure that we consider the method as "used".
+            ' Such methods are essentially event handlers and are normally
+            ' not referenced directly.
             For Each method In DirectCast(context.Symbol, INamedTypeSymbol).GetMembers().OfType(Of IMethodSymbol)
                 If Not method.HandledEvents.IsEmpty Then
                     onSymbolUsageFound(method, ValueUsageInfo.Read)
@@ -20,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedMembers
             Next
 
             ' Register syntax node action for HandlesClause
-            ' This is a temporary workaround for following bugs:
+            ' This is a workaround for following bugs:
             '  1. https://github.com/dotnet/roslyn/issues/30978
             '  2. https://github.com/dotnet/roslyn/issues/30979
 

--- a/src/Features/VisualBasic/Portable/RemoveUnusedMembers/VisualBasicRemoveUnusedMembersDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/RemoveUnusedMembers/VisualBasicRemoveUnusedMembersDiagnosticAnalyzer.vb
@@ -9,5 +9,36 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedMembers
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Friend NotInheritable Class VisualBasicRemoveUnusedMembersDiagnosticAnalyzer
         Inherits AbstractRemoveUnusedMembersDiagnosticAnalyzer(Of DocumentationCommentTriviaSyntax, IdentifierNameSyntax)
+
+        Protected Overrides Sub RegisterCustomSymbolReferenceActions(context As SymbolStartAnalysisContext, onSymbolUsageFound As Action(Of ISymbol, ValueUsageInfo))
+            ' Mark all methods with handles clause as having a read reference
+            ' to ensure that we consider the method as "used".
+            For Each method In DirectCast(context.Symbol, INamedTypeSymbol).GetMembers().OfType(Of IMethodSymbol)
+                If Not method.HandledEvents.IsEmpty Then
+                    onSymbolUsageFound(method, ValueUsageInfo.Read)
+                End If
+            Next
+
+            ' Register syntax node action for HandlesClause
+            ' This is a temporary workaround for following bugs:
+            '  1. https://github.com/dotnet/roslyn/issues/30978
+            '  2. https://github.com/dotnet/roslyn/issues/30979
+
+            context.RegisterSyntaxNodeAction(
+                Sub(syntaxNodeContext As SyntaxNodeAnalysisContext)
+                    AnalyzeHandlesClause(syntaxNodeContext, onSymbolUsageFound)
+                End Sub,
+                SyntaxKind.HandlesClause)
+        End Sub
+
+        Private Sub AnalyzeHandlesClause(context As SyntaxNodeAnalysisContext, onSymbolUsageFound As Action(Of ISymbol, ValueUsageInfo))
+            ' Identify all symbol references within the HandlesClause.
+            For Each node In context.Node.DescendantNodes()
+                Dim symbolInfo = context.SemanticModel.GetSymbolInfo(node, context.CancellationToken)
+                For Each symbol In symbolInfo.GetAllSymbols()
+                    onSymbolUsageFound(symbol, ValueUsageInfo.Read)
+                Next
+            Next
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
…ause

Fixes #30895

This analyzer does not function correctly in presence of VB handles clause due to IOperation bugs #30978 and #30979. This change adds a temporary workaround to the analyzer to handle this case specially.

~~TODO: File a bug to track reverting the temporary workaround once #30978 and #30979 are fixed.~~ Filed https://github.com/dotnet/roslyn/issues/30981