### PR TITLE
Add a new SuppressMessageAttribute target scope to suppress diagnosti…

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -12,9 +13,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal partial class SuppressMessageAttributeState
     {
-        private static readonly SmallDictionary<string, TargetScope> s_suppressMessageScopeTypes = new SmallDictionary<string, TargetScope>()
+        private static readonly SmallDictionary<string, TargetScope> s_suppressMessageScopeTypes = new SmallDictionary<string, TargetScope>(StringComparer.OrdinalIgnoreCase)
             {
-                { null, TargetScope.None },
+                { string.Empty, TargetScope.None },
                 { "module", TargetScope.Module },
                 { "namespace", TargetScope.Namespace },
                 { "resource", TargetScope.Resource },
@@ -24,10 +25,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             };
 
         private static bool TryGetTargetScope(SuppressMessageInfo info, out TargetScope scope)
-        {
-            string scopeString = info.Scope != null ? info.Scope.ToLowerInvariant() : null;
-            return s_suppressMessageScopeTypes.TryGetValue(scopeString, out scope);
-        }
+            => s_suppressMessageScopeTypes.TryGetValue(info.Scope ?? string.Empty, out scope);
 
         private readonly Compilation _compilation;
         private GlobalSuppressions _lazyGlobalSuppressions;
@@ -170,7 +168,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         {
                             return true;
                         }
+                    }
 
+                    if (!declaredSymbols.IsEmpty)
+                    {
                         inImmediatelyContainingSymbol = false;
                     }
                 }

--- a/src/Test/Utilities/Portable/Diagnostics/SuppressMessageAttributeTests.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/SuppressMessageAttributeTests.cs
@@ -110,6 +110,101 @@ namespace N4
                 Diagnostic("Declaration", "N3"));
         }
 
+        [Fact, WorkItem(486, "https://github.com/dotnet/roslyn/issues/486")]
+        public async Task GlobalSuppressionOnNamespaces_NamespaceAndChildren()
+        {
+            await VerifyCSharpAsync(@"
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage(""Test"", ""Declaration"", Scope=""NamespaceAndChildren"", Target=""N.N1"")]
+[module: SuppressMessage(""Test"", ""Declaration"", Scope=""NamespaceAndChildren"", Target=""N4"")]
+
+namespace N
+{
+    namespace N1
+    {
+        namespace N2.N3
+        {
+        }
+    }
+}
+
+namespace N4
+{
+    namespace N5
+    {
+    }
+}
+
+namespace N.N1.N6.N7
+{
+}
+",
+                new[] { new WarningOnNamePrefixDeclarationAnalyzer("N") },
+                Diagnostic("Declaration", "N"));
+        }
+
+        [Fact, WorkItem(486, "https://github.com/dotnet/roslyn/issues/486")]
+        public async Task GlobalSuppressionOnTypesAndNamespaces_NamespaceAndChildren()
+        {
+            await VerifyCSharpAsync(@"
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage(""Test"", ""Declaration"", Scope=""NamespaceAndChildren"", Target=""N.N1.N2"")]
+[module: SuppressMessage(""Test"", ""Declaration"", Scope=""NamespaceAndChildren"", Target=""N4"")]
+[module: SuppressMessage(""Test"", ""Declaration"", Scope=""Type"", Target=""C2"")]
+
+namespace N
+{
+    namespace N1
+    {
+        class C1
+        {
+        }
+
+        namespace N2.N3
+        {
+            class C2
+            {
+            }
+
+            class C3
+            {
+                class C4
+                {
+                }
+            }
+        }
+    }
+}
+
+namespace N4
+{
+    namespace N5
+    {
+        class C5
+        {
+        }
+    }
+
+    class C6
+    {
+    }
+}
+
+namespace N.N1.N2.N7
+{
+    class C7
+    {
+    }
+}
+",
+                new[] { new WarningOnNamePrefixDeclarationAnalyzer("N"), new WarningOnNamePrefixDeclarationAnalyzer("C") },
+                Diagnostic("Declaration", "N"),
+                Diagnostic("Declaration", "N1"),
+                Diagnostic("Declaration", "C1"));
+        }
+
         [Fact]
         public async Task GlobalSuppressionOnTypes()
         {
@@ -350,6 +445,23 @@ namespace A
                 Diagnostic("Token", "}").WithLocation(9, 1));
         }
 
