### PR TITLE
Use the new IBlankLineIndentationService in the string-splitting feature.

### DIFF
--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.InterpolatedStringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.InterpolatedStringSplitter.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.Formatting.FormattingOptions;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
 {
@@ -17,8 +18,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                 Document document, int position,
                 SyntaxNode root, SourceText sourceText,
                 InterpolatedStringExpressionSyntax interpolatedStringExpression,
-                bool useTabs, int tabSize, CancellationToken cancellationToken)
-                : base(document, position, root, sourceText, useTabs, tabSize, cancellationToken)
+                bool useTabs, int tabSize, IndentStyle indentStyle,
+                CancellationToken cancellationToken)
+                : base(document, position, root, sourceText, useTabs, tabSize, indentStyle, cancellationToken)
             {
                 _interpolatedStringExpression = interpolatedStringExpression;
             }

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.InterpolatedStringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.InterpolatedStringSplitter.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                 return SyntaxFactory.BinaryExpression(
                     SyntaxKind.AddExpression,
                     leftExpression,
-                    GetPlusToken(),
+                    PlusNewLineToken,
                     rightExpression.WithAdditionalAnnotations(RightNodeAnnotation));
             }
 

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.SimpleStringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.SimpleStringSplitter.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                 return SyntaxFactory.BinaryExpression(
                     SyntaxKind.AddExpression,
                     leftExpression,
-                    GetPlusToken(),
+                    PlusNewLineToken,
                     rightExpression.WithAdditionalAnnotations(RightNodeAnnotation));
             }
 

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.SimpleStringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.SimpleStringSplitter.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.Formatting.FormattingOptions;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
 {
@@ -12,8 +13,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
             private const char QuoteCharacter = '"';
             private readonly SyntaxToken _token;
 
-            public SimpleStringSplitter(Document document, int position, SyntaxNode root, SourceText sourceText, SyntaxToken token, bool useTabs, int tabSize, CancellationToken cancellationToken)
-                : base(document, position, root, sourceText, useTabs, tabSize, cancellationToken)
+            public SimpleStringSplitter(
+                Document document, int position,
+                SyntaxNode root, SourceText sourceText, SyntaxToken token,
+                bool useTabs, int tabSize, IndentStyle indentStyle, CancellationToken cancellationToken)
+                : base(document, position, root, sourceText, useTabs, tabSize, indentStyle, cancellationToken)
             {
                 _token = token;
             }

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.StringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.StringSplitter.cs
@@ -16,6 +16,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
         {
             protected static readonly SyntaxAnnotation RightNodeAnnotation = new SyntaxAnnotation();
 
+            protected static readonly SyntaxToken PlusNewLineToken = SyntaxFactory.Token(
+                leading: default,
+                SyntaxKind.PlusToken,
+                SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed));
+
             protected readonly Document Document;
             protected readonly int CursorPosition;
             protected readonly SourceText SourceText;
@@ -123,14 +128,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                 workspace.TryApplyChanges(newDocument.Project.Solution);
 
                 return finalCaretPosition;
-            }
-
-            protected static SyntaxToken GetPlusToken()
-            {
-                return SyntaxFactory.Token(
-                    default(SyntaxTriviaList),
-                    SyntaxKind.PlusToken,
-                    SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed));
             }
 
             private (Document document, int caretPosition) SplitString()

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.StringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.StringSplitter.cs
@@ -112,19 +112,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                     return null;
                 }
 
-                return TrySplitWorker();
+                return SplitWorker();
             }
 
-            private int? TrySplitWorker()
+            private int SplitWorker()
             {
-                var newDocumentAndCaretPosition = SplitString();
-                if (newDocumentAndCaretPosition == null)
-                {
-                    return null;
-                }
-
-                var newDocument = newDocumentAndCaretPosition.Item1;
-                var finalCaretPosition = newDocumentAndCaretPosition.Item2;
+                var (newDocument, finalCaretPosition) = SplitString();
 
                 var workspace = Document.Project.Solution.Workspace;
                 workspace.TryApplyChanges(newDocument.Project.Solution);
@@ -140,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                     SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed));
             }
 
