### PR TITLE
Smart indent when users type '{' even if 'format on typing' is off.

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -56,9 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
             // on typing" is off, if "smart indent" is on, we'll still format this.  (However, we
             // won't touch anything else in the block this close curly belongs to.).
             //
-            // TODO(cyrusn): Should we expose an option for this?  Personally, i don't think so.
-            // If a user doesn't want this behavior, they can turn off 'smart indent' and control
-            // everything themselves.  
+            // See extended comment in GetFormattingChangesAsync for more details on this.
             if (smartIndentOn)
             {
                 if (ch == '{' || ch == '}')

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -1650,6 +1650,106 @@ class C
             await AssertFormatOnArbitraryNodeAsync(node, expected);
         }
 
+        [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoSmartIndentOpenBraceEvenWithFormatWhileTypingOff1()
+        {
+            var code = 
+@"class Program
+{
+    void M()
+    {
+        if (true)
+            {$$
+    }
+}";
+
+            var expected =
+@"class Program
+{
+    void M()
+    {
+        if (true)
+        {
+    }
+}";
+            var optionSet = new Dictionary<OptionKey, object>
+            {
+                { new OptionKey(FormattingOptions.SmartIndent, LanguageNames.CSharp), FormattingOptions.IndentStyle.Smart },
+                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnTyping, LanguageNames.CSharp),  false },
+                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnCloseBrace, LanguageNames.CSharp),  false },
+            };
+
+            AssertFormatAfterTypeChar(code, expected, optionSet);
+        }
+
+        [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoSmartIndentOpenBraceEvenWithFormatWhileTypingOff2()
+        {
+            // We only smart indent the { if it's on it's own line.
+            var code =
+@"class Program
+{
+    void M()
+    {
+        if (true){$$
+    }
+}";
+
+            var expected =
+@"class Program
+{
+    void M()
+    {
+        if (true){
+    }
+}";
+            var optionSet = new Dictionary<OptionKey, object>
+            {
+                { new OptionKey(FormattingOptions.SmartIndent, LanguageNames.CSharp), FormattingOptions.IndentStyle.Smart },
+                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnTyping, LanguageNames.CSharp),  false },
+                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnCloseBrace, LanguageNames.CSharp),  false },
+            };
+
+            AssertFormatAfterTypeChar(code, expected, optionSet);
+        }
+
+        [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoSmartIndentCloseBraceEvenWithFormatWhileTypingOff1()
+        {
+            var code =
+@"class Program
+{
+    void M()
+    {
+        if (true)
+        {
+            }$$
+    }
+}";
+
+            var expected =
+@"class Program
+{
+    void M()
+    {
+        if (true)
+        {
+        }
+    }
+}";
+            var optionSet = new Dictionary<OptionKey, object>
+            {
+                { new OptionKey(FormattingOptions.SmartIndent, LanguageNames.CSharp), FormattingOptions.IndentStyle.Smart },
+                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnTyping, LanguageNames.CSharp),  false },
+                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnCloseBrace, LanguageNames.CSharp),  false },
+            };
+
+            AssertFormatAfterTypeChar(code, expected, optionSet);
+        }
+
         private void AssertFormatAfterTypeChar(string code, string expected, Dictionary<OptionKey, object> changedOptionSet = null)
         {
             using (var workspace = TestWorkspace.CreateCSharp(code))

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -1768,6 +1768,81 @@ class C
 
         [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoSmartIndentOpenBraceEvenWithFormatWhileTypingOff5()
+        {
+            // Typing the { should not affect the formating of the preceding tokens.
+            var code =
+@"class Program
+{
+    void M()
+    {
+        if ( true )
+            {$$
+    }
+}";
+
+            var expected =
+@"class Program
+{
+    void M()
+    {
+        if ( true )
+        {
+    }
+}";
+
+            AssertFormatAfterTypeChar(code, expected, SmartIndentButDoNotFormatWhileTyping());
+        }
+
+        [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoSmartIndentOpenBraceEvenWithFormatWhileTypingOff6()
+        {
+            // Typing the { should not affect the formating of the preceding tokens.
+            var code =
+@"class Program
+{
+    void M()
+    {
+        if ( true ){$$
+    }
+}";
+
+            var expected =
+@"class Program
+{
+    void M()
+    {
+        if ( true ){
+    }
+}";
+
+            AssertFormatAfterTypeChar(code, expected, SmartIndentButDoNotFormatWhileTyping());
+        }
+
+        [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoSmartIndentOpenBraceEvenWithFormatWhileTypingOff7()
+        {
+            var code =
+@"class Program
+{
+    void M()
+        {$$
+}";
+
+            var expected =
+@"class Program
+{
+    void M()
+    {
+}";
+
+            AssertFormatAfterTypeChar(code, expected, SmartIndentButDoNotFormatWhileTyping());
+        }
+
+        [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public void DoSmartIndentCloseBraceEvenWithFormatWhileTypingOff1()
         {
             var code =
@@ -1817,6 +1892,51 @@ class C
     {
         if (true) {
         }
+    }
+}";
+
+            AssertFormatAfterTypeChar(code, expected, SmartIndentButDoNotFormatWhileTyping());
+        }
+
+        [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoSmartIndentCloseBraceEvenWithFormatWhileTypingOff3()
+        {
+            var code =
+@"class Program
+{
+    void M()
+    {
+        }$$
+}";
+
+            var expected =
+@"class Program
+{
+    void M()
+    {
+    }
+}";
+
+            AssertFormatAfterTypeChar(code, expected, SmartIndentButDoNotFormatWhileTyping());
+        }
+
+        [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoSmartIndentCloseBraceEvenWithFormatWhileTypingOff4()
+        {
+            // Should not affect formatting of open brace
+            var code =
+@"class Program
+{
+    void M() {
+        }$$
+}";
+
+            var expected =
+@"class Program
+{
+    void M() {
     }
 }";
 

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -21,6 +21,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
 {
     public class FormattingEngineTests : FormattingEngineTestBase
     {
+        private static Dictionary<OptionKey, object> SmartIndentButDoNotFormatWhileTyping()
+        {
+            return new Dictionary<OptionKey, object>
+            {
+                { new OptionKey(FormattingOptions.SmartIndent, LanguageNames.CSharp), FormattingOptions.IndentStyle.Smart },
+                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnTyping, LanguageNames.CSharp),  false },
+                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnCloseBrace, LanguageNames.CSharp),  false },
+            };
+        }
+
         [WpfFact]
         [WorkItem(539682, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539682")]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
@@ -1654,7 +1664,7 @@ class C
         [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public void DoSmartIndentOpenBraceEvenWithFormatWhileTypingOff1()
         {
-            var code = 
+            var code =
 @"class Program
 {
     void M()
@@ -1673,19 +1683,40 @@ class C
         {
     }
 }";
-            var optionSet = new Dictionary<OptionKey, object>
-            {
-                { new OptionKey(FormattingOptions.SmartIndent, LanguageNames.CSharp), FormattingOptions.IndentStyle.Smart },
-                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnTyping, LanguageNames.CSharp),  false },
-                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnCloseBrace, LanguageNames.CSharp),  false },
-            };
 
-            AssertFormatAfterTypeChar(code, expected, optionSet);
+            AssertFormatAfterTypeChar(code, expected, SmartIndentButDoNotFormatWhileTyping());
         }
 
         [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public void DoSmartIndentOpenBraceEvenWithFormatWhileTypingOff2()
+        {
+            var code =
+@"class Program
+{
+    void M()
+    {
+        if (true)
+        {}$$
+    }
+}";
+
+            var expected =
+@"class Program
+{
+    void M()
+    {
+        if (true)
+        { }
+    }
+}";
+
+            AssertFormatAfterTypeChar(code, expected, SmartIndentButDoNotFormatWhileTyping());
+        }
+
+        [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoSmartIndentOpenBraceEvenWithFormatWhileTypingOff3()
         {
             // We only smart indent the { if it's on it's own line.
             var code =
@@ -1705,14 +1736,34 @@ class C
         if (true){
     }
 }";
-            var optionSet = new Dictionary<OptionKey, object>
-            {
-                { new OptionKey(FormattingOptions.SmartIndent, LanguageNames.CSharp), FormattingOptions.IndentStyle.Smart },
-                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnTyping, LanguageNames.CSharp),  false },
-                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnCloseBrace, LanguageNames.CSharp),  false },
-            };
 
-            AssertFormatAfterTypeChar(code, expected, optionSet);
+            AssertFormatAfterTypeChar(code, expected, SmartIndentButDoNotFormatWhileTyping());
+        }
+
+        [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoSmartIndentOpenBraceEvenWithFormatWhileTypingOff4()
+        {
+            // We only smart indent the { if it's on it's own line.
+            var code =
+@"class Program
+{
+    void M()
+    {
+        if (true){}$$
+    }
+}";
+
+            var expected =
+@"class Program
+{
+    void M()
+    {
+        if (true){ }
+    }
+}";
+
+            AssertFormatAfterTypeChar(code, expected, SmartIndentButDoNotFormatWhileTyping());
         }
 
         [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
@@ -1740,14 +1791,36 @@ class C
         }
     }
 }";
-            var optionSet = new Dictionary<OptionKey, object>
-            {
-                { new OptionKey(FormattingOptions.SmartIndent, LanguageNames.CSharp), FormattingOptions.IndentStyle.Smart },
-                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnTyping, LanguageNames.CSharp),  false },
-                { new OptionKey(FeatureOnOffOptions.AutoFormattingOnCloseBrace, LanguageNames.CSharp),  false },
-            };
 
-            AssertFormatAfterTypeChar(code, expected, optionSet);
+            AssertFormatAfterTypeChar(code, expected, SmartIndentButDoNotFormatWhileTyping());
+        }
+
+        [WorkItem(30787, "https://github.com/dotnet/roslyn/issues/30787")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void DoSmartIndentCloseBraceEvenWithFormatWhileTypingOff2()
+        {
+            // Note that the { is not updated since we are not formatting.
+            var code =
+@"class Program
+{
+    void M()
+    {
+        if (true) {
+            }$$
+    }
+}";
+
+            var expected =
+@"class Program
+{
+    void M()
+    {
+        if (true) {
+        }
+    }
+}";
+
+            AssertFormatAfterTypeChar(code, expected, SmartIndentButDoNotFormatWhileTyping());
         }
 
         private void AssertFormatAfterTypeChar(string code, string expected, Dictionary<OptionKey, object> changedOptionSet = null)

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting.Rules;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/30787

This brings open-brace handling in line with how we handle close braces.  With close-braces, we will treat typing the close-brace as a smart-indent trigger, even if the user has turned off 'format while typing'.  In this case, only indentation affected, and no other code should be touched.  

This is now extended to open braces as well.  If a user types an open brace is on a new line, and they only have smart-indent on, and htey have disabled format-while-typing, we'll also treat this as a smart-indent trigger, placing the open brace at teh correct indentation level, even if the the previous 'enter' command might have the user indented further.