### PR TITLE
add output paths as one of causes to reanalyze solution cralwer.

### DIFF
--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -287,6 +287,42 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [Fact]
+        public async Task Project_OutputFilePath_Change()
+        {
+            using (var workspace = new WorkCoordinatorWorkspace(SolutionCrawler))
+            {
+                var solutionInfo = GetInitialSolutionInfo_2Projects_10Documents(workspace);
+                workspace.OnSolutionAdded(solutionInfo);
+                await WaitWaiterAsync(workspace.ExportProvider);
+
+                var projectId = workspace.CurrentSolution.Projects.First(p => p.Name == "P1").Id;
+                var newSolution = workspace.CurrentSolution.WithProjectOutputFilePath(projectId, "/newPath");
+                var worker = await ExecuteOperation(workspace, w => w.ChangeProject(projectId, newSolution));
+
+                Assert.Equal(5, worker.SyntaxDocumentIds.Count);
+                Assert.Equal(5, worker.DocumentIds.Count);
+            }
+        }
+
+        [Fact]
+        public async Task Project_OutputRefFilePath_Change()
+        {
+            using (var workspace = new WorkCoordinatorWorkspace(SolutionCrawler))
+            {
+                var solutionInfo = GetInitialSolutionInfo_2Projects_10Documents(workspace);
+                workspace.OnSolutionAdded(solutionInfo);
+                await WaitWaiterAsync(workspace.ExportProvider);
+
+                var projectId = workspace.CurrentSolution.Projects.First(p => p.Name == "P1").Id;
+                var newSolution = workspace.CurrentSolution.WithProjectOutputRefFilePath(projectId, "/newPath");
+                var worker = await ExecuteOperation(workspace, w => w.ChangeProject(projectId, newSolution));
+
+                Assert.Equal(5, worker.SyntaxDocumentIds.Count);
+                Assert.Equal(5, worker.DocumentIds.Count);
+            }
+        }
+
+        [Fact]
         public async Task Test_NeedsReanalysisOnOptionChanged()
         {
             using (var workspace = new WorkCoordinatorWorkspace(SolutionCrawler))

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -506,7 +506,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     !object.Equals(oldProject.AssemblyName, newProject.AssemblyName) ||
                     !object.Equals(oldProject.Name, newProject.Name) ||
                     !object.Equals(oldProject.AnalyzerOptions, newProject.AnalyzerOptions) ||
-                    !object.Equals(oldProject.DefaultNamespace, newProject.DefaultNamespace))
+                    !object.Equals(oldProject.DefaultNamespace, newProject.DefaultNamespace) ||
+                    !object.Equals(oldProject.OutputFilePath, newProject.OutputFilePath) ||
+                    !object.Equals(oldProject.OutputRefFilePath, newProject.OutputRefFilePath))
                 {
                     projectConfigurationChange = projectConfigurationChange.With(InvocationReasons.ProjectConfigurationChanged);
                 }


### PR DESCRIPTION
output paths are not specifically affecting semantics of code but some analyzer such as source based test discovery requires it to generate correct data. so they want to be re-analyzed when those are changed as well.

since output path are rarely get changed. decide to add it as one of cause to reanalyze projects.