-            private Tuple<Document, int> SplitString()
+            private (Document document, int caretPosition) SplitString()
             {
                 var splitString = CreateSplitString();
 
@@ -149,16 +142,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                 var rightExpression = newRoot.GetAnnotatedNodes(RightNodeAnnotation).Single();
 
                 var indentString = GetIndentString(newRoot);
-                if (indentString == null)
-                {
-                    return null;
-                }
-
                 var newRightExpression = rightExpression.WithLeadingTrivia(SyntaxFactory.ElasticWhitespace(indentString));
                 var newRoot2 = newRoot.ReplaceNode(rightExpression, newRightExpression);
                 var newDocument2 = Document.WithSyntaxRoot(newRoot2);
 
-                return Tuple.Create(newDocument2, rightExpression.Span.Start + indentString.Length + StringOpenQuoteLength());
+                return (newDocument2, rightExpression.Span.Start + indentString.Length + StringOpenQuoteLength());
             }
 
             private string GetIndentString(SyntaxNode newRoot)

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.cs
@@ -79,8 +79,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
             if (document != null)
             {
                 var options = document.GetOptionsAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
-                var enabled = options.GetOption(
-                    SplitStringLiteralOptions.Enabled);
+                var enabled = options.GetOption(SplitStringLiteralOptions.Enabled);
+                var indentStyle = options.GetOption(FormattingOptions.SmartIndent, document.Project.Language);
 
                 if (enabled)
                 {
@@ -132,11 +132,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
         {
             var useTabs = options.GetOption(FormattingOptions.UseTabs);
             var tabSize = options.GetOption(FormattingOptions.TabSize);
+            var indentStyle = options.GetOption(FormattingOptions.SmartIndent, LanguageNames.CSharp);
 
             var root = document.GetSyntaxRootSynchronously(cancellationToken);
             var sourceText = root.SyntaxTree.GetText(cancellationToken);
 
-            var splitter = StringSplitter.Create(document, position, root, sourceText, useTabs, tabSize, cancellationToken);
+            var splitter = StringSplitter.Create(
+                document, position, root, sourceText, 
+                useTabs, tabSize, indentStyle, cancellationToken);
             if (splitter == null)
             {
                 return null;

--- a/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
+using static Microsoft.CodeAnalysis.Formatting.FormattingOptions;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
@@ -27,10 +28,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
         /// failure.
         /// </summary>
         private void TestWorker(
-            string inputMarkup, string expectedOutputMarkup, Action callback, bool verifyUndo = true)
+            string inputMarkup,
+            string expectedOutputMarkup,
+            Action callback,
+            bool verifyUndo = true,
+            IndentStyle indentStyle = IndentStyle.Smart)
         {
             using (var workspace = TestWorkspace.CreateCSharp(inputMarkup))
             {
+                workspace.Options = workspace.Options.WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle);
+
                 var document = workspace.Documents.Single();
                 var view = document.GetTextView();
 
@@ -76,7 +83,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
         /// this known test infrastructure issure. This bug does not represent a product
         /// failure.
         /// </summary>
-        private void TestHandled(string inputMarkup, string expectedOutputMarkup, bool verifyUndo = true)
+        private void TestHandled(
+            string inputMarkup, string expectedOutputMarkup,
+            bool verifyUndo = true, IndentStyle indentStyle = IndentStyle.Smart)
         {
             TestWorker(
                 inputMarkup, expectedOutputMarkup,
@@ -84,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
                 {
                     Assert.True(false, "Should not reach here.");
                 },
-                verifyUndo);
+                verifyUndo, indentStyle);
         }
 
         private void TestNotHandled(string inputMarkup)
@@ -281,6 +290,56 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestInEmptyString_BlockIndent()
+        {
+            // Do not verifyUndo because of https://github.com/dotnet/roslyn/issues/28033
+            // When that issue is fixed, we can reenable verifyUndo
+            TestHandled(
+@"class C
+{
+    void M()
+    {
+        var v = ""[||]"";
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        var v = """" +
+        ""[||]"";
+    }
+}",
+            verifyUndo: false,
+            IndentStyle.Block);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestInEmptyString_NoneIndent()
+        {
+            // Do not verifyUndo because of https://github.com/dotnet/roslyn/issues/28033
+            // When that issue is fixed, we can reenable verifyUndo
+            TestHandled(
+@"class C
+{
+    void M()
+    {
+        var v = ""[||]"";
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        var v = """" +
+""[||]"";
+    }
+}",
+            verifyUndo: false,
+            IndentStyle.None);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
         public void TestInEmptyInterpolatedString()
         {
             TestHandled(
@@ -299,6 +358,48 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
             $""[||]"";
     }
 }");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestInEmptyInterpolatedString_BlockIndent()
+        {
+            TestHandled(
+@"class C
+{
+    void M()
+    {
+        var v = $""[||]"";
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        var v = $"""" +
+        $""[||]"";
+    }
+}", indentStyle: IndentStyle.Block);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestInEmptyInterpolatedString_NoneIndent()
+        {
+            TestHandled(
+@"class C
+{
+    void M()
+    {
+        var v = $""[||]"";
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        var v = $"""" +
+$""[||]"";
+    }
+}", indentStyle: IndentStyle.None);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/31120

Ready for review.  Switch to using a service that cannot fail.  This also means that string-splitting works even if your indentation setting is set to 'block' or 'none'.