### PR TITLE
Add CFG based dataflow analysis framework to the Workspaces layer

### DIFF
--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -198,7 +198,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             // NOTE: This flow graph walking algorithm has been forked into Workspaces layer's
             //       implementation of "CustomDataFlowAnalysis",
             //       we should keep them in sync as much as possible.
-
             var continueDispatchAfterFinally = PooledDictionary<ControlFlowRegion, bool>.GetInstance();
             var dispatchedExceptionsFromRegions = PooledHashSet<ControlFlowRegion>.GetInstance();
             MarkReachableBlocks(blocks, firstBlockOrdinal: 0, lastBlockOrdinal: blocks.Count - 1,

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -195,6 +195,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
         private static void MarkReachableBlocks(ArrayBuilder<BasicBlockBuilder> blocks)
         {
+            // NOTE: This flow graph walking algorithm has been forked into Workspaces layer's
+            //       implementation of "CustomDataFlowAnalysis",
+            //       we should keep them in sync as much as possible.
+
             var continueDispatchAfterFinally = PooledDictionary<ControlFlowRegion, bool>.GetInstance();
             var dispatchedExceptionsFromRegions = PooledHashSet<ControlFlowRegion>.GetInstance();
             MarkReachableBlocks(blocks, firstBlockOrdinal: 0, lastBlockOrdinal: blocks.Count - 1,

--- a/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
@@ -73,6 +73,16 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             var actualFlowGraph = GetFlowGraph(compilation, graph);
             OperationTreeVerifier.Verify(expectedFlowGraph, actualFlowGraph);
+
+            // Basic block reachability analysis verification using a test-only dataflow analyzer
+            // that uses the dataflow analysis engine linked from the Workspaces layer.
+            // This provides test coverage for Workspace layer dataflow analysis engine
+            // for all ContolFlowGraphs created in compiler layer's flow analysis unit tests.
+            var reachabilityVector = BasicBlockReachabilityDataFlowAnalyzer.Run(graph);
+            for (int i = 0; i < graph.Blocks.Length; i++)
+            {
+                Assert.Equal(graph.Blocks[i].IsReachable, reachabilityVector[i]);
+            }
         }
 
         public static string GetFlowGraph(Compilation compilation, ControlFlowGraph graph)

--- a/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             // Basic block reachability analysis verification using a test-only dataflow analyzer
             // that uses the dataflow analysis engine linked from the Workspaces layer.
             // This provides test coverage for Workspace layer dataflow analysis engine
-            // for all ContolFlowGraphs created in compiler layer's flow analysis unit tests.
+            // for all ControlFlowGraphs created in compiler layer's flow analysis unit tests.
             var reachabilityVector = BasicBlockReachabilityDataFlowAnalyzer.Run(graph);
             for (int i = 0; i < graph.Blocks.Length; i++)
             {

--- a/src/Test/Utilities/Portable/Compilation/FlowAnalysis/BasicBlockReachabilityDataFlowAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Compilation/FlowAnalysis/BasicBlockReachabilityDataFlowAnalyzer.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis
+{
+    internal sealed class BasicBlockReachabilityDataFlowAnalyzer : DataFlowAnalyzer<bool>
+    {
+        private BitVector _visited = BitVector.Empty;
+        private BasicBlockReachabilityDataFlowAnalyzer() { }
+
+        public static BitVector Run(ControlFlowGraph controlFlowGraph)
+        {
+            var analyzer = new BasicBlockReachabilityDataFlowAnalyzer();
+            _ = CustomDataFlowAnalysis<bool>.Run(controlFlowGraph, analyzer, CancellationToken.None);
+            return analyzer._visited;
+        }
+
+        // Do not analyze unreachable control flow branches and blocks.
+        // This way all blocks that are called back to be analyzed in AnalyzeBlock are reachable
+        // and the remaining blocks are unreachable. 
+        public override bool AnalyzeUnreachableBlocks => false;
+
+        public override bool AnalyzeBlock(BasicBlock basicBlock, CancellationToken cancellationToken)
+        {
+            SetCurrentAnalysisData(basicBlock, isReachable: true);
+            return true;
+        }
+
+        public override bool AnalyzeNonConditionalBranch(BasicBlock basicBlock, bool currentIsReachable, CancellationToken cancellationToken)
+        {
+            // Feasibility of control flow branches is analyzed by the core CustomDataFlowAnalysis
+            // walker. If it identifies a branch as infeasible, it never invokes
+            // this callback.
+            // Assert that we are on a reachable control flow path, and retain the current reachability.
+            Debug.Assert(currentIsReachable);
+
+            return currentIsReachable;
+        }
+
+        public override (bool fallThroughSuccessorData, bool conditionalSuccessorData) AnalyzeConditionalBranch(
+            BasicBlock basicBlock,
+            bool currentIsReachable,
+            CancellationToken cancellationToken)
+        {
+            // Feasibility of control flow branches is analyzed by the core CustomDataFlowAnalysis
+            // walker. If it identifies a branch as infeasible, it never invokes
+            // this callback.
+            // Assert that we are on a reachable control flow path, and retain the current reachability
+            // for both the destination blocks.
+            Debug.Assert(currentIsReachable);
+
+            return (currentIsReachable, currentIsReachable);
+        }
+
+        public override void SetCurrentAnalysisData(BasicBlock basicBlock, bool isReachable)
+        {
+            _visited[basicBlock.Ordinal] = isReachable;
+        }
+
+        public override bool GetCurrentAnalysisData(BasicBlock basicBlock) => _visited[basicBlock.Ordinal];
+
+        // A basic block is considered unreachable by default.
+        public override bool GetEmptyAnalysisData() => false;
+
+        // Destination block is reachable if either of the precedecessor blocks are reachable.
+        public override bool Merge(bool predecessor1IsReachable, bool predecessor2IsReachable, CancellationToken cancellationToken)
+            => predecessor1IsReachable || predecessor2IsReachable;
+
+        public override bool IsEqual(bool isReachable1, bool isReachable2)
+            => isReachable1 == isReachable2;
+    }
+}

--- a/src/Test/Utilities/Portable/Roslyn.Test.Utilities.csproj
+++ b/src/Test/Utilities/Portable/Roslyn.Test.Utilities.csproj
@@ -82,6 +82,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>TestResource.resx</DependentUpon>
     </Compile>
+    <Compile Include="..\..\..\Workspaces\Core\Portable\Extensions\ControlFlowRegionExtensions.cs" Link="Compilation\FlowAnalysis\ControlFlowRegionExtensions.cs" />
+    <Compile Include="..\..\..\Workspaces\Core\Portable\FlowAnalysis\CustomDataFlowAnalysis.cs" Link="Compilation\FlowAnalysis\CustomDataFlowAnalysis.cs" />
+    <Compile Include="..\..\..\Workspaces\Core\Portable\FlowAnalysis\DataFlowAnalyzer.cs" Link="Compilation\FlowAnalysis\DataFlowAnalyzer.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="TestResource.resx">

--- a/src/Workspaces/Core/Portable/Extensions/BasicBlockExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/BasicBlockExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis
+{
+    internal static partial class BasicBlockExtensions
+    {
+        public static IEnumerable<IOperation> DescendantOperations(this BasicBlock basicBlock)
+        {
+            foreach (var statement in basicBlock.Operations)
+            {
+                foreach (var operation in statement.DescendantsAndSelf())
+                {
+                    yield return operation;
+                }
+            }
+
+            if (basicBlock.BranchValue != null)
+            {
+                foreach (var operation in basicBlock.BranchValue.DescendantsAndSelf())
+                {
+                    yield return operation;
+                }
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Extensions/ControlFlowGraphExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/ControlFlowGraphExtensions.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis
+{
+    internal static partial class ControlFlowGraphExtensions
+    {
+        public static BasicBlock EntryBlock(this ControlFlowGraph cfg)
+        {
+            var firstBlock = cfg.Blocks[0];
+            Debug.Assert(firstBlock.Kind == BasicBlockKind.Entry);
+            return firstBlock;
+        }
+
+        public static BasicBlock ExitBlock(this ControlFlowGraph cfg)
+        {
+            var lastBlock = cfg.Blocks[cfg.Blocks.Length - 1];
+            Debug.Assert(lastBlock.Kind == BasicBlockKind.Exit);
+            return lastBlock;
+        }
+
+        public static IEnumerable<IOperation> DescendantOperations(this ControlFlowGraph cfg)
+        {
+            foreach (BasicBlock block in cfg.Blocks)
+            {
+                foreach (IOperation operation in block.DescendantOperations())
+                {
+                    yield return operation;
+                }
+            }
+        }
+
+        public static IEnumerable<T> DescendantOperations<T>(this ControlFlowGraph cfg, OperationKind operationKind)
+            where T : IOperation
+        {
+            Debug.Assert(cfg != null);
+
+            foreach (var descendant in cfg.DescendantOperations())
+            {
+                if (descendant?.Kind == operationKind)
+                {
+                    yield return (T)descendant;
+                }
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Extensions/ControlFlowGraphExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/ControlFlowGraphExtensions.cs
@@ -2,6 +2,8 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis.Utilities;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis
 {
@@ -16,34 +18,16 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
         public static BasicBlock ExitBlock(this ControlFlowGraph cfg)
         {
-            var lastBlock = cfg.Blocks[cfg.Blocks.Length - 1];
+            var lastBlock = cfg.Blocks.Last();
             Debug.Assert(lastBlock.Kind == BasicBlockKind.Exit);
             return lastBlock;
         }
 
         public static IEnumerable<IOperation> DescendantOperations(this ControlFlowGraph cfg)
-        {
-            foreach (BasicBlock block in cfg.Blocks)
-            {
-                foreach (IOperation operation in block.DescendantOperations())
-                {
-                    yield return operation;
-                }
-            }
-        }
+            => cfg.Blocks.SelectMany(b => b.DescendantOperations());
 
         public static IEnumerable<T> DescendantOperations<T>(this ControlFlowGraph cfg, OperationKind operationKind)
             where T : IOperation
-        {
-            Debug.Assert(cfg != null);
-
-            foreach (var descendant in cfg.DescendantOperations())
-            {
-                if (descendant?.Kind == operationKind)
-                {
-                    yield return (T)descendant;
-                }
-            }
-        }
+            => cfg.DescendantOperations().Where(d => d?.Kind == operationKind).Cast<T>();
     }
 }

--- a/src/Workspaces/Core/Portable/Extensions/ControlFlowRegionExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/ControlFlowRegionExtensions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis
+{
+    internal static partial class ControlFlowRegionExtensions
+    {
+        internal static bool ContainsBlock(this ControlFlowRegion region, int destinationOrdinal)
+        {
+            return region.FirstBlockOrdinal <= destinationOrdinal && region.LastBlockOrdinal >= destinationOrdinal;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
@@ -1,16 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
-using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Simplification;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
             | typeof(x)       |      |       |             |             |       ✔️        | ️
             | out var x       |      |  ✔️   |             |             |                 | ️
             | case X x:       |      |  ✔️   |             |             |                 | ️
-            | obj is X x      |  ✔️  |  ✔️   |             |             |                 |
+            | obj is X x      |      |  ✔️   |             |             |                 |
 
             */
             if (operation is ILocalReferenceOperation localReference &&
@@ -68,15 +68,15 @@ namespace Microsoft.CodeAnalysis
 
                     case IIsPatternOperation _:
                         // A declaration pattern within an is pattern is a
-                        // both a write and read for the declared local.
-                        // For example, 'x' is both written and read in the following expression:
+                        // write for the declared local.
+                        // For example, 'x' is defined and assigned the value from 'obj' below:
                         //      if (obj is X x)
                         //
-                        return ValueUsageInfo.ReadWrite;
+                        return ValueUsageInfo.Write;
 
                     default:
                         Debug.Fail("Unhandled declaration pattern context");
-                        
+
                         // Conservatively assume read/write.
                         return ValueUsageInfo.ReadWrite;
                 }

--- a/src/Workspaces/Core/Portable/FlowAnalysis/CustomDataFlowAnalysis.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/CustomDataFlowAnalysis.cs
@@ -1,0 +1,394 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis
+{
+    internal static class CustomDataFlowAnalysis<TBlockAnalysisData>
+    {
+        /// <summary>
+        /// Runs dataflow analysis for the given <paramref name="analyzer"/> on the given <paramref name="controlFlowGraph"/>.
+        /// </summary>
+        /// <param name="controlFlowGraph">Control flow graph on which to execute analysis.</param>
+        /// <param name="analyzer">Dataflow analyzer.</param>
+        /// <returns>Block analysis data at the end of the exit block.</returns>
+        public static TBlockAnalysisData Run(ControlFlowGraph controlFlowGraph, DataFlowAnalyzer<TBlockAnalysisData> analyzer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var blocks = controlFlowGraph.Blocks;
+            var continueDispatchAfterFinally = PooledDictionary<ControlFlowRegion, bool>.GetInstance();
+            var dispatchedExceptionsFromRegions = PooledHashSet<ControlFlowRegion>.GetInstance();
+            int firstBlockOrdinal = 0;
+            int lastBlockOrdinal = blocks.Length - 1;
+
+            var unreachableBlocksToVisit = ArrayBuilder<BasicBlock>.GetInstance();
+            if (analyzer.AnalyzeUnreachableBlocks)
+            {
+                for (int i = firstBlockOrdinal; i <= lastBlockOrdinal; i++)
+                {
+                    if (!blocks[i].IsReachable)
+                    {
+                        unreachableBlocksToVisit.Add(blocks[i]);
+                    }
+                }
+            }
+
+            var initialAnalysisData = analyzer.GetCurrentAnalysisData(blocks[0]);
+            if (initialAnalysisData == default)
+            {
+                initialAnalysisData = analyzer.GetEmptyAnalysisData();
+            }
+
+            var result = RunCore(blocks, analyzer, firstBlockOrdinal, lastBlockOrdinal,
+                                 initialAnalysisData,
+                                 unreachableBlocksToVisit,
+                                 outOfRangeBlocksToVisit: null,
+                                 continueDispatchAfterFinally,
+                                 dispatchedExceptionsFromRegions,
+                                 cancellationToken);
+            Debug.Assert(unreachableBlocksToVisit.Count == 0);
+            unreachableBlocksToVisit.Free();
+            continueDispatchAfterFinally.Free();
+            dispatchedExceptionsFromRegions.Free();
+            return result;
+        }
+
+        private static TBlockAnalysisData RunCore(
+            ImmutableArray<BasicBlock> blocks,
+            DataFlowAnalyzer<TBlockAnalysisData> analyzer,
+            int firstBlockOrdinal,
+            int lastBlockOrdinal,
+            TBlockAnalysisData initialAnalysisData,
+            ArrayBuilder<BasicBlock> unreachableBlocksToVisit,
+            SortedSet<int> outOfRangeBlocksToVisit,
+            PooledDictionary<ControlFlowRegion, bool> continueDispatchAfterFinally,
+            PooledHashSet<ControlFlowRegion> dispatchedExceptionsFromRegions,
+            CancellationToken cancellationToken)
+        {
+            var toVisit = new SortedSet<int>();
+
+            var firstBlock = blocks[firstBlockOrdinal];
+            analyzer.SetCurrentAnalysisData(firstBlock, initialAnalysisData);
+            toVisit.Add(firstBlock.Ordinal);
+
+            var processedBlocks = PooledHashSet<BasicBlock>.GetInstance();
+            TBlockAnalysisData resultAnalysisData = default;
+
+            do
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                BasicBlock current;
+                if (toVisit.Count > 0)
+                {
+                    var min = toVisit.Min;
+                    toVisit.Remove(min);
+                    current = blocks[min];
+                }
+                else
+                {
+                    int index;
+                    current = null;
+                    for (index = 0; index < unreachableBlocksToVisit.Count; index++)
+                    {
+                        var unreachableBlock = unreachableBlocksToVisit[index];
+                        if (unreachableBlock.Ordinal >= firstBlockOrdinal && unreachableBlock.Ordinal <= lastBlockOrdinal)
+                        {
+                            current = unreachableBlock;
+                            break;
+                        }
+                    }
+
+                    if (current == null)
+                    {
+                        continue;
+                    }
+
+                    unreachableBlocksToVisit.RemoveAt(index);
+                    if (processedBlocks.Contains(current))
+                    {
+                        // Already processed from a branch from another unreachable block.
+                        continue;
+                    }
+
+                    analyzer.SetCurrentAnalysisData(current, analyzer.GetEmptyAnalysisData());
+                }
+
+                if (current.Ordinal < firstBlockOrdinal || current.Ordinal > lastBlockOrdinal)
+                {
+                    outOfRangeBlocksToVisit.Add(current.Ordinal);
+                    continue;
+                }
+
+                if (current.Ordinal == current.EnclosingRegion.FirstBlockOrdinal)
+                {
+                    // We are revisiting first block of a region, so we need to again dispatch exceptions from region.
+                    dispatchedExceptionsFromRegions.Remove(current.EnclosingRegion);
+                }
+
+                TBlockAnalysisData fallThroughAnalysisData = analyzer.AnalyzeBlock(current, cancellationToken);
+                bool fallThroughSuccessorIsReachable = true;
+
+                if (current.ConditionKind != ControlFlowConditionKind.None)
+                {
+                    TBlockAnalysisData conditionalSuccessorAnalysisData;
+                    (fallThroughAnalysisData, conditionalSuccessorAnalysisData) = analyzer.AnalyzeConditionalBranch(current, fallThroughAnalysisData, cancellationToken);
+
+                    bool conditionalSuccesorIsReachable = true;
+                    if (current.BranchValue.ConstantValue.HasValue && current.BranchValue.ConstantValue.Value is bool constant)
+                    {
+                        if (constant == (current.ConditionKind == ControlFlowConditionKind.WhenTrue))
+                        {
+                            fallThroughSuccessorIsReachable = false;
+                        }
+                        else
+                        {
+                            conditionalSuccesorIsReachable = false;
+                        }
+                    }
+
+                    if (conditionalSuccesorIsReachable || analyzer.AnalyzeUnreachableBlocks)
+                    {
+                        FollowBranch(current, current.ConditionalSuccessor, conditionalSuccessorAnalysisData);
+                    }
+                }
+                else
+                {
+                    fallThroughAnalysisData = analyzer.AnalyzeNonConditionalBranch(current, fallThroughAnalysisData, cancellationToken);
+                }
+
+                if (fallThroughSuccessorIsReachable || analyzer.AnalyzeUnreachableBlocks)
+                {
+                    ControlFlowBranch branch = current.FallThroughSuccessor;
+                    FollowBranch(current, branch, fallThroughAnalysisData);
+
+                    if (current.EnclosingRegion.Kind == ControlFlowRegionKind.Finally &&
+                        current.Ordinal == lastBlockOrdinal)
+                    {
+                        continueDispatchAfterFinally[current.EnclosingRegion] = branch.Semantics != ControlFlowBranchSemantics.Throw &&
+                            branch.Semantics != ControlFlowBranchSemantics.Rethrow &&
+                            current.FallThroughSuccessor.Semantics == ControlFlowBranchSemantics.StructuredExceptionHandling;
+                    }
+                }
+
+                if (current.Ordinal == lastBlockOrdinal)
+                {
+                    resultAnalysisData = fallThroughAnalysisData;
+                }
+
+                // We are using very simple approach: 
+                // If try block is reachable, we should dispatch an exception from it, even if it is empty.
+                // To simplify implementation, we dispatch exception from every reachable basic block and rely
+                // on dispatchedExceptionsFromRegions cache to avoid doing duplicate work.
+                DispatchException(current.EnclosingRegion);
+
+                processedBlocks.Add(current);
+            }
+            while (toVisit.Count != 0 || unreachableBlocksToVisit.Count != 0);
+
+            return resultAnalysisData;
+
+            // Local functions.
+            void FollowBranch(BasicBlock current, ControlFlowBranch branch, TBlockAnalysisData currentAnalsisData)
+            {
+                if (branch == null)
+                {
+                    return;
+                }
+
+                switch (branch.Semantics)
+                {
+                    case ControlFlowBranchSemantics.None:
+                    case ControlFlowBranchSemantics.ProgramTermination:
+                    case ControlFlowBranchSemantics.StructuredExceptionHandling:
+                    case ControlFlowBranchSemantics.Throw:
+                    case ControlFlowBranchSemantics.Rethrow:
+                    case ControlFlowBranchSemantics.Error:
+                        Debug.Assert(branch.Destination == null);
+                        return;
+
+                    case ControlFlowBranchSemantics.Regular:
+                    case ControlFlowBranchSemantics.Return:
+                        Debug.Assert(branch.Destination != null);
+
+                        if (StepThroughFinally(current.EnclosingRegion, branch.Destination, ref currentAnalsisData))
+                        {
+                            var destination = branch.Destination;
+                            var currentDestinationData = analyzer.GetCurrentAnalysisData(destination);
+                            var mergedAnalysisData = analyzer.Merge(currentDestinationData, currentAnalsisData, cancellationToken);
+                            // We need to analyze the destination block if both the following conditions are met:
+                            //  1. Either the current block is reachable both destination and current are non-reachable
+                            //  2. Either the new analysis data for destination has changed or destination block hasn't
+                            //     been processed.
+                            if ((current.IsReachable || !destination.IsReachable) &&
+                                (!analyzer.IsEqual(currentDestinationData, mergedAnalysisData) || !processedBlocks.Contains(destination)))
+                            {
+                                analyzer.SetCurrentAnalysisData(destination, mergedAnalysisData);
+                                toVisit.Add(branch.Destination.Ordinal);
+                            }
+                        }
+
+                        return;
+
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(branch.Semantics);
+                }
+            }
+
+            // Returns whether we should proceed to the destination after finallies were taken care of.
+            bool StepThroughFinally(ControlFlowRegion region, BasicBlock destination, ref TBlockAnalysisData currentAnalysisData)
+            {
+                int destinationOrdinal = destination.Ordinal;
+                while (!region.ContainsBlock(destinationOrdinal))
+                {
+                    Debug.Assert(region.Kind != ControlFlowRegionKind.Root);
+                    ControlFlowRegion enclosing = region.EnclosingRegion;
+                    if (region.Kind == ControlFlowRegionKind.Try && enclosing.Kind == ControlFlowRegionKind.TryAndFinally)
+                    {
+                        Debug.Assert(enclosing.NestedRegions[0] == region);
+                        Debug.Assert(enclosing.NestedRegions[1].Kind == ControlFlowRegionKind.Finally);
+                        if (!StepThroughSingleFinally(enclosing.NestedRegions[1], ref currentAnalysisData))
+                        {
+                            // The point that continues dispatch is not reachable. Cancel the dispatch.
+                            return false;
+                        }
+                    }
+
+                    region = enclosing;
+                }
+
+                return true;
+            }
+
+            // Returns whether we should proceed with dispatch after finally was taken care of.
+            bool StepThroughSingleFinally(ControlFlowRegion @finally, ref TBlockAnalysisData currentAnalysisData)
+            {
+                Debug.Assert(@finally.Kind == ControlFlowRegionKind.Finally);
+                var previousAnalysisData = analyzer.GetCurrentAnalysisData(blocks[@finally.FirstBlockOrdinal]);
+                var mergedAnalysisData = analyzer.Merge(previousAnalysisData, currentAnalysisData, cancellationToken);
+                if (!analyzer.IsEqual(previousAnalysisData, mergedAnalysisData))
+                {
+                    // For simplicity, we do a complete walk of the finally/filter region in isolation
+                    // to make sure that the resume dispatch point is reachable from its beginning.
+                    // It could also be reachable through invalid branches into the finally and we don't want to consider 
+                    // these cases for regular finally handling.
+                    currentAnalysisData = RunCore(blocks,
+                                                  analyzer,
+                                                  @finally.FirstBlockOrdinal,
+                                                  @finally.LastBlockOrdinal,
+                                                  mergedAnalysisData,
+                                                  unreachableBlocksToVisit,
+                                                  outOfRangeBlocksToVisit: toVisit,
+                                                  continueDispatchAfterFinally,
+                                                  dispatchedExceptionsFromRegions,
+                                                  cancellationToken);
+                }
+
+                if (!continueDispatchAfterFinally.TryGetValue(@finally, out bool dispatch))
+                {
+                    dispatch = false;
+                    continueDispatchAfterFinally.Add(@finally, false);
+                }
+
+                return dispatch;
+            }
+
+            void DispatchException(ControlFlowRegion fromRegion)
+            {
+                do
+                {
+                    if (!dispatchedExceptionsFromRegions.Add(fromRegion))
+                    {
+                        return;
+                    }
+
+                    ControlFlowRegion enclosing = fromRegion.Kind == ControlFlowRegionKind.Root ? null : fromRegion.EnclosingRegion;
+                    if (fromRegion.Kind == ControlFlowRegionKind.Try)
+                    {
+                        switch (enclosing.Kind)
+                        {
+                            case ControlFlowRegionKind.TryAndFinally:
+                                Debug.Assert(enclosing.NestedRegions[0] == fromRegion);
+                                Debug.Assert(enclosing.NestedRegions[1].Kind == ControlFlowRegionKind.Finally);
+                                var currentAnalysisData = analyzer.GetCurrentAnalysisData(blocks[fromRegion.FirstBlockOrdinal]);
+                                if (!StepThroughSingleFinally(enclosing.NestedRegions[1], ref currentAnalysisData))
+                                {
+                                    // The point that continues dispatch is not reachable. Cancel the dispatch.
+                                    return;
+                                }
+                                break;
+
+                            case ControlFlowRegionKind.TryAndCatch:
+                                Debug.Assert(enclosing.NestedRegions[0] == fromRegion);
+                                DispatchExceptionThroughCatches(enclosing, startAt: 1);
+                                break;
+
+                            default:
+                                throw ExceptionUtilities.UnexpectedValue(enclosing.Kind);
+                        }
+                    }
+                    else if (fromRegion.Kind == ControlFlowRegionKind.Filter)
+                    {
+                        // If filter throws, dispatch is resumed at the next catch with an original exception
+                        Debug.Assert(enclosing.Kind == ControlFlowRegionKind.FilterAndHandler);
+                        ControlFlowRegion tryAndCatch = enclosing.EnclosingRegion;
+                        Debug.Assert(tryAndCatch.Kind == ControlFlowRegionKind.TryAndCatch);
+
+                        int index = tryAndCatch.NestedRegions.IndexOf(enclosing, startIndex: 1);
+
+                        if (index > 0)
+                        {
+                            DispatchExceptionThroughCatches(tryAndCatch, startAt: index + 1);
+                            fromRegion = tryAndCatch;
+                            continue;
+                        }
+
+                        throw ExceptionUtilities.Unreachable;
+                    }
+
+                    fromRegion = enclosing;
+                }
+                while (fromRegion != null);
+            }
+
+            void DispatchExceptionThroughCatches(ControlFlowRegion tryAndCatch, int startAt)
+            {
+                // For simplicity, we do not try to figure out whether a catch clause definitely
+                // handles all exceptions.
+
+                Debug.Assert(tryAndCatch.Kind == ControlFlowRegionKind.TryAndCatch);
+                Debug.Assert(startAt > 0);
+                Debug.Assert(startAt <= tryAndCatch.NestedRegions.Length);
+
+                for (int i = startAt; i < tryAndCatch.NestedRegions.Length; i++)
+                {
+                    ControlFlowRegion @catch = tryAndCatch.NestedRegions[i];
+
+                    switch (@catch.Kind)
+                    {
+                        case ControlFlowRegionKind.Catch:
+                            toVisit.Add(@catch.FirstBlockOrdinal);
+                            break;
+
+                        case ControlFlowRegionKind.FilterAndHandler:
+                            BasicBlock entryBlock = blocks[@catch.FirstBlockOrdinal];
+                            Debug.Assert(@catch.NestedRegions[0].Kind == ControlFlowRegionKind.Filter);
+                            Debug.Assert(entryBlock.Ordinal == @catch.NestedRegions[0].FirstBlockOrdinal);
+
+                            toVisit.Add(entryBlock.Ordinal);
+                            break;
+
+                        default:
+                            throw ExceptionUtilities.UnexpectedValue(@catch.Kind);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FlowAnalysis/CustomDataFlowAnalysis.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/CustomDataFlowAnalysis.cs
@@ -17,6 +17,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// <param name="controlFlowGraph">Control flow graph on which to execute analysis.</param>
         /// <param name="analyzer">Dataflow analyzer.</param>
         /// <returns>Block analysis data at the end of the exit block.</returns>
+        /// <remarks>
+        /// Algorithm for this CFG walker has been forked from <see cref="ControlFlowGraphBuilder"/>'s internal
+        /// implementation for basic block reachability computation: "MarkReachableBlocks",
+        /// we should keep them in sync as much as possible.
+        /// </remarks>
         public static TBlockAnalysisData Run(ControlFlowGraph controlFlowGraph, DataFlowAnalyzer<TBlockAnalysisData> analyzer, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Workspaces/Core/Portable/FlowAnalysis/DataFlowAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/DataFlowAnalyzer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         public abstract void SetCurrentAnalysisData(BasicBlock basicBlock, TBlockAnalysisData data);
 
         /// <summary>
-        /// Analyze the given basic block and return the block analysis data at the end of the block for it's succesors.
+        /// Analyze the given basic block and return the block analysis data at the end of the block for its successors.
         /// </summary>
         public abstract TBlockAnalysisData AnalyzeBlock(BasicBlock basicBlock, CancellationToken cancellationToken);
 

--- a/src/Workspaces/Core/Portable/FlowAnalysis/DataFlowAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/DataFlowAnalyzer.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis
+{
+    /// <summary>
+    /// Analyzer to execute custom dataflow analysis on a control flow graph.
+    /// </summary>
+    /// <typeparam name="TBlockAnalysisData">Custom data tracked for each basic block with values at start of the block.</typeparam>
+    internal abstract class DataFlowAnalyzer<TBlockAnalysisData> : IDisposable
+    {
+        /// <summary>
+        /// Gets current analysis data for the given basic block.
+        /// </summary>
+        public abstract TBlockAnalysisData GetCurrentAnalysisData(BasicBlock basicBlock);
+
+        /// <summary>
+        /// Gets empty analysis data for first analysis pass on a basic block.
+        /// </summary>
+        public abstract TBlockAnalysisData GetEmptyAnalysisData();
+
+        /// <summary>
+        /// Updates the current analysis data for the given basic block.
+        /// </summary>
+        public abstract void SetCurrentAnalysisData(BasicBlock basicBlock, TBlockAnalysisData data);
+
+        /// <summary>
+        /// Analyze the given basic block and return the block analysis data at the end of the block for it's succesors.
+        /// </summary>
+        public abstract TBlockAnalysisData AnalyzeBlock(BasicBlock basicBlock, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Analyze the non-conditional fallthrough successor branch for the given basic block
+        /// and return the block analysis data for the branch destination.
+        /// </summary>
+        public abstract TBlockAnalysisData AnalyzeNonConditionalBranch(BasicBlock basicBlock, TBlockAnalysisData currentAnalysisData, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Analyze the given conditional branch for the given basic block and return the
+        /// block analysis data for the branch destinations for the fallthrough and
+        /// conditional successor branches.
+        /// </summary>
+        public abstract (TBlockAnalysisData fallThroughSuccessorData, TBlockAnalysisData conditionalSuccessorData) AnalyzeConditionalBranch(
+            BasicBlock basicBlock, TBlockAnalysisData currentAnalysisData, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Merge the given block analysis data instances to produce the resultant merge data.
+        /// </summary>
+        public abstract TBlockAnalysisData Merge(TBlockAnalysisData analysisData1, TBlockAnalysisData analysisData2, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Returns true if both the given block analysis data instances should be considered equivalent by analysis.
+        /// </summary>
+        public abstract bool IsEqual(TBlockAnalysisData analysisData1, TBlockAnalysisData analysisData2);
+
+        /// <summary>
+        /// Flag indicating if the dataflow analysis should run on unreachable blocks.
+        /// </summary>
+        public abstract bool AnalyzeUnreachableBlocks { get; }
+
+        public virtual void Dispose()
+        {
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FlowAnalysis/LValueFlowCaptureProvider.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/LValueFlowCaptureProvider.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis
+{
+    /// <summary>
+    /// Helper class to detect <see cref="IFlowCaptureOperation"/>s that are l-value captures.
+    /// L-value captures are essentially captures of a symbol's location/address.
+    /// Corresponding <see cref="IFlowCaptureReferenceOperation"/>s which share the same
+    /// <see cref="CaptureId"/> as this flow capture, dereferences and writes to this locaion
+    /// subsequently in the flow graph.
+    /// For example, consider the below code:
+    ///     a[i] = x ?? a[j];
+    /// The control flow graph contains an initial flow capture of "a[i]" to capture the l-value
+    /// of this array element:
+    ///     FC0 (a[i])
+    /// Then it evaluates the right hand side, which can have different
+    /// values on different control flow paths, and the resultant value is then written
+    /// to the captured location:
+    ///     FCR0 = result
+    /// </summary>
+    /// <remarks>
+    /// NOTE: This type is a temporary workaround for https://github.com/dotnet/roslyn/issues/31007
+    /// and it can be deleted once that feature is implemented.
+    /// </remarks>
+    internal static class LValueFlowCapturesProvider
+    {
+        public static ImmutableHashSet<CaptureId> CreateLValueFlowCaptures(ControlFlowGraph cfg)
+        {
+            // This method identifies flow capture reference operations that are target of an assignment
+            // and marks them as lvalue flow captures.
+            // Note that currently the control flow graph does not contain flow captures
+            // that are r-value captures at some point and l-values captures at other point in
+            // the flow graph. The debug only asserts in this method ensure this invariant.
+            // If these asserts fire, we should adjust this algorithm.
+
+            ImmutableHashSet<CaptureId>.Builder lvalueFlowCaptureIdBuilder = null;
+#if DEBUG
+            var rvalueFlowCaptureIds = new HashSet<CaptureId>();
+#endif
+            foreach (var flowCaptureReference in cfg.DescendantOperations<IFlowCaptureReferenceOperation>(OperationKind.FlowCaptureReference))
+            {
+                if (flowCaptureReference.Parent is IAssignmentOperation assignment &&
+                    assignment.Target == flowCaptureReference ||
+                    flowCaptureReference.IsInLeftOfDeconstructionAssignment(out _))
+                {
+                    lvalueFlowCaptureIdBuilder = lvalueFlowCaptureIdBuilder ?? ImmutableHashSet.CreateBuilder<CaptureId>();
+                    lvalueFlowCaptureIdBuilder.Add(flowCaptureReference.Id);
+                }
+#if DEBUG
+                else
+                {
+                    rvalueFlowCaptureIds.Add(flowCaptureReference.Id);
+                }
+#endif
+            }
+
+#if DEBUG
+            if (lvalueFlowCaptureIdBuilder != null)
+            {
+                foreach (var captureId in lvalueFlowCaptureIdBuilder)
+                {
+                    Debug.Assert(!rvalueFlowCaptureIds.Contains(captureId), "Flow capture used as both an r-value and an l-value?");
+                }
+            }
+#endif
+
+            return lvalueFlowCaptureIdBuilder != null ? lvalueFlowCaptureIdBuilder.ToImmutable() : ImmutableHashSet<CaptureId>.Empty;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FlowAnalysis/LValueFlowCaptureProvider.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/LValueFlowCaptureProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
     /// Helper class to detect <see cref="IFlowCaptureOperation"/>s that are l-value captures.
     /// L-value captures are essentially captures of a symbol's location/address.
     /// Corresponding <see cref="IFlowCaptureReferenceOperation"/>s which share the same
-    /// <see cref="CaptureId"/> as this flow capture, dereferences and writes to this locaion
+    /// <see cref="CaptureId"/> as this flow capture, dereferences and writes to this location
     /// subsequently in the flow graph.
     /// For example, consider the below code:
     ///     a[i] = x ?? a[j];

--- a/src/Workspaces/Core/Portable/FlowAnalysis/LValueFlowCaptureProvider.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/LValueFlowCaptureProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
     ///     FCR0 = result
     /// </summary>
     /// <remarks>
-    /// NOTE: This type is a temporary workaround for https://github.com/dotnet/roslyn/issues/31007
+    /// NOTE: This type is a workaround for https://github.com/dotnet/roslyn/issues/31007
     /// and it can be deleted once that feature is implemented.
     /// </remarks>
     internal static class LValueFlowCapturesProvider

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.AnalysisData.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.AnalysisData.cs
@@ -41,6 +41,18 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
             /// <summary>
             /// Map from each (symbol, write) to a boolean indicating if the value assigned
             /// at the write is read on some control flow path.
+            /// For example, consider the following code:
+            /// <code>
+            ///     int x = 0;
+            ///     x = 1;
+            ///     Console.WriteLine(x);
+            /// </code>
+            /// This map will have two entries for 'x':
+            ///     1. Key = (symbol: x, write: 'int x = 0')
+            ///        Value = 'false', because value assigned to 'x' here **is never** read. 
+            ///     2. Key = (symbol: x, write: 'x = 1')
+            ///        Value = 'true', because value assigned to 'x' here **may be** read on
+            ///        some control flow path.
             /// </summary>
             protected PooledDictionary<(ISymbol symbol, IOperation operation), bool> SymbolsWriteBuilder { get; }
 

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.AnalysisData.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.AnalysisData.cs
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
             {
                 foreach (var instance in _allocatedBasicBlockAnalysisDatas)
                 {
-                    instance.Free();
+                    instance.Dispose();
                 }
 
                 _allocatedBasicBlockAnalysisDatas.Free();

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.AnalysisData.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.AnalysisData.cs
@@ -1,0 +1,230 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
+{
+    internal static partial class SymbolUsageAnalysis
+    {
+        /// <summary>
+        /// Core analysis data to drive the operation <see cref="Walker"/>
+        /// for operation tree based analysis OR control flow graph based analysis.
+        /// </summary>
+        private abstract class AnalysisData : IDisposable
+        {
+            /// <summary>
+            /// Pooled <see cref="BasicBlockAnalysisData"/> allocated during analysis with the
+            /// current <see cref="AnalysisData"/> instance, which will be freed during <see cref="Dispose"/>.
+            /// </summary>
+            private readonly ArrayBuilder<BasicBlockAnalysisData> _allocatedBasicBlockAnalysisDatas;
+            
+            protected AnalysisData(
+                PooledDictionary<(ISymbol symbol, IOperation operation), bool> symbolWriteBuilder,
+                PooledHashSet<ISymbol> symbolsRead,
+                PooledHashSet<IMethodSymbol> lambdaOrLocalFunctionsBeingAnalyzed)
+            {
+                SymbolsWriteBuilder = symbolWriteBuilder;
+                SymbolsReadBuilder = symbolsRead;
+                LambdaOrLocalFunctionsBeingAnalyzed = lambdaOrLocalFunctionsBeingAnalyzed;
+
+                _allocatedBasicBlockAnalysisDatas = ArrayBuilder<BasicBlockAnalysisData>.GetInstance();
+                CurrentBlockAnalysisData = CreateBlockAnalysisData();
+            }
+
+            /// <summary>
+            /// Map from each (symbol, write) to a boolean indicating if the value assigned
+            /// at the write is read on some control flow path.
+            /// </summary>
+            protected PooledDictionary<(ISymbol symbol, IOperation operation), bool> SymbolsWriteBuilder { get; }
+
+            /// <summary>
+            /// Set of locals/parameters that are read at least once.
+            /// </summary>
+            protected PooledHashSet<ISymbol> SymbolsReadBuilder { get; }
+
+            /// <summary>
+            /// Set of lambda/local functions whose invocations are currently being analyzed to prevent
+            /// infinite recursion for analyzing code with recursive lambda/local function calls.
+            /// </summary>
+            protected PooledHashSet<IMethodSymbol> LambdaOrLocalFunctionsBeingAnalyzed { get; }
+
+            /// <summary>
+            /// Current block analysis data used for analysis.
+            /// </summary>
+            public BasicBlockAnalysisData CurrentBlockAnalysisData { get; }
+
+            /// <summary>
+            /// Creates an immutable <see cref="SymbolUsageResult"/> for the current analysis data.
+            /// </summary>
+            public SymbolUsageResult ToResult()
+                => new SymbolUsageResult(SymbolsWriteBuilder.ToImmutableDictionary(),
+                                         SymbolsReadBuilder.ToImmutableHashSet());
+
+            public BasicBlockAnalysisData AnalyzeLocalFunctionInvocation(IMethodSymbol localFunction, CancellationToken cancellationToken)
+            {
+                if (!LambdaOrLocalFunctionsBeingAnalyzed.Add(localFunction))
+                {
+                    ResetState();
+                    return CurrentBlockAnalysisData;
+                }
+                else
+                {
+                    var result = AnalyzeLocalFunctionInvocationCore(localFunction, cancellationToken);
+                    LambdaOrLocalFunctionsBeingAnalyzed.Remove(localFunction);
+                    return result;
+                }
+            }
+
+            public BasicBlockAnalysisData AnalyzeLambdaInvocation(IFlowAnonymousFunctionOperation lambda, CancellationToken cancellationToken)
+            {
+                if (!LambdaOrLocalFunctionsBeingAnalyzed.Add(lambda.Symbol))
+                {
+                    ResetState();
+                    return CurrentBlockAnalysisData;
+                }
+                else
+                {
+                    var result = AnalyzeLambdaInvocationCore(lambda, cancellationToken);
+                    LambdaOrLocalFunctionsBeingAnalyzed.Remove(lambda.Symbol);
+                    return result;
+                }
+            }
+
+            protected abstract BasicBlockAnalysisData AnalyzeLocalFunctionInvocationCore(IMethodSymbol localFunction, CancellationToken cancellationToken);
+            protected abstract BasicBlockAnalysisData AnalyzeLambdaInvocationCore(IFlowAnonymousFunctionOperation lambda, CancellationToken cancellationToken);
+
+            // Methods specific to flow capture analysis for CFG based dataflow analysis.
+            public abstract bool IsLValueFlowCapture(CaptureId captureId);
+            public abstract void OnLValueCaptureFound(ISymbol symbol, IOperation operation, CaptureId captureId);
+            public abstract void OnLValueDereferenceFound(CaptureId captureId);
+
+            // Methods specific to delegate analysis to track potential delegate invocation targets for CFG based dataflow analysis.
+            public abstract bool IsTrackingDelegateCreationTargets { get; }
+            public abstract void SetTargetsFromSymbolForDelegate(IOperation write, ISymbol symbol);
+            public abstract void SetLambdaTargetForDelegate(IOperation write, IFlowAnonymousFunctionOperation lambdaTarget);
+            public abstract void SetLocalFunctionTargetForDelegate(IOperation write, IMethodReferenceOperation localFunctionTarget);
+            public abstract void SetEmptyInvocationTargetsForDelegate(IOperation write);
+            public abstract bool TryGetDelegateInvocationTargets(IOperation write, out ImmutableHashSet<IOperation> targets);
+
+            protected static PooledDictionary<(ISymbol Symbol, IOperation Write), bool> CreateSymbolsWriteMap(
+                ImmutableArray<IParameterSymbol> parameters)
+            {
+                var symbolsWriteMap = PooledDictionary<(ISymbol Symbol, IOperation Write), bool>.GetInstance();
+                return UpdateSymbolsWriteMap(symbolsWriteMap, parameters);
+            }
+
+            protected static PooledDictionary<(ISymbol Symbol, IOperation Write), bool> UpdateSymbolsWriteMap(
+                PooledDictionary<(ISymbol Symbol, IOperation Write), bool> symbolsWriteMap,
+                ImmutableArray<IParameterSymbol> parameters)
+            {
+                // Mark parameters as being written from the value provided at the call site.
+                // Note that the write operation is "null" as there is no corresponding IOperation for parameter definition.
+                foreach (var parameter in parameters)
+                {
+                    (ISymbol, IOperation) key = (parameter, null);
+                    if (!symbolsWriteMap.ContainsKey(key))
+                    {
+                        symbolsWriteMap.Add(key, false);
+                    }
+                }
+
+                return symbolsWriteMap;
+            }
+
+            public BasicBlockAnalysisData CreateBlockAnalysisData()
+            {
+                var instance = BasicBlockAnalysisData.GetInstance();
+                _allocatedBasicBlockAnalysisDatas.Add(instance);
+                return instance;
+            }
+
+            public void OnReadReferenceFound(ISymbol symbol)
+            {
+                if (symbol.Kind == SymbolKind.Discard)
+                {
+                    return;
+                }
+
+                // Mark all the current reaching writes of symbol as read.
+                if (SymbolsWriteBuilder.Count != 0)
+                {
+                    var currentWrites = CurrentBlockAnalysisData.GetCurrentWrites(symbol);
+                    foreach (var write in currentWrites)
+                    {
+                        SymbolsWriteBuilder[(symbol, write)] = true;
+                    }
+                }
+
+                // Mark the current symbol as read.
+                SymbolsReadBuilder.Add(symbol);
+            }
+
+            public void OnWriteReferenceFound(ISymbol symbol, IOperation operation, bool maybeWritten)
+            {
+                var symbolAndWrite = (symbol, operation);
+                if (symbol.Kind == SymbolKind.Discard)
+                {
+                    // Skip discard symbols and also for already processed writes (back edge from loops).
+                    return;
+                }
+
+                // Add a new write for the given symbol at the given operation.
+                CurrentBlockAnalysisData.OnWriteReferenceFound(symbol, operation, maybeWritten);
+
+                // Only mark as unused write if we are processing it for the first time (not from back edge for loops)
+                if (!SymbolsWriteBuilder.ContainsKey(symbolAndWrite) &&
+                    !maybeWritten)
+                {
+                    SymbolsWriteBuilder.Add((symbol, operation), false);
+                }
+            }
+
+            /// <summary>
+            /// Resets all the currently tracked symbol writes to be conservatively marked as read.
+            /// </summary>
+            public void ResetState()
+            {
+                foreach (var symbol in SymbolsWriteBuilder.Keys.Select(d => d.symbol).ToArray())
+                {
+                    OnReadReferenceFound(symbol);
+                }
+            }
+
+            public void SetCurrentBlockAnalysisDataFrom(BasicBlockAnalysisData newBlockAnalysisData)
+            {
+                Debug.Assert(newBlockAnalysisData != null);
+                CurrentBlockAnalysisData.SetAnalysisDataFrom(newBlockAnalysisData);
+            }
+
+            public void Dispose()
+            {
+                DisposeAllocatedBasicBlockAnalysisData();
+                DisposeCoreData();
+            }
+
+            protected virtual void DisposeCoreData()
+            {
+                SymbolsWriteBuilder.Free();
+                SymbolsReadBuilder.Free();
+                LambdaOrLocalFunctionsBeingAnalyzed.Free();
+            }
+
+            protected void DisposeAllocatedBasicBlockAnalysisData()
+            {
+                foreach (var instance in _allocatedBasicBlockAnalysisDatas)
+                {
+                    instance.Free();
+                }
+
+                _allocatedBasicBlockAnalysisDatas.Free();
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
@@ -2,8 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -16,7 +14,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
         /// based dataflow analysis OR for the entire executable code block for high level operation
         /// tree based analysis.
         /// </summary>
-        private sealed class BasicBlockAnalysisData
+        private sealed class BasicBlockAnalysisData : IDisposable
         {
             private static readonly ObjectPool<BasicBlockAnalysisData> s_pool =
                 new ObjectPool<BasicBlockAnalysisData>(() => new BasicBlockAnalysisData());
@@ -34,7 +32,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
 
             public static BasicBlockAnalysisData GetInstance() => s_pool.Allocate();
 
-            public void Free()
+            public void Dispose()
             {
                 FreeAndClearValues();
                 s_pool.Free(this);
@@ -141,6 +139,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                 BasicBlockAnalysisData data2,
                 Func<BasicBlockAnalysisData> createBasicBlockAnalysisData)
             {
+                // Ensure that we don't return 'null' data if other the other data is non-null,
+                // even if latter is Empty.
                 if (data1 == null)
                 {
                     return data2;

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.BasicBlockAnalysisData.cs
@@ -1,0 +1,178 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
+{
+    internal static partial class SymbolUsageAnalysis
+    {
+        /// <summary>
+        /// Analysis data for a particular <see cref="BasicBlock"/> for <see cref="ControlFlowGraph"/>
+        /// based dataflow analysis OR for the entire executable code block for high level operation
+        /// tree based analysis.
+        /// </summary>
+        private sealed class BasicBlockAnalysisData : IEquatable<BasicBlockAnalysisData>
+        {
+            private static readonly ObjectPool<BasicBlockAnalysisData> s_pool =
+                new ObjectPool<BasicBlockAnalysisData>(() => new BasicBlockAnalysisData());
+
+            /// <summary>
+            /// Map from each symbol to possible set of reachable write operations that are live at current program point.
+            /// A write is live if there is no intermediate write operation that overwrites it.
+            /// </summary>
+            private readonly Dictionary<ISymbol, PooledHashSet<IOperation>> _reachingWrites;
+
+            private BasicBlockAnalysisData()
+            {
+                _reachingWrites = new Dictionary<ISymbol, PooledHashSet<IOperation>>();
+            }
+
+            public static BasicBlockAnalysisData GetInstance() => s_pool.Allocate();
+
+            public void Free()
+            {
+                FreeAndClearValues();
+                s_pool.Free(this);
+            }
+
+            private void FreeAndClearValues()
+            {
+                foreach (var value in _reachingWrites.Values)
+                {
+                    value.Free();
+                }
+
+                _reachingWrites.Clear();
+            }
+
+            public void SetAnalysisDataFrom(BasicBlockAnalysisData other)
+            {
+                if (ReferenceEquals(this, other))
+                {
+                    return;
+                }
+
+                FreeAndClearValues();
+                AddEntries(_reachingWrites, other);
+            }
+
+            /// <summary>
+            /// Gets the currently reachable writes for the given symbol.
+            /// </summary>
+            public IEnumerable<IOperation> GetCurrentWrites(ISymbol symbol)
+            {
+                if (_reachingWrites.TryGetValue(symbol, out var values))
+                {
+                    foreach (var value in values)
+                    {
+                        yield return value;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Marks the given symbol write as a new unread write operation,
+            /// potentially clearing out the prior write operations if <paramref name="maybeWritten"/> is <code>false</code>.
+            /// </summary>
+            public void OnWriteReferenceFound(ISymbol symbol, IOperation operation, bool maybeWritten)
+            {
+                if (!_reachingWrites.TryGetValue(symbol, out var values))
+                {
+                    values = PooledHashSet<IOperation>.GetInstance();
+                    _reachingWrites.Add(symbol, values);
+                }
+                else if (!maybeWritten)
+                {
+                    values.Clear();
+                }
+
+                values.Add(operation);
+            }
+
+            public bool Equals(BasicBlockAnalysisData other)
+                => this.GetHashCode() == (other?.GetHashCode() ?? 0);
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as BasicBlockAnalysisData);
+            }
+
+            public override int GetHashCode()
+            {
+                var hashCode = _reachingWrites.Count;
+                foreach ((int keyHash, int valueHash) in _reachingWrites.Select(GetKeyValueHashCodeTuple).OrderBy(hashTuple => hashTuple.keyHash))
+                {
+                    hashCode = Hash.Combine(Hash.Combine(keyHash, valueHash), hashCode);
+                }
+
+                return hashCode;
+
+                // Local functions.
+                (int keyHash, int valueHash) GetKeyValueHashCodeTuple(KeyValuePair<ISymbol, PooledHashSet<IOperation>> keyValuePair)
+                    => (keyValuePair.Key.GetHashCode(), Hash.Combine(keyValuePair.Value.Count, Hash.CombineValues(keyValuePair.Value)));
+            }
+
+            private bool IsEmpty => _reachingWrites.Count == 0;
+
+            public static BasicBlockAnalysisData Merge(
+                BasicBlockAnalysisData data1,
+                BasicBlockAnalysisData data2,
+                Func<BasicBlockAnalysisData> createBasicBlockAnalysisData)
+            {
+                if (data1 == null)
+                {
+                    return data2;
+                }
+                else if (data2 == null)
+                {
+                    return data1;
+                }
+                else if (data1.IsEmpty)
+                {
+                    return data2;
+                }
+                else if (data2.IsEmpty)
+                {
+                    return data1;
+                }
+
+                var mergedData = createBasicBlockAnalysisData();
+                AddEntries(mergedData._reachingWrites, data1);
+                AddEntries(mergedData._reachingWrites, data2);
+
+                if (mergedData.Equals(data1))
+                {
+                    return data1;
+                }
+                else if (mergedData.Equals(data2))
+                {
+                    return data2;
+                }
+
+                return mergedData;
+            }
+
+            private static void AddEntries(Dictionary<ISymbol, PooledHashSet<IOperation>> result, BasicBlockAnalysisData source)
+            {
+                if (source != null)
+                {
+                    foreach (var kvp in source._reachingWrites)
+                    {
+                        if (!result.TryGetValue(kvp.Key, out var values))
+                        {
+                            values = PooledHashSet<IOperation>.GetInstance();
+                            result.Add(kvp.Key, values);
+                        }
+
+                        values.AddRange(kvp.Value);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.FlowGraphAnalysisData.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.FlowGraphAnalysisData.cs
@@ -1,0 +1,499 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
+{
+    internal static partial class SymbolUsageAnalysis
+    {
+        private sealed partial class DataFlowAnalyzer : DataFlowAnalyzer<BasicBlockAnalysisData>
+        {
+            private sealed class FlowGraphAnalysisData : AnalysisData
+            {
+                private readonly ImmutableArray<IParameterSymbol> _parameters;
+
+                /// <summary>
+                /// Map from basic block to current <see cref="BasicBlockAnalysisData"/> for dataflow analysis.
+                /// </summary>
+                private readonly PooledDictionary<BasicBlock, BasicBlockAnalysisData> _analysisDataByBasicBlockMap;
+
+                /// <summary>
+                /// Callback to analyze lambda/local function invocations and return new block analysis data.
+                /// </summary>
+                private readonly Func<IMethodSymbol, ControlFlowGraph, AnalysisData, CancellationToken, BasicBlockAnalysisData> _analyzeLocalFunctionOrLambdaInvocation;
+
+                /// <summary>
+                /// Map from flow capture ID to set of captured symbol addresses along all possible control flow paths.
+                /// </summary>
+                private readonly PooledDictionary<CaptureId, PooledHashSet<(ISymbol, IOperation)>> _lValueFlowCapturesMap;
+
+                /// <summary>
+                /// Map from operations to potential delegate creation targets that could be invoked via delegate invocation
+                /// on the operation.
+                /// Used to analyze delegate creations/invocations of lambdas and local/functions defined in a method.
+                /// </summary>
+                private readonly PooledDictionary<IOperation, PooledHashSet<IOperation>> _reachingDelegateCreationTargets;
+
+                /// <summary>
+                /// Map from local functions to the <see cref="ControlFlowGraph"/> where the local function was accessed
+                /// to create an invocable delegate. This control flow graph is required to lazily get or create the
+                /// control flow graph for this local function at delegate invocation callsite.
+                /// </summary>
+                private readonly PooledDictionary<IMethodSymbol, ControlFlowGraph> _localFunctionTargetsToAccessingCfgMap;
+
+                /// <summary>
+                /// Map from lambdas to the <see cref="ControlFlowGraph"/> where the lambda was defined
+                /// to create an invocable delegate. This control flow graph is required to lazily get or create the
+                /// control flow graph for this lambda at delegate invocation callsite.
+                /// </summary>
+                private readonly PooledDictionary<IFlowAnonymousFunctionOperation, ControlFlowGraph> _lambdaTargetsToAccessingCfgMap;
+
+                /// <summary>
+                /// Map from basic block range to set of writes within this block range.
+                /// Used for try-catch-finally analysis, where start of catch/finally blocks should
+                /// consider all writes in the corresponding try block as reachable.
+                /// </summary>
+                private readonly PooledDictionary<(int firstBlockOrdinal, int lastBlockOrdinal), PooledHashSet<(ISymbol, IOperation)>> _symbolWritesInsideBlockRangeMap;
+
+                private FlowGraphAnalysisData(
+                    ControlFlowGraph controlFlowGraph,
+                    ImmutableArray<IParameterSymbol> parameters,
+                    PooledDictionary<BasicBlock, BasicBlockAnalysisData> analysisDataByBasicBlockMap,
+                    PooledDictionary<(ISymbol symbol, IOperation operation), bool> symbolsWriteMap,
+                    PooledHashSet<ISymbol> symbolsRead,
+                    PooledHashSet<IMethodSymbol> lambdaOrLocalFunctionsBeingAnalyzed,
+                    Func<IMethodSymbol, ControlFlowGraph, AnalysisData, CancellationToken, BasicBlockAnalysisData> analyzeLocalFunctionOrLambdaInvocation,
+                    PooledDictionary<IOperation, PooledHashSet<IOperation>> reachingDelegateCreationTargets,
+                    PooledDictionary<IMethodSymbol, ControlFlowGraph> localFunctionTargetsToAccessingCfgMap,
+                    PooledDictionary<IFlowAnonymousFunctionOperation, ControlFlowGraph> lambdaTargetsToAccessingCfgMap)
+                    : base(symbolsWriteMap, symbolsRead, lambdaOrLocalFunctionsBeingAnalyzed)
+                {
+                    ControlFlowGraph = controlFlowGraph;
+                    _parameters = parameters;
+                    _analysisDataByBasicBlockMap = analysisDataByBasicBlockMap;
+                    _analyzeLocalFunctionOrLambdaInvocation = analyzeLocalFunctionOrLambdaInvocation;
+                    _reachingDelegateCreationTargets = reachingDelegateCreationTargets;
+                    _localFunctionTargetsToAccessingCfgMap = localFunctionTargetsToAccessingCfgMap;
+                    _lambdaTargetsToAccessingCfgMap = lambdaTargetsToAccessingCfgMap;
+
+                    _lValueFlowCapturesMap = PooledDictionary<CaptureId, PooledHashSet<(ISymbol, IOperation)>>.GetInstance();
+                    LValueFlowCapturesInGraph = LValueFlowCapturesProvider.CreateLValueFlowCaptures(controlFlowGraph);
+                    _symbolWritesInsideBlockRangeMap = PooledDictionary<(int firstBlockOrdinal, int lastBlockOrdinal), PooledHashSet<(ISymbol, IOperation)>>.GetInstance();
+                }
+
+                public static FlowGraphAnalysisData Create(
+                    ControlFlowGraph cfg,
+                    ISymbol owningSymbol,
+                    Func<IMethodSymbol, ControlFlowGraph, AnalysisData, CancellationToken, BasicBlockAnalysisData> analyzeLocalFunctionOrLambdaInvocation)
+                {
+                    Debug.Assert(cfg.Parent == null);
+
+                    var parameters = owningSymbol.GetParameters();
+                    return new FlowGraphAnalysisData(
+                        cfg,
+                        parameters,
+                        analysisDataByBasicBlockMap: CreateAnalysisDataByBasicBlockMap(cfg),
+                        symbolsWriteMap: CreateSymbolsWriteMap(parameters),
+                        symbolsRead: PooledHashSet<ISymbol>.GetInstance(),
+                        lambdaOrLocalFunctionsBeingAnalyzed: PooledHashSet<IMethodSymbol>.GetInstance(),
+                        analyzeLocalFunctionOrLambdaInvocation,
+                        reachingDelegateCreationTargets: PooledDictionary<IOperation, PooledHashSet<IOperation>>.GetInstance(),
+                        localFunctionTargetsToAccessingCfgMap: PooledDictionary<IMethodSymbol, ControlFlowGraph>.GetInstance(),
+                        lambdaTargetsToAccessingCfgMap: PooledDictionary<IFlowAnonymousFunctionOperation, ControlFlowGraph>.GetInstance());
+                }
+
+                public static FlowGraphAnalysisData Create(
+                    ControlFlowGraph cfg,
+                    IMethodSymbol lambdaOrLocalFunction,
+                    FlowGraphAnalysisData parentAnalysisData)
+                {
+                    Debug.Assert(cfg.Parent != null);
+                    Debug.Assert(lambdaOrLocalFunction.IsAnonymousFunction() || lambdaOrLocalFunction.IsLocalFunction());
+                    Debug.Assert(parentAnalysisData != null);
+
+                    var parameters = lambdaOrLocalFunction.GetParameters();
+                    return new FlowGraphAnalysisData(
+                        cfg,
+                        parameters,
+                        analysisDataByBasicBlockMap: CreateAnalysisDataByBasicBlockMap(cfg),
+                        symbolsWriteMap: UpdateSymbolsWriteMap(parentAnalysisData.SymbolsWriteBuilder, parameters),
+                        symbolsRead: parentAnalysisData.SymbolsReadBuilder,
+                        lambdaOrLocalFunctionsBeingAnalyzed: parentAnalysisData.LambdaOrLocalFunctionsBeingAnalyzed,
+                        analyzeLocalFunctionOrLambdaInvocation: parentAnalysisData._analyzeLocalFunctionOrLambdaInvocation,
+                        reachingDelegateCreationTargets: parentAnalysisData._reachingDelegateCreationTargets,
+                        localFunctionTargetsToAccessingCfgMap: parentAnalysisData._localFunctionTargetsToAccessingCfgMap,
+                        lambdaTargetsToAccessingCfgMap: parentAnalysisData._lambdaTargetsToAccessingCfgMap);
+                }
+
+                private static PooledDictionary<BasicBlock, BasicBlockAnalysisData> CreateAnalysisDataByBasicBlockMap(
+                    ControlFlowGraph cfg)
+                {
+                    var builder = PooledDictionary<BasicBlock, BasicBlockAnalysisData>.GetInstance();
+                    foreach (var block in cfg.Blocks)
+                    {
+                        builder.Add(block, null);
+                    }
+
+                    return builder;
+                }
+
+                public ControlFlowGraph ControlFlowGraph { get; }
+
+                /// <summary>
+                /// Flow captures for l-value or address captures.
+                /// </summary>
+                public ImmutableHashSet<CaptureId> LValueFlowCapturesInGraph { get; }
+
+                public BasicBlockAnalysisData GetCurrentBlockAnalysisData(BasicBlock basicBlock)
+                    => _analysisDataByBasicBlockMap[basicBlock];
+
+                public BasicBlockAnalysisData GetOrCreateBlockAnalysisData(BasicBlock basicBlock)
+                {
+                    if (_analysisDataByBasicBlockMap[basicBlock] == null)
+                    {
+                        _analysisDataByBasicBlockMap[basicBlock] = CreateBlockAnalysisData();
+                    }
+
+                    HandleCatchOrFilterOrFinallyInitialization(basicBlock);
+                    return _analysisDataByBasicBlockMap[basicBlock];
+                }
+
+                private PooledHashSet<(ISymbol, IOperation)> GetOrCreateSymbolWritesInBlockRange(int firstBlockOrdinal, int lastBlockOrdinal)
+                {
+                    if (!_symbolWritesInsideBlockRangeMap.TryGetValue((firstBlockOrdinal, lastBlockOrdinal), out var writesInBlockRange))
+                    {
+                        // Compute all descendant operations in basic block range.
+                        var operations = PooledHashSet<IOperation>.GetInstance();
+                        for (int i = firstBlockOrdinal; i <= lastBlockOrdinal; i++)
+                        {
+                            foreach (var operation in ControlFlowGraph.Blocks[i].DescendantOperations())
+                            {
+                                operations.Add(operation);
+                            }
+                        }
+
+                        // Filter down the operations to writes within this block range.
+                        writesInBlockRange = PooledHashSet<(ISymbol, IOperation)>.GetInstance();
+                        foreach (var (symbol, write) in SymbolsWriteBuilder.Where(kvp => !kvp.Value).Select(kvp => kvp.Key).ToArray())
+                        {
+                            if (write != null && operations.Contains(write))
+                            {
+                                writesInBlockRange.Add((symbol, write));
+                            }
+                        }
+                    }
+
+                    return writesInBlockRange;
+                }
+
+                /// <summary>
+                /// Special handling to ensure that at start of catch/filter/finally region analysis,
+                /// we mark all symbol writes from the corresponding try region as reachable in the
+                /// catch/filter/finally region.
+                /// </summary>
+                /// <param name="basicBlock"></param>
+                private void HandleCatchOrFilterOrFinallyInitialization(BasicBlock basicBlock)
+                {
+                    Debug.Assert(_analysisDataByBasicBlockMap[basicBlock] != null);
+
+                    // Ensure we are processing a basic block with following properties:
+                    //  1. It has no predecessors
+                    //  2. It is not the entry block
+                    //  3. It is the first block of its enclosing region.
+                    if (!basicBlock.Predecessors.IsEmpty ||
+                        basicBlock.Kind == BasicBlockKind.Entry ||
+                        basicBlock.EnclosingRegion.FirstBlockOrdinal != basicBlock.Ordinal)
+                    {
+                        return;
+                    }
+
+                    // Find the outermost region for which this block is the first block.
+                    var outermostEnclosingRegionStartingBlock = basicBlock.EnclosingRegion;
+                    while (outermostEnclosingRegionStartingBlock.EnclosingRegion?.FirstBlockOrdinal == basicBlock.Ordinal)
+                    {
+                        outermostEnclosingRegionStartingBlock = outermostEnclosingRegionStartingBlock.EnclosingRegion;
+                    }
+
+                    // Check if we are at start of catch or filter or finally.
+                    switch (outermostEnclosingRegionStartingBlock.Kind)
+                    {
+                        case ControlFlowRegionKind.Catch:
+                        case ControlFlowRegionKind.Filter:
+                        case ControlFlowRegionKind.FilterAndHandler:
+                        case ControlFlowRegionKind.Finally:
+                            break;
+
+                        default:
+                            return;
+                    }
+
+                    // Find the outer try/catch or try/finally for this region.
+                    ControlFlowRegion containingTryCatchFinallyRegion = null;
+                    var currentRegion = outermostEnclosingRegionStartingBlock;
+                    do
+                    {
+                        switch (currentRegion.Kind)
+                        {
+                            case ControlFlowRegionKind.TryAndCatch:
+                            case ControlFlowRegionKind.TryAndFinally:
+                                containingTryCatchFinallyRegion = currentRegion;
+                                break;
+                        }
+
+                        currentRegion = currentRegion.EnclosingRegion;
+                    }
+                    while (containingTryCatchFinallyRegion == null);
+
+                    // All symbol writes reachable at start of try region are considered reachable at start of catch/finally region.
+                    var firstBasicBlockInOutermostRegion = ControlFlowGraph.Blocks[containingTryCatchFinallyRegion.FirstBlockOrdinal];
+                    var mergedAnalysisData = _analysisDataByBasicBlockMap[basicBlock];
+                    mergedAnalysisData.SetAnalysisDataFrom(GetCurrentBlockAnalysisData(firstBasicBlockInOutermostRegion));
+
+                    // All symbol writes within the try region are considered reachable at start of catch/finally region.
+                    foreach (var (symbol, write) in GetOrCreateSymbolWritesInBlockRange(containingTryCatchFinallyRegion.FirstBlockOrdinal, basicBlock.Ordinal - 1))
+                    {
+                        mergedAnalysisData.OnWriteReferenceFound(symbol, write, maybeWritten: true);
+                        SymbolsWriteBuilder[(symbol, write)] = true;
+                        SymbolsReadBuilder.Add(symbol);
+                    }
+
+                    SetBlockAnalysisData(basicBlock, mergedAnalysisData);
+                }
+
+                public void SetCurrentBlockAnalysisDataFrom(BasicBlock basicBlock)
+                    => SetCurrentBlockAnalysisDataFrom(GetOrCreateBlockAnalysisData(basicBlock));
+
+                public void SetAnalysisDataOnEntryBlockStart()
+                {
+                    foreach (var parameter in _parameters)
+                    {
+                        SymbolsWriteBuilder[(parameter, null)] = false;
+                        CurrentBlockAnalysisData.OnWriteReferenceFound(parameter, operation: null, maybeWritten: false);
+                    }
+                }
+
+                public void SetBlockAnalysisData(BasicBlock basicBlock, BasicBlockAnalysisData data)
+                    => _analysisDataByBasicBlockMap[basicBlock] = data;
+
+                public void SetBlockAnalysisDataFrom(BasicBlock basicBlock, BasicBlockAnalysisData data)
+                    => GetOrCreateBlockAnalysisData(basicBlock).SetAnalysisDataFrom(data);
+
+                public void SetAnalysisDataOnExitBlockEnd()
+                {
+                    if (SymbolsWriteBuilder.Count == 0)
+                    {
+                        return;
+                    }
+
+                    // Mark all reachable definitions for ref/out parameters at end of exit block as used.
+                    foreach (var parameter in _parameters)
+                    {
+                        if (parameter.RefKind == RefKind.Ref || parameter.RefKind == RefKind.Out)
+                        {
+                            var currentWrites = CurrentBlockAnalysisData.GetCurrentWrites(parameter);
+                            foreach (var write in currentWrites)
+                            {
+                                if (write != null)
+                                {
+                                    SymbolsWriteBuilder[(parameter, write)] = true;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                public override bool IsLValueFlowCapture(CaptureId captureId)
+                    => LValueFlowCapturesInGraph.Contains(captureId);
+
+                public override void OnLValueCaptureFound(ISymbol symbol, IOperation operation, CaptureId captureId)
+                {
+                    if (!_lValueFlowCapturesMap.TryGetValue(captureId, out var captures))
+                    {
+                        captures = PooledHashSet<(ISymbol, IOperation)>.GetInstance();
+                        _lValueFlowCapturesMap.Add(captureId, captures);
+                    }
+
+                    captures.Add((symbol, operation));
+                }
+
+                public override void OnLValueDereferenceFound(CaptureId captureId)
+                {
+                    if (_lValueFlowCapturesMap.TryGetValue(captureId, out var captures))
+                    {
+                        var mayBeWritten = captures.Count > 1;
+                        foreach (var (symbol, write) in captures)
+                        {
+                            OnWriteReferenceFound(symbol, write, mayBeWritten);
+                        }
+                    }
+                }
+
+                protected override BasicBlockAnalysisData AnalyzeLocalFunctionInvocationCore(IMethodSymbol localFunction, CancellationToken cancellationToken)
+                {
+                    Debug.Assert(localFunction.IsLocalFunction());
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!_localFunctionTargetsToAccessingCfgMap.TryGetValue(localFunction, out var accessingCfg))
+                    {
+                        accessingCfg = ControlFlowGraph;
+                    }
+
+                    var localFunctionCfg = accessingCfg.GetLocalFunctionControlFlowGraphInScope(localFunction, cancellationToken);
+                    return _analyzeLocalFunctionOrLambdaInvocation(localFunction, localFunctionCfg, this, cancellationToken);
+                }
+
+                protected override BasicBlockAnalysisData AnalyzeLambdaInvocationCore(IFlowAnonymousFunctionOperation lambda, CancellationToken cancellationToken)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!_lambdaTargetsToAccessingCfgMap.TryGetValue(lambda, out var accessingCfg))
+                    {
+                        accessingCfg = ControlFlowGraph;
+                    }
+
+                    var lambdaCfg = accessingCfg.GetAnonymousFunctionControlFlowGraphInScope(lambda, cancellationToken);
+                    return _analyzeLocalFunctionOrLambdaInvocation(lambda.Symbol, lambdaCfg, this, cancellationToken);
+                }
+
+                public override bool IsTrackingDelegateCreationTargets => true;
+                public override void SetTargetsFromSymbolForDelegate(IOperation write, ISymbol symbol)
+                {
+                    // Transfer reaching delegate creation targets when assigning from a local/parameter symbol
+                    // that has known set of potential delegate creation targets. For example, this method will be called
+                    // for definition 'y' from symbol 'x' for below code:
+                    //      Action x = () => { };
+                    //      Action y = x;
+
+                    var targetsBuilder = PooledHashSet<IOperation>.GetInstance();
+                    foreach (var symbolWrite in CurrentBlockAnalysisData.GetCurrentWrites(symbol))
+                    {
+                        if (symbolWrite == null)
+                        {
+                            continue;
+                        }
+
+                        if (!_reachingDelegateCreationTargets.TryGetValue(symbolWrite, out var targetsBuilderForSymbolWrite))
+                        {
+                            // Unable to find delegate creation targets for this symbol write.
+                            // Bail out without setting targets.
+                            targetsBuilder.Free();
+                            return;
+                        }
+                        else
+                        {
+                            foreach (var target in targetsBuilderForSymbolWrite)
+                            {
+                                targetsBuilder.Add(target);
+                            }
+                        }
+                    }
+
+                    _reachingDelegateCreationTargets[write] = targetsBuilder;
+                }
+
+                public override void SetLambdaTargetForDelegate(IOperation write, IFlowAnonymousFunctionOperation lambdaTarget)
+                {
+                    // Sets a lambda delegate target for the current write.
+                    // For example, this method will be called for the definition 'x' below with assigned lambda.
+                    //      Action x = () => { };
+
+                    SetReachingDelegateTargetCore(write, lambdaTarget);
+                    _lambdaTargetsToAccessingCfgMap[lambdaTarget] = ControlFlowGraph;
+                }
+
+                public override void SetLocalFunctionTargetForDelegate(IOperation write, IMethodReferenceOperation localFunctionTarget)
+                {
+                    // Sets a local function delegate target for the current write.
+                    // For example, this method will be called for the definition 'x' below with assigned LocalFunction delegate.
+                    //      Action x = LocalFunction;
+                    //      void LocalFunction() { }
+
+                    Debug.Assert(localFunctionTarget.Method.IsLocalFunction());
+                    SetReachingDelegateTargetCore(write, localFunctionTarget);
+                    _localFunctionTargetsToAccessingCfgMap[localFunctionTarget.Method] = ControlFlowGraph;
+                }
+
+                public override void SetEmptyInvocationTargetsForDelegate(IOperation write)
+                    => SetReachingDelegateTargetCore(write, targetOpt: null);
+
+                private void SetReachingDelegateTargetCore(IOperation write, IOperation targetOpt)
+                {
+                    var targetsBuilder = PooledHashSet<IOperation>.GetInstance();
+                    if (targetOpt != null)
+                    {
+                        targetsBuilder.Add(targetOpt);
+                    }
+
+                    _reachingDelegateCreationTargets[write] = targetsBuilder;
+                }
+
+                public override bool TryGetDelegateInvocationTargets(IOperation write, out ImmutableHashSet<IOperation> targets)
+                {
+                    // Attempts to return potential lamba/local function delegate invocation targets for the given write.
+                    if (_reachingDelegateCreationTargets.TryGetValue(write, out var targetsBuilder))
+                    {
+                        targets = targetsBuilder.ToImmutableHashSet();
+                        return true;
+                    }
+
+                    targets = ImmutableHashSet<IOperation>.Empty;
+                    return false;
+                }
+
+                protected override void DisposeCoreData()
+                {
+                    // We share the base analysis data structures between primary method's flow graph analysis
+                    // and it's inner lambda/local function flow graph analysis.
+                    // Dispose the base data structures only for primary method's flow analysis data.
+                    if (ControlFlowGraph.Parent == null)
+                    {
+                        DisposeForNonLocalFunctionOrLambdaAnalsis();
+                    }
+
+                    DisposeCommon();
+                    return;
+
+                    // Local functions.
+                    void DisposeForNonLocalFunctionOrLambdaAnalsis()
+                    {
+                        base.DisposeCoreData();
+
+                        foreach (var creations in _reachingDelegateCreationTargets.Values)
+                        {
+                            creations.Free();
+                        }
+                        _reachingDelegateCreationTargets.Free();
+
+                        _localFunctionTargetsToAccessingCfgMap.Free();
+                        _lambdaTargetsToAccessingCfgMap.Free();
+                    }
+
+                    void DisposeCommon()
+                    {
+                        // Note the base type already disposes the BasicBlockAnalysisData values
+                        // allocated by us, so we only need to free the map.
+                        _analysisDataByBasicBlockMap.Free();
+
+                        foreach (var captures in _lValueFlowCapturesMap.Values)
+                        {
+                            captures.Free();
+                        }
+                        _lValueFlowCapturesMap.Free();
+
+                        foreach (var operations in _symbolWritesInsideBlockRangeMap.Values)
+                        {
+                            operations.Free();
+                        }
+                        _symbolWritesInsideBlockRangeMap.Free();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
             }
 
             public override BasicBlockAnalysisData GetCurrentAnalysisData(BasicBlock basicBlock)
-                => _analysisData.GetCurrentBlockAnalysisData(basicBlock);
+                => _analysisData.GetBlockAnalysisData(basicBlock);
 
             public override BasicBlockAnalysisData GetEmptyAnalysisData()
                 => _analysisData.CreateBlockAnalysisData();

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.cs
@@ -1,0 +1,171 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
+{
+    internal static partial class SymbolUsageAnalysis
+    {
+        /// <summary>
+        /// Dataflow analysis to compute symbol usage information (i.e. reads/writes) for locals/parameters
+        /// in a given control flow graph, along with the information of whether or not the writes
+        /// may be read on some control flow path.
+        /// </summary>
+        private sealed partial class DataFlowAnalyzer : DataFlowAnalyzer<BasicBlockAnalysisData>
+        {
+            private readonly FlowGraphAnalysisData _analysisData;
+            private readonly CancellationToken _cancellationToken;
+
+            private DataFlowAnalyzer(ControlFlowGraph cfg, ISymbol owningSymbol, CancellationToken cancellationToken)
+            {
+                _analysisData = FlowGraphAnalysisData.Create(cfg, owningSymbol, AnalyzeLocalFunctionOrLambdaInvocation);
+                _cancellationToken = cancellationToken;
+            }
+
+            private DataFlowAnalyzer(
+                ControlFlowGraph cfg,
+                IMethodSymbol lambdaOrLocalFunction,
+                FlowGraphAnalysisData parentAnalysisData,
+                CancellationToken cancellationToken)
+            {
+                _analysisData = FlowGraphAnalysisData.Create(cfg, lambdaOrLocalFunction, parentAnalysisData);
+                _cancellationToken = cancellationToken;
+
+                var entryBlockAnalysisData = GetEmptyAnalysisData();
+                entryBlockAnalysisData.SetAnalysisDataFrom(parentAnalysisData.CurrentBlockAnalysisData);
+                _analysisData.SetBlockAnalysisData(cfg.EntryBlock(), entryBlockAnalysisData);
+            }
+
+            public static SymbolUsageResult RunAnalysis(ControlFlowGraph cfg, ISymbol owningSymbol, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                using (var analyzer = new DataFlowAnalyzer(cfg, owningSymbol, cancellationToken))
+                {
+                    _ = CustomDataFlowAnalysis<BasicBlockAnalysisData>.Run(cfg, analyzer, cancellationToken);
+                    return analyzer._analysisData.ToResult();
+                }
+            }
+
+            public override void Dispose()
+                => _analysisData.Dispose();
+
+            private static BasicBlockAnalysisData AnalyzeLocalFunctionOrLambdaInvocation(
+                IMethodSymbol localFunctionOrLambda,
+                ControlFlowGraph cfg,
+                AnalysisData parentAnalysisData,
+                CancellationToken cancellationToken)
+            {
+                Debug.Assert(localFunctionOrLambda.IsLocalFunction() || localFunctionOrLambda.IsAnonymousFunction());
+
+                cancellationToken.ThrowIfCancellationRequested();
+                using (var analyzer = new DataFlowAnalyzer(cfg, localFunctionOrLambda, (FlowGraphAnalysisData)parentAnalysisData, cancellationToken))
+                {
+                    var resultBlockAnalysisData = CustomDataFlowAnalysis<BasicBlockAnalysisData>.Run(cfg, analyzer, cancellationToken);
+                    if (resultBlockAnalysisData == null)
+                    {
+                        // Unreachable exit block from lambda/local.
+                        // So use our current analysis data.
+                        return parentAnalysisData.CurrentBlockAnalysisData;
+                    }
+
+                    // We need to return a cloned basic block analysis data as disposing the DataFlowAnalyzer
+                    // created above will dispose all basic block analysis data instances allocated by it.
+                    var clonedBasicBlockData = parentAnalysisData.CreateBlockAnalysisData();
+                    clonedBasicBlockData.SetAnalysisDataFrom(resultBlockAnalysisData);
+                    return clonedBasicBlockData;
+                }
+            }
+
+            // Don't analyze blocks which are unreachable, as any write
+            // in such a block which has a read outside will be marked redundant, which will just be noise for users.
+            // For example,
+            //      int x;
+            //      if (true)
+            //          x = 0;
+            //      else
+            //          x = 1; // This will be marked redundant if "AnalyzeUnreachableBlocks = true"
+            //      return x;
+            public override bool AnalyzeUnreachableBlocks => false;
+
+            public override BasicBlockAnalysisData AnalyzeBlock(BasicBlock basicBlock, CancellationToken cancellationToken)
+            {
+                BeforeBlockAnalysis();
+                Walker.AnalyzeOperationsAndUpdateData(basicBlock.Operations, _analysisData, cancellationToken);
+                AfterBlockAnalysis();
+                return _analysisData.CurrentBlockAnalysisData;
+
+                // Local functions.
+                void BeforeBlockAnalysis()
+                {
+                    // Initialize current block analysis data.
+                    _analysisData.SetCurrentBlockAnalysisDataFrom(basicBlock);
+
+                    // At start of entry block, handle parameter definitions from method declaration.
+                    if (basicBlock.Kind == BasicBlockKind.Entry)
+                    {
+                        _analysisData.SetAnalysisDataOnEntryBlockStart();
+                    }
+                }
+
+                void AfterBlockAnalysis()
+                {
+                    // At end of entry block, handle ref/out parameter definitions from method declaration.
+                    if (basicBlock.Kind == BasicBlockKind.Exit)
+                    {
+                        _analysisData.SetAnalysisDataOnExitBlockEnd();
+                    }
+                }
+            }
+
+            public override BasicBlockAnalysisData AnalyzeNonConditionalBranch(
+                BasicBlock basicBlock,
+                BasicBlockAnalysisData currentBlockAnalysisData,
+                CancellationToken cancellationToken)
+                => AnalyzeBranch(basicBlock, currentBlockAnalysisData, cancellationToken);
+
+            public override (BasicBlockAnalysisData fallThroughSuccessorData, BasicBlockAnalysisData conditionalSuccessorData) AnalyzeConditionalBranch(
+                BasicBlock basicBlock,
+                BasicBlockAnalysisData currentAnalysisData,
+                CancellationToken cancellationToken)
+            {
+                var resultAnalysisData = AnalyzeBranch(basicBlock, currentAnalysisData, cancellationToken);
+                return (resultAnalysisData, resultAnalysisData);
+            }
+
+            private BasicBlockAnalysisData AnalyzeBranch(
+                BasicBlock basicBlock,
+                BasicBlockAnalysisData currentBlockAnalysisData,
+                CancellationToken cancellationToken)
+            {
+                // Initialize current analysis data
+                _analysisData.SetCurrentBlockAnalysisDataFrom(currentBlockAnalysisData);
+
+                // Analyze the branch value
+                var operations = SpecializedCollections.SingletonEnumerable(basicBlock.BranchValue);
+                Walker.AnalyzeOperationsAndUpdateData(operations, _analysisData, cancellationToken);
+                return _analysisData.CurrentBlockAnalysisData;
+            }
+
+            public override BasicBlockAnalysisData GetCurrentAnalysisData(BasicBlock basicBlock)
+                => _analysisData.GetCurrentBlockAnalysisData(basicBlock);
+
+            public override BasicBlockAnalysisData GetEmptyAnalysisData()
+                => _analysisData.CreateBlockAnalysisData();
+
+            public override void SetCurrentAnalysisData(BasicBlock basicBlock, BasicBlockAnalysisData data)
+                => _analysisData.SetBlockAnalysisDataFrom(basicBlock, data);
+
+            public override bool IsEqual(BasicBlockAnalysisData analysisData1, BasicBlockAnalysisData analysisData2)
+                => analysisData1 == null ? analysisData2 == null : analysisData1.Equals(analysisData2);
+
+            public override BasicBlockAnalysisData Merge(
+                BasicBlockAnalysisData analysisData1,
+                BasicBlockAnalysisData analysisData2,
+                CancellationToken cancellationToken)
+                => BasicBlockAnalysisData.Merge(analysisData1, analysisData2, GetEmptyAnalysisData);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.OperationTreeAnalysisData.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.OperationTreeAnalysisData.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
+{
+    internal static partial class SymbolUsageAnalysis
+    {
+        private sealed class OperationTreeAnalysisData : AnalysisData
+        {
+            private readonly Func<IMethodSymbol, BasicBlockAnalysisData> _analyzeLocalFunction;
+
+            private OperationTreeAnalysisData(
+                PooledDictionary<(ISymbol symbol, IOperation operation), bool> symbolsWriteMap,
+                PooledHashSet<ISymbol> symbolsRead,
+                PooledHashSet<IMethodSymbol> lambdaOrLocalFunctionsBeingAnalyzed,
+                Func<IMethodSymbol, BasicBlockAnalysisData> analyzeLocalFunction)
+                : base(symbolsWriteMap, symbolsRead, lambdaOrLocalFunctionsBeingAnalyzed)     
+            {
+                _analyzeLocalFunction = analyzeLocalFunction;
+            }
+
+            public static OperationTreeAnalysisData Create(
+                ISymbol owningSymbol,
+                Func<IMethodSymbol, BasicBlockAnalysisData> analyzeLocalFunction)
+            {
+                return new OperationTreeAnalysisData(
+                    symbolsWriteMap: CreateSymbolsWriteMap(owningSymbol.GetParameters()),
+                    symbolsRead: PooledHashSet<ISymbol>.GetInstance(),
+                    lambdaOrLocalFunctionsBeingAnalyzed: PooledHashSet<IMethodSymbol>.GetInstance(),
+                    analyzeLocalFunction);
+            }
+
+            protected override BasicBlockAnalysisData AnalyzeLocalFunctionInvocationCore(IMethodSymbol localFunction, CancellationToken cancellationToken)
+            {
+                _ = UpdateSymbolsWriteMap(SymbolsWriteBuilder, localFunction.Parameters);
+                return _analyzeLocalFunction(localFunction);
+            }
+
+            // Lambda target needs flow analysis, not supported/reachable in operation tree based analysis.
+            protected override BasicBlockAnalysisData AnalyzeLambdaInvocationCore(IFlowAnonymousFunctionOperation lambda, CancellationToken cancellationToken)
+                => throw ExceptionUtilities.Unreachable;
+
+            public override bool IsLValueFlowCapture(CaptureId captureId)
+                => throw ExceptionUtilities.Unreachable;
+            public override void OnLValueCaptureFound(ISymbol symbol, IOperation operation, CaptureId captureId)
+                => throw ExceptionUtilities.Unreachable;
+            public override void OnLValueDereferenceFound(CaptureId captureId)
+                => throw ExceptionUtilities.Unreachable;
+
+            public override bool IsTrackingDelegateCreationTargets => false;
+            public override void SetLambdaTargetForDelegate(IOperation write, IFlowAnonymousFunctionOperation lambdaTarget)
+                => throw ExceptionUtilities.Unreachable;
+            public override void SetLocalFunctionTargetForDelegate(IOperation write, IMethodReferenceOperation localFunctionTarget)
+                => throw ExceptionUtilities.Unreachable;
+            public override void SetEmptyInvocationTargetsForDelegate(IOperation write)
+                => throw ExceptionUtilities.Unreachable;
+            public override void SetTargetsFromSymbolForDelegate(IOperation write, ISymbol symbol)
+                => throw ExceptionUtilities.Unreachable;
+            public override bool TryGetDelegateInvocationTargets(IOperation write, out ImmutableHashSet<IOperation> targets)
+                => throw ExceptionUtilities.Unreachable;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
@@ -113,35 +113,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                     isWrittenTo = false;
                 }
 
-                if (isReadFrom && isWrittenTo)
-                {
-                    // Read/Write could either be:
-                    //  1. A read followed by a write. For example, increment "i++", compound assignment "i += 1", etc.
-                    //  2. A declaration/write followed by a read. For example, declaration pattern 'int i' inside
-                    //     an is pattern exprssion "if (x is int i)").
-                    // Handle scenario 2 (declaration pattern) specially and use an assert to catch unknown cases.
-                    if (operation.Kind == OperationKind.DeclarationPattern && operation.Parent?.Kind == OperationKind.IsPattern)
-                    {
-                        OnWriteReferenceFound(symbol, operation, maybeWritten: false);
-
-                        // Special handling for implicit IsPattern parent operation.
-                        // In ControlFlowGraph, we generate implicit IsPattern operation for pattern case clauses,
-                        // where is the read is not observable and we want to consider such case clause declaration patterns
-                        // as just a write.
-                        if (!operation.Parent.IsImplicit)
-                        {
-                            OnReadReferenceFound(symbol);
-                        }
-
-                        return;
-                    }
-
-                    Debug.Assert(operation.Parent is IIncrementOrDecrementOperation ||
-                                 operation.Parent is IArgumentOperation argument && argument.Parameter.RefKind == RefKind.Ref ||
-                                 operation.Parent is IReDimClauseOperation reDimClause && reDimClause.Operand == operation,
-                                 "Unhandled read-write ordering");
-                }
-
                 if (isReadFrom)
                 {
                     if (operation.Parent is IFlowCaptureOperation flowCapture &&
@@ -156,7 +127,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                 }
 
                 if (isWrittenTo)
-                {   
+                {
                     // maybeWritten == 'ref' argument.
                     OnWriteReferenceFound(symbol, operation, maybeWritten: valueUsageInfo == ValueUsageInfo.ReadableWritableReference);
                 }
@@ -320,7 +291,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                     AnalyzePossibleDelegateInvocation(operation.Value);
                 }
             }
-            
+
             public override void VisitLocalFunction(ILocalFunctionOperation operation)
             {
                 // Skip visiting if we are doing an operation tree walk.
@@ -461,7 +432,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                     _currentAnalysisData.ResetState();
                     return;
                 }
-                
+
                 switch (targets.Count)
                 {
                     case 0:

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
@@ -1,0 +1,516 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
+{
+    internal static partial class SymbolUsageAnalysis
+    {
+        /// <summary>
+        /// Operations walker used for walking high-level operation tree
+        /// as well as control flow graph based operations.
+        /// </summary>
+        private sealed class Walker : OperationWalker
+        {
+            private AnalysisData _currentAnalysisData;
+            private IOperation _currentRootOperation;
+            private CancellationToken _cancellationToken;
+            private PooledDictionary<IAssignmentOperation, PooledHashSet<(ISymbol, IOperation)>> _pendingWritesMap;
+
+            private static readonly ObjectPool<Walker> s_visitorPool = new ObjectPool<Walker>(() => new Walker());
+            private Walker() { }
+
+            public static void AnalyzeOperationsAndUpdateData(
+                IEnumerable<IOperation> operations,
+                AnalysisData analysisData,
+                CancellationToken cancellationToken)
+            {
+                var visitor = s_visitorPool.Allocate();
+                try
+                {
+                    visitor.Visit(operations, analysisData, cancellationToken);
+                }
+                finally
+                {
+                    s_visitorPool.Free(visitor);
+                }
+            }
+
+            private void Visit(IEnumerable<IOperation> operations, AnalysisData analysisData, CancellationToken cancellationToken)
+            {
+                Debug.Assert(_currentAnalysisData == null);
+                Debug.Assert(_currentRootOperation == null);
+                Debug.Assert(_pendingWritesMap == null);
+
+                _pendingWritesMap = PooledDictionary<IAssignmentOperation, PooledHashSet<(ISymbol, IOperation)>>.GetInstance();
+                try
+                {
+                    _currentAnalysisData = analysisData;
+                    _cancellationToken = cancellationToken;
+
+                    foreach (var operation in operations)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        _currentRootOperation = operation;
+                        Visit(operation);
+                    }
+                }
+                finally
+                {
+                    _currentAnalysisData = null;
+                    _currentRootOperation = null;
+                    _cancellationToken = default;
+
+                    foreach (var pendingWrites in _pendingWritesMap.Values)
+                    {
+                        pendingWrites.Free();
+                    }
+                    _pendingWritesMap.Free();
+                    _pendingWritesMap = null;
+                }
+            }
+
+            private void OnReadReferenceFound(ISymbol symbol)
+                => _currentAnalysisData.OnReadReferenceFound(symbol);
+
+            private void OnWriteReferenceFound(ISymbol symbol, IOperation operation, bool maybeWritten)
+            {
+                _currentAnalysisData.OnWriteReferenceFound(symbol, operation, maybeWritten);
+                ProcessPossibleDelegateCreationAssignment(symbol, operation);
+            }
+
+            private void OnLValueCaptureFound(ISymbol symbol, IOperation operation, CaptureId captureId)
+                => _currentAnalysisData.OnLValueCaptureFound(symbol, operation, captureId);
+
+            private void OnLValueDereferenceFound(CaptureId captureId)
+                 => _currentAnalysisData.OnLValueDereferenceFound(captureId);
+
+            private void OnReferenceFound(ISymbol symbol, IOperation operation)
+            {
+                var valueUsageInfo = operation.GetValueUsageInfo();
+                var isReadFrom = valueUsageInfo.IsReadFrom();
+                var isWrittenTo = valueUsageInfo.IsWrittenTo();
+
+                if (isWrittenTo && MakePendingWrite())
+                {
+                    // Certain writes are processed at a later visit
+                    // and are marked as a pending write for post processing.
+                    // For example, consider the write to 'x' in "x = M(x, ...)".
+                    // We visit the Target (left) of assignment before visiting the Value (right)
+                    // of the assignment, as there might be expressions on the left that are evaluated first.
+                    // We don't want to mark the symbol read while processing the left of assignment
+                    // as there can be references on the right, which reads the prior value.
+                    // Instead we mark this as a pending write, which will be processed when we finish visiting the assignment.
+                    isWrittenTo = false;
+                }
+
+                if (isReadFrom && isWrittenTo)
+                {
+                    // Read/Write could either be:
+                    //  1. A read followed by a write. For example, increment "i++", compound assignment "i += 1", etc.
+                    //  2. A declaration/write followed by a read. For example, declaration pattern 'int i' inside
+                    //     an is pattern exprssion "if (x is int i)").
+                    // Handle scenario 2 (declaration pattern) specially and use an assert to catch unknown cases.
+                    if (operation.Kind == OperationKind.DeclarationPattern && operation.Parent?.Kind == OperationKind.IsPattern)
+                    {
+                        OnWriteReferenceFound(symbol, operation, maybeWritten: false);
+
+                        // Special handling for implicit IsPattern parent operation.
+                        // In ControlFlowGraph, we generate implicit IsPattern operation for pattern case clauses,
+                        // where is the read is not observable and we want to consider such case clause declaration patterns
+                        // as just a write.
+                        if (!operation.Parent.IsImplicit)
+                        {
+                            OnReadReferenceFound(symbol);
+                        }
+
+                        return;
+                    }
+
+                    Debug.Assert(operation.Parent is IIncrementOrDecrementOperation ||
+                                 operation.Parent is IArgumentOperation argument && argument.Parameter.RefKind == RefKind.Ref ||
+                                 operation.Parent is IReDimClauseOperation reDimClause && reDimClause.Operand == operation,
+                                 "Unhandled read-write ordering");
+                }
+
+                if (isReadFrom)
+                {
+                    if (operation.Parent is IFlowCaptureOperation flowCapture &&
+                        _currentAnalysisData.IsLValueFlowCapture(flowCapture.Id))
+                    {
+                        OnLValueCaptureFound(symbol, operation, flowCapture.Id);
+                    }
+                    else
+                    {
+                        OnReadReferenceFound(symbol);
+                    }
+                }
+
+                if (isWrittenTo)
+                {   
+                    // maybeWritten == 'ref' argument.
+                    OnWriteReferenceFound(symbol, operation, maybeWritten: valueUsageInfo == ValueUsageInfo.ReadableWritableReference);
+                }
+
+                if (operation.Parent is IIncrementOrDecrementOperation &&
+                    operation.Parent.Parent?.Kind != OperationKind.ExpressionStatement)
+                {
+                    OnReadReferenceFound(symbol);
+                }
+
+                return;
+
+                // Local functions
+                bool MakePendingWrite()
+                {
+                    Debug.Assert(isWrittenTo);
+
+                    if (operation.Parent is IAssignmentOperation assignmentOperation &&
+                        assignmentOperation.Target == operation)
+                    {
+                        var set = PooledHashSet<(ISymbol, IOperation)>.GetInstance();
+                        set.Add((symbol, operation));
+                        _pendingWritesMap.Add(assignmentOperation, set);
+                        return true;
+                    }
+                    else if(operation.IsInLeftOfDeconstructionAssignment(out var deconstructionAssignment))
+                    {
+                        if (!_pendingWritesMap.TryGetValue(deconstructionAssignment, out var set))
+                        {
+                            set = PooledHashSet<(ISymbol, IOperation)>.GetInstance();
+                            _pendingWritesMap.Add(deconstructionAssignment, set);
+                        }
+
+                        set.Add((symbol, operation));
+                        return true;
+                    }
+
+                    return false;
+                }
+            }
+
+            private void ProcessPendingWritesForAssignmentTarget(IAssignmentOperation operation)
+            {
+                if (_pendingWritesMap.TryGetValue(operation, out var pendingWrites))
+                {
+                    foreach (var (symbol, write) in pendingWrites)
+                    {
+                        OnWriteReferenceFound(symbol, write, maybeWritten: false);
+
+                        if (operation.Kind == OperationKind.CompoundAssignment &&
+                            operation.Parent?.Kind != OperationKind.ExpressionStatement)
+                        {
+                            OnReadReferenceFound(symbol);
+                        }
+                    }
+
+                    _pendingWritesMap.Remove(operation);
+                }
+            }
+
+            public override void VisitSimpleAssignment(ISimpleAssignmentOperation operation)
+            {
+                base.VisitSimpleAssignment(operation);
+                ProcessPendingWritesForAssignmentTarget(operation);
+            }
+
+            public override void VisitCompoundAssignment(ICompoundAssignmentOperation operation)
+            {
+                base.VisitCompoundAssignment(operation);
+                ProcessPendingWritesForAssignmentTarget(operation);
+            }
+
+            public override void VisitDeconstructionAssignment(IDeconstructionAssignmentOperation operation)
+            {
+                base.VisitDeconstructionAssignment(operation);
+                ProcessPendingWritesForAssignmentTarget(operation);
+            }
+
+            public override void VisitLocalReference(ILocalReferenceOperation operation)
+            {
+                OnReferenceFound(operation.Local, operation);
+            }
+
+            public override void VisitParameterReference(IParameterReferenceOperation operation)
+            {
+                OnReferenceFound(operation.Parameter, operation);
+            }
+
+            public override void VisitVariableDeclarator(IVariableDeclaratorOperation operation)
+            {
+                var variableInitializer = operation.GetVariableInitializer();
+                if (variableInitializer != null ||
+                    operation.Parent is IForEachLoopOperation forEachLoop && forEachLoop.LoopControlVariable == operation ||
+                    operation.Parent is ICatchClauseOperation catchClause && catchClause.ExceptionDeclarationOrExpression == operation)
+                {
+                    OnWriteReferenceFound(operation.Symbol, operation, maybeWritten: false);
+                }
+
+                base.VisitVariableDeclarator(operation);
+            }
+
+            public override void VisitFlowCaptureReference(IFlowCaptureReferenceOperation operation)
+            {
+                base.VisitFlowCaptureReference(operation);
+
+                if (_currentAnalysisData.IsLValueFlowCapture(operation.Id))
+                {
+                    OnLValueDereferenceFound(operation.Id);
+                }
+            }
+
+            public override void VisitDeclarationPattern(IDeclarationPatternOperation operation)
+            {
+                OnReferenceFound(operation.DeclaredSymbol, operation);
+            }
+
+            public override void VisitInvocation(IInvocationOperation operation)
+            {
+                base.VisitInvocation(operation);
+
+                switch (operation.TargetMethod.MethodKind)
+                {
+                    case MethodKind.AnonymousFunction:
+                    case MethodKind.DelegateInvoke:
+                        if (operation.Instance != null)
+                        {
+                            AnalyzePossibleDelegateInvocation(operation.Instance);
+                        }
+                        else
+                        {
+                            _currentAnalysisData.ResetState();
+                        }
+                        break;
+
+                    case MethodKind.LocalFunction:
+                        AnalyzeLocalFunctionInvocation(operation.TargetMethod);
+                        break;
+                }
+            }
+
+            private void AnalyzeLocalFunctionInvocation(IMethodSymbol localFunction)
+            {
+                Debug.Assert(localFunction.IsLocalFunction());
+
+                var newAnalysisData = _currentAnalysisData.AnalyzeLocalFunctionInvocation(localFunction, _cancellationToken);
+                _currentAnalysisData.SetCurrentBlockAnalysisDataFrom(newAnalysisData);
+            }
+
+            private void AnalyzeLambdaInvocation(IFlowAnonymousFunctionOperation lambda)
+            {
+                var newAnalysisData = _currentAnalysisData.AnalyzeLambdaInvocation(lambda, _cancellationToken);
+                _currentAnalysisData.SetCurrentBlockAnalysisDataFrom(newAnalysisData);
+            }
+
+            public override void VisitArgument(IArgumentOperation operation)
+            {
+                base.VisitArgument(operation);
+
+                if (operation.Value.Type.IsDelegateType())
+                {
+                    AnalyzePossibleDelegateInvocation(operation.Value);
+                }
+            }
+            
+            public override void VisitLocalFunction(ILocalFunctionOperation operation)
+            {
+                // Skip visiting if we are doing an operation tree walk.
+                // This will only happen if the operation is not the current root operation.
+                if (_currentRootOperation != operation)
+                {
+                    return;
+                }
+
+                base.VisitLocalFunction(operation);
+            }
+
+            public override void VisitAnonymousFunction(IAnonymousFunctionOperation operation)
+            {
+                // Skip visiting if we are doing an operation tree walk.
+                // This will only happen if the operation is not the current root operation.
+                if (_currentRootOperation != operation)
+                {
+                    return;
+                }
+
+                base.VisitAnonymousFunction(operation);
+            }
+
+            public override void VisitFlowAnonymousFunction(IFlowAnonymousFunctionOperation operation)
+            {
+                // Skip visiting if we are not analyzing an invocation of this lambda.
+                // This will only happen if the operation is not the current root operation.
+                if (_currentRootOperation != operation)
+                {
+                    return;
+                }
+
+                base.VisitFlowAnonymousFunction(operation);
+            }
+
+            private void ProcessPossibleDelegateCreationAssignment(ISymbol symbol, IOperation write)
+            {
+                if (!_currentAnalysisData.IsTrackingDelegateCreationTargets ||
+                    symbol.GetSymbolType()?.TypeKind != TypeKind.Delegate)
+                {
+                    return;
+                }
+
+                IOperation initializerValue = null;
+                if (write is IVariableDeclaratorOperation variableDeclarator)
+                {
+                    initializerValue = variableDeclarator.GetVariableInitializer()?.Value;
+                }
+                else if (write.Parent is ISimpleAssignmentOperation simpleAssignment)
+                {
+                    initializerValue = simpleAssignment.Value;
+                }
+
+                if (initializerValue != null)
+                {
+                    ProcessPossibleDelegateCreation(initializerValue, write);
+                }
+            }
+
+            private void ProcessPossibleDelegateCreation(IOperation creation, IOperation write)
+            {
+                var currentOperation = creation;
+                while (true)
+                {
+                    switch (currentOperation.Kind)
+                    {
+                        case OperationKind.Conversion:
+                            currentOperation = ((IConversionOperation)currentOperation).Operand;
+                            continue;
+
+                        case OperationKind.Parenthesized:
+                            currentOperation = ((IParenthesizedOperation)currentOperation).Operand;
+                            continue;
+
+                        case OperationKind.DelegateCreation:
+                            currentOperation = ((IDelegateCreationOperation)currentOperation).Target;
+                            continue;
+
+                        case OperationKind.AnonymousFunction:
+                            // We don't support lambda target analysis for operation tree
+                            // and control flow graph should have replaced 'AnonymousFunction' nodes
+                            // with 'FlowAnonymousFunction' nodes.
+                            throw ExceptionUtilities.Unreachable;
+
+                        case OperationKind.FlowAnonymousFunction:
+                            _currentAnalysisData.SetLambdaTargetForDelegate(write, (IFlowAnonymousFunctionOperation)currentOperation);
+                            return;
+
+                        case OperationKind.MethodReference:
+                            var methodReference = (IMethodReferenceOperation)currentOperation;
+                            if (methodReference.Method.IsLocalFunction())
+                            {
+                                _currentAnalysisData.SetLocalFunctionTargetForDelegate(write, methodReference);
+                            }
+                            else
+                            {
+                                _currentAnalysisData.SetEmptyInvocationTargetsForDelegate(write);
+                            }
+                            return;
+
+                        case OperationKind.LocalReference:
+                            var localReference = (ILocalReferenceOperation)currentOperation;
+                            _currentAnalysisData.SetTargetsFromSymbolForDelegate(write, localReference.Local);
+                            return;
+
+                        case OperationKind.ParameterReference:
+                            var parameterReference = (IParameterReferenceOperation)currentOperation;
+                            _currentAnalysisData.SetTargetsFromSymbolForDelegate(write, parameterReference.Parameter);
+                            return;
+
+                        case OperationKind.Literal:
+                            if (currentOperation.ConstantValue.Value is null)
+                            {
+                                _currentAnalysisData.SetEmptyInvocationTargetsForDelegate(write);
+                            }
+                            return;
+
+                        default:
+                            return;
+                    }
+                }
+            }
+
+            private void AnalyzePossibleDelegateInvocation(IOperation operation)
+            {
+                Debug.Assert(operation.Type.IsDelegateType());
+
+                if (!_currentAnalysisData.IsTrackingDelegateCreationTargets)
+                {
+                    return;
+                }
+
+                ProcessPossibleDelegateCreation(creation: operation, write: operation);
+                if (!_currentAnalysisData.TryGetDelegateInvocationTargets(operation, out var targets))
+                {
+                    // Failed to identify targets, so conservatively reset the state.
+                    _currentAnalysisData.ResetState();
+                    return;
+                }
+                
+                switch (targets.Count)
+                {
+                    case 0:
+                        // None of the delegate invocation targets are lambda/local functions.
+                        break;
+
+                    case 1:
+                        // Single target, just analyze it explicitly.
+                        AnalyzeDelegateInvocation(targets.Single());
+                        break;
+
+                    default:
+                        // Multiple potential lambda/local function targets.
+                        // Analyze each one and then merge the outputs from all.
+                        var savedCurrentAnalysisData = _currentAnalysisData.CreateBlockAnalysisData();
+                        savedCurrentAnalysisData.SetAnalysisDataFrom(_currentAnalysisData.CurrentBlockAnalysisData);
+
+                        var mergedAnalysisData = _currentAnalysisData.CreateBlockAnalysisData();
+                        foreach (var target in targets)
+                        {
+                            _currentAnalysisData.SetCurrentBlockAnalysisDataFrom(savedCurrentAnalysisData);
+                            AnalyzeDelegateInvocation(target);
+                            mergedAnalysisData = BasicBlockAnalysisData.Merge(mergedAnalysisData,
+                                _currentAnalysisData.CurrentBlockAnalysisData, _currentAnalysisData.CreateBlockAnalysisData);
+                        }
+                        _currentAnalysisData.SetCurrentBlockAnalysisDataFrom(mergedAnalysisData);
+                        break;
+                }
+
+                return;
+
+                // Local functions.
+                void AnalyzeDelegateInvocation(IOperation target)
+                {
+                    switch (target.Kind)
+                    {
+                        case OperationKind.FlowAnonymousFunction:
+                            AnalyzeLambdaInvocation((IFlowAnonymousFunctionOperation)target);
+                            break;
+
+                        case OperationKind.MethodReference:
+                            AnalyzeLocalFunctionInvocation(((IMethodReferenceOperation)target).Method);
+                            break;
+
+                        default:
+                            throw ExceptionUtilities.Unreachable;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                         _pendingWritesMap.Add(assignmentOperation, set);
                         return true;
                     }
-                    else if(operation.IsInLeftOfDeconstructionAssignment(out var deconstructionAssignment))
+                    else if (operation.IsInLeftOfDeconstructionAssignment(out var deconstructionAssignment))
                     {
                         if (!_pendingWritesMap.TryGetValue(deconstructionAssignment, out var set))
                         {
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                     case MethodKind.DelegateInvoke:
                         if (operation.Instance != null)
                         {
-                            AnalyzePossibleDelegateInvocation(operation.Instance);
+                            AnalyzePossibleDelegateInvocation(operation.Instance, isInvocation: true);
                         }
                         else
                         {
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
 
                 if (operation.Value.Type.IsDelegateType())
                 {
-                    AnalyzePossibleDelegateInvocation(operation.Value);
+                    AnalyzePossibleDelegateInvocation(operation.Value, isInvocation: false);
                 }
             }
 
@@ -416,7 +416,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                 }
             }
 
-            private void AnalyzePossibleDelegateInvocation(IOperation operation)
+            private void AnalyzePossibleDelegateInvocation(IOperation operation, bool isInvocation)
             {
                 Debug.Assert(operation.Type.IsDelegateType());
 
@@ -440,12 +440,25 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                         break;
 
                     case 1:
-                        // Single target, just analyze it explicitly.
-                        AnalyzeDelegateInvocation(targets.Single());
+                        // Single target.
+                        // If we know it is an explicit invocation that will certainly be invoked,
+                        // analyze it explicitly and overwrite current state.
+                        // Otherise, this represents a potential invocation, so we need to merge the current
+                        // state with the state on the control flow path where invocation did happen.
+                        if (isInvocation)
+                        {
+                            AnalyzeDelegateInvocation(targets.Single());
+                        }
+                        else
+                        {
+                            // We have this logic in the default case.
+                            goto default;
+                        }
+
                         break;
 
                     default:
-                        // Multiple potential lambda/local function targets.
+                        // Multiple potential lambda/local function targets OR we need to merge with current state.
                         // Analyze each one and then merge the outputs from all.
                         var savedCurrentAnalysisData = _currentAnalysisData.CreateBlockAnalysisData();
                         savedCurrentAnalysisData.SetAnalysisDataFrom(_currentAnalysisData.CurrentBlockAnalysisData);
@@ -458,6 +471,15 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                             mergedAnalysisData = BasicBlockAnalysisData.Merge(mergedAnalysisData,
                                 _currentAnalysisData.CurrentBlockAnalysisData, _currentAnalysisData.CreateBlockAnalysisData);
                         }
+
+                        if (!isInvocation)
+                        {
+                            // This represents a potential invocation, so we need to merge the current
+                            // state with the state on the control flow path where invocation did happen.
+                            mergedAnalysisData = BasicBlockAnalysisData.Merge(mergedAnalysisData,
+                                savedCurrentAnalysisData, _currentAnalysisData.CreateBlockAnalysisData);
+                        }
+
                         _currentAnalysisData.SetCurrentBlockAnalysisDataFrom(mergedAnalysisData);
                         break;
                 }

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.Operations;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
+{
+    /// <summary>
+    /// Analysis to compute all the symbol writes for local and parameter
+    /// symbols in an executable code block, along with the information of whether or not the definition
+    /// may be read on some control flow path.
+    /// </summary>
+    internal static partial class SymbolUsageAnalysis
+    {
+        /// <summary>
+        /// Runs dataflow analysis on the given control flow graph to compute symbol usage results
+        /// for symbol read/writes.
+        /// </summary>
+        public static SymbolUsageResult Run(ControlFlowGraph cfg, ISymbol owningSymbol, CancellationToken cancellationToken)
+            => DataFlowAnalyzer.RunAnalysis(cfg, owningSymbol, cancellationToken);
+
+        /// <summary>
+        /// Runs a fast, non-precise operation tree based analysis to compute symbol usage results
+        /// for symbol read/writes.
+        /// </summary>
+        public static SymbolUsageResult Run(IOperation rootOperation, ISymbol owningSymbol, CancellationToken cancellationToken)
+        {
+            AnalysisData analysisData = null;
+            using (analysisData = OperationTreeAnalysisData.Create(owningSymbol, AnalyzeLocalFunction))
+            {
+                var operations = SpecializedCollections.SingletonEnumerable(rootOperation);
+                Walker.AnalyzeOperationsAndUpdateData(operations, analysisData, cancellationToken);
+                return analysisData.ToResult();
+            }
+
+            // Local functions.
+            BasicBlockAnalysisData AnalyzeLocalFunction(IMethodSymbol localFunction)
+            {
+                var localFunctionOperation = rootOperation.Descendants()
+                    .FirstOrDefault(o => (o as ILocalFunctionOperation)?.Symbol == localFunction);
+
+                // Can likely be null for broken code.
+                if (localFunctionOperation != null)
+                {
+                    var operations = SpecializedCollections.SingletonEnumerable(localFunctionOperation);
+                    Walker.AnalyzeOperationsAndUpdateData(operations, analysisData, cancellationToken);
+                }
+
+                return analysisData.CurrentBlockAnalysisData;
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageResult.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageResult.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
+{
+    internal sealed class SymbolUsageResult
+    {
+        public SymbolUsageResult(
+            ImmutableDictionary<(ISymbol symbol, IOperation write), bool> symbolWritesMap,
+            ImmutableHashSet<ISymbol> symbolsRead)
+        {
+            SymbolWritesMap = symbolWritesMap;
+            SymbolsRead = symbolsRead;
+        }
+
+        /// <summary>
+        /// Map from each symbol write to a boolean indicating if the value assinged
+        /// at write is used/read on some control flow path.
+        /// </summary>
+        public ImmutableDictionary<(ISymbol symbol, IOperation write), bool> SymbolWritesMap { get; }
+
+        /// <summary>
+        /// Set of locals/parameters that are read at least once.
+        /// </summary>
+        public ImmutableHashSet<ISymbol> SymbolsRead { get; }
+
+        public bool HasUnreadSymbolWrites()
+        {
+            foreach (var kvp in SymbolWritesMap)
+            {
+                if (!kvp.Value)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Gets symbol writes that have are never read.
+        /// </summary>
+        public IEnumerable<(ISymbol Symbol, IOperation WriteOperation)> GetUnreadSymbolWrites()
+        {
+            foreach (var kvp in SymbolWritesMap)
+            {
+                if (!kvp.Value)
+                {
+                    yield return kvp.Key;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the initial value of the parameter from the caller is used.
+        /// </summary>
+        public bool IsInitialParameterValueUsed(IParameterSymbol parameter)
+        {
+            foreach (var kvp in SymbolWritesMap)
+            {
+                if (kvp.Key.write == null && kvp.Key.symbol == parameter)
+                {
+                    return kvp.Value;
+                }
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        /// <summary>
+        /// Gets the write count for a given local/parameter symbol.
+        /// </summary>
+        public int GetSymbolWriteCount(ISymbol symbol)
+        {
+            int count = 0;
+            foreach (var kvp in SymbolWritesMap)
+            {
+                if (kvp.Key.symbol == symbol)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+}


### PR DESCRIPTION
This PR extracts out the flow-analysis component from #30777 for easier code review.

Support added in this PR:
1. Core dataflow walker to walk the control flow graph and compute/track custom analysis data (CustomDataFlowAnalysis).
2. Internal API (DataFlowAnalyzer) to implement custom dataflow analysis on top of the above walker.
3. Implementation of a SymbolUsageAnalysis dataflow analyzer to compute read/write usages for local and parameter symbols
4. Implementation of a test-only BasicBlockReachabilityDataFlowAnalyzer to compute and validate basic block reachability on all CFGs generated in compiler's flow analysis unit tests.

Please refer to #30777 for the unit tests for SymbolUsageAnalysis. This PR is targeting a feature branch, which will get unit tests from #30777 before it gets merged into master or dev16.0-preview2 branch.