### PR TITLE
Don't warn on conversion of error type. Analyze arguments of invocations with errors

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3363,20 +3363,23 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var resultType = TypeSymbolWithAnnotations.Create(targetType, resultAnnotation);
 
-            // Need to report all warnings that apply since the warnings can be suppressed individually.
-            if (reportTopLevelWarnings)
+            if (operandType.TypeSymbol?.IsErrorType() != true)
             {
-                ReportNullableAssignmentIfNecessary(node, targetTypeWithNullability, resultType, useLegacyWarnings: useLegacyWarnings, assignmentKind, target);
-            }
-            if (reportNestedWarnings && !canConvertNestedNullability)
-            {
-                if (assignmentKind == AssignmentKind.Argument)
+                // Need to report all warnings that apply since the warnings can be suppressed individually.
+                if (reportTopLevelWarnings)
                 {
-                    ReportNullabilityMismatchInArgument(node, operandType.TypeSymbol, target, targetType);
+                    ReportNullableAssignmentIfNecessary(node, targetTypeWithNullability, resultType, useLegacyWarnings: useLegacyWarnings, assignmentKind, target);
                 }
-                else
+                if (reportNestedWarnings && !canConvertNestedNullability)
                 {
-                    ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, node.Syntax, GetTypeAsDiagnosticArgument(operandType.TypeSymbol), targetType);
+                    if (assignmentKind == AssignmentKind.Argument)
+                    {
+                        ReportNullabilityMismatchInArgument(node, operandType.TypeSymbol, target, targetType);
+                    }
+                    else
+                    {
+                        ReportDiagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, node.Syntax, GetTypeAsDiagnosticArgument(operandType.TypeSymbol), targetType);
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2021,20 +2021,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // https://github.com/dotnet/roslyn/issues/29605 Can we handle some error cases?
             // (Compare with CSharpOperationFactory.CreateBoundCallOperation.)
-            if (!node.HasErrors)
+            ImmutableArray<RefKind> refKindsOpt = node.ArgumentRefKindsOpt;
+            (ImmutableArray<BoundExpression> arguments, ImmutableArray<Conversion> conversions) = RemoveArgumentConversions(node.Arguments, refKindsOpt);
+            if (!receiverType.IsNull)
             {
-                if (!receiverType.IsNull)
-                {
-                    // Update method based on inferred receiver type.
-                    method = (MethodSymbol)AsMemberOfResultType(receiverType, method);
-                }
-
-                ImmutableArray<RefKind> refKindsOpt = node.ArgumentRefKindsOpt;
-                (ImmutableArray<BoundExpression> arguments, ImmutableArray<Conversion> conversions) = RemoveArgumentConversions(node.Arguments, refKindsOpt);
-                ImmutableArray<int> argsToParamsOpt = node.ArgsToParamsOpt;
-
-                method = VisitArguments(node, arguments, refKindsOpt, method.Parameters, argsToParamsOpt, node.Expanded, node.InvokedAsExtensionMethod, conversions, method);
+                // Update method based on inferred receiver type.
+                method = (MethodSymbol)AsMemberOfResultType(receiverType, method);
             }
+
+            method = VisitArguments(node, arguments, refKindsOpt, method.Parameters, node.ArgsToParamsOpt,
+                node.Expanded, node.InvokedAsExtensionMethod, conversions, method);
 
             UpdateStateForCall(node);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -9050,6 +9050,130 @@ class C
         }
 
         [Fact]
