### PR TITLE
Partially early bind AsyncMethodBuilderAttribute:

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1550,6 +1550,37 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
+        /// <summary>
+        /// Returns true if the type is generic or non-generic custom task-like type due to the
+        /// [AsyncMethodBuilder(typeof(B))] attribute. It returns the "B".
+        /// </summary>
+        /// <param name="builderArgument">The argument to the <see cref="AsyncMethodBuilderAttribute"/> or null if not a custom task</param>
+        /// <returns>True if this type is a custom task type</returns>
+        /// <remarks>
+        /// The definition of "custom task-like type" is one that has an [AsyncMethodBuilder(typeof(B))] attribute,
+        /// no more, no less. Validation of builder type B is left for elsewhere. This method returns B
+        /// without validation of any kind.
+        /// </remarks>
+        public virtual bool IsCustomTaskType(out object builderArgument)
+        {
+            if (this.Arity < 2)
+            {
+                foreach (var attr in this.GetAttributes())
+                {
+                    if (attr.IsTargetAttribute(this, AttributeDescription.AsyncMethodBuilderAttribute)
+                        && attr.CommonConstructorArguments.Length == 1
+                        && attr.CommonConstructorArguments[0].Kind == TypedConstantKind.Type)
+                    {
+                        builderArgument = attr.CommonConstructorArguments[0].Value;
+                        return true;
+                    }
+                }
+            }
+
+            builderArgument = null;
+            return false;
+        }
+
         #region INamedTypeSymbol Members
 
         int INamedTypeSymbol.Arity

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 diagnostics.Add(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, location, name, tpEnclosing.ContainingType);
                             }
                         }
