### PR TITLE
Classify CSharp Discards as Keywords

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -10,8 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return IsReservedKeyword(kind)
                 || IsContextualKeyword(kind)
-                || kind == SyntaxKind.DiscardDesignation
-                || kind == SyntaxKind.UnderscoreToken;
+                || kind == SyntaxKind.DiscardDesignation;
         }
 
         public static IEnumerable<SyntaxKind> GetReservedKeywordKinds()

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -8,8 +8,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public static bool IsKeywordKind(SyntaxKind kind)
         {
-            return IsReservedKeyword(kind)
-                || IsContextualKeyword(kind);
+            return IsReservedKeyword(kind) || IsContextualKeyword(kind);
         }
 
         public static IEnumerable<SyntaxKind> GetReservedKeywordKinds()

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -8,7 +8,10 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public static bool IsKeywordKind(SyntaxKind kind)
         {
-            return IsReservedKeyword(kind) || IsContextualKeyword(kind);
+            return IsReservedKeyword(kind)
+                || IsContextualKeyword(kind)
+                || kind == SyntaxKind.DiscardDesignation
+                || kind == SyntaxKind.UnderscoreToken;
         }
 
         public static IEnumerable<SyntaxKind> GetReservedKeywordKinds()

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -9,8 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static bool IsKeywordKind(SyntaxKind kind)
         {
             return IsReservedKeyword(kind)
-                || IsContextualKeyword(kind)
-                || kind == SyntaxKind.DiscardDesignation;
+                || IsContextualKeyword(kind);
         }
 
         public static IEnumerable<SyntaxKind> GetReservedKeywordKinds()

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests_Preprocessor.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests_Preprocessor.cs
@@ -934,7 +934,7 @@ aeu";
             await TestInMethodAsync(
                 code: @"M2(out var _);",
                 expected: Classifications(Identifier("M2"), Punctuation.OpenParen, Keyword("out"), Identifier("var"),
-                    Identifier("_"), Punctuation.CloseParen, Punctuation.Semicolon));
+                    Keyword("_"), Punctuation.CloseParen, Punctuation.Semicolon));
         }
 
         [Fact]
@@ -943,7 +943,7 @@ aeu";
             await TestInMethodAsync(
                 code: @"switch (1) { case int _: }",
                 expected: Classifications(Keyword("switch"), Punctuation.OpenParen, Number("1"), Punctuation.CloseParen,
-                    Punctuation.OpenCurly, Keyword("case"), Keyword("int"), Identifier("_"), Punctuation.Colon, Punctuation.CloseCurly));
+                    Punctuation.OpenCurly, Keyword("case"), Keyword("int"), Keyword("_"), Punctuation.Colon, Punctuation.CloseCurly));
         }
 
         [Fact]
@@ -952,7 +952,7 @@ aeu";
             await TestInMethodAsync(
                 code: @"var (x, _) = (1, 2);",
                 expected: Classifications(Identifier("var"), Punctuation.OpenParen, Identifier("x"), Punctuation.Comma,
-                    Identifier("_"), Punctuation.CloseParen, Operators.Equals, Punctuation.OpenParen, Number("1"),
+                    Keyword("_"), Punctuation.CloseParen, Operators.Equals, Punctuation.OpenParen, Number("1"),
                     Punctuation.Comma, Number("2"), Punctuation.CloseParen, Punctuation.Semicolon));
         }
 
@@ -961,8 +961,8 @@ aeu";
         {
             await TestInMethodAsync(
                 code: @"(var _, var _) = (1, 2);",
-                expected: Classifications(Punctuation.OpenParen, Identifier("var"), Identifier("_"), Punctuation.Comma,
-                    Identifier("var"), Identifier("_"), Punctuation.CloseParen, Operators.Equals, Punctuation.OpenParen,
+                expected: Classifications(Punctuation.OpenParen, Identifier("var"), Keyword("_"), Punctuation.Comma,
+                    Identifier("var"), Keyword("_"), Punctuation.CloseParen, Operators.Equals, Punctuation.OpenParen,
                     Number("1"), Punctuation.Comma, Number("2"), Punctuation.CloseParen, Punctuation.Semicolon));
         }
 

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -25,10 +25,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
         /// <returns>The correct syntactic classification for the token.</returns>
         public static string GetClassification(SyntaxToken token)
         {
-            if (token.IsKind(SyntaxKind.DiscardDesignation, SyntaxKind.UnderscoreToken))
-            {
-                return ClassificationTypeNames.Identifier;
-            }
             if (SyntaxFacts.IsKeywordKind(token.Kind()))
             {
                 return ClassificationTypeNames.Keyword;

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
         /// <returns>The correct syntactic classification for the token.</returns>
         public static string GetClassification(SyntaxToken token)
         {
+            // When classifying `_`, IsKeywordKind handles UnderscoreToken, but need to additional check for DiscardDesignation
             if (SyntaxFacts.IsKeywordKind(token.Kind()) || token.IsKind(SyntaxKind.DiscardDesignation))
             {
                 return ClassificationTypeNames.Keyword;

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
         /// <returns>The correct syntactic classification for the token.</returns>
         public static string GetClassification(SyntaxToken token)
         {
-            if (SyntaxFacts.IsKeywordKind(token.Kind()))
+            if (SyntaxFacts.IsKeywordKind(token.Kind()) || token.IsKind(SyntaxKind.DiscardDesignation))
             {
                 return ClassificationTypeNames.Keyword;
             }


### PR DESCRIPTION
Classify CSharp Discards as Keywords. As discussed in #28284.