+        [WorkItem(29916, "https://github.com/dotnet/roslyn/issues/29916")]
+        public void PassingParameters_UnknownMethod()
+        {
+            CSharpCompilation c = CreateCompilation(new[] { @"
+class C
+{
+    static int F(object x)
+    {
+        Missing(F(null)); // 1
+        Missing(F(x = null)); // 2
+        x.ToString(); // 3
+
+        Missing(F(x = this)); // 4
+        x.ToString();
+        return 0;
+    }
+}
+" }, options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics(
+                // (6,9): error CS0103: The name 'Missing' does not exist in the current context
+                //         Missing(F(null)); // 1
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(6, 9),
+                // (6,19): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //         Missing(F(null)); // 1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 19),
+                // (7,9): error CS0103: The name 'Missing' does not exist in the current context
+                //         Missing(F(x = null)); // 2
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(7, 9),
+                // (7,19): warning CS8604: Possible null reference argument for parameter 'x' in 'int C.F(object x)'.
+                //         Missing(F(x = null)); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x = null").WithArguments("x", "int C.F(object x)").WithLocation(7, 19),
+                // (7,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         Missing(F(x = null)); // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(7, 23),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         x.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 9),
+                // (10,9): error CS0103: The name 'Missing' does not exist in the current context
+                //         Missing(F(x = this)); // 4
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(10, 9),
+                // (10,23): error CS0026: Keyword 'this' is not valid in a static property, static method, or static field initializer
+                //         Missing(F(x = this)); // 4
+                Diagnostic(ErrorCode.ERR_ThisInStaticMeth, "this").WithLocation(10, 23)
+                );
+        }
+
+        [Fact]
+        [WorkItem(29916, "https://github.com/dotnet/roslyn/issues/29916")]
+        public void PassingParameters_UnknownMethod_AffectingState()
+        {
+            CSharpCompilation c = CreateCompilation(new[] { @"
+class C
+{
+    object F(object x)
+    {
+        Missing(
+            F(x = null) /*warn*/,
+            x.ToString() /*warn*/,
+            F(x = this),
+            x.ToString());
+        return x;
+    }
+}
+" }, options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics(
+                // (6,9): error CS0103: The name 'Missing' does not exist in the current context
+                //         Missing(
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(6, 9),
+                // (7,15): warning CS8604: Possible null reference argument for parameter 'x' in 'object C.F(object x)'.
+                //             F(x = null) /*warn*/,
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x = null").WithArguments("x", "object C.F(object x)").WithLocation(7, 15),
+                // (7,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             F(x = null) /*warn*/,
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(7, 19),
+                // (8,13): warning CS8602: Possible dereference of a null reference.
+                //             x.ToString() /*warn*/,
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13)
+                );
+        }
+
+        [Fact]
+        [WorkItem(29916, "https://github.com/dotnet/roslyn/issues/29916")]
+        public void PassingParameters_UnknownMethod_AffectingConditionalState()
+        {
+            CSharpCompilation c = CreateCompilation(new[] { @"
+class C
+{
+    int F(object x)
+    {
+        if (G(F(x = null)))
+        {
+            x.ToString(); // 1
+        }
+        else
+        {
+            x.ToString(); // 2
+        }
+        return 0;
+    }
+}
+" }, options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics(
+                // (6,13): error CS0103: The name 'G' does not exist in the current context
+                //         if (G(F(x = null)))
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "G").WithArguments("G").WithLocation(6, 13),
+                // (6,17): warning CS8604: Possible null reference argument for parameter 'x' in 'int C.F(object x)'.
+                //         if (G(F(x = null)))
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x = null").WithArguments("x", "int C.F(object x)").WithLocation(6, 17),
+                // (6,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         if (G(F(x = null)))
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(6, 21),
+                // (8,13): warning CS8602: Possible dereference of a null reference.
+                //             x.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13),
+                // (12,13): warning CS8602: Possible dereference of a null reference.
+                //             x.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(12, 13)
+                );
+        }
+
+        [Fact]
         public void DuplicateArguments()
         {
             var source =
@@ -10447,6 +10571,44 @@ public class C
         }
 
         [Fact]
+        [WorkItem(29916, "https://github.com/dotnet/roslyn/issues/29916")]
+        public void NotNullWhenFalse_EqualsTrue_InErrorInvocation()
+        {
+            CSharpCompilation c = CreateCompilation(new[] { @"
+using System.Runtime.CompilerServices;
+public class C
+{
+    public void Main(string? s)
+    {
+        if (Missing(MyIsNullOrEmpty(s)))
+        {
+            s.ToString(); // 1
+        }
+        else
+        {
+            s.ToString(); // 2
+        }
+
+        s.ToString();
+    }
+    public static bool MyIsNullOrEmpty([NotNullWhenFalse] string? s) => throw null;
+}
+", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics(
+                // (7,13): error CS0103: The name 'Missing' does not exist in the current context
+                //         if (Missing(MyIsNullOrEmpty(s)))
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(7, 13),
+                // (9,13): warning CS8602: Possible dereference of a null reference.
+                //             s.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
+                // (13,13): warning CS8602: Possible dereference of a null reference.
+                //             s.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 13)
+                );
+        }
+
+        [Fact]
         [WorkItem(29855, "https://github.com/dotnet/roslyn/issues/29855")]
         public void NotNullWhenFalse_EqualsFalse()
         {
@@ -10636,6 +10798,46 @@ public class C
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(10, 13),
                 // (15,13): warning CS8602: Possible dereference of a null reference.
                 //             s2.ToString(); // warn 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(15, 13)
+                );
+        }
+
+        [Fact]
+        public void MethodWithOutNullableParameter_AfterEnsuresNotNull_InErrorInvocation()
+        {
+            CSharpCompilation c = CreateCompilation(new[] { @"
+using System.Runtime.CompilerServices;
+public class C
+{
+    public void Main(string? s)
+    {
+        if (Missing(M(s, out string? s2)))
+        {
+            s.ToString();
+            s2.ToString(); // 1
+        }
+        else
+        {
+            s.ToString();
+            s2.ToString(); // 2
+        }
+
+        s.ToString();
+        s2.ToString();
+    }
+    public static bool M([EnsuresNotNull] string? s, out string? s2) => throw null;
+}
+", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics(
+                // (7,13): error CS0103: The name 'Missing' does not exist in the current context
+                //         if (Missing(M(s, out string? s2)))
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(7, 13),
+                // (10,13): warning CS8602: Possible dereference of a null reference.
+                //             s2.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(10, 13),
+                // (15,13): warning CS8602: Possible dereference of a null reference.
+                //             s2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(15, 13)
                 );
         }
@@ -11773,6 +11975,31 @@ class C
         }
 
         [Fact]
+        [WorkItem(29916, "https://github.com/dotnet/roslyn/issues/29916")]
+        public void AssertsTrue_NotNull_InErrorInvocation()
+        {
+            CSharpCompilation c = CreateCompilation(new[] { @"
+using System.Runtime.CompilerServices;
+class C
+{
+    void Main(C? c)
+    {
+        Missing(MyAssert(c != null));
+        c.ToString();
+    }
+
+    void MyAssert([AssertsTrue] bool condition) => throw null;
+}
+", AssertsTrueAttributeDefinition }, options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics(
+                // (7,9): error CS0103: The name 'Missing' does not exist in the current context
+                //         Missing(MyAssert(c != null));
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(7, 9)
+                );
+        }
+
+        [Fact]
         public void AssertsTrue_NotNull_NullConditionalAccess()
         {
             CSharpCompilation c = CreateCompilation(new[] { @"
@@ -11812,6 +12039,34 @@ class C
 ", AssertsTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         c.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9)
+                );
+        }
+
+        [Fact]
+        [WorkItem(29916, "https://github.com/dotnet/roslyn/issues/29916")]
+        public void AssertsTrue_Null_InErrorInvocation()
+        {
+            CSharpCompilation c = CreateCompilation(new[] { @"
+using System.Runtime.CompilerServices;
+class C
+{
+    void Main(C? c)
+    {
+        Missing(MyAssert(c == null));
+        c.ToString();
+    }
+
+    void MyAssert([AssertsTrue] bool condition) => throw null;
+}
+", AssertsTrueAttributeDefinition }, options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics(
+                // (7,9): error CS0103: The name 'Missing' does not exist in the current context
+                //         Missing(MyAssert(c == null));
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(7, 9),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         c.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9)
@@ -12905,7 +13160,10 @@ class C
             c.VerifyDiagnostics(
                 // (6,35): error CS1503: Argument 1: cannot convert from 'void' to 'string'
                 //         if (!string.IsNullOrEmpty(M2(null)))
-                Diagnostic(ErrorCode.ERR_BadArgType, "M2(null)").WithArguments("1", "void", "string").WithLocation(6, 35)
+                Diagnostic(ErrorCode.ERR_BadArgType, "M2(null)").WithArguments("1", "void", "string").WithLocation(6, 35),
+                // (6,38): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //         if (!string.IsNullOrEmpty(M2(null)))
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 38)
                 );
         }
 
@@ -13687,6 +13945,30 @@ public class C
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         s2.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(8, 9)
+                );
+        }
+
+        [Fact]
+        [WorkItem(29916, "https://github.com/dotnet/roslyn/issues/29916")]
+        public void EnsuresNotNull_InErrorInvocation()
+        {
+            CSharpCompilation c = CreateCompilation(new[] { @"
+using System.Runtime.CompilerServices;
+public class C
+{
+    void M(string? s1, string? s2)
+    {
+        Missing(ThrowIfNull(s1, s2 = s1));
+        s2.ToString();
+    }
+    public static void ThrowIfNull([EnsuresNotNull] string? x1, string? x2) => throw null;
+}
+", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics(
+                // (7,9): error CS0103: The name 'Missing' does not exist in the current context
+                //         Missing(ThrowIfNull(s1, s2 = s1));
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(7, 9)
                 );
         }
 
@@ -28496,9 +28778,9 @@ class C
     }
 }";
             CreateCompilation(new[] { source }, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (6,9): warning CS8619: Nullability of reference types in value of type '?' doesn't match target type 'string'.
+                // (6,15): error CS1627: Expression expected after yield return
                 //         yield return;
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "yield return;").WithArguments("?", "string").WithLocation(6, 9)
+                Diagnostic(ErrorCode.ERR_EmptyYield, "return").WithLocation(6, 15)
                 );
         }
 
