### PR TITLE
Add some additional shims to VisualStudioProjectTracker

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
@@ -397,7 +397,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             IVsHierarchy hierarchy, uint itemid)
         {
             return new ContainedLanguage<TPackage, TLanguageService>(
-                bufferCoordinator, this.Package.ComponentModel, project, hierarchy, itemid,
+                bufferCoordinator, this.Package.ComponentModel, project, hierarchy, itemid, projectTrackerOpt: null, project.Id,
                 (TLanguageService)this);
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -64,6 +64,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             Hierarchy = hierarchy;
             Guid = projectGuid;
             Language = language;
+            ProjectTracker = projectTracker;
             _visualStudioWorkspace = workspace;
 
             this.DisplayName = hierarchy != null && hierarchy.TryGetName(out var name) ? name : projectSystemName;
@@ -112,9 +113,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         internal HostDiagnosticUpdateSource HostDiagnosticUpdateSource { get; }
 
-        public virtual ProjectId Id => VisualStudioProject.Id;
+        public virtual ProjectId Id => VisualStudioProject?.Id ?? ExplicitId;
+
+        internal ProjectId ExplicitId { get; set; }
 
         public string Language { get; }
+        public VisualStudioProjectTracker ProjectTracker { get; }
 
         /// <summary>
         /// The <see cref="IVsHierarchy"/> for this project.  NOTE: May be null in Deferred Project Load cases.

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
@@ -9,9 +9,14 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
-    [Obsolete("This is a compatibility shim for TypeScript; please do not use it.")]
+    [Obsolete("This is a compatibility shim for TypeScript and Live Share; please do not use it.")]
     internal sealed class DocumentProvider
     {
+        [Obsolete("This is a compatibility shim for Live Share; please do not use it.")]
+        public DocumentProvider(VisualStudioProjectTracker projectTracker, IServiceProvider serviceProvider, VisualStudioDocumentTrackingService documentTrackingService)
+        {
+        }
+
         [Obsolete("This overload is a compatibility shim for TypeScript; please do not use it.")]
         public IVisualStudioHostDocument TryGetDocumentForFile(
             AbstractProject hostProject,

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -3,10 +3,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Extensions;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
@@ -16,22 +18,53 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private readonly VisualStudioProjectFactory _projectFactory;
         internal IThreadingContext ThreadingContext { get; }
 
-        internal ImmutableArray<AbstractProject> ImmutableProjects => ImmutableArray<AbstractProject>.Empty;
+        [Obsolete("This is a compatibility shim for Live Share; please do not use it.")]
+        internal ImmutableArray<AbstractProject> ImmutableProjects => _projects.Values.ToImmutableArray();
 
         internal HostWorkspaceServices WorkspaceServices => _workspace.Services;
 
-        [Obsolete("This is a compatibility shim for TypeScript; please do not use it.")]
-        private readonly Dictionary<ProjectId, AbstractProject> _typeScriptProjects = new Dictionary<ProjectId, AbstractProject>();
+        [Obsolete("This is a compatibility shim for TypeScript and Live Share; please do not use it.")]
+        private readonly Dictionary<ProjectId, AbstractProject> _projects = new Dictionary<ProjectId, AbstractProject>();
 
+        [Obsolete("This is a compatibility shim; please do not use it.")]
         public VisualStudioProjectTracker(Workspace workspace, VisualStudioProjectFactory projectFactory, IThreadingContext threadingContext)
         {
             _workspace = workspace;
             _projectFactory = projectFactory;
             ThreadingContext = threadingContext;
+            DocumentProvider = new DocumentProvider(this, null, null);
+        }
+
+        [Obsolete("This is a compatibility shim for Live Share; please do not use it.")]
+        public VisualStudioProjectTracker(IServiceProvider serviceProvider, Workspace workspace)
+        {
+            _workspace = workspace;
+            ThreadingContext = serviceProvider.GetMefService<IThreadingContext>();
+
+            // This is used by Live Share to target their own workspace which is not the standard VS workspace; as a result this shouldn't have a project factory
+            // at all, because that's only targeting the VisualStudioWorkspace.
+            _projectFactory = null;
+
+            // We don't set DocumentProvider, because Live Share creates their own and then sets it later.
         }
 
         [Obsolete("This is a compatibility shim for TypeScript; please do not use it.")]
-        public DocumentProvider DocumentProvider => new DocumentProvider();
+        public DocumentProvider DocumentProvider { get; set; }
+
+        public Workspace Workspace => _workspace;
+
+        [Obsolete("This is a compatibility shim for Live Share; please do not use it.")]
+        public void InitializeProviders(DocumentProvider documentProvider, VisualStudioMetadataReferenceManager metadataReferenceProvider, VisualStudioRuleSetManager ruleSetFileProvider)
+        {
+            DocumentProvider = documentProvider;
+        }
+
+        [Obsolete("This is a compatibility shim for Live Share; please do not use it.")]
+        public void StartPushingToWorkspaceAndNotifyOfOpenDocuments(IEnumerable<AbstractProject> projects)
+        {
+            // This shim doesn't expect to get actual things passed to it
+            Debug.Assert(!projects.Any());
+        }
 
         /*
           
@@ -62,7 +95,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         public AbstractProject GetProject(ProjectId projectId)
         {
             // HACK: if we have a TypeScript project, they expect to return the real thing deriving from AbstractProject
-            if (_typeScriptProjects.TryGetValue(projectId, out var typeScriptProject))
+            if (_projects.TryGetValue(projectId, out var typeScriptProject))
             {
                 return typeScriptProject;
             }
@@ -110,29 +143,45 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             public override ProjectId Id => _id;
         }
 
-        [Obsolete("This is a compatibility shim for TypeScript; please do not use it.")]
+        [Obsolete("This is a compatibility shim for TypeScript and Live Share; please do not use it.")]
         public void AddProject(AbstractProject project)
         {
-            project.VisualStudioProject = _projectFactory.CreateAndAddToWorkspace(project.ProjectSystemName, project.Language);
-            project.UpdateVisualStudioProjectProperties();
-        
-            _typeScriptProjects[project.Id] = project;
+            if (_projectFactory != null)
+            {
+                project.VisualStudioProject = _projectFactory.CreateAndAddToWorkspace(project.ProjectSystemName, project.Language);
+                project.UpdateVisualStudioProjectProperties();
+            }
+            else
+            {
+                // We don't have an ID, so make something up
+                project.ExplicitId = ProjectId.CreateNewId(project.ProjectSystemName);
+                Workspace.OnProjectAdded(ProjectInfo.Create(project.ExplicitId, VersionStamp.Create(), project.ProjectSystemName, project.ProjectSystemName, project.Language));
+            }
+
+            _projects[project.Id] = project;
         }
 
         [Obsolete("This is a compatibility shim for TypeScript; please do not use it.")]
         public bool ContainsProject(AbstractProject project)
         {
             // This will be set as long as the project has been added and not since removed
-            return project.VisualStudioProject != null;
+            return _projects.Values.Contains(project);
         }
 
         [Obsolete("This is a compatibility shim for TypeScript; please do not use it.")]
         public void RemoveProject(AbstractProject project)
         {
-            _typeScriptProjects.Remove(project.Id);
+            _projects.Remove(project.Id);
 
-            project.VisualStudioProject.RemoveFromWorkspace();
-            project.VisualStudioProject = null;
+            if (project.ExplicitId != null)
+            {
+                Workspace.OnProjectRemoved(project.ExplicitId);
+            }
+            else
+            {
+                project.VisualStudioProject.RemoveFromWorkspace();
+                project.VisualStudioProject = null;
+            }
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         }
 
         private readonly IComponentModel _componentModel;
-        private readonly VisualStudioWorkspace _workspace;
+        private readonly Workspace _workspace;
         private readonly ITextDifferencingSelectorService _differenceSelectorService;
         private readonly HostType _hostType;
         private readonly ReiteratedVersionSnapshotTracker _snapshotTracker;
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             ITextBuffer subjectBuffer,
             ITextBuffer dataBuffer,
             IVsTextBufferCoordinator bufferCoordinator,
-            VisualStudioWorkspace workspace,
+            Workspace workspace,
             VisualStudioProject project,
             IVsHierarchy hierarchy,
             uint itemId,
@@ -179,7 +179,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
         public DocumentId FindProjectDocumentIdWithItemId(uint itemidInsertionPoint)
         {
-            var hierarchy = _workspace.GetHierarchy(_project.Id);
+            // We cast to VisualStudioWorkspace because the expectation is this isn't being used in Live Share workspaces
+            var hierarchy = ((VisualStudioWorkspace)_workspace).GetHierarchy(_project.Id);
 
             foreach (var document in _workspace.CurrentSolution.GetProject(_project.Id).Documents)
             {
@@ -194,7 +195,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
         public uint FindItemIdOfDocument(Document document)
         {
-            var hierarchy = _workspace.GetHierarchy(_project.Id);
+            // We cast to VisualStudioWorkspace because the expectation is this isn't being used in Live Share workspaces
+            var hierarchy = ((VisualStudioWorkspace)_workspace).GetHierarchy(_project.Id);
             return hierarchy.TryGetItemId(_workspace.CurrentSolution.GetDocument(document.Id).FilePath);
         }
 

--- a/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
                 itemid As UInteger,
                 languageService As VisualBasicLanguageService,
                 sourceCodeKind As SourceCodeKind)
-            MyBase.New(bufferCoordinator, componentModel, project, hierarchy, itemid, languageService, VisualBasicHelperFormattingRule.Instance)
+            MyBase.New(bufferCoordinator, componentModel, project, hierarchy, itemid, projectTrackerOpt:=Nothing, project.Id, languageService, VisualBasicHelperFormattingRule.Instance)
         End Sub
 
         Public Function AddStaticEventBinding(pszClassName As String,


### PR DESCRIPTION
Live Share was still using VisualStudioProjectTracker to add projects to their own workspace. This restores enough support for that to work.

**Customer scenario:** try using Live Share with an ASP.NET or C# project. Live Share experience for the C# editing won't work, or might crash.
**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/718112
**Workarounds, if any:** don't use Live Share.
**Risk:** moderate
**Performance impact:** none.

**Is this a regression from a previous update?** Yes.
**Root cause analysis:** Live Share was using some internal code that was changed and refactored for other Dev16 performance work. This fix adds shims for the internal methods they were calling back.
**How was the bug found?** testing by the Live Share team.
**Test documentation updated?** n/a
