### PR TITLE
Allow multiple calls to GetAsyncEnumerator

### DIFF
--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -96,7 +96,8 @@ The state machine for an async-iterator method primarily implements `IAsyncEnume
 It is similar to a state machine produced for an async method. It contains builder and awaiter fields, used to run the state machine in the background (when an `await` is reached in the async-iterator). It also captures parameter values (if any) or `this` (if needed).
 But it contains additional state:
 - a promise of a value-or-end,
-- a current yielded value of type `T`.
+- a current yielded value of type `T`,
+- an `int` capturing the id of the thread that created it.
 
 The central method of the state machine is `MoveNext()`. It gets run by `MoveNextAsync()`, or as a background continuation initiated from these from an `await` in the method.
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
@@ -106,10 +106,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Binder.GetWellKnownTypeMember(F.Compilation, member, bag, body.Syntax.Location);
         }
 
-        protected override bool PreserveInitialParameterValues
-        {
-            get { return false; }
-        }
+        // Should only be true for async-enumerables, not async-enumerators. Tracked by https://github.com/dotnet/roslyn/issues/31057
+        protected override bool PreserveInitialParameterValuesAndThreadId
+            => method.IsIterator;
 
         protected override void GenerateControlFields()
         {
@@ -158,6 +157,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Constructor
+            GenerateConstructor();
+        }
+
+        protected virtual void GenerateConstructor()
+        {
             if (stateMachineType.TypeKind == TypeKind.Class)
             {
                 F.CurrentFunction = stateMachineType.Constructor;

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncStateMachine.cs
@@ -25,7 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             CSharpCompilation compilation = asyncMethod.DeclaringCompilation;
             var interfaces = ArrayBuilder<NamedTypeSymbol>.GetInstance();
 
-            if (asyncMethod.IsIterator)
+            bool isIterator = asyncMethod.IsIterator;
+            if (isIterator)
             {
                 var elementType = TypeMap.SubstituteType(asyncMethod.IteratorElementType).TypeSymbol;
                 this.IteratorElementType = elementType;
@@ -51,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             interfaces.Add(compilation.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_IAsyncStateMachine));
             _interfaces = interfaces.ToImmutableAndFree();
 
-            _constructor = new AsyncConstructor(this);
+            _constructor = isIterator ? (MethodSymbol)new IteratorConstructor(this) : new AsyncConstructor(this);
         }
 
         public override TypeKind TypeKind

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorConstructor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly ImmutableArray<ParameterSymbol> _parameters;
 
-        internal IteratorConstructor(IteratorStateMachine container)
+        internal IteratorConstructor(StateMachineTypeSymbol container)
             : base(container)
         {
             var intType = container.DeclaringCompilation.GetSpecialType(SpecialType.System_Int32);

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly bool _isEnumerable;
 
         private FieldSymbol _currentField;
-        private FieldSymbol _initialThreadIdField;
 
         private IteratorRewriter(
             BoundStatement body,
@@ -160,10 +159,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override bool PreserveInitialParameterValues
-        {
-            get { return _isEnumerable; }
-        }
+        protected override bool PreserveInitialParameterValuesAndThreadId
+            => _isEnumerable;
 
         protected override void GenerateControlFields()
         {
@@ -171,14 +168,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Add a field: T current
             _currentField = F.StateMachineField(_elementType, GeneratedNames.MakeIteratorCurrentFieldName());
-
-            // if it is an enumerable, and either Environment.CurrentManagedThreadId or Thread.ManagedThreadId are available
-            // add a field: int initialThreadId
-            bool addInitialThreadId = _isEnumerable && CanGetThreadId();
-
-            _initialThreadIdField = addInitialThreadId
-                ? F.StateMachineField(F.SpecialType(SpecialType.System_Int32), GeneratedNames.MakeIteratorCurrentThreadIdFieldName())
-                : null;
         }
 
         protected override void GenerateMethodImplementations()
@@ -243,6 +232,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        /// <summary>
+        /// Add IEnumerator&lt;elementType> IEnumerable&lt;elementType>.GetEnumerator()
+        /// </summary>
         private void GenerateEnumerableImplementation(ref BoundExpression managedThreadId)
         {
             var IEnumerable_GetEnumerator = F.SpecialMethod(SpecialMember.System_Collections_IEnumerable__GetEnumerator);
@@ -250,88 +242,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var IEnumerableOfElementType = F.SpecialType(SpecialType.System_Collections_Generic_IEnumerable_T).Construct(_elementType);
             var IEnumerableOfElementType_GetEnumerator = F.SpecialMethod(SpecialMember.System_Collections_Generic_IEnumerable_T__GetEnumerator).AsMember(IEnumerableOfElementType);
 
-            // generate the code for GetEnumerator()
-            // .NET Core has removed the Thread class. We can the managed thread id by making a call to 
-            // Environment.CurrentManagedThreadId. If that method is not present (pre 4.5) fall back to the old behavior.
-            //    IEnumerable<elementType> result;
-            //    if (this.initialThreadId == Thread.CurrentThread.ManagedThreadId && this.state == -2)
-            //    {
-            //        this.state = 0;
-            //        result = this;
-            //    }
-            //    else
-            //    {
-            //        result = new Ints0_Impl(0);
-            //    }
-            //    result.parameter = this.parameterProxy; // copy all of the parameter proxies
-
-            // Add IEnumerator<elementType> IEnumerable<elementType>.GetEnumerator()
-
-            // The implementation doesn't depend on the method body of the iterator method.
-            // Only on it's parameters and staticness.
-            var getEnumeratorGeneric = OpenMethodImplementation(
-                IEnumerableOfElementType_GetEnumerator,
-                hasMethodBodyDependency: false);
-
-            var bodyBuilder = ArrayBuilder<BoundStatement>.GetInstance();
-            var resultVariable = F.SynthesizedLocal(stateMachineType, null);      // iteratorClass result;
-            BoundStatement makeIterator = F.Assignment(F.Local(resultVariable), F.New(stateMachineType.Constructor, F.Literal(0))); // result = new IteratorClass(0)
-
-            var thisInitialized = F.GenerateLabel("thisInitialized");
-
-            if ((object)_initialThreadIdField != null)
-            {
-                managedThreadId = MakeCurrentThreadId();
-
-                makeIterator = F.If(
-                    condition: F.LogicalAnd(                                   // if (this.state == -2 && this.initialThreadId == Thread.CurrentThread.ManagedThreadId)
-                            F.IntEqual(F.Field(F.This(), stateField), F.Literal(StateMachineStates.FinishedStateMachine)),
-                        F.IntEqual(F.Field(F.This(), _initialThreadIdField), managedThreadId)),
-                    thenClause: F.Block(                                       // then
-                            F.Assignment(F.Field(F.This(), stateField), F.Literal(StateMachineStates.FirstUnusedState)),  // this.state = 0;
-                            F.Assignment(F.Local(resultVariable), F.This()),       // result = this;
-                            method.IsStatic || method.ThisParameter.Type.IsReferenceType ?   // if this is a reference type, no need to copy it since it is not assignable
-                                F.Goto(thisInitialized) :                          // goto thisInitialized
-                                (BoundStatement)F.StatementList()),
-                    elseClauseOpt:
-                        makeIterator // else result = new IteratorClass(0)
-                        );
-            }
-
-            bodyBuilder.Add(makeIterator);
-
-            // Initialize all the parameter copies
-            var copySrc = initialParameters;
-            var copyDest = nonReusableLocalProxies;
-            if (!method.IsStatic)
-            {
-                // starting with "this"
-                CapturedSymbolReplacement proxy;
-                if (copyDest.TryGetValue(method.ThisParameter, out proxy))
-                {
-                    bodyBuilder.Add(
-                        F.Assignment(
-                            proxy.Replacement(F.Syntax, stateMachineType => F.Local(resultVariable)),
-                            copySrc[method.ThisParameter].Replacement(F.Syntax, stateMachineType => F.This())));
-                }
-            }
-
-            bodyBuilder.Add(F.Label(thisInitialized));
-
-            foreach (var parameter in method.Parameters)
-            {
-                CapturedSymbolReplacement proxy;
-                if (copyDest.TryGetValue(parameter, out proxy))
-                {
-                    bodyBuilder.Add(
-                        F.Assignment(
-                            proxy.Replacement(F.Syntax, stateMachineType => F.Local(resultVariable)),
-                            copySrc[parameter].Replacement(F.Syntax, stateMachineType => F.This())));
-                }
-            }
-
-            bodyBuilder.Add(F.Return(F.Local(resultVariable)));
-            F.CloseMethod(F.Block(ImmutableArray.Create(resultVariable), bodyBuilder.ToImmutableAndFree()));
+            // generate GetEnumerator()
+            var getEnumeratorGeneric = GenerateIteratorGetEnumerator(IEnumerableOfElementType_GetEnumerator, ref managedThreadId, StateMachineStates.FirstUnusedState);
 
             // Generate IEnumerable.GetEnumerator
             var getEnumerator = OpenMethodImplementation(IEnumerable_GetEnumerator);
@@ -340,6 +252,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void GenerateConstructor(BoundExpression managedThreadId)
         {
+            // Produces:
+            // .ctor(int state)
+            // {
+            //     this.state = state;
+            //     this.initialThreadId = <managedThreadId>;
+            // }
+            Debug.Assert(stateMachineType.Constructor is IteratorConstructor);
+
             F.CurrentFunction = stateMachineType.Constructor;
             var bodyBuilder = ArrayBuilder<BoundStatement>.GetInstance();
             bodyBuilder.Add(F.BaseInitialization());
@@ -348,7 +268,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (managedThreadId != null)
             {
                 // this.initialThreadId = Thread.CurrentThread.ManagedThreadId;
-                bodyBuilder.Add(F.Assignment(F.Field(F.This(), _initialThreadIdField), managedThreadId));
+                bodyBuilder.Add(F.Assignment(F.Field(F.This(), initialThreadIdField), managedThreadId));
             }
 
             bodyBuilder.Add(F.Return());

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -435,6 +435,16 @@ public class C
         }
 
         [Fact]
+        public void MissingTypeAndMembers_AsyncVoidMethodBuilder()
+        {
+            VerifyMissingMember(WellKnownMember.System_Runtime_CompilerServices_AsyncVoidMethodBuilder__Create,
+                // (5,64): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.AsyncVoidMethodBuilder.Create'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Runtime.CompilerServices.AsyncVoidMethodBuilder", "Create").WithLocation(5, 64)
+                );
+        }
+
+        [Fact]
         public void MissingTypeAndMembers_ManualResetValueTaskSourceLogic()
         {
             VerifyMissingMember(WellKnownMember.System_Threading_Tasks_ManualResetValueTaskSourceLogic_T__ctor,
@@ -959,6 +969,90 @@ class C
             CompileAndVerify(comp, expectedOutput: "0 1 2 3 4 5");
         }
 
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(30275, "https://github.com/dotnet/roslyn/issues/30275")]
+        public void CallingGetEnumeratorTwice()
+        {
+            string source = @"
+using static System.Console;
+class C
+{
+    static async System.Collections.Generic.IAsyncEnumerable<int> M(int value)
+    {
+        Write(""1 "");
+        await System.Threading.Tasks.Task.CompletedTask;
+        Write(""2 "");
+        yield return 3;
+        Write(""4 "");
+        value++;
+        Write($""{value} "");
+    }
+    static async System.Threading.Tasks.Task Main()
+    {
+        var enumerable = M(1);
+        await using (var enumerator1 = enumerable.GetAsyncEnumerator())
+        {
+            await using (var enumerator2 = enumerable.GetAsyncEnumerator())
+            {
+                if (!await enumerator1.MoveNextAsync()) throw null;
+                Write($""Stream1:{enumerator1.Current} "");
+                if (!await enumerator2.MoveNextAsync()) throw null;
+                Write($""Stream2:{enumerator2.Current} "");
+                if (await enumerator1.MoveNextAsync()) throw null;
+                if (await enumerator2.MoveNextAsync()) throw null;
+                Write(""Done"");
+            }
+        }
+    }
+}";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_common }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "1 2 Stream1:3 1 2 Stream2:3 4 2 4 2 Done");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(30275, "https://github.com/dotnet/roslyn/issues/30275")]
+        public void CallingGetEnumeratorTwice2()
+        {
+            string source = @"
+using static System.Console;
+class C
+{
+    static async System.Collections.Generic.IAsyncEnumerable<int> M(int value)
+    {
+        Write(""1 "");
+        await System.Threading.Tasks.Task.CompletedTask;
+        Write(""2 "");
+        yield return 3;
+        Write(""4 "");
+        value++;
+        Write($""{value} "");
+    }
+    static async System.Threading.Tasks.Task Main()
+    {
+        var enumerable = M(1);
+        await using (var enumerator1 = enumerable.GetAsyncEnumerator())
+        {
+            await using (var enumerator2 = enumerable.GetAsyncEnumerator())
+            {
+                if (!await enumerator1.MoveNextAsync()) throw null;
+                Write($""Stream1:{enumerator1.Current} "");
+                if (await enumerator1.MoveNextAsync()) throw null;
+
+                if (!await enumerator2.MoveNextAsync()) throw null;
+                Write($""Stream2:{enumerator2.Current} "");
+                if (await enumerator2.MoveNextAsync()) throw null;
+
+                Write(""Done"");
+            }
+        }
+    }
+}";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_common }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "1 2 Stream1:3 4 2 1 2 Stream2:3 4 2 Done");
+        }
+
         [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void AsyncIteratorWithAwaitCompletedAndYield()
         {
@@ -992,24 +1086,62 @@ class C
 
                 verifier.VerifyIL("C.M", @"
 {
-  // Code size       38 (0x26)
-  .maxstack  2
-  .locals init (C.<M>d__0 V_0)
-  IL_0000:  newobj     ""C.<M>d__0..ctor()""
-  IL_0005:  stloc.0
-  IL_0006:  ldloc.0
-  IL_0007:  call       ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder System.Runtime.CompilerServices.AsyncVoidMethodBuilder.Create()""
-  IL_000c:  stfld      ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<M>d__0.<>t__builder""
-  IL_0011:  ldloc.0
-  IL_0012:  ldc.i4.m1
-  IL_0013:  stfld      ""int C.<M>d__0.<>1__state""
-  IL_0018:  ldloc.0
-  IL_0019:  ldloc.0
-  IL_001a:  newobj     ""System.Threading.Tasks.ManualResetValueTaskSourceLogic<bool>..ctor(System.Runtime.CompilerServices.IStrongBox<System.Threading.Tasks.ManualResetValueTaskSourceLogic<bool>>)""
-  IL_001f:  stfld      ""System.Threading.Tasks.ManualResetValueTaskSourceLogic<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-  IL_0024:  ldloc.0
-  IL_0025:  ret
+  // Code size        8 (0x8)
+  .maxstack  1
+  IL_0000:  ldc.i4.s   -2
+  IL_0002:  newobj     ""C.<M>d__0..ctor(int)""
+  IL_0007:  ret
 }", sequencePoints: "C.M", source: source);
+
+                if (options == TestOptions.DebugExe)
+                {
+                    verifier.VerifyIL("C.<M>d__0..ctor", @"
+{
+  // Code size       49 (0x31)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  call       ""object..ctor()""
+  IL_0006:  nop
+  IL_0007:  ldarg.0
+  IL_0008:  ldarg.1
+  IL_0009:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_000e:  ldarg.0
+  IL_000f:  call       ""int System.Environment.CurrentManagedThreadId.get""
+  IL_0014:  stfld      ""int C.<M>d__0.<>l__initialThreadId""
+  IL_0019:  ldarg.0
+  IL_001a:  call       ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder System.Runtime.CompilerServices.AsyncVoidMethodBuilder.Create()""
+  IL_001f:  stfld      ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<M>d__0.<>t__builder""
+  IL_0024:  ldarg.0
+  IL_0025:  ldarg.0
+  IL_0026:  newobj     ""System.Threading.Tasks.ManualResetValueTaskSourceLogic<bool>..ctor(System.Runtime.CompilerServices.IStrongBox<System.Threading.Tasks.ManualResetValueTaskSourceLogic<bool>>)""
+  IL_002b:  stfld      ""System.Threading.Tasks.ManualResetValueTaskSourceLogic<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+  IL_0030:  ret
+}", sequencePoints: "C+<M>d__0..ctor", source: source);
+                }
+                else
+                {
+                    verifier.VerifyIL("C.<M>d__0..ctor", @"
+{
+  // Code size       48 (0x30)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  call       ""object..ctor()""
+  IL_0006:  ldarg.0
+  IL_0007:  ldarg.1
+  IL_0008:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_000d:  ldarg.0
+  IL_000e:  call       ""int System.Environment.CurrentManagedThreadId.get""
+  IL_0013:  stfld      ""int C.<M>d__0.<>l__initialThreadId""
+  IL_0018:  ldarg.0
+  IL_0019:  call       ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder System.Runtime.CompilerServices.AsyncVoidMethodBuilder.Create()""
+  IL_001e:  stfld      ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<M>d__0.<>t__builder""
+  IL_0023:  ldarg.0
+  IL_0024:  ldarg.0
+  IL_0025:  newobj     ""System.Threading.Tasks.ManualResetValueTaskSourceLogic<bool>..ctor(System.Runtime.CompilerServices.IStrongBox<System.Threading.Tasks.ManualResetValueTaskSourceLogic<bool>>)""
+  IL_002a:  stfld      ""System.Threading.Tasks.ManualResetValueTaskSourceLogic<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+  IL_002f:  ret
+}", sequencePoints: "C+<M>d__0..ctor", source: source);
+                }
 
                 verifier.VerifyIL("C.<M>d__0.System.Collections.Generic.IAsyncEnumerator<int>.get_Current()", @"
 {
@@ -1079,10 +1211,28 @@ class C
 }");
                 verifier.VerifyIL("C.<M>d__0.System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator()", @"
 {
-  // Code size        2 (0x2)
-  .maxstack  1
+  // Code size       43 (0x2b)
+  .maxstack  2
+  .locals init (C.<M>d__0 V_0)
   IL_0000:  ldarg.0
-  IL_0001:  ret
+  IL_0001:  ldfld      ""int C.<M>d__0.<>1__state""
+  IL_0006:  ldc.i4.s   -2
+  IL_0008:  bne.un.s   IL_0022
+  IL_000a:  ldarg.0
+  IL_000b:  ldfld      ""int C.<M>d__0.<>l__initialThreadId""
+  IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
+  IL_0015:  bne.un.s   IL_0022
+  IL_0017:  ldarg.0
+  IL_0018:  ldc.i4.m1
+  IL_0019:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_001e:  ldarg.0
+  IL_001f:  stloc.0
+  IL_0020:  br.s       IL_0029
+  IL_0022:  ldc.i4.m1
+  IL_0023:  newobj     ""C.<M>d__0..ctor(int)""
+  IL_0028:  stloc.0
+  IL_0029:  ldloc.0
+  IL_002a:  ret
 }");
                 verifier.VerifyIL("C.<M>d__0.System.Threading.Tasks.Sources.IValueTaskSource<bool>.GetResult(short)", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -1125,7 +1125,7 @@ class C
         Write($""{value} "");
         await Task.Delay(10);
     }
-    static async System.Threading.Tasks.Task Main()
+    static async Task Main()
     {
         var enumerable = M(41);
         await foreach (var item1 in enumerable)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -1005,7 +1005,7 @@ class C
         }
     }
 }";
-            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_common }, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, AsyncStreamsTypes }, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "1 2 Stream1:3 1 2 Stream2:3 4 2 4 2 Done");
         }
@@ -1048,7 +1048,7 @@ class C
         }
     }
 }";
-            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_common }, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, AsyncStreamsTypes }, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "1 2 Stream1:3 4 2 1 2 Stream2:3 4 2 Done");
         }
@@ -1097,7 +1097,7 @@ class C
         Write(""Done"");
     }
 }";
-            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_common }, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, AsyncStreamsTypes }, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "Stream1:0 Stream2:0 1 2 Stream1:3 4 2 1 2 Stream2:3 4 2 Done");
         }
@@ -1142,7 +1142,7 @@ class C
         Write(""Done"");
     }
 }";
-            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_common }, options: TestOptions.DebugExe);
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, AsyncStreamsTypes }, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "Stream1:0 1 2 Stream1:3 4 42 Await Stream2:0 1 2 Stream2:3 4 42 Done");
         }


### PR DESCRIPTION
The state machine for iterator methods is meant to be used as an enumerable which can produce multiple enumerators, but it also acts as the first enumerator that is returned.
The state machine for async methods is meant to be used only once. The state machine for async-iterator initially followed that design, but we're changing that.

With this PR, the setup of an async-iterator method becomes more like that of an iterator method than that of an async method. 
Every time you call `GetAsyncEnumerator()`, you get a fresh enumerator (either by recycling one that is finished, or by instantiate and initializing a new one. 
This implies that the state machine for async-iterator methods must keep a copy of the original parameters.

Since this design is very much like iterator methods, I have refactored some of the code from `IteratorRewriter` as helper methods and re-used them.

Fixes https://github.com/dotnet/roslyn/issues/30275

Before:
```C#
	[CompilerGenerated]
	private sealed class <M>d__0<T> : IAsyncEnumerable<T>, IAsyncEnumerator<T>, IAsyncDisposable, IValueTaskSource<bool>, IStrongBox<ManualResetValueTaskSourceLogic<bool>>, IAsyncStateMachine
	{
...
		[DebuggerHidden]
		ValueTask<bool> IAsyncEnumerator<T>.MoveNextAsync()
		{
			if (<>1__state == -2)
			{
				return default(ValueTask<bool>);
			}
			<>v__promiseOfValueOrEnd.Reset();
			<M>d__0<T> stateMachine = this;
			<>t__builder.Start(ref stateMachine);
			return new ValueTask<bool>(this, <>v__promiseOfValueOrEnd.Version);
		}

		[DebuggerHidden]
		IAsyncEnumerator<T> IAsyncEnumerable<T>.GetAsyncEnumerator()
		{
			return this;
		}
	}

	[AsyncStateMachine(typeof(<M>d__0<>))]
	[IteratorStateMachine(typeof(<M>d__0<>))]
	private static IAsyncEnumerable<T> M<T>(T value)
	{
		<M>d__0<T> <M>d__ = new <M>d__0<T>();
		<M>d__.value = value;
		<M>d__.<>t__builder = AsyncVoidMethodBuilder.Create();
		<M>d__.<>1__state = -1;
		<M>d__.<>v__promiseOfValueOrEnd = new ManualResetValueTaskSourceLogic<bool>(<M>d__);
		return <M>d__;
	}
