### PR TITLE
Fix Edit and Continue in CPS projects

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/EditAndContinueTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/EditAndContinueTests.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue.Interop;
+using Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
+{
+    [UseExportProvider]
+    public class EditAndContinueTests
+    {
+        [WpfFact, WorkItem(31034, "https://github.com/dotnet/roslyn/issues/31034")]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void EditAndContinueInterfacesAreImplemented()
+        {
+            using (var environment = new TestEnvironment())
+            using (var project = CSharpHelpers.CreateCSharpCPSProject(environment, "Test", binOutputPath: null))
+            {
+                Assert.IsAssignableFrom<IVsENCRebuildableProjectCfg2>(project);
+                Assert.IsAssignableFrom<IVsENCRebuildableProjectCfg4>(project);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IVsENCRebuildableProjectCfg.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IVsENCRebuildableProjectCfg.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using EncInterop = Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue.Interop;
+using ShellInterop = Microsoft.VisualStudio.Shell.Interop;
+using VsTextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.CPS
+{
+    internal partial class CPSProject : EncInterop.IVsENCRebuildableProjectCfg2, EncInterop.IVsENCRebuildableProjectCfg4
+    {
+        public int HasCustomMetadataEmitter(out bool value)
+        {
+            value = true;
+            return VSConstants.S_OK;
+        }
+
+        public int StartDebuggingPE()
+        {
+            return _editAndContinueProject.StartDebuggingPE();
+        }
+
+        public int StopDebuggingPE()
+        {
+            return _editAndContinueProject.StopDebuggingPE();
+        }
+
+        public int GetPEidentity(Guid[] pMVID, string[] pbstrPEName)
+        {
+            return _editAndContinueProject.GetPEidentity(pMVID, pbstrPEName);
+        }
+
+        public int EnterBreakStateOnPE(EncInterop.ENC_BREAKSTATE_REASON encBreakReason, ShellInterop.ENC_ACTIVE_STATEMENT[] pActiveStatements, uint cActiveStatements)
+        {
+            return _editAndContinueProject.EnterBreakStateOnPE(encBreakReason, pActiveStatements, cActiveStatements);
+        }
+
+        public int GetExceptionSpanCount(out uint pcExceptionSpan)
+        {
+            pcExceptionSpan = default;
+            return _editAndContinueProject.GetExceptionSpanCount(out pcExceptionSpan);
+        }
+
+        public int GetExceptionSpans(uint celt, ShellInterop.ENC_EXCEPTION_SPAN[] rgelt, ref uint pceltFetched)
+        {
+            return _editAndContinueProject.GetExceptionSpans(celt, rgelt, ref pceltFetched);
+        }
+
+        public int GetCurrentExceptionSpanPosition(uint id, VsTextSpan[] ptsNewPosition)
+        {
+            return _editAndContinueProject.GetCurrentExceptionSpanPosition(id, ptsNewPosition);
+        }
+
+        public int GetENCBuildState(ShellInterop.ENC_BUILD_STATE[] pENCBuildState)
+        {
+            return _editAndContinueProject.GetENCBuildState(pENCBuildState);
+        }
+
+        public int ExitBreakStateOnPE()
+        {
+            return _editAndContinueProject.ExitBreakStateOnPE();
+        }
+
+        public int GetCurrentActiveStatementPosition(uint id, VsTextSpan[] ptsNewPosition)
+        {
+            return _editAndContinueProject.GetCurrentActiveStatementPosition(id, ptsNewPosition);
+        }
+
+        public int EncApplySucceeded(int hrApplyResult)
+        {
+            return _editAndContinueProject.EncApplySucceeded(hrApplyResult);
+        }
+
+        public int GetPEBuildTimeStamp(Microsoft.VisualStudio.OLE.Interop.FILETIME[] pTimeStamp)
+        {
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int BuildForEnc(object pUpdatePE)
+        {
+            return _editAndContinueProject.BuildForEnc(pUpdatePE);
+        }
+    }
+}


### PR DESCRIPTION
The problem was our CPSProject type no longer was implementing the ENC interfaces the project system expects; this copy/pastes the same code over that's being used for AbstractLegacyProject.

<details><summary>Ask Mode template</summary>

### Customer scenario

Try to use edit and continue in an CPS-based C# or VB project. It just silently doesn't work, potentially resulting in strange debugger behavior since it then can't match up source files after an edit.

### Bugs this fixes

#31034 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/725662

### Workarounds, if any

None.

### Risk

Low.

### Performance impact

None.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

The problem occurred because the larger project system refactoring accidentally caused us to drop certain interfaces we must implement that CPS expected. Our type hierarchy was changed around and the implementation that was on a base class wasn't there anymore. CPS in Edit and Continue itself was accidentally dropped from our test matrix.

### How was the bug found?

Dogfooding.

</details>
