### PR TITLE
change build errors to show up at the end rather than at the top.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -391,8 +391,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     switch (value)
                     {
                         case WellKnownDiagnosticTags.Build:
-                            // any error from build is highest priority
-                            return ErrorRank.Lexical;
+                            // any error from build gets lowest priority
+                            // see https://github.com/dotnet/roslyn/issues/28807
+                            //
+                            // this is only used when intellisense (live) errors are involved.
+                            // with "build only" filter on, we use order of errors came in from build for ordering
+                            // and doesn't use ErrorRank for ordering (by giving same rank for all errors)
+                            //
+                            // when live errors are involved, by default, error list will use the following to sort errors
+                            // error rank > project rank > project name > file name > line > column
+                            // which will basically make syntax errors show up before declaration error and method body semantic errors
+                            // among same type of errors, leaf project's error will show up first and then projects that depends on the leaf projects
+                            //
+                            // any build errors mixed with live errors will show up at the end. when live errors are on, some of errors
+                            // still left as build errors such as errors produced after CompilationStages.Compile or ones listed here
+                            // http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Compilation/CSharpCompilerDiagnosticAnalyzer.cs,23 or similar ones for VB
+                            // and etc.
+                            return ErrorRank.PostBuild;
                         case nameof(ErrorRank.Lexical):
                             return ErrorRank.Lexical;
                         case nameof(ErrorRank.Syntactic):


### PR DESCRIPTION
fix https://github.com/dotnet/roslyn/issues/28807

after some discussion, decided to show build errors at the end when it is mixed with live errors.