### PR TITLE
Make sure we convert project references back on project removal

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpReferencesTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpReferencesTests.cs
@@ -85,6 +85,29 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
             }
         }
 
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void RemoveProjectConvertsProjectReferencesBack()
+        {
+            using (var environment = new TestEnvironment())
+            {
+                var project1 = CreateCSharpCPSProject(environment, "project1", commandLineArguments: @"/out:c:\project1.dll");
+                var project2 = CreateCSharpCPSProject(environment, "project2");
+
+                // Add project reference as metadata reference: since this is known to be the output path of project1, the metadata reference is converted to a project reference
+                project2.AddMetadataReference(@"c:\project1.dll", new MetadataReferenceProperties());
+                Assert.Single(environment.Workspace.CurrentSolution.GetProject(project2.Id).AllProjectReferences);
+
+                // Remove project1. project2's reference should have been converted back
+                project1.Dispose();
+                Assert.Empty(environment.Workspace.CurrentSolution.GetProject(project2.Id).AllProjectReferences);
+                Assert.Single(environment.Workspace.CurrentSolution.GetProject(project2.Id).MetadataReferences);
+
+                project2.Dispose();
+            }
+        }
+
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void AddRemoveAnalyzerReference_CPS()

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1390,6 +1390,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             SetSolutionAndRaiseWorkspaceChanged_NoLock(modifiedSolution, projectIdsChanged);
         }
 
+        /// <summary>
+        /// Finds all projects that had a project reference to <paramref name="projectId"/> and convert it back to a metadata reference.
+        /// </summary>
+        /// <param name="projectId">The <see cref="ProjectId"/> of the project being referenced.</param>
+        /// <param name="outputPath">The output path of the given project to remove the link to.</param>
         private void ConvertProjectReferencesToMetadataReferences_NoLock(ProjectId projectId, string outputPath)
         {
             var modifiedSolution = this.CurrentSolution;


### PR DESCRIPTION
If we don't do this, projects will end up with dangling project references, which isn't something we want. Even if the project later reloads, the fact there's still old ProjectIds floating around causes us to fail to convert to P2P references again later.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/714766.