### PR TITLE
Fix issue where we show the 'ReSharper is suspended' gold bar before ReSharper has finished loading

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/ReSharperStatus.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/ReSharperStatus.cs
@@ -13,13 +13,8 @@ namespace Microsoft.CodeAnalysis.Experimentation
         /// </summary>
         Suspended,
         /// <summary>
-        /// ReSharper is running.
+        /// ReSharper is installed and enabled.
         /// </summary>
-        Enabled,
-        /// <summary>
-        /// Need to wait longer for ReSharper to report status
-        /// </summary>
-        Undetermined
-
+        Enabled
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/ReSharperStatus.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/ReSharperStatus.cs
@@ -15,6 +15,11 @@ namespace Microsoft.CodeAnalysis.Experimentation
         /// <summary>
         /// ReSharper is running.
         /// </summary>
-        Enabled
+        Enabled,
+        /// <summary>
+        /// Need to wait longer for ReSharper to report status
+        /// </summary>
+        Undetermined
+
     }
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/659765

In some scenarios we display the gold bar with "*We notice you suspended 'ReSharper Ultimate'.  Reset Keymappings to continue to navigate and refactor"* when ReSharper is in fact running.  This occurs when launching VS by opening a project that takes a while to load, for example a project that last had a XAML page open.

We originally did a single check for ReSharper's Suspend button;  if it was active ReSharper was assumed to be running, if not it was assumed to be suspended.  

This fix will instead periodically check for ReSharper's Resume button to be active, and if that doesn't occur after a reasonable amount of time will assume ReSharper is running.  