### PR TITLE
Fixing inferred type for yield return in async iterator methods

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -5141,6 +5141,36 @@ class Program
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestWithYieldReturnInAsyncMethod()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System.Collections.Generic;
+
+class Program
+{
+    async IAsyncEnumerable<int> Goo()
+    {
+        yield return [|Bar|]();
+    }
+}",
+@"using System;
+using System.Collections.Generic;
+
+class Program
+{
+    async IAsyncEnumerable<int> Goo()
+    {
+        yield return Bar();
+    }
+
+    private int Bar()
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
         [WorkItem(30235, "https://github.com/dotnet/roslyn/issues/30235")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public async Task TestWithYieldReturnInLocalFunction()

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -4716,6 +4716,34 @@ class Program
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TestWithYieldReturnInAsyncMethod()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+using System.Collections.Generic;
+
+class Program
+{
+    async IAsyncEnumerable<DayOfWeek> Goo()
+    {
+        yield return [|abc|];
+    }
+}",
+@"using System;
+using System.Collections.Generic;
+
+class Program
+{
+    private DayOfWeek abc;
+
+    async IAsyncEnumerable<DayOfWeek> Goo()
+    {
+        yield return abc;
+    }
+}");
+        }
+
         [WorkItem(30235, "https://github.com/dotnet/roslyn/issues/30235")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public async Task TestWithYieldReturnInLocalFunction()

--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -1060,20 +1060,61 @@ class C
         }
 
         [WorkItem(827897, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827897")]
-        [Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
-        public async Task TestYieldReturnInMethod()
+        [Theory, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        [InlineData("IEnumerable")]
+        [InlineData("IEnumerator")]
+        [InlineData("InvalidGenericType")]
+        public async Task TestYieldReturnInMethod(string returnTypeName)
         {
             var markup =
-@"using System.Collections.Generic;
+$@"using System.Collections.Generic;
 
-class Program
-{
-    IEnumerable<int> M()
-    {
+class C
+{{
+    {returnTypeName}<int> M()
+    {{
         yield return [|abc|]
-    }
-}";
+    }}
+}}";
             await TestAsync(markup, "global::System.Int32");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        [InlineData("IAsyncEnumerable")]
+        [InlineData("IAsyncEnumerator")]
+        [InlineData("InvalidGenericType")]
+        public async Task TestYieldReturnInAsyncMethod(string returnTypeName)
+        {
+            var markup =
+$@"namespace System.Collections.Generic
+{{
+    class C
+    {{
+        interface {returnTypeName}<T> {{ }}
+        async {returnTypeName}<int> M()
+        {{
+            yield return [|abc|]
+        }}
+    }}
+}}";
+            await TestAsync(markup, "global::System.Int32");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        [InlineData("int[]")]
+        [InlineData("InvalidNonGenericType")]
+        [InlineData("InvalidGenericType<int, int>")]
+        public async Task TestYieldReturnInvalidTypeInMethod(string returnType)
+        {
+            var markup =
+$@"class C
+{{
+    {returnType} M()
+    {{
+        yield return [|abc|]
+    }}
+}}";
+            await TestAsync(markup, "global::System.Object");
         }
 
         [WorkItem(30235, "https://github.com/dotnet/roslyn/issues/30235")]
@@ -1083,7 +1124,7 @@ class Program
             var markup =
 @"using System.Collections.Generic;
 
-class Program
+class C
 {
     void M()
     {
@@ -1094,6 +1135,44 @@ class Program
     }
 }";
             await TestAsync(markup, "global::System.Int32");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        public async Task TestYieldReturnInPropertyGetter()
+        {
+            var markup =
+@"using System.Collections.Generic;
+
+class C
+{
+    IEnumerable<int> P
+    {
+        get
+        {
+            yield return [|abc|]
+        }
+    }
+}";
+            await TestAsync(markup, "global::System.Int32");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        public async Task TestYieldReturnInPropertySetter()
+        {
+            var markup =
+@"using System.Collections.Generic;
+
+class C
+{
+    IEnumerable<int> P
+    {
+        set
+        {
+            yield return [|abc|]
+        }
+    }
+}";
+            await TestAsync(markup, "global::System.Object");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]

--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -1088,9 +1088,9 @@ class C
             var markup =
 $@"namespace System.Collections.Generic
 {{
+    interface {returnTypeName}<T> {{ }}
     class C
     {{
-        interface {returnTypeName}<T> {{ }}
         async {returnTypeName}<int> M()
         {{
             yield return [|abc|]

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -1777,6 +1777,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var memberSymbol = GetDeclaredMemberSymbolFromOriginalSemanticModel(declaration);
 
                 var memberType = GetMemberType(memberSymbol, out _);
+
                 // We don't care what the type is, as long as it has 1 type argument. This will work for IEnumerable, IEnumerator,
                 // IAsyncEnumerable, IAsyncEnumerator and it's also good for error recovery in case there is a missing using.
                 return memberType is INamedTypeSymbol namedType && namedType.TypeArguments.Length == 1

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -1777,7 +1777,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var memberSymbol = GetDeclaredMemberSymbolFromOriginalSemanticModel(declaration);
 
                 var memberType = GetMemberType(memberSymbol, out _);
-
+                // We don't care what the type is, as long as it has 1 type argument. This will work for IEnumerable, IEnumerator,
+                // IAsyncEnumerable, IAsyncEnumerator and it's also good for error recovery in case there is a missing using.
                 return memberType is INamedTypeSymbol namedType && namedType.TypeArguments.Length == 1
                     ? SpecializedCollections.SingletonEnumerable(new TypeInferenceInfo(namedType.TypeArguments[0]))
                     : SpecializedCollections.EmptyEnumerable<TypeInferenceInfo>();

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -1778,16 +1778,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var memberType = GetMemberType(memberSymbol, out _);
 
-                if (memberType is INamedTypeSymbol namedType)
-                {
-                    if (memberType.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T ||
-                        memberType.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerator_T)
-                    {
-                        return SpecializedCollections.SingletonEnumerable(new TypeInferenceInfo(namedType.TypeArguments[0]));
-                    }
-                }
-
-                return SpecializedCollections.EmptyEnumerable<TypeInferenceInfo>();
+                return memberType is INamedTypeSymbol namedType && namedType.TypeArguments.Length == 1
+                    ? SpecializedCollections.SingletonEnumerable(new TypeInferenceInfo(namedType.TypeArguments[0]))
+                    : SpecializedCollections.EmptyEnumerable<TypeInferenceInfo>();
             }
 
             private static ITypeSymbol GetMemberType(ISymbol memberSymbol, out bool isAsync)


### PR DESCRIPTION
Towards #24037:
> ## Productivity (code fixers/refactorings/etc):
>  Review TypeInferrer #30211 (comment)

The fix is just to return the type argument, not matter what the type is. I think that's actually good for error recovery, in case someone is just missing a `using`.

Tagging @jcouv