### PR TITLE
Delete a bunch of unused versions from FixedPackages.props

### DIFF
--- a/build/Targets/FixedPackages.props
+++ b/build/Targets/FixedPackages.props
@@ -9,21 +9,6 @@
   <PropertyGroup>
     <MicrosoftBuildFixedVersion>14.3.0</MicrosoftBuildFixedVersion>
     <MicrosoftBuildTasksCoreFixedVersion>14.3.0</MicrosoftBuildTasksCoreFixedVersion>
-    <MicrosoftNETCoreAppFixedVersion>2.0.0-preview2-002066-00</MicrosoftNETCoreAppFixedVersion>
-    <MicrosoftVisualStudioCoreUtilityFixedVersion>14.0.23205</MicrosoftVisualStudioCoreUtilityFixedVersion>
-    <MicrosoftVisualStudioEditorFixedVersion>14.0.23205</MicrosoftVisualStudioEditorFixedVersion>
-    <MicrosoftVisualStudioShell140FixedVersion>14.0.23205</MicrosoftVisualStudioShell140FixedVersion>
-    <MicrosoftVisualStudioTextDataFixedVersion>14.0.23205</MicrosoftVisualStudioTextDataFixedVersion>
-    <MicrosoftVisualStudioTextLogicFixedVersion>14.0.23205</MicrosoftVisualStudioTextLogicFixedVersion>
-    <MicrosoftVisualStudioTextUIFixedVersion>14.0.23205</MicrosoftVisualStudioTextUIFixedVersion>
-    <MicrosoftVisualStudioTextUIWpfFixedVersion>14.0.23205</MicrosoftVisualStudioTextUIWpfFixedVersion>
-    <MicrosoftVisualStudioUtilitiesFixedVersion>14.0.23205</MicrosoftVisualStudioUtilitiesFixedVersion>
-    <MicrosoftVSSDKBuildToolsFixedVersion>14.3.25420</MicrosoftVSSDKBuildToolsFixedVersion>
-    <MicrosoftVisualStudioComponentModelHostFixedVersion>14.0.25424</MicrosoftVisualStudioComponentModelHostFixedVersion>
-    <NETStandardLibraryFixedVersion>2.0.0-beta-25123-01</NETStandardLibraryFixedVersion>
-    <NewtonsoftJsonFixedVersion>9.0.1</NewtonsoftJsonFixedVersion>
-    <SystemCollectionsImmutableFixedVersion>1.1.36</SystemCollectionsImmutableFixedVersion>
-    <SystemReflectionMetadataFixedVersion>1.0.21</SystemReflectionMetadataFixedVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Just going to delete the unused ones. The ones that are left are still used, and I'll leave those to somebody who understands the build task versioning to figure out.