```

After:
```C#
	[CompilerGenerated]
	private sealed class <M>d__0<T> : IAsyncEnumerable<T>, IAsyncEnumerator<T>, IAsyncDisposable, IValueTaskSource<bool>, IStrongBox<ManualResetValueTaskSourceLogic<bool>>, IAsyncStateMachine
	{
...
		[DebuggerHidden]
		public <M>d__0(int <>1__state)
		{
			this.<>1__state = <>1__state;
			<>l__initialThreadId = Environment.CurrentManagedThreadId;
			<>t__builder = AsyncVoidMethodBuilder.Create();
			<>v__promiseOfValueOrEnd = new ManualResetValueTaskSourceLogic<bool>(this);
		}

		[DebuggerHidden]
		IAsyncEnumerator<T> IAsyncEnumerable<T>.GetAsyncEnumerator()
		{
			<M>d__0<T> <M>d__;
			if (<>1__state == -2 && <>l__initialThreadId == Environment.CurrentManagedThreadId)
			{
				<>1__state = 0;
				<M>d__ = this;
			}
			else
			{
				<M>d__ = new <M>d__0<T>(0); // make a new enumerator instance if needed
			}
			<M>d__.value = <>3__value; // copy parameters
			return <M>d__;
		}
	}


	[AsyncStateMachine(typeof(<M>d__0<>))]
	[IteratorStateMachine(typeof(<M>d__0<>))]
	private static IAsyncEnumerable<T> M<T>(T value)
	{
		<M>d__0<T> <M>d__ = new <M>d__0<T>(-2);
		<M>d__.<>3__value = value; // save parameters
		return <M>d__;
	}
```