@@ -35054,7 +35336,6 @@ class C<T>
     }
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/29916: WRN_NullabilityMismatchInAssignment, WRN_NullReferenceReturn are cascading, caused by the binding error.
             comp.VerifyDiagnostics(
                 // (6,17): error CS0023: Operator '?' cannot be applied to operand of type 'T'
                 //         return f?.Invoke();
@@ -40291,20 +40572,18 @@ class C
     static void G(object?* x, object* y)
     {
         var z = CreatePointer(A.F)/*T:object**/;
-        F(x, x)/*T:object**/;
-        F(x, y)/*T:object**/;
-        F(x, z)/*T:object**/;
-        F(y, x)/*T:object**/;
-        F(y, y)/*T:object**/;
-        F(y, z)/*T:object**/;
-        F(z, x)/*T:object**/;
-        F(z, y)/*T:object**/;
+        F(x, x)/*T:object?**/;
+        F(x, y)/*T:object!**/;
+        F(x, z)/*T:object?**/;
+        F(y, x)/*T:object!**/;
+        F(y, y)/*T:object!**/;
+        F(y, z)/*T:object!**/;
+        F(z, x)/*T:object?**/;
+        F(z, y)/*T:object!**/;
         F(z, z)/*T:object**/;
     }
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(TestOptions.UnsafeDebugDll), references: new[] { ref0 });
-            // NullableWalker.VisitCall is currently skipping F(x, y), etc. because
-            // each BoundCall has errors.
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
                 // (4,12): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('T')
