### PR TITLE
Remove assertion that this must be called on the UI thread

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Options/LocalUserRegistryOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/LocalUserRegistryOptionPersister.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
     /// Serializes options marked with <see cref="LocalUserProfileStorageLocation"/> to the local hive-specific registry.
     /// </summary>
     [Export(typeof(IOptionPersister))]
-    internal sealed class LocalUserRegistryOptionPersister : ForegroundThreadAffinitizedObject, IOptionPersister
+    internal sealed class LocalUserRegistryOptionPersister : IOptionPersister
     {
         /// <summary>
         /// An object to gate access to <see cref="_registryKey"/>.
@@ -28,9 +28,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public LocalUserRegistryOptionPersister(IThreadingContext threadingContext, [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
-            : base(threadingContext, assertIsForeground: true) // The VSRegistry.RegistryRoot call requires being on the UI thread or else it will marshal and risk deadlock
+        public LocalUserRegistryOptionPersister([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
         {
+            // Starting in Dev16, the ILocalRegistry service behind this call is free-threaded, and since the service is offered by msenv.dll can be requested
+            // without any marshalling (explicit or otherwise) to the UI thread.
             this._registryKey = VSRegistry.RegistryRoot(serviceProvider, __VsLocalRegistryType.RegType_UserSettings, writable: true);
         }
 


### PR DESCRIPTION
Starting in Dev16, this is longer a requirement, so we can remove the check so we can make more of this lazy.

Code flow note: this is going into master-vs-deps directly. I just want this bit out of the way as I do other refactorings in master.