+        [Fact, WorkItem(486, "https://github.com/dotnet/roslyn/issues/486")]
+        public async Task SuppressSyntaxDiagnosticsOnNamespaceAndChildDeclarationCSharp()
+        {
+            await VerifyTokenDiagnosticsCSharpAsync(@"
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""Test"", ""Token"", Scope=""NamespaceAndChildren"", Target=""A.B"")]
+namespace A
+[|{
+    namespace B
+    {
+        class C {}
+    }
+}|]
+",
+                Diagnostic("Token", "{").WithLocation(4, 1),
+                Diagnostic("Token", "}").WithLocation(9, 1));
+        }
+
         [Fact]
         public async Task SuppressSyntaxDiagnosticsOnNamespaceDeclarationBasic()
         {
@@ -370,11 +482,29 @@ End|] Namespace
                 Diagnostic("Token", "End").WithLocation(8, 1));
         }
 
-        [Fact]
-        public async Task DontSuppressSyntaxDiagnosticsInRootNamespaceBasic()
+        [Fact, WorkItem(486, "https://github.com/dotnet/roslyn/issues/486")]
+        public async Task SuppressSyntaxDiagnosticsOnNamespaceAndChildrenDeclarationBasic()
         {
-            await VerifyBasicAsync(@"
-<module: System.Diagnostics.SuppressMessage(""Test"", ""Comment"", Scope:=""Namespace"", Target:=""RootNamespace"")>
+            await VerifyTokenDiagnosticsBasicAsync(@"
+<assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""Test"", ""Token"", Scope:=""NamespaceAndChildren"", Target:=""A.B"")>
+Namespace [|A
+    Namespace B 
+        Class C
+        End Class
+    End Namespace
+End|] Namespace
+",
+                Diagnostic("Token", "A").WithLocation(3, 11),
+                Diagnostic("Token", "End").WithLocation(8, 1));
+        }
+
+        [Theory, WorkItem(486, "https://github.com/dotnet/roslyn/issues/486")]
+        [InlineData("Namespace")]
+        [InlineData("NamespaceAndChildren")]
+        public async Task DontSuppressSyntaxDiagnosticsInRootNamespaceBasic(string scope)
+        {
+            await VerifyBasicAsync($@"
+<module: System.Diagnostics.SuppressMessage(""Test"", ""Comment"", Scope:=""{scope}"", Target:=""RootNamespace"")>
 ' In root namespace
 ",
                 rootNamespace: "RootNamespace",

--- a/src/Test/Utilities/Portable/Diagnostics/SuppressMessageAttributeTests.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/SuppressMessageAttributeTests.cs
@@ -117,7 +117,7 @@ namespace N4
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage(""Test"", ""Declaration"", Scope=""NamespaceAndChildren"", Target=""N.N1"")]
-[module: SuppressMessage(""Test"", ""Declaration"", Scope=""NamespaceAndChildren"", Target=""N4"")]
+[module: SuppressMessage(""Test"", ""Declaration"", Scope=""namespaceandchildren"", Target=""N4"")]
 
 namespace N
 {


### PR DESCRIPTION
…cs in a namespace and all its descendant symbols

Fixes #486

This SuppressMessageAttribute feature has been requested for a very long time and still gets frequent customer requests to date.

The current "Namespace" target scope for SuppressMessageAttribute suppresses diagnostics only in nodes directly contained within the namespace, but not in any of it's descendant symbols. This makes it very tedious to suppress certain analyzer diagnostics in entire namespace as one needs to add suppressions to individual types/namespaces within the namespace. This also creates a maintenance nightmare.

This PR adds a new target scope "NamespaceAndChildren" which suppresses diagnostics on the corresponding namespace and all its descendant symbols/members. Better naming suggestions for this scope name are welcome!

Example: `[assembly: SuppressMessage("Test", "Declaration", Scope="NamespaceAndChildren", Target="N.N1")]`