### PR TITLE
enable non fatal watson in extract method

### DIFF
--- a/src/Features/Core/Portable/ExtractMethod/ExtractMethodMatrix.cs
+++ b/src/Features/Core/Portable/ExtractMethod/ExtractMethodMatrix.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Roslyn.Utilities;
 
@@ -93,9 +94,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
             // Some combination we didn't anticipate.  Can't do anything here.  Log the issue
             // and bail out.
-            Logger.Log(
-                FunctionId.Refactoring_ExtractMethod_UnknownMatrixItem,
-                KeyValueLogMessage.Create(d => d["unknown_key"] = key.ToString()));
+            FatalError.ReportWithoutCrash(new Exception($"extract method encountered unknown states: {key.ToString()}"));
+
             return false;
         }
 


### PR DESCRIPTION
use NFW on unexpected states so that we can have a way to get a dump