-                    next:;
+next:;
                     }
                     else if (!typeParameterMismatchReported)
                     {
@@ -599,14 +599,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (CSharpAttributeData.IsTargetEarlyAttribute(arguments.AttributeType, arguments.AttributeSyntax, AttributeDescription.AsyncMethodBuilderAttribute))
             {
                 boundAttribute = arguments.Binder.GetAttribute(arguments.AttributeSyntax, arguments.AttributeType, out hasAnyDiagnostics);
-                if (!boundAttribute.HasErrors)
-                {
-                    var typeData = arguments.GetOrCreateData<CommonTypeEarlyWellKnownAttributeData>();
-                    typeData.AsyncMethodBuilderTarget = boundAttribute.ConstructorArguments.FirstOrDefault();
 
-                    // don't return the attribute. We need to bind it again later for full diagnostic reporting
-                }
+                var typeData = arguments.GetOrCreateData<CommonTypeEarlyWellKnownAttributeData>();
+                typeData.AsyncMethodBuilderTarget = boundAttribute.ConstructorArguments.FirstOrDefault();
 
+                // don't return the attribute. We need to bind it again later for full diagnostic reporting
                 return null;
             }
 
@@ -1200,7 +1197,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 //     we will not emit Obsolete even if Deprecated or Experimental was used.
                 //     we do not want to get into a scenario where different kinds of deprecation are combined together.
                 //
-                if (obsoleteData == null && !this.IsRestrictedType(ignoreSpanLikeTypes:true))
+                if (obsoleteData == null && !this.IsRestrictedType(ignoreSpanLikeTypes: true))
                 {
                     AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_ObsoleteAttribute__ctor,
                         ImmutableArray.Create(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -596,6 +596,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return null;
             }
 
+            if (CSharpAttributeData.IsTargetEarlyAttribute(arguments.AttributeType, arguments.AttributeSyntax, AttributeDescription.AsyncMethodBuilderAttribute))
+            {
+                boundAttribute = arguments.Binder.GetAttribute(arguments.AttributeSyntax, arguments.AttributeType, out hasAnyDiagnostics);
+                if (!boundAttribute.HasErrors)
+                {
+                    var typeData = arguments.GetOrCreateData<CommonTypeEarlyWellKnownAttributeData>();
+                    typeData.AsyncMethodBuilderTarget = boundAttribute.ConstructorArguments.FirstOrDefault();
+
+                    // don't return the attribute. We need to bind it again later for full diagnostic reporting
+                }
+
+                return null;
+            }
+
             return base.EarlyDecodeWellKnownAttribute(ref arguments);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1442,54 +1442,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// Returns true if the type is generic or non-generic custom task-like type due to the
-        /// [AsyncMethodBuilder(typeof(B))] attribute. It returns the "B".
-        /// </summary>
-        /// <remarks>
-        /// For the Task types themselves, this method might return true or false depending on mscorlib.
-        /// The definition of "custom task-like type" is one that has an [AsyncMethodBuilder(typeof(B))] attribute,
-        /// no more, no less. Validation of builder type B is left for elsewhere. This method returns B
-        /// without validation of any kind.
-        /// </remarks>
-        internal static bool IsCustomTaskType(this NamedTypeSymbol type, out object builderArgument)
-        {
-            Debug.Assert((object)type != null);
-
-            var arity = type.Arity;
-            if (arity < 2)
-            {
-                // special case for SourceNamedTypeSymbol which early decodes method builder to prevent possible binding loops
-                if (type is SourceNamedTypeSymbol namedTypeSymbol)
-                {
-                    var earlyDecodeData = namedTypeSymbol.GetEarlyDecodedWellKnownAttributeData();
-                    if (earlyDecodeData != null 
-                        && earlyDecodeData.AsyncMethodBuilderTarget.Kind == TypedConstantKind.Type)
-                    {
-                        builderArgument = namedTypeSymbol.GetEarlyDecodedWellKnownAttributeData().AsyncMethodBuilderTarget.Value;
-                        return true;
-                    }
-                }
-                else
-                {
-                    // Find the AsyncBuilder attribute.
-                    foreach (var attr in type.GetAttributes())
-                    {
-                        if (attr.IsTargetAttribute(type, AttributeDescription.AsyncMethodBuilderAttribute)
-                            && attr.CommonConstructorArguments.Length == 1
-                            && attr.CommonConstructorArguments[0].Kind == TypedConstantKind.Type)
-                        {
-                            builderArgument = attr.CommonConstructorArguments[0].Value;
-                            return true;
-                        }
-                    }
-                }
-            }
-
-            builderArgument = null;
-            return false;
-        }
-
-        /// <summary>
         /// Replace Task-like types with Task types.
         /// </summary>
         internal static TypeSymbol NormalizeTaskTypes(this TypeSymbol type, CSharpCompilation compilation)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1463,7 +1463,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     var earlyDecodeData = namedTypeSymbol.GetEarlyDecodedWellKnownAttributeData();
                     if (earlyDecodeData != null 
-                        && !earlyDecodeData.AsyncMethodBuilderTarget.IsNull 
                         && earlyDecodeData.AsyncMethodBuilderTarget.Kind == TypedConstantKind.Type)
                     {
                         builderArgument = namedTypeSymbol.GetEarlyDecodedWellKnownAttributeData().AsyncMethodBuilderTarget.Value;

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeEarlyWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeEarlyWellKnownAttributeData.cs
@@ -109,5 +109,26 @@ namespace Microsoft.CodeAnalysis
             }
         }
         #endregion
+
+        #region AsyncMethodBuilderAttribute
+
+        private TypedConstant _asyncMethodBuilderTarget = default;
+
+        public TypedConstant AsyncMethodBuilderTarget
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _asyncMethodBuilderTarget;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _asyncMethodBuilderTarget = value;
+                SetDataStored();
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
- Perform early binding on AsyncMethodBuilder attribute for SourceNamedTypeSymbol to store the target type
- Discard the partially early bound attribute so it wil still be bound later with fully reported diagnostics
- When checking for task like, special case SourceNamedTypeSymbol to check the early bound data instead of getting all the attributes
- Add a test to show repro

Fixes #27228