### PR TITLE
Offer completion for `#nullable enable|disable`

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/DirectiveTriviaSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/DirectiveTriviaSyntax.cs
@@ -52,6 +52,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                         return ((LoadDirectiveTriviaSyntax)this).LoadKeyword;
                     case SyntaxKind.ShebangDirectiveTrivia:
                         return ((ShebangDirectiveTriviaSyntax)this).ExclamationToken;
+                    case SyntaxKind.NullableDirectiveTrivia:
+                        return ((NullableDirectiveTriviaSyntax)this).NullableKeyword;
                     default:
                         throw ExceptionUtilities.UnexpectedValue(this.Kind());
                 }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -247,6 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.LoadDirectiveTrivia:
                 case SyntaxKind.BadDirectiveTrivia:
                 case SyntaxKind.ShebangDirectiveTrivia:
+                case SyntaxKind.NullableDirectiveTrivia:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -260,6 +260,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                             Assert.Equal(exp.Text, setting.ValueText);
                             Assert.True(setting.Kind() == SyntaxKind.EnableKeyword || setting.Kind() == SyntaxKind.DisableKeyword);
                         }
+                        Assert.Equal(SyntaxKind.NullableKeyword, nn.DirectiveNameToken.Kind());
+                        Assert.True(SyntaxFacts.IsPreprocessorDirective(SyntaxKind.NullableDirectiveTrivia));
+                        Assert.True(SyntaxFacts.IsPreprocessorKeyword(SyntaxKind.NullableKeyword));
                         break;
                     default:
                         if (null != exp.Text)

--- a/src/EditorFeatures/CSharpTest2/Recommendations/DisableKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/DisableKeywordRecommenderTests.cs
@@ -16,6 +16,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
             await VerifyKeywordAsync(@"#nullable $$");
         }
 
