### PR TITLE
Correct the Syntax of IUnaryOperation (logical not) in control flow g…

### DIFF
--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IReturnStatement.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IReturnStatement.cs
@@ -446,7 +446,7 @@ Block[B1] - Block
     Predecessors: [B0]
     Statements (0)
     Next (Return) Block[B2]
-        IUnaryOperation (UnaryOperatorKind.Not) (OperationKind.UnaryOperator, Type: System.Boolean) (Syntax: '!f')
+        IUnaryOperation (UnaryOperatorKind.Not) (OperationKind.Unary, Type: System.Boolean) (Syntax: '!f')
           Operand: 
             IParameterReferenceOperation: f (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'f')
 Block[B2] - Exit

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IReturnStatement.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IReturnStatement.cs
@@ -423,6 +423,42 @@ Block[B4] - Exit
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
         [Fact]
+        public void ReturnFlow_UnaryNegation()
+        {
+            var source = @"
+class C
+{
+    bool F(bool f)
+    /*<bind>*/{
+        return !f;
+    }/*</bind>*/
+}";
+
+            var compilation = CreateCompilation(source);
+
+            compilation.VerifyDiagnostics();
+
+            string expectedGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+Block[B1] - Block
+    Predecessors: [B0]
+    Statements (0)
+    Next (Return) Block[B2]
+        IUnaryOperation (UnaryOperatorKind.Not) (OperationKind.UnaryOperator, Type: System.Boolean) (Syntax: '!f')
+          Operand: 
+            IParameterReferenceOperation: f (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'f')
+Block[B2] - Exit
+    Predecessors: [B1]
+    Statements (0)
+";
+            VerifyFlowGraphForTest<BlockSyntax>(compilation, expectedGraph);
+        }
+
+
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
         public void ReturnFlow_07()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IReturnStatement.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IReturnStatement.cs
@@ -423,42 +423,6 @@ Block[B4] - Exit
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
         [Fact]
-        public void ReturnFlow_UnaryNegation()
-        {
-            var source = @"
-class C
-{
-    bool F(bool f)
-    /*<bind>*/{
-        return !f;
-    }/*</bind>*/
-}";
-
-            var compilation = CreateCompilation(source);
-
-            compilation.VerifyDiagnostics();
-
-            string expectedGraph = @"
-Block[B0] - Entry
-    Statements (0)
-    Next (Regular) Block[B1]
-Block[B1] - Block
-    Predecessors: [B0]
-    Statements (0)
-    Next (Return) Block[B2]
-        IUnaryOperation (UnaryOperatorKind.Not) (OperationKind.Unary, Type: System.Boolean) (Syntax: '!f')
-          Operand: 
-            IParameterReferenceOperation: f (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'f')
-Block[B2] - Exit
-    Predecessors: [B1]
-    Statements (0)
-";
-            VerifyFlowGraphForTest<BlockSyntax>(compilation, expectedGraph);
-        }
-
-
-        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
         public void ReturnFlow_07()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IUnaryOperatorExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IUnaryOperatorExpression.cs
@@ -3510,6 +3510,73 @@ Block[B5] - Exit
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
         [Fact]
+        public void LogicalNotFlow_02()
+        {
+            var source = @"
+class C
+{
+    bool F(bool f)
+    /*<bind>*/{
+        return !f;
+    }/*</bind>*/
+}";
+
+            string expectedGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+Block[B1] - Block
+    Predecessors: [B0]
+    Statements (0)
+    Next (Return) Block[B2]
+        IUnaryOperation (UnaryOperatorKind.Not) (OperationKind.Unary, Type: System.Boolean) (Syntax: '!f')
+          Operand: 
+            IParameterReferenceOperation: f (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'f')
+Block[B2] - Exit
+    Predecessors: [B1]
+    Statements (0)
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
+        }
+
+
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
+        public void LogicalNotFlow_03()
+        {
+            var source = @"
+class C
+{
+    bool F(bool f)
+    /*<bind>*/{
+        return !!f;
+    }/*</bind>*/
+}";
+
+            string expectedGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+Block[B1] - Block
+    Predecessors: [B0]
+    Statements (0)
+    Next (Return) Block[B2]
+        IParameterReferenceOperation: f (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'f')
+Block[B2] - Exit
+    Predecessors: [B1]
+    Statements (0)
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
+        }
+
+
+
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
         public void DynamicNotFlow_01()
         {
             string source = @"

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -2071,7 +2071,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         {
             if (IsBooleanLogicalNot(operation))
             {
-                return VisitConditionalExpression(operation.Operand, sense: false, captureIdForResult, fallToTrueOpt: null, fallToFalseOpt: null);
+                return VisitConditionalExpression(operation, sense: true, captureIdForResult, fallToTrueOpt: null, fallToFalseOpt: null);
             }
 
             return new UnaryOperation(operation.OperatorKind, Visit(operation.Operand), operation.IsLifted, operation.IsChecked, operation.OperatorMethod,

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IUnaryOperatorExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IUnaryOperatorExpression.vb
@@ -2208,5 +2208,83 @@ IUnaryOperation (UnaryOperatorKind.Minus) (OperatorMethod: Function C.op_UnaryNe
 
             VerifyOperationTreeForTest(Of UnaryExpressionSyntax)(source, expectedOperationTree)
         End Sub
+        
+        <CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)>
+        <Fact>
+        Public Sub LogicalNotFlow_01()
+            Dim source = <![CDATA[
+Imports System
+Public Class C
+    Function M(f as Boolean) As Boolean 'BIND:"Function M"
+        Return Not f
+    End Function
+End Class]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            Dim expectedFlowGraph = <![CDATA[
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1}
+
+.locals {R1}
+{
+    Locals: [M As System.Boolean]
+    Block[B1] - Block
+        Predecessors: [B0]
+        Statements (0)
+        Next (Return) Block[B2]
+            IUnaryOperation (UnaryOperatorKind.Not, Checked) (OperationKind.Unary, Type: System.Boolean) (Syntax: 'Not f')
+              Operand: 
+                IParameterReferenceOperation: f (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'f')
+            Leaving: {R1}
+}
+
+Block[B2] - Exit
+    Predecessors: [B1]
+    Statements (0)
+]]>.Value
+
+            VerifyFlowGraphAndDiagnosticsForTest(Of MethodBlockSyntax)(source, expectedFlowGraph, expectedDiagnostics)
+        End Sub
+        
+        <CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)>
+        <Fact>
+        Public Sub LogicalNotFlow_02()
+            Dim source = <![CDATA[
+Imports System
+Public Class C
+    Function M(f as Boolean) As Boolean 'BIND:"Function M"
+        Return Not Not f
+    End Function
+End Class]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            Dim expectedFlowGraph = <![CDATA[
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1}
+
+.locals {R1}
+{
+    Locals: [M As System.Boolean]
+    Block[B1] - Block
+        Predecessors: [B0]
+        Statements (0)
+        Next (Return) Block[B2]
+            IParameterReferenceOperation: f (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'f')
+            Leaving: {R1}
+}
+
+Block[B2] - Exit
+    Predecessors: [B1]
+    Statements (0)
+]]>.Value
+
+            VerifyFlowGraphAndDiagnosticsForTest(Of MethodBlockSyntax)(source, expectedFlowGraph, expectedDiagnostics)
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
…raph

In the current release, the IOperation control flow graph for a method:
```cs
void f() {
    var x = !g(); 
}
```
contains an `IUnaryOperation` for the logical not, but its `Syntax` is `InvocationExpressionSyntax` `g()` instead of `PrefixUnaryExpressionSyntax` `!g()`.