### PR TITLE
Block conversion of references to F# projects from C# projects

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpReferencesTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpReferencesTests.cs
@@ -109,6 +109,28 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
         }
 
         [WpfFact]
+        [WorkItem(461967, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/461967")]
+        [WorkItem(727173, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/727173")]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void AddingMetadataReferenceToProjectThatCannotCompileInTheIdeKeepsMetadataReference()
+        {
+            using (var environment = new TestEnvironment())
+            {
+                var project1 = CreateCSharpCPSProject(environment, "project1", commandLineArguments: @"/out:c:\project1.dll");
+                var project2 = CreateNonCompilableProject(environment, "project2", @"C:\project2.fsproj");
+                project2.BinOutputPath = "c:\\project2.dll";
+
+                project1.AddMetadataReference(project2.BinOutputPath, MetadataReferenceProperties.Assembly);
+
+                // We should not have converted that to a project reference, because we would have no way to produce the compilation
+                Assert.Empty(environment.Workspace.CurrentSolution.GetProject(project1.Id).AllProjectReferences);
+
+                project2.Dispose();
+                project1.Dispose();
+            }
+        }
+
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void AddRemoveAnalyzerReference_CPS()
         {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -362,7 +362,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             project = null;
 
             return
-                this.TryGetHierarchy(projectId, out hierarchy) && 
+                this.TryGetHierarchy(projectId, out hierarchy) &&
                 hierarchy.TryGetProject(out project);
         }
 
@@ -1452,7 +1452,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     if (string.Equals(convertedReference.path, outputPath, StringComparison.OrdinalIgnoreCase) &&
                         convertedReference.projectReference.ProjectId == projectId)
                     {
-                        var metadataReference = 
+                        var metadataReference =
                             CreateMetadataReference(
                                 convertedReference.path,
                                 new MetadataReferenceProperties(

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1040,7 +1040,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         internal override void SetDocumentContext(DocumentId documentId)
         {
             _foregroundObject.AssertIsForeground();
-            
+
             // Note: this method does not actually call into any workspace code here to change the workspace's context. The assumption is updating the running document table or
             // IVsHierarchies will raise the appropriate events which we are subscribed to.
 
@@ -1372,6 +1372,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
+        /// <summary>
+        /// Attempts to convert all metadata references to <paramref name="outputPath"/> to a project reference to <paramref name="projectId"/>.
+        /// </summary>
+        /// <param name="projectId">The <see cref="ProjectId"/> of the project that could be referenced in place of the output path.</param>
+        /// <param name="outputPath">The output path to replace.</param>
         private void ConvertMetadataReferencesToProjectReferences_NoLock(ProjectId projectId, string outputPath)
         {
             var modifiedSolution = this.CurrentSolution;
@@ -1379,26 +1384,53 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             foreach (var projectIdToRetarget in this.CurrentSolution.ProjectIds)
             {
-                foreach (PortableExecutableReference reference in modifiedSolution.GetProject(projectIdToRetarget).MetadataReferences)
+                if (CanConvertMetadataReferenceToProjectReference(projectIdToRetarget, referencedProjectId: projectId))
                 {
-                    if (string.Equals(reference.FilePath, outputPath, StringComparison.OrdinalIgnoreCase))
+                    foreach (PortableExecutableReference reference in modifiedSolution.GetProject(projectIdToRetarget).MetadataReferences)
                     {
-                        var projectReference = new ProjectReference(projectId, reference.Properties.Aliases, reference.Properties.EmbedInteropTypes);
-                        modifiedSolution = modifiedSolution.RemoveMetadataReference(projectIdToRetarget, reference)
-                                                           .AddProjectReference(projectIdToRetarget, projectReference);
+                        if (string.Equals(reference.FilePath, outputPath, StringComparison.OrdinalIgnoreCase))
+                        {
 
-                        projectIdsChanged.Add(projectIdToRetarget);
+                            var projectReference = new ProjectReference(projectId, reference.Properties.Aliases, reference.Properties.EmbedInteropTypes);
+                            modifiedSolution = modifiedSolution.RemoveMetadataReference(projectIdToRetarget, reference)
+                                                               .AddProjectReference(projectIdToRetarget, projectReference);
 
-                        GetReferenceInfo_NoLock(projectIdToRetarget).ConvertedProjectReferences.Add(
-                            (reference.FilePath, projectReference));
+                            projectIdsChanged.Add(projectIdToRetarget);
 
-                        // We have converted one, but you could have more than one reference with different aliases
-                        // that we need to convert, so we'll keep going
+                            GetReferenceInfo_NoLock(projectIdToRetarget).ConvertedProjectReferences.Add(
+                                (reference.FilePath, projectReference));
+
+                            // We have converted one, but you could have more than one reference with different aliases
+                            // that we need to convert, so we'll keep going
+                        }
                     }
                 }
             }
 
             SetSolutionAndRaiseWorkspaceChanged_NoLock(modifiedSolution, projectIdsChanged);
+        }
+
+        private bool CanConvertMetadataReferenceToProjectReference(ProjectId projectIdWithMetadataReference, ProjectId referencedProjectId)
+        {
+            var projectWithMetadataReference = CurrentSolution.GetProject(projectIdWithMetadataReference);
+            var referencedProject = CurrentSolution.GetProject(referencedProjectId);
+
+            // We don't want to convert a metadata reference to a project reference if the project being referenced isn't something
+            // we can create a Compilation for. For example, if we have a C# project, and it's referencing a F# project via a metadata reference
+            // everything would be fine if we left it a metadata reference. Converting it to a project reference means we couldn't create a Compilation
+            // anymore in the IDE, since the C# compilation would need to reference an F# compilation. F# projects referencing other F# projects though
+            // do expect this to work, and so we'll always allow references through of the same language.
+            if (projectWithMetadataReference.Language != referencedProject.Language)
+            {
+                if (projectWithMetadataReference.LanguageServices.GetService<ICompilationFactoryService>() != null &&
+                    referencedProject.LanguageServices.GetService<ICompilationFactoryService>() == null)
+                {
+                    // We're referencing something that we can't create a compilation from something that can, so keep the metadtata reference
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -1449,14 +1481,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             {
                 if (_projectsByOutputPath.TryGetValue(path, out var ids) && ids.Distinct().Count() == 1)
                 {
-                    var projectReference = new ProjectReference(
-                        ids.First(),
-                        aliases: properties.Aliases,
-                        embedInteropTypes: properties.EmbedInteropTypes);
+                    var projectIdToReference = ids.First();
 
-                    GetReferenceInfo_NoLock(referencingProject).ConvertedProjectReferences.Add((path, projectReference));
+                    if (CanConvertMetadataReferenceToProjectReference(referencingProject, projectIdToReference))
+                    {
+                        var projectReference = new ProjectReference(
+                            projectIdToReference,
+                            aliases: properties.Aliases,
+                            embedInteropTypes: properties.EmbedInteropTypes);
 
-                    return projectReference;
+                        GetReferenceInfo_NoLock(referencingProject).ConvertedProjectReferences.Add((path, projectReference));
+
+                        return projectReference;
+                    }
+                    else
+                    {
+                        return null;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
This was a policy we previously had in place, but I accidentally deleted the tests covering it in 2d86a7b.