+        [Fact]
+        [WorkItem(31130, "https://github.com/dotnet/roslyn/issues/31130")]
+        public async Task TestNotAfterNullableAndNewline()
+        {
+            await VerifyAbsenceAsync(@"
+#nullable 
+$$
+");
+        }
+
+
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAtRoot_Interactive()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/DisableKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/DisableKeywordRecommenderTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
@@ -9,6 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
     public class DisableKeywordRecommenderTests : KeywordRecommenderTests
     {
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(31130, "https://github.com/dotnet/roslyn/issues/31130")]
         public async Task TestAfterNullable()
         {
             await VerifyKeywordAsync(@"#nullable $$");

--- a/src/EditorFeatures/CSharpTest2/Recommendations/EnableKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/EnableKeywordRecommenderTests.cs
@@ -6,22 +6,28 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
 {
-    public class DisableKeywordRecommenderTests : KeywordRecommenderTests
+    [Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+    public class EnableKeywordRecommenderTests : KeywordRecommenderTests
     {
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [Fact]
         public async Task TestAfterNullable()
         {
             await VerifyKeywordAsync(@"#nullable $$");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotAtRoot_Interactive()
+        [Fact]
+        public async Task TestNotAfterHash()
         {
-            await VerifyAbsenceAsync(SourceCodeKind.Script,
-@"$$");
+            await VerifyAbsenceAsync(@"#$$");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [Fact]
+        public async Task TestNotAtRoot_Interactive()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Script, @"$$");
+        }
+
+        [Fact]
         public async Task TestNotAfterClass_Interactive()
         {
             await VerifyAbsenceAsync(SourceCodeKind.Script,
@@ -29,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
 $$");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [Fact]
         public async Task TestNotAfterGlobalStatement_Interactive()
         {
             await VerifyAbsenceAsync(SourceCodeKind.Script,
@@ -37,7 +43,7 @@ $$");
 $$");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [Fact]
         public async Task TestNotAfterGlobalVariableDeclaration_Interactive()
         {
             await VerifyAbsenceAsync(SourceCodeKind.Script,
@@ -45,37 +51,28 @@ $$");
 $$");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [Fact]
         public async Task TestNotInUsingAlias()
         {
-            await VerifyAbsenceAsync(
-@"using Goo = $$");
+            await VerifyAbsenceAsync(@"using Goo = $$");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [Fact]
         public async Task TestNotInEmptyStatement()
         {
-            await VerifyAbsenceAsync(AddInsideMethod(
-@"$$"));
+            await VerifyAbsenceAsync(AddInsideMethod(@"$$"));
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotAfterHash()
-        {
-            await VerifyAbsenceAsync(@"#$$");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [Fact]
         public async Task TestNotAfterPragma()
         {
             await VerifyAbsenceAsync(@"#pragma $$");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestAfterPragmaWarning()
+        [Fact]
+        public async Task TestNotAfterPragmaWarning()
         {
-            await VerifyKeywordAsync(
-@"#pragma warning $$");
+            await VerifyAbsenceAsync(@"#pragma warning $$");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/EnableKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/EnableKeywordRecommenderTests.cs
@@ -19,6 +19,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
 
         [Fact]
         [WorkItem(31130, "https://github.com/dotnet/roslyn/issues/31130")]
+        public async Task TestNotAfterNullableAndNewline()
+        {
+            await VerifyAbsenceAsync(@"
+#nullable 
+$$
+");
+        }
+
+        [Fact]
+        [WorkItem(31130, "https://github.com/dotnet/roslyn/issues/31130")]
         public async Task TestNotAfterHash()
         {
             await VerifyAbsenceAsync(@"#$$");

--- a/src/EditorFeatures/CSharpTest2/Recommendations/EnableKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/EnableKeywordRecommenderTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
@@ -10,12 +11,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
     public class EnableKeywordRecommenderTests : KeywordRecommenderTests
     {
         [Fact]
+        [WorkItem(31130, "https://github.com/dotnet/roslyn/issues/31130")]
         public async Task TestAfterNullable()
         {
             await VerifyKeywordAsync(@"#nullable $$");
         }
 
         [Fact]
+        [WorkItem(31130, "https://github.com/dotnet/roslyn/issues/31130")]
         public async Task TestNotAfterHash()
         {
             await VerifyAbsenceAsync(@"#$$");

--- a/src/EditorFeatures/CSharpTest2/Recommendations/NullableKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/NullableKeywordRecommenderTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
+{
+    [Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+    public class NullableKeywordRecommenderTests : KeywordRecommenderTests
+    {
+        [Fact]
+        public async Task TestNotAtRoot_Interactive()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Script,
+@"$$");
+        }
+
+        [Fact]
+        public async Task TestNotAfterClass_Interactive()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Script,
+@"class C { }
+$$");
+        }
+
+        [Fact]
+        public async Task TestNotAfterGlobalStatement_Interactive()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Script,
+@"System.Console.WriteLine();
+$$");
+        }
+
+        [Fact]
+        public async Task TestNotAfterGlobalVariableDeclaration_Interactive()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Script,
+@"int i = 0;
+$$");
+        }
+
+        [Fact]
+        public async Task TestNotInUsingAlias()
+        {
+            await VerifyAbsenceAsync(
+@"using Goo = $$");
+        }
+
+        [Fact]
+        public async Task TestNotInEmptyStatement()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"$$"));
+        }
+
+        [Fact]
+        public async Task TestAfterHash()
+        {
+            await VerifyKeywordAsync(
+@"#$$");
+        }
+
+        [Fact]
+        public async Task TestAfterHashAndSpace()
+        {
+            await VerifyKeywordAsync(
+@"# $$");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest2/Recommendations/NullableKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/NullableKeywordRecommenderTests.cs
@@ -67,5 +67,12 @@ $$");
             await VerifyKeywordAsync(
 @"# $$");
         }
+
+        [Fact]
+        public async Task TestNotAfterHashAndNullable()
+        {
+            await VerifyAbsenceAsync(
+@"#nullable $$");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
@@ -96,6 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 new NameOfKeywordRecommender(),
                 new NamespaceKeywordRecommender(),
                 new NewKeywordRecommender(),
+                new NullableKeywordRecommender(),
                 new NullKeywordRecommender(),
                 new ObjectKeywordRecommender(),
                 new OnKeywordRecommender(),

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 new DynamicKeywordRecommender(),
                 new ElifKeywordRecommender(),
                 new ElseKeywordRecommender(),
+                new EnableKeywordRecommender(),
                 new EndIfKeywordRecommender(),
                 new EndRegionKeywordRecommender(),
                 new EnumKeywordRecommender(),

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DisableKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DisableKeywordRecommender.cs
@@ -14,12 +14,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
         {
-            // # pragma warning |
-            // # pragma warning d|
             var previousToken1 = context.TargetToken;
             var previousToken2 = previousToken1.GetPreviousToken(includeSkipped: true);
             var previousToken3 = previousToken2.GetPreviousToken(includeSkipped: true);
 
+            if (previousToken1.Kind() == SyntaxKind.NullableKeyword &&
+                previousToken2.Kind() == SyntaxKind.HashToken)
+            {
+                // # nullable |
+                // # nullable d|
+                return true;
+            }
+            
+            // # pragma warning |
+            // # pragma warning d|
             return
                 previousToken1.Kind() == SyntaxKind.WarningKeyword &&
                 previousToken2.Kind() == SyntaxKind.PragmaKeyword &&

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/EnableKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/EnableKeywordRecommender.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
+{
+    internal class EnableKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    {
+        public EnableKeywordRecommender()
+            : base(SyntaxKind.EnableKeyword, isValidInPreprocessorContext: true)
+        {
+        }
+
+        protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
+        {
+            var previousToken1 = context.TargetToken;
+            var previousToken2 = previousToken1.GetPreviousToken(includeSkipped: true);
+
+            // # nullable |
+            // # nullable e|
+            return previousToken1.Kind() == SyntaxKind.NullableKeyword &&
+                previousToken2.Kind() == SyntaxKind.HashToken;
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/NullableKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/NullableKeywordRecommender.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
+{
+    internal class NullableKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    {
+        public NullableKeywordRecommender()
+            : base(SyntaxKind.NullableKeyword, isValidInPreprocessorContext: true)
+        {
+        }
+
+        protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
+        {
+            return context.IsPreProcessorKeywordContext;
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/NullableKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/NullableKeywordRecommender.cs
@@ -13,8 +13,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         }
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
-        {
-            return context.IsPreProcessorKeywordContext;
-        }
+            => context.IsPreProcessorKeywordContext;
     }
 }


### PR DESCRIPTION
This is mostly an IDE fix, but also includes a minor fix to compiler APIs.

`#nullable`
![image](https://user-images.githubusercontent.com/12466233/48462496-4216de00-e78d-11e8-995b-da11227e538e.png)

`#nullable enable|disable`
![image](https://user-images.githubusercontent.com/12466233/48462519-4fcc6380-e78d-11e8-839c-d6620e4bfded.png)

Addresses part of https://github.com/dotnet/roslyn/issues/31130