### PR TITLE
Fix the lifetime of IntegrationService

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationService/IntegrationService.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationService/IntegrationService.cs
@@ -68,5 +68,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
             return objectUri;
         }
+
+        // Ensure InProcComponents live forever
+        public override object InitializeLifetimeService()
+            => null;
     }
 }


### PR DESCRIPTION
This should fix errors during integration tests with the following message:

> Failed to write to an IPC Port: The pipe is being closed.

I believe this is the cause due to the following:

1. Prior to the failure, a `RemotingException` is thrown with the following message

    > Requested Service not found

2. The following page suggests the lifetime needs to be provided event when `RemotingServices.Marshal` is used:

    https://social.msdn.microsoft.com/Forums/en-US/b11fd4fb-95fd-43d5-90a9-bb906e54c7d0/object-exposed-with-remotingservicesmarshal-becoming-unavailable-over-time?forum=netfxremoting

📝 Rather than provide an `ISponsor`, I used the infinite-lifetime strategy used by other `InProcComponent` instances.