### PR TITLE
Use RepoRoot instead of repoDir

### DIFF
--- a/build/scripts/createrunsettings.ps1
+++ b/build/scripts/createrunsettings.ps1
@@ -7,9 +7,9 @@ $ErrorActionPreference = "Stop"
 
 try {
     . (Join-Path $PSScriptRoot "build-utils.ps1")
-    Push-Location $repoDir
+    Push-Location $RepoRoot
     
-    Write-Host "Repo Dir $repoDir"
+    Write-Host "Repo Dir $RepoRoot"
     Write-Host "Binaries Dir $binariesDir"
     
     $buildConfiguration = if ($release) { "Release" } else { "Debug" }
@@ -17,7 +17,7 @@ try {
     
     $optProfToolDir = Get-PackageDir "Roslyn.OptProf.RunSettings.Generator"
     $optProfToolExe = Join-Path $optProfToolDir "tools\roslyn.optprof.runsettings.generator.exe"
-    $configFile = Join-Path $repoDir "build\config\optprof.json"
+    $configFile = Join-Path $RepoRoot "build\config\optprof.json"
     $outputFolder = Join-Path $configDir "Insertion\RunSettings"
     $optProfArgs = "--configFile $configFile --outputFolder $outputFolder --buildNumber 28302.01 "
     


### PR DESCRIPTION
This variable was renamed in a different branch than where the optprof changes where originally merged.  Once the dev16p1 changes where merged to master the rename from here https://github.com/dotnet/roslyn/pull/30498 collided badly and broke the build