### PR TITLE
Do not mark a switch expression as erroneous just because it wasn't exhaustive.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
@@ -53,7 +53,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="switchArms"></param>
         /// <param name="decisionDag"></param>
         /// <param name="diagnostics"></param>
-        /// <returns>true if the switch expression is not exhaustive</returns>
         private bool CheckSwitchExpressionExhaustive(
             SwitchExpressionSyntax node,
             BoundExpression boundInputExpression,

--- a/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
@@ -45,14 +45,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Build the decision dag, giving an error if some cases are subsumed and an error if the switch expression is not exhaustive.
-        /// Returns true if there was a non-exhaustive warning reported.
+        /// Build the decision dag, giving an error if some cases are subsumed and a warning if the switch expression is not exhaustive.
         /// </summary>
         /// <param name="node"></param>
         /// <param name="boundInputExpression"></param>
         /// <param name="switchArms"></param>
         /// <param name="decisionDag"></param>
         /// <param name="diagnostics"></param>
+        /// <returns>true if there was a non-exhaustive warning reported</returns>
         private bool CheckSwitchExpressionExhaustive(
             SwitchExpressionSyntax node,
             BoundExpression boundInputExpression,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests4.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
@@ -1488,7 +1489,7 @@ class _
                 );
         }
 
-        [Fact]
+        [Fact, WorkItem(31167, "https://github.com/dotnet/roslyn/issues/31167")]
         public void NonExhaustiveBoolSwitchExpression()
         {
             var source = @"using System;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests4.cs
@@ -1487,5 +1487,45 @@ class _
                 Diagnostic(ErrorCode.ERR_SwitchArmSubsumed, "(null, true)").WithLocation(13, 13)
                 );
         }
+
+        [Fact]
+        public void NonExhaustiveBoolSwitchExpression()
+        {
+            var source = @"using System;
+class Program
+{
+    static void Main()
+    {
+        new Program().Start();
+    }
+    void Start()
+    {
+        Console.Write(M(true));
+        try
+        {
+            Console.Write(M(false));
+        }
+        catch (Exception)
+        {
+            Console.Write("" throw"");
+        }
+    }
+    public int M(bool b) 
+    {
+        return b switch
+        {
+           true => 1
+        }; 
+    }
+}
+";
+            var compilation = CreatePatternCompilation(source);
+            compilation.VerifyDiagnostics(
+                // (22,18): warning CS8509: The switch expression does not handle all possible inputs (it is not exhaustive).
+                //         return b switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithLocation(22, 18)
+                );
+            CompileAndVerify(compilation, expectedOutput: "1 throw");
+        }
     }
 }


### PR DESCRIPTION
Fixes #31167