### PR TITLE
Add an API to pass additional msbuild properties to workspace

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/AdditionalPropertyNames.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/AdditionalPropertyNames.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
+{
+    /// <summary>
+    /// A class that provides constants for common MSBuild property names.
+    /// </summary>
+    internal static class AdditionalPropertyNames
+    {
+        public const string RootNamespace = "rootnamespace";
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
@@ -23,6 +23,9 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         // Options.
         void SetOptions(string commandLineForOptions);
 
+        // Other project properties.
+        void SetProperty(string name, string value);
+
         // References.
         void AddMetadataReference(string referencePath, MetadataReferenceProperties properties);
         void RemoveMetadataReference(string referencePath);

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -133,6 +133,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             }
         }
 
+        public void SetProperty(string name, string value)
+        {
+            // TODO
+        }
+
         public void AddMetadataReference(string referencePath, MetadataReferenceProperties properties)
         {
             referencePath = FileUtilities.NormalizeAbsolutePath(referencePath);


### PR DESCRIPTION
I have separated new API which we agreed upon from the implementation in #30998. 

This is a breaking change for project system (see [here](https://github.com/dotnet/project-system/blob/d8de8cd390ab04474f8e88ec68b785757b14d350/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.ForegroundWorkspaceProjectContext.cs)). So we need to coordinate the insertion with project system. @jasonmalinowski mentioned the code linked above is deadcode, so we might not break anything after all. Either way, it needs to be verified.

This is blocked until https://github.com/dotnet/project-system/pull/4221 is merged

@jasonmalinowski @CyrusNajmabadi 