@@ -40317,31 +40596,37 @@ class C
                 //     static void G(object?* x, object* y)
                 Diagnostic(ErrorCode.ERR_ManagedAddr, "object*").WithArguments("object").WithLocation(5, 31),
                 // (8,9): error CS0306: The type 'object*' may not be used as a type argument
-                //         F(x, x)/*T:object?*!*/;
+                //         F(x, x)/*T:object?**/;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "F").WithArguments("object*").WithLocation(8, 9),
                 // (9,9): error CS0306: The type 'object*' may not be used as a type argument
-                //         F(x, y)/*T:object*!*/;
+                //         F(x, y)/*T:object!**/;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "F").WithArguments("object*").WithLocation(9, 9),
+                // (9,9): warning CS8638: The nullability of type arguments for method 'C.F<T>(T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         F(x, y)/*T:object!**/;
+                Diagnostic(ErrorCode.WRN_CantInferNullabilityOfMethodTypeArgs, "F(x, y)").WithArguments("C.F<T>(T, T)").WithLocation(9, 9),
                 // (10,9): error CS0306: The type 'object*' may not be used as a type argument
-                //         F(x, z)/*T:object*!*/;
+                //         F(x, z)/*T:object?**/;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "F").WithArguments("object*").WithLocation(10, 9),
                 // (11,9): error CS0306: The type 'object*' may not be used as a type argument
-                //         F(y, x)/*T:object*!*/;
+                //         F(y, x)/*T:object!**/;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "F").WithArguments("object*").WithLocation(11, 9),
+                // (11,9): warning CS8638: The nullability of type arguments for method 'C.F<T>(T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         F(y, x)/*T:object!**/;
+                Diagnostic(ErrorCode.WRN_CantInferNullabilityOfMethodTypeArgs, "F(y, x)").WithArguments("C.F<T>(T, T)").WithLocation(11, 9),
                 // (12,9): error CS0306: The type 'object*' may not be used as a type argument
-                //         F(y, y)/*T:object!*!*/;
+                //         F(y, y)/*T:object!**/;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "F").WithArguments("object*").WithLocation(12, 9),
                 // (13,9): error CS0306: The type 'object*' may not be used as a type argument
-                //         F(y, z)/*T:object*!*/;
+                //         F(y, z)/*T:object!**/;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "F").WithArguments("object*").WithLocation(13, 9),
                 // (14,9): error CS0306: The type 'object*' may not be used as a type argument
-                //         F(z, x)/*T:object*!*/;
+                //         F(z, x)/*T:object?**/;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "F").WithArguments("object*").WithLocation(14, 9),
                 // (15,9): error CS0306: The type 'object*' may not be used as a type argument
-                //         F(z, y)/*T:object*!*/;
+                //         F(z, y)/*T:object!**/;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "F").WithArguments("object*").WithLocation(15, 9),
                 // (16,9): error CS0306: The type 'object*' may not be used as a type argument
-                //         F(z, z)/*T:object*!*/;
+                //         F(z, z)/*T:object**/;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "F").WithArguments("object*").WithLocation(16, 9));
         }
 
@@ -56462,7 +56747,10 @@ class Program
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(12, 13),
                 // (14,9): error CS0176: Member 'C<object>.F()' cannot be accessed with an instance reference; qualify it with a type name instead
                 //         c2.F().ToString();
-                Diagnostic(ErrorCode.ERR_ObjectProhibited, "c2.F").WithArguments("C<object>.F()").WithLocation(14, 9));
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "c2.F").WithArguments("C<object>.F()").WithLocation(14, 9),
+                // (14,9): warning CS8602: Possible dereference of a null reference.
+                //         c2.F().ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2.F()").WithLocation(14, 9));
         }
 
         [Fact, WorkItem(30561, "https://github.com/dotnet/roslyn/issues/30561")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -10317,10 +10317,7 @@ class C
             c.VerifyDiagnostics(
                 // (6,16): error CS0103: The name 'bad' does not exist in the current context
                 //         return bad;
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "bad").WithArguments("bad").WithLocation(6, 16),
-                // (6,16): warning CS8619: Nullability of reference types in value of type '?' doesn't match target type 'string'.
-                //         return bad;
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "bad").WithArguments("?", "string").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "bad").WithArguments("bad").WithLocation(6, 16)
                 );
         }
 
@@ -28449,10 +28446,7 @@ class C
             CreateCompilation(new[] { source }, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (6,22): error CS0103: The name 'bad' does not exist in the current context
                 //         yield return bad;
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "bad").WithArguments("bad").WithLocation(6, 22),
-                // (6,22): warning CS8619: Nullability of reference types in value of type '?' doesn't match target type 'string'.
-                //         yield return bad;
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "bad").WithArguments("?", "string").WithLocation(6, 22)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "bad").WithArguments("bad").WithLocation(6, 22)
                 );
         }
 
@@ -28504,10 +28498,7 @@ class C
             CreateCompilation(new[] { source }, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (6,9): warning CS8619: Nullability of reference types in value of type '?' doesn't match target type 'string'.
                 //         yield return;
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "yield return;").WithArguments("?", "string").WithLocation(6, 9),
-                // (6,15): error CS1627: Expression expected after yield return
-                //         yield return;
-                Diagnostic(ErrorCode.ERR_EmptyYield, "return").WithLocation(6, 15)
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "yield return;").WithArguments("?", "string").WithLocation(6, 9)
                 );
         }
 
@@ -35067,13 +35058,7 @@ class C<T>
             comp.VerifyDiagnostics(
                 // (6,17): error CS0023: Operator '?' cannot be applied to operand of type 'T'
                 //         return f?.Invoke();
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "?").WithArguments("?", "T").WithLocation(6, 17),
-                // (6,16): warning CS8603: Possible null reference return.
-                //         return f?.Invoke();
-                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "f?.Invoke()").WithLocation(6, 16),
-                // (6,16): warning CS8619: Nullability of reference types in value of type '?' doesn't match target type 'T'.
-                //         return f?.Invoke();
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "f?.Invoke()").WithArguments("?", "T").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "?").WithArguments("?", "T").WithLocation(6, 17)
                 );
         }
 


### PR DESCRIPTION
1) Previously we would report warnings like `Nullability of reference types in value of type '?' doesn't match target type 'string'.` which result from an expression having an error type. We can suppress these.
2) On the other hand, we used to skip analysis of arguments if an invocation has errors.

Fixes https://github.com/dotnet/roslyn/issues/29916

PS: an alternative design I considered for the first issue: TSWA could always have an oblivious nullability when the TypeSymbol is an error type.