### PR TITLE
[DO NOT MERGE] Test PR to show FixAll results from analyzer/fixer added in #30777

### DIFF
--- a/src/CodeStyle/Core/CodeFixes/FormattingCodeFixHelper.cs
+++ b/src/CodeStyle/Core/CodeFixes/FormattingCodeFixHelper.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
     {
         internal static async Task<Document> FixOneAsync(Document document, OptionSet options, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
-            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            _ = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 
             // The span to format is the full line(s) containing the diagnostic
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_AnonymousTypes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_AnonymousTypes.cs
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 AnonymousObjectMemberDeclaratorSyntax fieldInitializer = initializers[i];
                 NameEqualsSyntax nameEquals = fieldInitializer.NameEquals;
                 ExpressionSyntax expression = fieldInitializer.Expression;
-
-                SyntaxToken nameToken = default(SyntaxToken);
+                _ = default(SyntaxToken);
+                SyntaxToken nameToken;
                 if (nameEquals != null)
                 {
                     nameToken = nameEquals.Name.Identifier;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -503,7 +503,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 suppressErrors, //don't cascade in these cases
                 diagnostics,
                 out memberResolutionResult,
-                out candidateConstructors,
+                out _,
                 allowProtectedConstructorsOfBaseType: true))
             {
                 resultKind = resultKind.WorseResultKind(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Conversion nestedConversion;
                 if (variable.HasNestedVariables)
                 {
-                    var elementSyntax = syntax.Kind() == SyntaxKind.TupleExpression ? ((TupleExpressionSyntax)syntax).Arguments[i] : syntax;
+                    _ = syntax.Kind() == SyntaxKind.TupleExpression ? ((TupleExpressionSyntax)syntax).Arguments[i] : syntax;
 
                     hasErrors |= !MakeDeconstructionConversion(tupleOrDeconstructedTypes[i], syntax, rightSyntax, diagnostics,
                         variable.NestedVariables, out nestedConversion);
@@ -724,7 +724,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         bool isVar;
                         bool isConst = false;
                         AliasSymbol alias;
-                        var declType = BindVariableType(component.Designation, diagnostics, component.Type, ref isConst, out isVar, out alias);
+                        var declType = BindVariableType(component.Designation, diagnostics, component.Type, ref isConst, out isVar, out _);
                         Debug.Assert(isVar == declType.IsNull);
                         if (component.Designation.Kind() == SyntaxKind.ParenthesizedVariableDesignation && !isVar)
                         {
@@ -777,7 +777,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 case SyntaxKind.DiscardDesignation:
                     {
-                        var discarded = (DiscardDesignationSyntax)node;
+                        _ = (DiscardDesignationSyntax)node;
                         return new DeconstructionVariable(BindDiscardExpression(syntax, declType), syntax);
                     }
                 case SyntaxKind.ParenthesizedVariableDesignation:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -675,7 +675,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool isVar;
             bool isConst = false;
             AliasSymbol alias;
-            var declType = BindVariableType(node.Designation, diagnostics, node.Type, ref isConst, out isVar, out alias);
+            var declType = BindVariableType(node.Designation, diagnostics, node.Type, ref isConst, out _, out _);
             Error(diagnostics, ErrorCode.ERR_DeclarationExpressionNotPermitted, node);
             return BindDeclarationVariables(declType, node.Designation, node, diagnostics);
         }
@@ -2117,8 +2117,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.TupleLiteral:
                     {
                         var tuple = (BoundTupleLiteral)operand;
-                        var targetElementTypes = default(ImmutableArray<TypeSymbolWithAnnotations>);
-
+                        _ = default(ImmutableArray<TypeSymbolWithAnnotations>);
+                        ImmutableArray<TypeSymbolWithAnnotations> targetElementTypes;
                         // If target is a tuple or compatible type with the same number of elements,
                         // report errors for tuple arguments that failed to convert, which would be more useful.
                         if (targetType.TryGetElementTypesIfTupleOrCompatible(out targetElementTypes) &&
@@ -2240,7 +2240,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static NameSyntax GetNameSyntax(SyntaxNode syntax)
         {
             string nameString;
-            return GetNameSyntax(syntax, out nameString);
+            return GetNameSyntax(syntax, out _);
         }
 
         /// <summary>
@@ -2440,7 +2440,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         bool isVar;
                         bool isConst = false;
                         AliasSymbol alias;
-                        var declType = BindVariableType(designation, diagnostics, typeSyntax, ref isConst, out isVar, out alias);
+                        var declType = BindVariableType(designation, diagnostics, typeSyntax, ref isConst, out isVar, out _);
                         Debug.Assert(isVar == declType.IsNull);
 
                         return new BoundDiscardExpression(declarationExpression, declType.TypeSymbol);
@@ -2473,7 +2473,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 bool isConst = false;
                 AliasSymbol alias;
-                var declType = BindVariableType(declarationExpression, diagnostics, typeSyntax, ref isConst, out isVar, out alias);
+                var declType = BindVariableType(declarationExpression, diagnostics, typeSyntax, ref isConst, out isVar, out _);
 
                 localSymbol.ScopeBinder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
 
@@ -5213,7 +5213,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private ImmutableArray<MethodSymbol> GetAccessibleConstructorsForOverloadResolution(NamedTypeSymbol type, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             ImmutableArray<MethodSymbol> allInstanceConstructors;
-            return GetAccessibleConstructorsForOverloadResolution(type, false, out allInstanceConstructors, ref useSiteDiagnostics);
+            return GetAccessibleConstructorsForOverloadResolution(type, false, out _, ref useSiteDiagnostics);
         }
 
         private ImmutableArray<MethodSymbol> GetAccessibleConstructorsForOverloadResolution(NamedTypeSymbol type, bool allowProtectedConstructorsOfBaseType, out ImmutableArray<MethodSymbol> allInstanceConstructors, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
@@ -6295,7 +6295,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(lookupResult.Symbols.Any());
                 var members = ArrayBuilder<Symbol>.GetInstance();
                 bool wasError;
-                Symbol symbol = GetSymbolOrMethodOrPropertyGroup(lookupResult, node, rightName, arity, members, diagnostics, out wasError);
+                Symbol symbol = GetSymbolOrMethodOrPropertyGroup(lookupResult, node, rightName, arity, members, diagnostics, out _);
                 Debug.Assert((object)symbol == null);
                 Debug.Assert(members.Count > 0);
                 methodGroup.PopulateWithExtensionMethods(left, members, typeArguments, lookupResult.Kind);
@@ -6349,8 +6349,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (!hasError)
                 {
                     var isFixedStatementExpression = SyntaxFacts.IsFixedStatementExpression(node);
-
-                    if (IsMoveableVariable(receiver, out Symbol accessedLocalOrParameterOpt) != isFixedStatementExpression)
+                    if (IsMoveableVariable(receiver, out Symbol _) != isFixedStatementExpression)
                     {
                         if (indexed)
                         {
@@ -7122,7 +7121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Ideally the runtime binder would choose between type and value based on the result of the overload resolution.
                     // We need to pick one or the other here. Dev11 compiler passes the type only if the value can't be accessed.
                     bool inStaticContext;
-                    bool useType = IsInstance(typeOrValue.Data.ValueSymbol) && !HasThis(isExplicit: false, inStaticContext: out inStaticContext);
+                    bool useType = IsInstance(typeOrValue.Data.ValueSymbol) && !HasThis(isExplicit: false, inStaticContext: out _);
 
                     receiverOpt = ReplaceTypeOrValueReceiver(typeOrValue, useType, diagnostics);
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // GenerateConversionForAssignment with objectType. However we want to preserve the original expression's
                             // natural type so that overload resolution may select a specialized implementation of string.Format,
                             // so we discard the result of that call and only preserve its diagnostics.
-                            var discarded = GenerateConversionForAssignment(objectType, value, diagnostics);
+                            _ = GenerateConversionForAssignment(objectType, value, diagnostics);
                             BoundExpression alignment = null;
                             BoundLiteral format = null;
                             if (interpolation.AlignmentClause != null)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // Ideally the runtime binder would choose between type and value based on the result of the overload resolution.
                             // We need to pick one or the other here. Dev11 compiler passes the type only if the value can't be accessed.
                             bool inStaticContext;
-                            bool useType = IsInstance(typeOrValue.Data.ValueSymbol) && !HasThis(isExplicit: false, inStaticContext: out inStaticContext);
+                            bool useType = IsInstance(typeOrValue.Data.ValueSymbol) && !HasThis(isExplicit: false, inStaticContext: out _);
 
                             BoundExpression finalReceiver = ReplaceTypeOrValueReceiver(typeOrValue, useType, diagnostics);
 
@@ -608,7 +608,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         // we want to force any unbound lambda arguments to cache an appropriate conversion if possible; see 9448.
                         DiagnosticBag discarded = DiagnosticBag.GetInstance();
-                        result = BindInvocationExpressionContinued(
+                        _ = BindInvocationExpressionContinued(
                             syntax, expression, methodName, resolution.OverloadResolutionResult, resolution.AnalyzedArguments,
                             resolution.MethodGroup, delegateTypeOpt: null, diagnostics: discarded, queryClause: queryClause);
                         discarded.Free();
@@ -1593,7 +1593,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             case SyntaxKind.ThisExpression:
                                 break;
                             default:
-                                ok = CheckSyntaxForNameofArgument(syntax.Expression, out name, diagnostics, false);
+                                ok = CheckSyntaxForNameofArgument(syntax.Expression, out _, diagnostics, false);
                                 break;
                         }
                         name = syntax.Name.Identifier.ValueText;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1369,7 +1369,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal bool IsAccessible(Symbol symbol, ref HashSet<DiagnosticInfo> useSiteDiagnostics, TypeSymbol accessThroughType = null, ConsList<Symbol> basesBeingResolved = null)
         {
             bool failedThroughTypeCheck;
-            return IsAccessible(symbol, accessThroughType, out failedThroughTypeCheck, ref useSiteDiagnostics, basesBeingResolved);
+            return IsAccessible(symbol, accessThroughType, out _, ref useSiteDiagnostics, basesBeingResolved);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2140,7 +2140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (!hasErrors)
                 {
                     Symbol accessedLocalOrParameterOpt;
-                    if (IsMoveableVariable(operand, out accessedLocalOrParameterOpt) != isFixedStatementAddressOfExpression)
+                    if (IsMoveableVariable(operand, out _) != isFixedStatementAddressOfExpression)
                     {
                         Error(diagnostics, isFixedStatementAddressOfExpression ? ErrorCode.ERR_FixedNotNeeded : ErrorCode.ERR_FixedNeeded, node);
                         hasErrors = true;
@@ -2383,7 +2383,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 underlyingType :
                 GetSpecialType(upconvertSpecialType, diagnostics, syntax);
 
-            newOperand = CreateConversion(newOperand, upconvertType, diagnostics);
+            _ = CreateConversion(newOperand, upconvertType, diagnostics);
 
             UnaryOperatorKind newKind = kind.Operator().WithType(upconvertSpecialType);
 
@@ -3235,14 +3235,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // if operand has a dynamic type, we do the same thing as though it were an object
                 operandType = GetSpecialType(SpecialType.System_Object, diagnostics, node);
-                operandTypeKind = operandType.TypeKind;
+                _ = operandType.TypeKind;
             }
 
             if (targetTypeKind == TypeKind.Dynamic)
             {
                 // for "as dynamic", we do the same thing as though it were an "as object"
                 targetType = GetSpecialType(SpecialType.System_Object, diagnostics, node);
-                targetTypeKind = targetType.TypeKind;
+                _ = targetType.TypeKind;
             }
 
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.ConstantPattern:
                     var constantPattern = (ConstantPatternSyntax)node;
                     return BindConstantPattern(
-                        constantPattern, operandType, constantPattern.Expression, hasErrors, diagnostics, out bool wasExpression);
+                        constantPattern, operandType, constantPattern.Expression, hasErrors, diagnostics, out bool _);
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(node.Kind());

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindUnsafeStatement(UnsafeStatementSyntax node, DiagnosticBag diagnostics)
         {
-            var unsafeBinder = this.GetBinder(node);
+            _ = this.GetBinder(node);
 
             if (!this.Compilation.Options.AllowUnsafe)
             {
@@ -2016,8 +2016,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.TupleLiteral:
                     {
                         var tuple = (BoundTupleLiteral)operand;
-                        var targetElementTypes = default(ImmutableArray<TypeSymbolWithAnnotations>);
-
+                        _ = default(ImmutableArray<TypeSymbolWithAnnotations>);
+                        ImmutableArray<TypeSymbolWithAnnotations> targetElementTypes;
                         // If target is a tuple or compatible type with the same number of elements,
                         // report errors for tuple arguments that failed to convert, which would be more useful.
                         if (targetType.TryGetElementTypesIfTupleOrCompatible(out targetElementTypes) &&
@@ -2107,7 +2107,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> tupleArguments,
             ImmutableArray<TypeSymbolWithAnnotations> targetElementTypes)
         {
-            var argLength = tupleArguments.Length;
+            _ = tupleArguments.Length;
 
             // report all leaf elements of the tuple literal that failed to convert
             // NOTE: we are not responsible for reporting use site errors here, just the failed leaf conversions.
@@ -2695,7 +2695,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (!badAsyncReturnAlreadyReported)
                     {
                         RefKind unusedRefKind;
-                        if (IsGenericTaskReturningAsyncMethod() && argument.Type == this.GetCurrentReturnType(out unusedRefKind))
+                        if (IsGenericTaskReturningAsyncMethod() && argument.Type == this.GetCurrentReturnType(out _))
                         {
                             // Since this is an async method, the return expression must be of type '{0}' rather than 'Task<{0}>'
                             Error(diagnostics, ErrorCode.ERR_BadAsyncReturnExpression, argument.Syntax, returnType);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.LookupSymbolsWithFallback(result, plainName, 0, ref useSiteDiagnostics, null, LookupOptions.NamespaceAliasesOnly);
                 diagnostics.Add(node, useSiteDiagnostics);
 
-                Symbol bindingResult = ResultSymbol(result, plainName, 0, node, diagnostics, false, out wasError, options: LookupOptions.NamespaceAliasesOnly);
+                Symbol bindingResult = ResultSymbol(result, plainName, 0, node, diagnostics, false, out _, options: LookupOptions.NamespaceAliasesOnly);
                 result.Free();
 
                 return bindingResult;
@@ -753,7 +753,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 bool wasError;
 
-                bindingResult = ResultSymbol(result, identifierValueText, 0, node, diagnostics, suppressUseSiteDiagnostics, out wasError, qualifierOpt, options);
+                bindingResult = ResultSymbol(result, identifierValueText, 0, node, diagnostics, suppressUseSiteDiagnostics, out _, qualifierOpt, options);
                 if (bindingResult.Kind == SymbolKind.Alias)
                 {
                     var aliasTarget = ((AliasSymbol)bindingResult).GetAliasTarget(basesBeingResolved);
@@ -834,7 +834,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (symbol.IsAlias)
             {
                 AliasSymbol discarded;
-                return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, (NamespaceOrTypeSymbol)UnwrapAlias(symbol.Symbol, out discarded, diagnostics, syntax, basesBeingResolved));
+                return NamespaceOrTypeOrAliasSymbolWithAnnotations.CreateUnannotated(NonNullTypesContext, (NamespaceOrTypeSymbol)UnwrapAlias(symbol.Symbol, out _, diagnostics, syntax, basesBeingResolved));
             }
 
             return symbol;
@@ -854,7 +854,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private Symbol UnwrapAlias(Symbol symbol, DiagnosticBag diagnostics, SyntaxNode syntax, ConsList<Symbol> basesBeingResolved = null)
         {
             AliasSymbol discarded;
-            return UnwrapAlias(symbol, out discarded, diagnostics, syntax, basesBeingResolved);
+            return UnwrapAlias(symbol, out _, diagnostics, syntax, basesBeingResolved);
         }
 
         private Symbol UnwrapAlias(Symbol symbol, out AliasSymbol alias, DiagnosticBag diagnostics, SyntaxNode syntax, ConsList<Symbol> basesBeingResolved = null)
@@ -1019,7 +1019,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             diagnostics.Add(node, useSiteDiagnostics);
 
             bool wasError;
-            Symbol lookupResultSymbol = ResultSymbol(lookupResult, plainName, arity, node, diagnostics, (basesBeingResolved != null), out wasError, qualifierOpt, options);
+            Symbol lookupResultSymbol = ResultSymbol(lookupResult, plainName, arity, node, diagnostics, (basesBeingResolved != null), out _, qualifierOpt, options);
 
             // As we said in the method above, there are three cases here:
             //

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             LookupResultKind resultKind;
             ImmutableArray<MethodSymbol> originalUserDefinedOperators;
             BoundExpression comparisonResult = new BoundTupleOperandPlaceholder(node, type);
-            UnaryOperatorAnalysisResult best = this.UnaryOperatorOverloadResolution(boolOpKind, comparisonResult, node, diagnostics, out resultKind, out originalUserDefinedOperators);
+            UnaryOperatorAnalysisResult best = this.UnaryOperatorOverloadResolution(boolOpKind, comparisonResult, node, diagnostics, out _, out _);
             if (best.HasValue)
             {
                 conversionForBool = best.Conversion;

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ForEachEnumeratorInfo.Builder builder = new ForEachEnumeratorInfo.Builder();
             TypeSymbolWithAnnotations inferredType;
-            bool hasErrors = !GetEnumeratorInfoAndInferCollectionElementType(ref builder, ref collectionExpr, diagnostics, out inferredType);
+            _ = !GetEnumeratorInfoAndInferCollectionElementType(ref builder, ref collectionExpr, diagnostics, out inferredType);
 
             ExpressionSyntax variables = ((ForEachVariableStatementSyntax)_syntax).Variable;
 

--- a/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (_syntax.Declaration != null)
             {
                 ImmutableArray<BoundLocalDeclaration> unused;
-                initializer = originalBinder.BindForOrUsingOrFixedDeclarations(node.Declaration, LocalDeclarationKind.RegularVariable, diagnostics, out unused);
+                initializer = originalBinder.BindForOrUsingOrFixedDeclarations(node.Declaration, LocalDeclarationKind.RegularVariable, diagnostics, out _);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Binder/PatternSwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternSwitchBinder.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var caseLabelSyntax = (CaseSwitchLabelSyntax)node;
                         var pattern = sectionBinder.BindConstantAsPattern(
-                            node, SwitchGoverningType, caseLabelSyntax.Value, node.HasErrors, diagnostics, out bool wasExpression);
+                            node, SwitchGoverningType, caseLabelSyntax.Value, node.HasErrors, diagnostics, out bool _);
                         bool hasErrors = pattern.HasErrors;
                         SyntaxNode innerValueSyntax = caseLabelSyntax.Value.SkipParens();
                         if (innerValueSyntax.Kind() == SyntaxKind.DefaultLiteralExpression)
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case SyntaxKind.DefaultSwitchLabel:
                     {
-                        var defaultLabelSyntax = (DefaultSwitchLabelSyntax)node;
+                        _ = (DefaultSwitchLabelSyntax)node;
                         var pattern = new BoundWildcardPattern(node);
                         bool hasErrors = pattern.HasErrors;
                         if (defaultLabel != null)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/AccessCheck.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/AccessCheck.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             bool failedThroughTypeCheck;
-            return IsSymbolAccessibleCore(symbol, within, null, out failedThroughTypeCheck, within.DeclaringCompilation, ref useSiteDiagnostics);
+            return IsSymbolAccessibleCore(symbol, within, null, out _, within.DeclaringCompilation, ref useSiteDiagnostics);
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol throughTypeOpt = null)
         {
             bool failedThroughTypeCheck;
-            return IsSymbolAccessibleCore(symbol, within, throughTypeOpt, out failedThroughTypeCheck, within.DeclaringCompilation, ref useSiteDiagnostics);
+            return IsSymbolAccessibleCore(symbol, within, throughTypeOpt, out _, within.DeclaringCompilation, ref useSiteDiagnostics);
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // type parameters are always accessible, so don't check those (so common it's
                     // worth optimizing this).
-                    if (typeArg.Kind != SymbolKind.TypeParameter && !IsSymbolAccessibleCore(typeArg.TypeSymbol, within, null, out unused, compilation, ref useSiteDiagnostics, basesBeingResolved))
+                    if (typeArg.Kind != SymbolKind.TypeParameter && !IsSymbolAccessibleCore(typeArg.TypeSymbol, within, null, out _, compilation, ref useSiteDiagnostics, basesBeingResolved))
                     {
                         return false;
                     }
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var containingType = type.ContainingType;
             return (object)containingType == null
                 ? IsNonNestedTypeAccessible(type.ContainingAssembly, type.DeclaredAccessibility, within)
-                : IsMemberAccessible(containingType, type.DeclaredAccessibility, within, null, out unused, compilation, ref useSiteDiagnostics, basesBeingResolved);
+                : IsMemberAccessible(containingType, type.DeclaredAccessibility, within, null, out _, compilation, ref useSiteDiagnostics, basesBeingResolved);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2087,7 +2087,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 t2,
                 Conversions.ClassifyImplicitConversionFromExpression(node, t2, ref useSiteDiagnostics),
                 ref useSiteDiagnostics,
-                out ignore);
+                out _);
         }
 
         // Determine whether t1 or t2 is a better conversion target from node, possibly considering parameter ref kinds.
@@ -2387,7 +2387,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             bool okToDowngradeToNeither;
-            return BetterConversionTargetCore(null, type1, default(Conversion), type2, default(Conversion), ref useSiteDiagnostics, out okToDowngradeToNeither, BetterConversionTargetRecursionLimit);
+            return BetterConversionTargetCore(null, type1, default(Conversion), type2, default(Conversion), ref useSiteDiagnostics, out _, BetterConversionTargetRecursionLimit);
         }
 
         private BetterResult BetterConversionTargetCore(
@@ -2402,7 +2402,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             bool okToDowngradeToNeither;
-            return BetterConversionTargetCore(null, type1, default(Conversion), type2, default(Conversion), ref useSiteDiagnostics, out okToDowngradeToNeither, betterConversionTargetRecursionLimit - 1);
+            return BetterConversionTargetCore(null, type1, default(Conversion), type2, default(Conversion), ref useSiteDiagnostics, out _, betterConversionTargetRecursionLimit - 1);
         }
 
         private BetterResult BetterConversionTarget(
@@ -2766,8 +2766,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             bool hasAnyRefOmittedArgument;
             EffectiveParameters effectiveParameters = expanded ?
-                GetEffectiveParametersInExpandedForm(method, argumentCount, argToParamMap, argumentRefKinds, isMethodGroupConversion, allowRefOmittedArguments, binder, out hasAnyRefOmittedArgument) :
-                GetEffectiveParametersInNormalForm(method, argumentCount, argToParamMap, argumentRefKinds, isMethodGroupConversion, allowRefOmittedArguments, binder, out hasAnyRefOmittedArgument);
+                GetEffectiveParametersInExpandedForm(method, argumentCount, argToParamMap, argumentRefKinds, isMethodGroupConversion, allowRefOmittedArguments, binder, out _) :
+                GetEffectiveParametersInNormalForm(method, argumentCount, argToParamMap, argumentRefKinds, isMethodGroupConversion, allowRefOmittedArguments, binder, out _);
             parameterTypes = effectiveParameters.ParameterTypes;
             parameterRefKinds = effectiveParameters.ParameterRefKinds;
         }
@@ -2794,7 +2794,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             where TMember : Symbol
         {
             bool discarded;
-            return GetEffectiveParametersInNormalForm(member, argumentCount, argToParamMap, argumentRefKinds, isMethodGroupConversion, allowRefOmittedArguments, _binder, hasAnyRefOmittedArgument: out discarded);
+            return GetEffectiveParametersInNormalForm(member, argumentCount, argToParamMap, argumentRefKinds, isMethodGroupConversion, allowRefOmittedArguments, _binder, hasAnyRefOmittedArgument: out _);
         }
 
         private static EffectiveParameters GetEffectiveParametersInNormalForm<TMember>(
@@ -2898,7 +2898,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool allowRefOmittedArguments) where TMember : Symbol
         {
             bool discarded;
-            return GetEffectiveParametersInExpandedForm(member, argumentCount, argToParamMap, argumentRefKinds, isMethodGroupConversion, allowRefOmittedArguments, _binder, hasAnyRefOmittedArgument: out discarded);
+            return GetEffectiveParametersInExpandedForm(member, argumentCount, argToParamMap, argumentRefKinds, isMethodGroupConversion, allowRefOmittedArguments, _binder, hasAnyRefOmittedArgument: out _);
         }
 
         private static EffectiveParameters GetEffectiveParametersInExpandedForm<TMember>(

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -235,14 +235,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var caseLabel = (CaseSwitchLabelSyntax)labelSyntax;
                         Debug.Assert(caseLabel.Value != null);
                         var boundLabelExpression = sectionBinder.BindValue(caseLabel.Value, tempDiagnosticBag, BindValueKind.RValue);
-                        boundLabelExpression = ConvertCaseExpression(labelSyntax, boundLabelExpression, sectionBinder, ref boundLabelConstantOpt, tempDiagnosticBag);
+                        _ = ConvertCaseExpression(labelSyntax, boundLabelExpression, sectionBinder, ref boundLabelConstantOpt, tempDiagnosticBag);
                         break;
 
                     case SyntaxKind.CasePatternSwitchLabel:
                         // bind the pattern, to cause its pattern variables to be inferred if necessary
                         var matchLabel = (CasePatternSwitchLabelSyntax)labelSyntax;
-                        var pattern = sectionBinder.BindPattern(
-                            SwitchGoverningExpression, matchLabel.Pattern, SwitchGoverningType, labelSyntax.HasErrors, tempDiagnosticBag);
+                        {
+                            _ = sectionBinder.BindPattern(
+      SwitchGoverningExpression, matchLabel.Pattern, SwitchGoverningType, labelSyntax.HasErrors, tempDiagnosticBag);
+                        }
+
                         break;
 
                     default:
@@ -592,7 +595,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundSwitchLabel BindSwitchSectionLabel(SwitchLabelSyntax node, Binder sectionBinder, LabelSymbol label, DiagnosticBag diagnostics)
         {
-            var switchGoverningType = SwitchGoverningType;
+            _ = SwitchGoverningType;
             BoundExpression boundLabelExpressionOpt = null;
             ConstantValue labelExpressionConstant = null;
 

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -68,13 +68,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert((object)disposableInterface != null);
             bool hasErrors = ReportUseSiteDiagnostics(disposableInterface, diagnostics, hasAwait ? _syntax.AwaitKeyword : _syntax.UsingKeyword);
-
-            Conversion iDisposableConversion = Conversion.NoConversion;
+            _ = Conversion.NoConversion;
             BoundMultipleLocalDeclarations declarationsOpt = null;
             BoundExpression expressionOpt = null;
             AwaitableInfo awaitOpt = null;
             TypeSymbol declarationTypeOpt = null;
-
+            Conversion iDisposableConversion;
             if (expressionSyntax != null)
             {
                 expressionOpt = this.BindTargetExpression(diagnostics, originalBinder);

--- a/src/Compilers/CSharp/Portable/Binder/WithLambdaParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithLambdaParametersBinder.cs
@@ -119,8 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var oldLocation = parameter.Locations[0];
 
             Debug.Assert(oldLocation != newLocation || oldLocation == Location.None, "same nonempty location refers to different symbols?");
-
-            SymbolKind parameterKind = parameter.Kind;
+            _ = parameter.Kind;
             // Quirk of the way we represent lambda parameters.                
             SymbolKind newSymbolKind = (object)newSymbol == null ? SymbolKind.Parameter : newSymbol.Kind;
 

--- a/src/Compilers/CSharp/Portable/BoundTree/DecisionTreeBuilder.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DecisionTreeBuilder.cs
@@ -334,7 +334,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal bool? ExpressionOfTypeMatchesPatternType(TypeSymbol expressionType, TypeSymbol patternType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            return Binder.ExpressionOfTypeMatchesPatternType(this._conversions, expressionType, patternType, ref _useSiteDiagnostics, out Conversion conversion, null, false);
+            return Binder.ExpressionOfTypeMatchesPatternType(this._conversions, expressionType, patternType, ref _useSiteDiagnostics, out Conversion _, null, false);
         }
 
         private DecisionTree AddByType(DecisionTree decision, TypeSymbol type, DecisionMaker makeDecision)

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if ((object)delegateReturnType != null && delegateReturnType.SpecialType != SpecialType.System_Void)
             {
                 object builderType;
-                if (delegateReturnType.IsCustomTaskType(out builderType))
+                if (delegateReturnType.IsCustomTaskType(out _))
                 {
                     taskType = delegateReturnType.ConstructedFrom;
                 }
@@ -639,7 +639,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             private ReturnInferenceCacheKey(ImmutableArray<TypeSymbolWithAnnotations> parameterTypes, ImmutableArray<RefKind> parameterRefKinds, NamedTypeSymbol taskLikeReturnTypeOpt)
             {
                 Debug.Assert(parameterTypes.Length == parameterRefKinds.Length);
-                Debug.Assert((object)taskLikeReturnTypeOpt == null || ((object)taskLikeReturnTypeOpt == taskLikeReturnTypeOpt.ConstructedFrom && taskLikeReturnTypeOpt.IsCustomTaskType(out var builderArgument)));
+                Debug.Assert((object)taskLikeReturnTypeOpt == null || ((object)taskLikeReturnTypeOpt == taskLikeReturnTypeOpt.ConstructedFrom && taskLikeReturnTypeOpt.IsCustomTaskType(out var _)));
                 this.ParameterTypes = parameterTypes;
                 this.ParameterRefKinds = parameterRefKinds;
                 this.TaskLikeReturnTypeOpt = taskLikeReturnTypeOpt;
@@ -714,7 +714,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var delegateReturnType = invoke.ReturnType.TypeSymbol as NamedTypeSymbol;
                         if ((object)delegateReturnType != null && delegateReturnType.SpecialType != SpecialType.System_Void)
                         {
-                            if (delegateReturnType.IsCustomTaskType(out var builderType))
+                            if (delegateReturnType.IsCustomTaskType(out var _))
                             {
                                 taskLikeReturnTypeOpt = delegateReturnType.ConstructedFrom;
                             }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -3143,7 +3143,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 if (IsVarianceCast(expr.Type, mergeTypeOfAlternative))
                 {
                     EmitStaticCast(expr.Type, expr.Syntax);
-                    mergeTypeOfAlternative = expr.Type;
+                    _ = expr.Type;
                 }
                 else if (expr.Type.IsInterfaceType() && expr.Type != mergeTypeOfAlternative)
                 {
@@ -3167,7 +3167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 if (IsVarianceCast(expr.Type, mergeTypeOfConsequence))
                 {
                     EmitStaticCast(expr.Type, expr.Syntax);
-                    mergeTypeOfConsequence = expr.Type;
+                    _ = expr.Type;
                 }
                 else if (expr.Type.IsInterfaceType() && expr.Type != mergeTypeOfConsequence)
                 {
@@ -3204,7 +3204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 if (IsVarianceCast(expr.Type, mergeTypeOfLeftValue))
                 {
                     EmitStaticCast(expr.Type, expr.Syntax);
-                    mergeTypeOfLeftValue = expr.Type;
+                    _ = expr.Type;
                 }
                 else if (expr.Type.IsInterfaceType() && expr.Type != mergeTypeOfLeftValue)
                 {
@@ -3234,7 +3234,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 if (IsVarianceCast(expr.Type, mergeTypeOfRightValue))
                 {
                     EmitStaticCast(expr.Type, expr.Syntax);
-                    mergeTypeOfRightValue = expr.Type;
+                    _ = expr.Type;
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1503,7 +1503,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // checked(-x) is emitted as "0 - x"
             if (node.OperatorKind.IsChecked() && node.OperatorKind.Operator() == UnaryOperatorKind.UnaryMinus)
             {
-                var origStack = StackDepth();
+                _ = StackDepth();
                 PushEvalStack(new BoundDefaultExpression(node.Syntax, node.Operand.Type), ExprContext.Value);
                 BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
                 return node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, node.Type);

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we will need line tables anyways and it is better to not wait until we are in emit
             // where things run sequentially.
             bool isHiddenDummy;
-            tree.GetMappedLineSpanAndVisibility(default(TextSpan), out isHiddenDummy);
+            tree.GetMappedLineSpanAndVisibility(default(TextSpan), out _);
 
             return tree;
         }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var unusedDiagnostics = DiagnosticBag.GetInstance();
             Symbol unusedAmbiguityWinner;
-            var symbols = binder.BindCref(crefSyntax, out unusedAmbiguityWinner, unusedDiagnostics);
+            var symbols = binder.BindCref(crefSyntax, out _, unusedDiagnostics);
             unusedDiagnostics.Free();
             return symbols;
         }
@@ -400,7 +400,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var diagnostics = DiagnosticBag.GetInstance();
             AliasSymbol aliasOpt; // not needed.
-            NamedTypeSymbol attributeType = (NamedTypeSymbol)binder.BindType(attribute.Name, diagnostics, out aliasOpt).TypeSymbol;
+            NamedTypeSymbol attributeType = (NamedTypeSymbol)binder.BindType(attribute.Name, diagnostics, out _).TypeSymbol;
             var boundNode = new ExecutableCodeBinder(attribute, binder.ContainingMemberOrLambda, binder).BindAttribute(attribute, attributeType, diagnostics);
             diagnostics.Free();
 
@@ -926,7 +926,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Binder binder;
             ImmutableArray<Symbol> crefSymbols;
-            BoundNode boundNode = GetSpeculativelyBoundExpression(position, expression, bindingOption, out binder, out crefSymbols); //calls CheckAndAdjustPosition
+            BoundNode boundNode = GetSpeculativelyBoundExpression(position, expression, bindingOption, out _, out crefSymbols); //calls CheckAndAdjustPosition
             Debug.Assert(boundNode == null || crefSymbols.IsDefault);
             if (boundNode == null)
             {
@@ -1143,7 +1143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected int CheckAndAdjustPosition(int position)
         {
             SyntaxToken unused;
-            return CheckAndAdjustPosition(position, out unused);
+            return CheckAndAdjustPosition(position, out _);
         }
 
         protected int CheckAndAdjustPosition(int position, out SyntaxToken token)
@@ -1760,14 +1760,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             LookupResultKind resultKind;
             bool isDynamic;
             ImmutableArray<Symbol> unusedMemberGroup;
-            var symbols = GetSemanticSymbols(boundExpr, boundNodeForSyntacticParent, binderOpt, options, out isDynamic, out resultKind, out unusedMemberGroup);
+            var symbols = GetSemanticSymbols(boundExpr, boundNodeForSyntacticParent, binderOpt, options, out isDynamic, out resultKind, out _);
 
             if (highestBoundNode is BoundExpression highestBoundExpr)
             {
                 LookupResultKind highestResultKind;
                 bool highestIsDynamic;
                 ImmutableArray<Symbol> unusedHighestMemberGroup;
-                ImmutableArray<Symbol> highestSymbols = GetSemanticSymbols(highestBoundExpr, boundNodeForSyntacticParent, binderOpt, options, out highestIsDynamic, out highestResultKind, out unusedHighestMemberGroup);
+                ImmutableArray<Symbol> highestSymbols = GetSemanticSymbols(highestBoundExpr, boundNodeForSyntacticParent, binderOpt, options, out highestIsDynamic, out highestResultKind, out _);
 
                 if ((symbols.Length != 1 || resultKind == LookupResultKind.OverloadResolutionFailure) && highestSymbols.Length > 0)
                 {
@@ -2028,7 +2028,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 LookupResultKind resultKind;
                 ImmutableArray<Symbol> memberGroup;
                 bool isDynamic;
-                GetSemanticSymbols(boundExpr, boundNodeForSyntacticParent, binderOpt, options, out isDynamic, out resultKind, out memberGroup);
+                GetSemanticSymbols(boundExpr, boundNodeForSyntacticParent, binderOpt, options, out _, out _, out memberGroup);
 
                 return memberGroup;
             }

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1108,7 +1108,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundNode lowestBoundNode;
             BoundNode highestBoundNode;
             BoundNode boundParent;
-            GetBoundNodes(node, out bindableNode, out lowestBoundNode, out highestBoundNode, out boundParent);
+            GetBoundNodes(node, out _, out lowestBoundNode, out highestBoundNode, out boundParent);
 
             Debug.Assert(IsInTree(node), "Since the node is in the tree, we can always recompute the binder later");
             return base.GetSymbolInfoForNode(options, lowestBoundNode, highestBoundNode, boundParent, binderOpt: null);
@@ -1120,7 +1120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundNode lowestBoundNode;
             BoundNode highestBoundNode;
             BoundNode boundParent;
-            GetBoundNodes(node, out bindableNode, out lowestBoundNode, out highestBoundNode, out boundParent);
+            GetBoundNodes(node, out _, out lowestBoundNode, out highestBoundNode, out boundParent);
 
             return GetTypeInfoForNode(lowestBoundNode, highestBoundNode, boundParent);
         }
@@ -1131,7 +1131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundNode lowestBoundNode;
             BoundNode highestBoundNode;
             BoundNode boundParent;
-            GetBoundNodes(node, out bindableNode, out lowestBoundNode, out highestBoundNode, out boundParent);
+            GetBoundNodes(node, out _, out lowestBoundNode, out _, out boundParent);
 
             Debug.Assert(IsInTree(node), "Since the node is in the tree, we can always recompute the binder later");
             return base.GetMemberGroupForNode(options, lowestBoundNode, boundParent, binderOpt: null);
@@ -1143,7 +1143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundNode lowestBoundNode;
             BoundNode highestBoundNode;
             BoundNode boundParent;
-            GetBoundNodes(node, out bindableNode, out lowestBoundNode, out highestBoundNode, out boundParent);
+            GetBoundNodes(node, out _, out lowestBoundNode, out _, out _);
 
             Debug.Assert(IsInTree(node), "Since the node is in the tree, we can always recompute the binder later");
             return base.GetIndexerGroupForNode(lowestBoundNode, binderOpt: null);

--- a/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
@@ -1140,7 +1140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             Location ignoredLocation;
-            bool? declaredCompliance = GetDeclaredCompliance(symbol, out ignoredLocation);
+            bool? declaredCompliance = GetDeclaredCompliance(symbol, out _);
             if (declaredCompliance.HasValue)
             {
                 compliance = declaredCompliance.GetValueOrDefault() ? Compliance.DeclaredTrue : Compliance.DeclaredFalse;

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                               options.WarningLevel,
                                                               options.GeneralDiagnosticOption,
                                                               options.SpecificDiagnosticOptions,
-                                                              out hasPragmaSuppression);
+                                                              out _);
         }
 
         public override int ERR_FailedToCreateTempFile => (int)ErrorCode.ERR_CantMakeTempFile;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/CSharpDataFlowAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/CSharpDataFlowAnalysis.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                var discarded = DataFlowsIn; // force DataFlowsIn to be computed
+                _ = DataFlowsIn; // force DataFlowsIn to be computed
                 if (_dataFlowsOut.IsDefault)
                 {
                     var result = Succeeded
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (_succeeded == null)
                 {
-                    var discarded = DataFlowsIn;
+                    _ = DataFlowsIn;
                 }
 
                 return _succeeded.Value;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowAnalysis.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (_succeeded == null)
                 {
-                    var discarded = EntryPoints;
+                    _ = EntryPoints;
                 }
 
                 return _succeeded.Value;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <returns></returns>
         protected bool Analyze(ref bool badRegion, DiagnosticBag diagnostics)
         {
-            ImmutableArray<PendingBranch> returns = Analyze(ref badRegion);
+            _ = Analyze(ref badRegion);
 
             if (diagnostics != null)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -387,7 +387,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         protected void Analyze(ref bool badRegion, DiagnosticBag diagnostics)
         {
-            ImmutableArray<PendingBranch> returns = Analyze(ref badRegion);
+            _ = Analyze(ref badRegion);
             if (diagnostics != null)
             {
                 foreach (Symbol captured in _capturedVariables)
@@ -1639,7 +1639,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitLocalDeclaration(BoundLocalDeclaration node)
         {
-            int slot = GetOrCreateSlot(node.LocalSymbol); // not initially assigned
+            _ = GetOrCreateSlot(node.LocalSymbol); // not initially assigned
             if (initiallyAssignedVariables?.Contains(node.LocalSymbol) == true)
             {
                 // When data flow analysis determines that the variable is sometimes
@@ -1867,7 +1867,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected void CheckAssigned(BoundExpression expr, SyntaxNode node)
         {
             if (!this.State.Reachable) return;
-            int slot = MakeSlot(expr);
+            _ = MakeSlot(expr);
             switch (expr.Kind)
             {
                 case BoundKind.Local:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3182,11 +3182,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var lambda = (BoundLambda)operandOpt;
                         var delegateType = targetType.GetDelegateType();
-                        var methodSignatureOpt = lambda.UnboundLambda.HasExplicitlyTypedParameterList ? null : delegateType?.DelegateInvokeMethod;
+                        _ = lambda.UnboundLambda.HasExplicitlyTypedParameterList ? null : delegateType?.DelegateInvokeMethod;
                         var variableState = GetVariableState();
                         Analyze(compilation, lambda, Diagnostics, delegateInvokeMethod: delegateType?.DelegateInvokeMethod, returnTypes: null, initialState: variableState);
                         var unboundLambda = GetUnboundLambda(lambda, variableState);
-                        var boundLambda = unboundLambda.Bind(delegateType);
+                        _ = unboundLambda.Bind(delegateType);
                         if (!fromExplicitCast)
                         {
                             ReportNullabilityMismatchWithTargetDelegate(node.Syntax, delegateType, unboundLambda);
@@ -3210,7 +3210,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         // operand -> conversion "from" type
                         // May be distinct from method parameter type for Nullable<T>.
-                        operandType = ApplyConversion(
+                        _ = ApplyConversion(
                             node,
                             operandOpt,
                             conversion.UserDefinedFromConversion,
@@ -3232,7 +3232,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         operandType = ClassifyAndApplyConversion(operandOpt ?? node, parameter.Type, operandType, useLegacyWarnings, AssignmentKind.Argument, target: parameter);
 
                         // method parameter type -> method return type
-                        operandType = methodOpt.ReturnType;
+                        _ = methodOpt.ReturnType;
 
                         // method return type -> conversion "to" type
                         // May be distinct from method return type for Nullable<T>.
@@ -3981,8 +3981,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitUnaryOperator(BoundUnaryOperator node)
         {
             Debug.Assert(!IsConditionalState);
-
-            var result = base.VisitUnaryOperator(node);
+            _ = base.VisitUnaryOperator(node);
             TypeSymbolWithAnnotations resultType = default;
 
             // Update method based on inferred operand type: see https://github.com/dotnet/roslyn/issues/29605.
@@ -4377,7 +4376,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var @event = node.Event;
             if (!node.Event.IsStatic)
             {
-                @event = (EventSymbol)AsMemberOfResultType(_resultType, @event);
+                _ = (EventSymbol)AsMemberOfResultType(_resultType, @event);
                 // https://github.com/dotnet/roslyn/issues/30598: Mark receiver as not null
                 // after arguments have been visited, and only if the receiver has not changed.
                 CheckPossibleNullReceiver(receiverOpt);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -2796,7 +2796,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // whose condition is not true, then the call has no effect and it is ignored for the purposes of
                 // definite assignment analysis.
 
-                LocalState savedState = savedState = this.State.Clone();
+                LocalState savedState = _ = this.State.Clone();
                 SetUnreachable();
 
                 VisitArguments(node.Arguments, default(ImmutableArray<RefKind>), node.AddMethod);

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -810,7 +810,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var awaitContainingCatches = _awaitContainingCatches;
                     if (awaitContainingCatches == null)
                     {
-                        _awaitContainingCatches = awaitContainingCatches = new HashSet<BoundCatchBlock>();
+                        _awaitContainingCatches = _ = new HashSet<BoundCatchBlock>();
                     }
 
                     _awaitContainingCatches.Add(node);

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector_SequencePoints.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector_SequencePoints.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             SyntaxNode node;
             TextSpan? part;
-            GetBreakpointSpan(declaratorSyntax, out node, out part);
+            GetBreakpointSpan(declaratorSyntax, out _, out part);
             var result = BoundSequencePoint.Create(declaratorSyntax, part, rewrittenStatement);
             result.WasCompilerGenerated = rewrittenStatement.WasCompilerGenerated;
             return result;

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -84,8 +84,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             F.CurrentFunction = moveNextMethod;
             int initialState;
             GeneratedLabelSymbol initialLabel;
-            AddState(out initialState, out initialLabel);
-            var newBody = (BoundStatement)Visit(body);
+            AddState(out _, out initialLabel);
+            _ = (BoundStatement)Visit(body);
 
             // switch(cachedState) {
             //    case 0: goto state_0;
@@ -97,8 +97,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // state = -1;
             // [optional: cachedThis = capturedThis;] 
             // [[rewritten body]]
-            newBody = F.Block((object)cachedThis == null?
-                                ImmutableArray.Create(cachedState):
+            BoundStatement newBody = F.Block((object)cachedThis == null ?
+                                ImmutableArray.Create(cachedState) :
                                 ImmutableArray.Create(cachedState, cachedThis),
 
                     F.HiddenSequencePoint(),
@@ -379,7 +379,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // rewrite finally block into a Finally method.
             F.CurrentFunction = finallyMethod;
-            var rewrittenHandler = (BoundStatement)this.Visit(node.FinallyBlockOpt);
+            _ = (BoundStatement)this.Visit(node.FinallyBlockOpt);
 
             _tryNestingLevel--;
             PopFrame();
@@ -390,8 +390,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             //      return;
             // }
             Debug.Assert(frame.parent.finalizeState == _currentFinallyFrame.finalizeState);
-            rewrittenHandler = F.Block((object)this.cachedThis != null?
-                                            ImmutableArray.Create(this.cachedThis):
+            BoundStatement rewrittenHandler = F.Block((object)cachedThis != null ?
+                                            ImmutableArray.Create(cachedThis) :
                                             ImmutableArray<LocalSymbol>.Empty,
                                 F.Assignment(F.Field(F.This(), stateField), F.Literal(frame.parent.finalizeState)),
                                 CacheThisIfNeeded(),

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var getEnumeratorGeneric = GenerateIteratorGetEnumerator(IEnumerableOfElementType_GetEnumerator, ref managedThreadId, StateMachineStates.FirstUnusedState);
 
             // Generate IEnumerable.GetEnumerator
-            var getEnumerator = OpenMethodImplementation(IEnumerable_GetEnumerator);
+            _ = OpenMethodImplementation(IEnumerable_GetEnumerator);
             F.CloseMethod(F.Return(F.Call(F.This(), getEnumeratorGeneric)));
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -423,7 +423,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (closure.CapturedEnvironments.Count == 0 &&
                          _analysis.MethodsConvertedToDelegates.Contains(originalMethod))
                 {
-                    translatedLambdaContainer = containerAsFrame = GetStaticFrame(Diagnostics, syntax);
+                    translatedLambdaContainer = _ = GetStaticFrame(Diagnostics, syntax);
                     closureKind = ClosureKind.Singleton;
                     closureOrdinal = LambdaDebugInfo.StaticClosureOrdinal;
                 }
@@ -879,7 +879,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                        loweredSymbol.ClosureKind,
                                        ref method,
                                        out receiver,
-                                       out constructedFrame);
+                                       out _);
         }
 
         /// <summary>
@@ -1337,12 +1337,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             DebugId lambdaId;
             RewriteLambdaOrLocalFunction(
                 node,
-                out closureKind,
-                out translatedLambdaContainer,
-                out containerAsFrame,
-                out lambdaScope,
-                out topLevelMethodId,
-                out lambdaId);
+                out _,
+                out _,
+                out _,
+                out _,
+                out _,
+                out _);
 
             return new BoundNoOpStatement(node.Syntax, NoOpStatementFlavor.Default);
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureMethod.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         originalMethod,
                         this,
                         out typeParameters,
-                        out constructedFromTypeParameters,
+                        out _,
                         lambdaFrame.OriginalContainingMethodOpt);
                     break;
                 case ClosureKind.ThisOnly: // all type parameters on method
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         originalMethod,
                         this,
                         out typeParameters,
-                        out constructedFromTypeParameters,
+                        out _,
                         stopAt: null);
                     break;
                 default:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return base.VisitArrayAccess(node);
             }
 
-            var syntax = node.Syntax;
+            _ = node.Syntax;
             var F = _factory;
             var indexLocal = F.StoreToTemp(
                 VisitExpression(node.Indices[0]),

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -1846,7 +1846,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol method;
             if (operatorKind == BinaryOperatorKind.DelegateEqual || operatorKind == BinaryOperatorKind.DelegateNotEqual)
             {
-                method = (MethodSymbol)_compilation.Assembly.GetSpecialTypeMember(member);
+                _ = (MethodSymbol)_compilation.Assembly.GetSpecialTypeMember(member);
                 if (loweredRight.IsLiteralNull() ||
                     loweredLeft.IsLiteralNull() ||
                     (object)(method = (MethodSymbol)_compilation.Assembly.GetSpecialTypeMember(member)) == null)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -1311,7 +1311,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundExpression memberNameLiteral = MakeLiteral(syntax, ConstantValue.Create(path), compilation.GetSpecialType(SpecialType.System_String), localRewriter);
                 defaultValue = MakeConversionNode(memberNameLiteral, parameterType, @checked: false);
             }
-            else if (parameter.IsCallerMemberName && ((callerSourceLocation = GetCallerLocation(syntax, enableCallerInfo)) != null))
+            else if (parameter.IsCallerMemberName && ((_ = GetCallerLocation(syntax, enableCallerInfo)) != null))
             {
                 string memberName;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             NamedTypeSymbol tokenType = _factory.WellKnownType(WellKnownType.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationToken);
-            NamedTypeSymbol marshalType = _factory.WellKnownType(WellKnownType.System_Runtime_InteropServices_WindowsRuntime_WindowsRuntimeMarshal);
+            _ = _factory.WellKnownType(WellKnownType.System_Runtime_InteropServices_WindowsRuntime_WindowsRuntimeMarshal);
 
             NamedTypeSymbol actionType = _factory.WellKnownType(WellKnownType.System_Action_T).Construct(tokenType);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // string.Substring(start, end - start)
                     var rangeStartSymbol = (PropertySymbol)F.WellKnownMember(WellKnownMember.System_Range__Start);
                     var rangeEndSymbol = (PropertySymbol)F.WellKnownMember(WellKnownMember.System_Range__End);
-                    var arrayCopySymbol = F.WellKnownMethod(WellKnownMember.System_Array__Copy);
+                    _ = F.WellKnownMethod(WellKnownMember.System_Array__Copy);
 
                     var startLocal = F.StoreToTemp(
                         F.Conditional(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 // Unknown if the input is null. First test for null
                                 var notNullLabel = _factory.GenerateLabel("notNull");
-                                var inputExpression = byType.Expression;
+                                _ = byType.Expression;
                                 var objectType = _factory.SpecialType(SpecialType.System_Object);
                                 var nullValue = _factory.Null(objectType);
                                 BoundExpression notNull =

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // Input must be used no more than once in the result. If it is needed repeatedly store its value in a temp and use the temp.
         BoundExpression MakeIsPattern(BoundPattern loweredPattern, BoundExpression loweredInput)
         {
-            var syntax = _factory.Syntax = loweredPattern.Syntax;
+            _ = _factory.Syntax = loweredPattern.Syntax;
             switch (loweredPattern.Kind)
             {
                 case BoundKind.DeclarationPattern:

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -815,7 +815,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
         private IDynamicInvocationOperation CreateBoundDynamicCollectionElementInitializerOperation(BoundDynamicCollectionElementInitializer boundCollectionElementInitializer)
         {
-            Lazy<IOperation> operation = new Lazy<IOperation>(() => Create(boundCollectionElementInitializer.ImplicitReceiver));
+            _ = new Lazy<IOperation>(() => Create(boundCollectionElementInitializer.ImplicitReceiver));
             Lazy<ImmutableArray<IOperation>> arguments = new Lazy<ImmutableArray<IOperation>>(() => boundCollectionElementInitializer.Arguments.SelectAsArray(n => Create(n)));
             SyntaxNode syntax = boundCollectionElementInitializer.Syntax;
             ITypeSymbol type = boundCollectionElementInitializer.Type;
@@ -1013,7 +1013,7 @@ namespace Microsoft.CodeAnalysis.Operations
             SyntaxNode bindingSyntax = boundMethodGroup.Syntax;
             ITypeSymbol bindingType = null;
             Optional<object> bindingConstantValue = ConvertToOptional(boundMethodGroup.ConstantValue);
-            bool isImplicit = boundMethodGroup.WasCompilerGenerated;
+            _ = boundMethodGroup.WasCompilerGenerated;
             return new LazyMethodReferenceExpression(methodSymbol, isVirtual, instance, _semanticModel, bindingSyntax, bindingType, bindingConstantValue, boundMethodGroup.WasCompilerGenerated);
         }
 

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Operations
                                                             ImmutableArray<IOperation>.Empty :
                                                             boundLocalDeclaration.ArgumentsOpt.SelectAsArray(arg => Create(arg));
             ILocalSymbol symbol = boundLocalDeclaration.LocalSymbol;
-            SyntaxNode syntaxNode = boundLocalDeclaration.Syntax;
+            _ = boundLocalDeclaration.Syntax;
             ITypeSymbol type = null;
             Optional<object> constantValue = default;
             bool isImplicit = false;

--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -515,7 +515,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 if (isActive && !guid.IsMissing)
                 {
                     Guid tmp;
-                    if (!Guid.TryParse(guid.ValueText, out tmp))
+                    if (!Guid.TryParse(guid.ValueText, out _))
                     {
                         guid = this.AddError(guid, ErrorCode.WRN_IllegalPPChecksum);
                     }

--- a/src/Compilers/CSharp/Portable/Parser/Directives.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Directives.cs
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     }
 
                     bool tmp;
-                    return new DirectiveStack(CompleteIf(_directives, out tmp));
+                    return new DirectiveStack(CompleteIf(_directives, out _));
                 case SyntaxKind.EndRegionDirectiveTrivia:
                     var prevRegion = GetPreviousRegion(_directives);
                     if (prevRegion == null || !prevRegion.Any())

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1890,7 +1890,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private TypeParameterConstraintSyntax ParseTypeParameterConstraint()
         {
             SyntaxToken questionToken = null;
-            var syntaxKind = this.CurrentToken.Kind;
+            _ = this.CurrentToken.Kind;
 
             switch (this.CurrentToken.Kind)
             {
@@ -5281,7 +5281,7 @@ tryAgain:
 
                 do
                 {
-                    lastTokenOfList = this.EatToken();
+                    _ = this.EatToken();
 
                     // Type arguments cannot contain attributes, so if this is an open square, we early out and assume it is not a type argument
                     if (this.CurrentToken.Kind == SyntaxKind.OpenBracketToken)
@@ -5296,7 +5296,7 @@ tryAgain:
                         return result;
                     }
 
-                    switch (this.ScanType(out lastTokenOfList))
+                    switch (this.ScanType(out _))
                     {
                         case ScanTypeFlags.NotType:
                             lastTokenOfList = null;
@@ -5886,7 +5886,7 @@ tryAgain:
         private ScanTypeFlags ScanType()
         {
             SyntaxToken lastTokenOfType;
-            return ScanType(out lastTokenOfType);
+            return ScanType(out _);
         }
 
         private ScanTypeFlags ScanType(out SyntaxToken lastTokenOfType)
@@ -5933,7 +5933,7 @@ tryAgain:
         private void ScanNamedTypePart()
         {
             SyntaxToken lastTokenOfType;
-            ScanNamedTypePart(out lastTokenOfType);
+            ScanNamedTypePart(out _);
         }
 
         private ScanTypeFlags ScanNamedTypePart(out SyntaxToken lastTokenOfType)
@@ -5958,7 +5958,7 @@ tryAgain:
         private ScanTypeFlags ScanNonArrayType()
         {
             SyntaxToken lastTokenOfType;
-            return ScanNonArrayType(ParseTypeMode.Normal, out lastTokenOfType);
+            return ScanNonArrayType(ParseTypeMode.Normal, out _);
         }
 
         private ScanTypeFlags ScanNonArrayType(ParseTypeMode mode, out SyntaxToken lastTokenOfType)
@@ -5994,7 +5994,7 @@ tryAgain:
                         isAlias = false;
                     }
 
-                    lastTokenOfType = this.EatToken();
+                    _ = this.EatToken();
 
                     result = this.ScanNamedTypePart(out lastTokenOfType);
                     if (result == ScanTypeFlags.NotType)
@@ -6016,7 +6016,7 @@ tryAgain:
             }
             else if (this.CurrentToken.Kind == SyntaxKind.OpenParenToken)
             {
-                lastTokenOfType = this.EatToken();
+                _ = this.EatToken();
 
                 result = this.ScanTupleType(out lastTokenOfType);
                 if (result == ScanTypeFlags.NotType)
@@ -6076,20 +6076,20 @@ tryAgain:
         /// </summary>
         private ScanTypeFlags ScanTupleType(out SyntaxToken lastTokenOfType)
         {
-            var tupleElementType = ScanType(out lastTokenOfType);
+            var tupleElementType = ScanType(out _);
             if (tupleElementType != ScanTypeFlags.NotType)
             {
                 if (IsTrueIdentifier())
                 {
-                    lastTokenOfType = this.EatToken();
+                    _ = this.EatToken();
                 }
 
                 if (this.CurrentToken.Kind == SyntaxKind.CommaToken)
                 {
                     do
                     {
-                        lastTokenOfType = this.EatToken();
-                        tupleElementType = ScanType(out lastTokenOfType);
+                        _ = this.EatToken();
+                        tupleElementType = ScanType(out _);
 
                         if (tupleElementType == ScanTypeFlags.NotType)
                         {
@@ -6099,7 +6099,7 @@ tryAgain:
 
                         if (IsTrueIdentifier())
                         {
-                            lastTokenOfType = this.EatToken();
+                            _ = this.EatToken();
                         }
                     }
                     while (this.CurrentToken.Kind == SyntaxKind.CommaToken);
@@ -9185,8 +9185,8 @@ tryAgain:
                     if (isAssignmentOperator)
                     {
                         ExpressionSyntax rhs = opKind == SyntaxKind.SimpleAssignmentExpression && CurrentToken.Kind == SyntaxKind.RefKeyword
-                            ? rhs = CheckFeatureAvailability(ParsePossibleRefExpression(), MessageID.IDS_FeatureRefReassignment)
-                            : rhs = this.ParseSubExpression(newPrecedence);
+                            ? _ = CheckFeatureAvailability(ParsePossibleRefExpression(), MessageID.IDS_FeatureRefReassignment)
+                            : _ = this.ParseSubExpression(newPrecedence);
 
                         if (opKind == SyntaxKind.CoalesceAssignmentExpression)
                         {

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -666,7 +666,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                 case '&':
                     TextWindow.AdvanceChar();
-                    if ((character = TextWindow.PeekChar()) == '=')
+                    if ((_ = TextWindow.PeekChar()) == '=')
                     {
                         TextWindow.AdvanceChar();
                         info.Kind = SyntaxKind.AmpersandEqualsToken;
@@ -872,7 +872,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 case '\\':
                     {
                         // Could be unicode escape. Try that.
-                        character = TextWindow.PeekCharOrUnicodeEscape(out surrogateCharacter);
+                        character = TextWindow.PeekCharOrUnicodeEscape(out _);
 
                         isEscaped = true;
                         if (SyntaxFacts.IsIdentifierStartCharacter(character))
@@ -911,7 +911,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     if (isEscaped)
                     {
                         SyntaxDiagnosticInfo error;
-                        TextWindow.NextCharOrUnicodeEscape(out surrogateCharacter, out error);
+                        TextWindow.NextCharOrUnicodeEscape(out _, out error);
                         AddError(error);
                     }
                     else
@@ -1847,7 +1847,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                     if (isEscaped)
                                     {
                                         SyntaxDiagnosticInfo error;
-                                        TextWindow.NextCharOrUnicodeEscape(out surrogateCharacter, out error);
+                                        TextWindow.NextCharOrUnicodeEscape(out _, out error);
                                         AddError(error);
                                     }
                                     else
@@ -2919,7 +2919,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 case '\\':
                     {
                         // Could be unicode escape. Try that.
-                        character = TextWindow.PeekCharOrUnicodeEscape(out surrogateCharacter);
+                        character = TextWindow.PeekCharOrUnicodeEscape(out _);
                         isEscaped = true;
                         if (SyntaxFacts.IsIdentifierStartCharacter(character))
                         {
@@ -2946,7 +2946,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         if (isEscaped)
                         {
                             SyntaxDiagnosticInfo error;
-                            TextWindow.NextCharOrUnicodeEscape(out surrogateCharacter, out error);
+                            TextWindow.NextCharOrUnicodeEscape(out _, out error);
                             AddError(error);
                         }
                         else
@@ -3919,7 +3919,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                 case '&':
                     TextWindow.Reset(beforeConsumed);
-                    if (!TextWindow.TryScanXmlEntity(out consumedChar, out consumedSurrogate))
+                    if (!TextWindow.TryScanXmlEntity(out consumedChar, out _))
                     {
                         TextWindow.Reset(beforeConsumed);
                         this.ScanXmlEntity(ref info);

--- a/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             SyntaxDiagnosticInfo error = null;
             bool closeQuoteMissing;
-            ScanInterpolatedStringLiteralTop(null, isVerbatim, ref info, ref error, out closeQuoteMissing);
+            ScanInterpolatedStringLiteralTop(null, isVerbatim, ref info, ref error, out _);
             this.AddError(error);
         }
 
@@ -430,7 +430,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                             var escapeStart = lexer.TextWindow.Position;
                             char c2;
-                            char ch = lexer.ScanEscapeSequence(out c2);
+                            char ch = lexer.ScanEscapeSequence(out _);
                             if ((ch == '{' || ch == '}') && error == null)
                             {
                                 error = lexer.MakeError(escapeStart, lexer.TextWindow.Position - escapeStart, ErrorCode.ERR_EscapedCurly, ch);
@@ -457,7 +457,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         // normal string & char constants can have escapes
                         var pos = lexer.TextWindow.Position;
                         char c2;
-                        ch = lexer.ScanEscapeSequence(out c2);
+                        ch = lexer.ScanEscapeSequence(out _);
                         if ((ch == '{' || ch == '}') && error == null)
                         {
                             error = lexer.MakeError(pos, 1, ErrorCode.ERR_EscapedCurly, ch);

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -526,7 +526,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // Native compiler allows only a specific GUID format: "D" format (32 digits separated by hyphens)
             Guid guid;
-            if (!Guid.TryParseExact(guidString, "D", out guid))
+            if (!Guid.TryParseExact(guidString, "D", out _))
             {
                 // CS0591: Invalid value for argument to '{0}' attribute
                 Location attributeArgumentSyntaxLocation = this.GetAttributeArgumentSyntaxLocation(0, nodeOpt);

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -400,7 +400,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool isOptionalUse = false)
         {
             DiagnosticInfo diagnosticInfo;
-            var ctorSymbol = (MethodSymbol)Binder.GetWellKnownTypeMember(this, constructor, out diagnosticInfo, isOptional: true);
+            var ctorSymbol = (MethodSymbol)Binder.GetWellKnownTypeMember(this, constructor, out _, isOptional: true);
 
             if ((object)ctorSymbol == null)
             {
@@ -424,7 +424,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var builder = new ArrayBuilder<KeyValuePair<string, TypedConstant>>(namedArguments.Length);
                 foreach (var arg in namedArguments)
                 {
-                    var wellKnownMember = Binder.GetWellKnownTypeMember(this, arg.Key, out diagnosticInfo, isOptional: true);
+                    var wellKnownMember = Binder.GetWellKnownTypeMember(this, arg.Key, out _, isOptional: true);
                     if (wellKnownMember == null || wellKnownMember is ErrorTypeSymbol)
                     {
                         // if this assert fails, UseSiteErrors for "member" have not been checked before emitting ...

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -433,7 +433,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             var metadataDecoder = new MetadataDecoder(moduleSymbol, method);
             SignatureHeader signatureHeader;
             BadImageFormatException mrEx;
-            var methodParams = metadataDecoder.GetSignatureForMethod(method.Handle, out signatureHeader, out mrEx, setParamHandles: false);
+            var methodParams = metadataDecoder.GetSignatureForMethod(method.Handle, out _, out mrEx, setParamHandles: false);
 
             if (mrEx != null)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 if (!_packedFlags.IsExplicitOverrideIsPopulated)
                 {
-                    var unused = this.ExplicitInterfaceImplementations;
+                    _ = this.ExplicitInterfaceImplementations;
                     Debug.Assert(_packedFlags.IsExplicitOverrideIsPopulated);
                 }
                 return _packedFlags.IsExplicitFinalizerOverride;
@@ -467,7 +467,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 if (!_packedFlags.IsExplicitOverrideIsPopulated)
                 {
-                    var unused = this.ExplicitInterfaceImplementations;
+                    _ = this.ExplicitInterfaceImplementations;
                     Debug.Assert(_packedFlags.IsExplicitOverrideIsPopulated);
                 }
                 return _packedFlags.IsExplicitClassOverride;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             // Ignore whether or not extension attributes were found
             bool ignore;
-            var loadedCustomAttributes = GetCustomAttributesFilterExtensions(token, out ignore);
+            var loadedCustomAttributes = GetCustomAttributesFilterExtensions(token, out _);
             ImmutableInterlocked.InterlockedInitialize(ref customAttributes, loadedCustomAttributes);
         }
 
@@ -653,7 +653,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         internal (AssemblySymbol FirstSymbol, AssemblySymbol SecondSymbol) GetAssembliesForForwardedType(ref MetadataTypeName fullName)
         {
             string matchedName;
-            (int firstIndex, int secondIndex) = this.Module.GetAssemblyRefsForForwardedType(fullName.FullName, ignoreCase: false, matchedName: out matchedName);
+            (int firstIndex, int secondIndex) = this.Module.GetAssemblyRefsForForwardedType(fullName.FullName, ignoreCase: false, matchedName: out _);
 
             if (firstIndex < 0)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             if (arity == 0)
             {
-                result = new PENamedTypeSymbolNonGeneric(moduleSymbol, containingNamespace, handle, emittedNamespaceName, out mangleName);
+                result = new PENamedTypeSymbolNonGeneric(moduleSymbol, containingNamespace, handle, emittedNamespaceName, out _);
             }
             else
             {
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     emittedNamespaceName,
                     genericParameterHandles,
                     arity,
-                    out mangleName);
+                    out _);
             }
 
             if (mrEx != null)
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             if (metadataArity == 0)
             {
-                result = new PENamedTypeSymbolNonGeneric(moduleSymbol, containingType, handle, null, out mangleName);
+                result = new PENamedTypeSymbolNonGeneric(moduleSymbol, containingType, handle, null, out _);
             }
             else
             {
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     null,
                     genericParameterHandles,
                     arity,
-                    out mangleName);
+                    out _);
             }
 
             if (mrEx != null || metadataArity < containerMetadataArity)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             var metadataDecoder = new MetadataDecoder(moduleSymbol, containingType);
             SignatureHeader callingConvention;
             BadImageFormatException propEx;
-            var propertyParams = metadataDecoder.GetSignatureForProperty(handle, out callingConvention, out propEx);
+            var propertyParams = metadataDecoder.GetSignatureForProperty(handle, out _, out propEx);
             Debug.Assert(propertyParams.Length > 0);
 
             var returnInfo = propertyParams[0];
@@ -122,9 +122,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             SignatureHeader unusedCallingConvention;
             BadImageFormatException getEx = null;
-            var getMethodParams = (object)getMethod == null ? null : metadataDecoder.GetSignatureForMethod(getMethod.Handle, out unusedCallingConvention, out getEx);
+            var getMethodParams = (object)getMethod == null ? null : metadataDecoder.GetSignatureForMethod(getMethod.Handle, out _, out getEx);
             BadImageFormatException setEx = null;
-            var setMethodParams = (object)setMethod == null ? null : metadataDecoder.GetSignatureForMethod(setMethod.Handle, out unusedCallingConvention, out setEx);
+            var setMethodParams = (object)setMethod == null ? null : metadataDecoder.GetSignatureForMethod(setMethod.Handle, out _, out setEx);
 
             // NOTE: property parameter names are not recorded in metadata, so we have to
             // use the parameter names from one of the indexers

--- a/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     containingType,
                     currType,
                     out bestMatch,
-                    out unused,
+                    out _,
                     out hiddenBuilder);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -934,7 +934,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                         targetParamsBuilder.Add(
                             new SignatureOnlyParameterSymbol(
                                 translator.Retarget(param.Type, RetargetOptions.RetargetPrimitiveTypesByTypeCode),
-                                translator.RetargetModifiers(param.RefCustomModifiers, out modifiersHaveChanged_Ignored),
+                                translator.RetargetModifiers(param.RefCustomModifiers, out _),
                                 param.IsParams,
                                 param.RefKind));
                     }
@@ -952,7 +952,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                         targetParamsBuilder.ToImmutableAndFree(),
                         method.RefKind,
                         translator.Retarget(method.ReturnType, RetargetOptions.RetargetPrimitiveTypesByTypeCode),
-                        translator.RetargetModifiers(method.RefCustomModifiers, out modifiersHaveChanged_Ignored),
+                        translator.RetargetModifiers(method.RefCustomModifiers, out _),
                         ImmutableArray<MethodSymbol>.Empty);
 
                     foreach (var retargetedMember in retargetedType.GetMembers(method.Name))
@@ -995,7 +995,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                     targetParamsBuilder.Add(
                         new SignatureOnlyParameterSymbol(
                             Retarget(param.Type, RetargetOptions.RetargetPrimitiveTypesByTypeCode),
-                            RetargetModifiers(param.RefCustomModifiers, out modifiersHaveChanged_Ignored),
+                            RetargetModifiers(param.RefCustomModifiers, out _),
                             param.IsParams,
                             param.RefKind));
                 }
@@ -1006,7 +1006,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                     targetParamsBuilder.ToImmutableAndFree(),
                     property.RefKind,
                     Retarget(property.Type, RetargetOptions.RetargetPrimitiveTypesByTypeCode),
-                    RetargetModifiers(property.RefCustomModifiers, out modifiersHaveChanged_Ignored),
+                    RetargetModifiers(property.RefCustomModifiers, out _),
                     property.IsStatic,
                     ImmutableArray<PropertySymbol>.Empty);
 
@@ -1051,7 +1051,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 if (lazyCustomModifiers.IsDefault)
                 {
                     bool modifiersHaveChanged;
-                    ImmutableArray<CustomModifier> newModifiers = this.RetargetModifiers(oldModifiers, out modifiersHaveChanged);
+                    ImmutableArray<CustomModifier> newModifiers = this.RetargetModifiers(oldModifiers, out _);
                     ImmutableInterlocked.InterlockedCompareExchange(ref lazyCustomModifiers, newModifiers, default(ImmutableArray<CustomModifier>));
                 }
 
@@ -1068,7 +1068,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 #if DEBUG
                 SynthesizedAttributeData x = null;
                 SourceAttributeData y = x; // Code below relies on the fact that SynthesizedAttributeData derives from SourceAttributeData.
-                x = (SynthesizedAttributeData)y;
+                _ = (SynthesizedAttributeData)y;
 #endif
                 foreach (var attributeData in attributes)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DiagnosticBag discardedDiagnostics = DiagnosticBag.GetInstance();
             TypeSymbol discardedExplicitInterfaceType;
             string discardedAliasOpt;
-            string methodName = GetMemberNameAndInterfaceSymbol(binder, explicitInterfaceSpecifierOpt, name, discardedDiagnostics, out discardedExplicitInterfaceType, out discardedAliasOpt);
+            string methodName = GetMemberNameAndInterfaceSymbol(binder, explicitInterfaceSpecifierOpt, name, discardedDiagnostics, out _, out _);
             discardedDiagnostics.Free();
 
             return methodName;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -1367,7 +1367,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 else
                 {
                     // Compute duplicate source assembly attributes, i.e. attributes with same constructor and arguments, that must not be emitted.
-                    var unused = GetUniqueSourceAssemblyAttributes();
+                    _ = GetUniqueSourceAssemblyAttributes();
                 }
 
                 // Load type forwarders from modules
@@ -2207,7 +2207,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 Version dummy;
                 string verString = (string)attribute.CommonConstructorArguments[0].Value;
-                if (!VersionHelper.TryParse(verString, version: out dummy))
+                if (!VersionHelper.TryParse(verString, version: out _))
                 {
                     Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt);
                     arguments.Diagnostics.Add(ErrorCode.WRN_InvalidVersionFormat, attributeArgumentSyntaxLocation);
@@ -2259,7 +2259,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Version dummy;
                 string verString = (string)attribute.CommonConstructorArguments[0].Value;
 
-                if (!VersionHelper.TryParseAssemblyVersion(verString, allowWildcard: false, version: out dummy))
+                if (!VersionHelper.TryParseAssemblyVersion(verString, allowWildcard: false, version: out _))
                 {
                     Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt);
                     arguments.Diagnostics.Add(ErrorCode.ERR_InvalidVersionFormat2, attributeArgumentSyntaxLocation);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -1040,7 +1040,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             base.ForceComplete(locationOpt, cancellationToken);
 
             // Force binding of default value.
-            var unused = this.ExplicitDefaultConstantValue;
+            _ = this.ExplicitDefaultConstantValue;
         }
     }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DelegateDeclarationSyntax syntax,
             DiagnosticBag diagnostics)
         {
-            var compilation = delegateType.DeclaringCompilation;
+            _ = delegateType.DeclaringCompilation;
             Binder binder = delegateType.GetBinder(syntax.ParameterList);
             RefKind refKind;
             TypeSyntax returnTypeSyntax = syntax.ReturnType.SkipRef(out refKind);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var isExplicitInterfaceImplementation = interfaceSpecifierSyntaxOpt != null;
             bool modifierErrors;
-            _modifiers = MakeModifiers(modifiers, isExplicitInterfaceImplementation, _location, diagnostics, out modifierErrors);
+            _modifiers = MakeModifiers(modifiers, isExplicitInterfaceImplementation, _location, diagnostics, out _);
             this.CheckAccessibility(_location, diagnostics);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (_typeSyntax.IsVar)
                 {
                     bool isVar;
-                    TypeSymbolWithAnnotations declType = this.TypeSyntaxBinder.BindTypeOrVarKeyword(_typeSyntax, new DiagnosticBag(), out isVar);
+                    _ = this.TypeSyntaxBinder.BindTypeOrVarKeyword(_typeSyntax, new DiagnosticBag(), out isVar);
                     return isVar;
                 }
 
@@ -328,7 +328,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             bool isVar;
             RefKind refKind;
-            TypeSymbolWithAnnotations declType = typeBinder.BindTypeOrVarKeyword(_typeSyntax.SkipRef(out refKind), diagnostics, out isVar);
+            TypeSymbolWithAnnotations declType = typeBinder.BindTypeOrVarKeyword(_typeSyntax.SkipRef(out _), diagnostics, out isVar);
 
             if (isVar)
             {
@@ -539,7 +539,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (this.IsConst && _constantTuple == null)
                 {
-                    var value = Microsoft.CodeAnalysis.ConstantValue.Bad;
+                    _ = Microsoft.CodeAnalysis.ConstantValue.Bad;
                     var initValueNodeLocation = _initializer.Value.Location;
                     var diagnostics = DiagnosticBag.GetInstance();
                     Debug.Assert(inProgress != this);
@@ -550,7 +550,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         boundInitValue = inProgressBinder.BindVariableOrAutoPropInitializerValue(_initializer, this.RefKind, type, diagnostics);
                     }
 
-                    value = ConstantValueUtils.GetAndValidateConstantValue(boundInitValue, this, type, initValueNodeLocation, diagnostics);
+                    ConstantValue value = ConstantValueUtils.GetAndValidateConstantValue(boundInitValue, this, type, initValueNodeLocation, diagnostics);
                     Interlocked.CompareExchange(ref _constantTuple, new EvaluatedConstant(value, diagnostics.ToReadOnlyAndFree()), null);
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -468,12 +468,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case CompletionPart.EnumUnderlyingType:
-                        var discarded = this.EnumUnderlyingType;
+                        {
+                            _ = this.EnumUnderlyingType;
+                        }
+
                         break;
 
                     case CompletionPart.TypeArguments:
                         {
-                            var tmp = this.TypeArgumentsNoUseSiteDiagnostics; // force type arguments
+                            _ = this.TypeArgumentsNoUseSiteDiagnostics; // force type arguments
                         }
                         break;
 
@@ -1396,8 +1399,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             CheckSpecialMemberErrors(diagnostics);
             CheckTypeParameterNameConflicts(diagnostics);
             CheckAccessorNameConflicts(diagnostics);
-
-            bool unused = KnownCircularStruct;
+            _ = KnownCircularStruct;
 
             CheckSequentialOnPartialType(diagnostics);
             CheckForProtectedInStaticClass(diagnostics);
@@ -1750,7 +1752,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             PropertySymbol prevIndexerBySignature;
-            if (indexersBySignature.TryGetValue(indexer, out prevIndexerBySignature))
+            if (indexersBySignature.TryGetValue(indexer, out _))
             {
                 // Type '{1}' already defines a member called '{0}' with the same parameter types
                 // NOTE: Dev10 prints "this" as the name of the indexer.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             if (member.IsOverride)
                             {
-                                CheckOverrideMember(method, method.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                CheckOverrideMember(method, method.OverriddenOrHiddenMembers, diagnostics, out _);
                             }
                             else
                             {
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 if ((object)sourceMethod != null) // skip submission initializer
                                 {
                                     var isNew = sourceMethod.IsNew;
-                                    CheckNonOverrideMember(method, isNew, method.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                    CheckNonOverrideMember(method, isNew, method.OverriddenOrHiddenMembers, diagnostics, out _);
                                 }
                             }
                         }
@@ -425,11 +425,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             {
                                 if ((object)getMethod != null)
                                 {
-                                    CheckOverrideMember(getMethod, getMethod.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                    CheckOverrideMember(getMethod, getMethod.OverriddenOrHiddenMembers, diagnostics, out _);
                                 }
                                 if ((object)setMethod != null)
                                 {
-                                    CheckOverrideMember(setMethod, setMethod.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                    CheckOverrideMember(setMethod, setMethod.OverriddenOrHiddenMembers, diagnostics, out _);
                                 }
                             }
                         }
@@ -442,11 +442,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             {
                                 if ((object)getMethod != null)
                                 {
-                                    CheckNonOverrideMember(getMethod, isNewProperty, getMethod.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                    CheckNonOverrideMember(getMethod, isNewProperty, getMethod.OverriddenOrHiddenMembers, diagnostics, out _);
                                 }
                                 if ((object)setMethod != null)
                                 {
-                                    CheckNonOverrideMember(setMethod, isNewProperty, setMethod.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                    CheckNonOverrideMember(setMethod, isNewProperty, setMethod.OverriddenOrHiddenMembers, diagnostics, out _);
                                 }
                             }
                         }
@@ -466,11 +466,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             {
                                 if ((object)addMethod != null)
                                 {
-                                    CheckOverrideMember(addMethod, addMethod.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                    CheckOverrideMember(addMethod, addMethod.OverriddenOrHiddenMembers, diagnostics, out _);
                                 }
                                 if ((object)removeMethod != null)
                                 {
-                                    CheckOverrideMember(removeMethod, removeMethod.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                    CheckOverrideMember(removeMethod, removeMethod.OverriddenOrHiddenMembers, diagnostics, out _);
                                 }
                             }
                         }
@@ -483,11 +483,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             {
                                 if ((object)addMethod != null)
                                 {
-                                    CheckNonOverrideMember(addMethod, isNewEvent, addMethod.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                    CheckNonOverrideMember(addMethod, isNewEvent, addMethod.OverriddenOrHiddenMembers, diagnostics, out _);
                                 }
                                 if ((object)removeMethod != null)
                                 {
-                                    CheckNonOverrideMember(removeMethod, isNewEvent, removeMethod.OverriddenOrHiddenMembers, diagnostics, out suppressAccessors);
+                                    CheckNonOverrideMember(removeMethod, isNewEvent, removeMethod.OverriddenOrHiddenMembers, diagnostics, out _);
                                 }
                             }
                         }
@@ -728,7 +728,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
                             }
                             else if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureNullableReferenceTypes) == true &&
-                                (compilation = overridingMember.DeclaringCompilation) != null &&
+                                (_ = overridingMember.DeclaringCompilation) != null &&
                                 !overridingMemberType.Equals(overriddenProperty.Type,
                                                              TypeCompareKind.AllIgnoreOptions & ~(TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreInsignificantNullableModifiersDifference)))
                             {
@@ -772,7 +772,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
                             }
                             else if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureNullableReferenceTypes) == true &&
-                                (compilation = overridingMember.DeclaringCompilation) != null &&
+                                (_ = overridingMember.DeclaringCompilation) != null &&
                                 !overridingMemberType.Equals(overriddenEvent.Type,
                                                              TypeCompareKind.AllIgnoreOptions & ~(TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreInsignificantNullableModifiersDifference)))
                             {
@@ -807,7 +807,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             }
                             else if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureNullableReferenceTypes) == true &&
                                 !overridingMember.IsImplicitlyDeclared && !overridingMember.IsAccessor() &&
-                                (compilation = overridingMember.DeclaringCompilation) != null &&
+                                (_ = overridingMember.DeclaringCompilation) != null &&
                                 !overridingMethod.ReturnType.Equals(overriddenMethod.ReturnType,
                                                                     TypeCompareKind.AllIgnoreOptions & ~(TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreInsignificantNullableModifiersDifference)))
                             {
@@ -817,7 +817,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureNullableReferenceTypes) == true &&
                             !overridingMember.IsImplicitlyDeclared && !overridingMember.IsAccessor() &&
-                            (compilation = overridingMember.DeclaringCompilation) != null)
+                            (_ = overridingMember.DeclaringCompilation) != null)
                         {
                             ImmutableArray<ParameterSymbol> overridingParameters = overridingMember.GetParameters();
                             ImmutableArray<ParameterSymbol> overriddenParameters;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -245,7 +245,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case CompletionPart.FixedSize:
-                        int discarded = this.FixedSize;
+                        {
+                            _ = this.FixedSize;
+                        }
+
                         break;
 
                     case CompletionPart.ConstantValue:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -777,7 +777,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case CompletionPart.Type:
-                        var unusedType = this.ReturnType;
+                        {
+                            _ = this.ReturnType;
+                        }
+
                         state.NotePartComplete(CompletionPart.Type);
                         break;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         if (attrData.IsTargetAttribute(a, AttributeDescription.GuidAttribute))
                         {
                             string guidString;
-                            if (attrData.TryGetGuidAttributeValue(out guidString))
+                            if (attrData.TryGetGuidAttributeValue(out _))
                             {
                                 hasGuidAttribute = true;
                             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (name == null)
                     {
                         name = typeParameterNames[i] = tp.Identifier.ValueText;
-                        varianceKind = typeParameterVarianceKeywords[i] = tp.VarianceKeyword.ValueText;
+                        _ = typeParameterVarianceKeywords[i] = tp.VarianceKeyword.ValueText;
                         for (int j = 0; j < i; j++)
                         {
                             if (name == typeParameterNames[j])
@@ -792,7 +792,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             foreach (SyntaxList<AttributeListSyntax> list in attributeLists)
             {
-                var syntaxTree = list.Node.SyntaxTree;
+                _ = list.Node.SyntaxTree;
                 QuickAttributeChecker checker = this.DeclaringCompilation.GetBinderFactory(list.Node.SyntaxTree).GetBinder(list.Node).QuickAttributeChecker;
 
                 foreach (AttributeListSyntax attrList in list)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // to make base resolution errors more deterministic
                     if ((object)ContainingType != null)
                     {
-                        var tmp = ContainingType.BaseTypeNoUseSiteDiagnostics;
+                        _ = ContainingType.BaseTypeNoUseSiteDiagnostics;
                     }
 
                     var diagnostics = DiagnosticBag.GetInstance();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             TypeSymbol explicitInterfaceType;
             string discardedAliasQualifier;
-            var name = ExplicitInterfaceHelpers.GetMemberNameAndInterfaceSymbol(bodyBinder, interfaceSpecifier, nameToken.ValueText, diagnostics, out explicitInterfaceType, out discardedAliasQualifier);
+            var name = ExplicitInterfaceHelpers.GetMemberNameAndInterfaceSymbol(bodyBinder, interfaceSpecifier, nameToken.ValueText, diagnostics, out explicitInterfaceType, out _);
             var location = new SourceLocation(nameToken);
 
             var methodKind = interfaceSpecifier == null
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 firstParam.Modifiers.Any(SyntaxKind.ThisKeyword);
 
             bool modifierErrors;
-            var declarationModifiers = this.MakeModifiers(modifiers, methodKind, location, diagnostics, out modifierErrors);
+            var declarationModifiers = this.MakeModifiers(modifiers, methodKind, location, diagnostics, out _);
 
             var isMetadataVirtualIgnoringModifiers = (object)explicitInterfaceType != null; //explicit impls must be marked metadata virtual
 
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             _lazyIsVararg = (arglistToken.Kind() == SyntaxKind.ArgListKeyword);
             RefKind refKind;
-            var returnTypeSyntax = syntax.ReturnType.SkipRef(out refKind);
+            var returnTypeSyntax = syntax.ReturnType.SkipRef(out _);
             _lazyReturnType = signatureBinder.BindType(returnTypeSyntax, diagnostics);
 
             // span-like types are returnable in general

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bodyBinder = bodyBinder.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.SuppressConstraintChecks, this);
 
             bool modifierErrors;
-            _modifiers = MakeModifiers(modifiers, isExplicitInterfaceImplementation, isIndexer, location, diagnostics, out modifierErrors);
+            _modifiers = MakeModifiers(modifiers, isExplicitInterfaceImplementation, isIndexer, location, diagnostics, out _);
             this.CheckAccessibility(location, diagnostics);
 
             this.CheckModifiers(location, isIndexer, diagnostics);
@@ -502,7 +502,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 var syntax = (BasePropertyDeclarationSyntax)_syntaxRef.GetSyntax();
                 RefKind refKind;
-                var typeSyntax = syntax.Type.SkipRef(out refKind);
+                var typeSyntax = syntax.Type.SkipRef(out _);
                 return typeSyntax.Kind() == SyntaxKind.PointerType;
             }
         }
@@ -1451,7 +1451,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private TypeSymbolWithAnnotations ComputeType(Binder binder, BasePropertyDeclarationSyntax syntax, DiagnosticBag diagnostics)
         {
             RefKind refKind;
-            var typeSyntax = syntax.Type.SkipRef(out refKind);
+            var typeSyntax = syntax.Type.SkipRef(out _);
             var type = binder.BindType(typeSyntax, diagnostics);
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -330,7 +330,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case CompletionPart.TypeParameterConstraints:
-                        var constraintTypes = this.ConstraintTypesNoUseSiteDiagnostics;
+                        {
+                            _ = this.ConstraintTypesNoUseSiteDiagnostics;
+                        }
 
                         // Nested type parameter references might not be valid in error scenarios.
                         //Debug.Assert(this.ContainingSymbol.IsContainingSymbolOfAllTypeParameters(this.ConstraintTypes));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             bool modifierErrors;
             var declarationModifiers = ModifierUtils.MakeAndCheckNontypeMemberModifiers(
-                syntax.Modifiers, defaultAccess, allowedModifiers, location, diagnostics, out modifierErrors);
+                syntax.Modifiers, defaultAccess, allowedModifiers, location, diagnostics, out _);
 
             this.CheckUnsafeModifier(declarationModifiers, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
@@ -369,7 +369,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             RefKind refKind;
             TypeSymbolWithAnnotations returnType;
             ImmutableArray<CustomModifier> customModifiers_Ignored;
-            GetTypeOrReturnType(symbol, out refKind, out returnType, out customModifiers_Ignored);
+            GetTypeOrReturnType(symbol, out _, out returnType, out _);
             return returnType;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             GeneratedNameKind kind;
             int openBracketOffset;
             int closeBracketOffset;
-            return TryParseGeneratedName(name, out kind, out openBracketOffset, out closeBracketOffset) ? kind : GeneratedNameKind.None;
+            return TryParseGeneratedName(name, out kind, out _, out _) ? kind : GeneratedNameKind.None;
         }
 
         // Parse the generated name. Returns true for names of the form

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 // The diagnostics that would be produced here will already have been captured and returned.
                 var droppedBag = DiagnosticBag.GetInstance();
-                var success = binder.GetAwaitableExpressionInfo(userMainInvocation, out _, out _, out _, out _getAwaiterGetResultCall, _userMainReturnTypeSyntax, droppedBag);
+                _ = binder.GetAwaitableExpressionInfo(userMainInvocation, out _, out _, out _, out _getAwaiterGetResultCall, _userMainReturnTypeSyntax, droppedBag);
                 droppedBag.Free();
 
                 Debug.Assert(

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1026,8 +1026,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private SmallDictionary<Symbol, Symbol> ComputeDefinitionToMemberMap()
         {
             var map = new SmallDictionary<Symbol, Symbol>(ReferenceEqualityComparer.Instance);
-
-            var underlyingDefinition = _underlyingType.OriginalDefinition;
+            _ = _underlyingType.OriginalDefinition;
             var members = GetMembers();
 
             // Go in reverse because we want members with default name, which precede the ones with

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             foreach (var typeParameter in typeParameters)
             {
                 // Invoke any method that forces constraints to be resolved.
-                var unused = typeParameter.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, early);
+                _ = typeParameter.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, early);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -566,7 +566,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public bool IsTupleCompatible()
         {
             int countOfItems;
-            return IsTupleCompatible(out countOfItems);
+            return IsTupleCompatible(out _);
         }
 
         /// <summary>
@@ -1135,7 +1135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (((CSharpParseOptions)implementingMember.Locations[0].SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureNullableReferenceTypes) == true &&
                 !implementingMember.IsImplicitlyDeclared && !implementingMember.IsAccessor() &&
-                (compilation = implementingMember.DeclaringCompilation) != null)
+                (_ = implementingMember.DeclaringCompilation) != null)
             {
                 Symbol implementedMember;
                 MethodSymbol implementedMethod;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1421,7 +1421,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
             object builderArgument;
-            return namedType.IsCustomTaskType(out builderArgument);
+            return namedType.IsCustomTaskType(out _);
         }
 
         internal static bool IsGenericTaskType(this TypeSymbol type, CSharpCompilation compilation)
@@ -1436,7 +1436,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return true;
             }
             object builderArgument;
-            return namedType.IsCustomTaskType(out builderArgument);
+            return namedType.IsCustomTaskType(out _);
         }
 
         internal static bool IsIAsyncEnumerableType(this TypeSymbol type, CSharpCompilation compilation)
@@ -1571,7 +1571,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             object builderArgument;
-            if (type.OriginalDefinition.IsCustomTaskType(out builderArgument))
+            if (type.OriginalDefinition.IsCustomTaskType(out _))
             {
                 int arity = type.Arity;
                 Debug.Assert(arity < 2);

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilder.cs
@@ -995,7 +995,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
         /// </summary>
         internal void DefineSequencePoint(SyntaxTree syntaxTree, TextSpan span)
         {
-            var curBlock = GetCurrentBlock();
+            _ = GetCurrentBlock();
             _lastSeqPointTree = syntaxTree;
 
             if (this.SeqPointsOpt == null)
@@ -1098,7 +1098,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
             }
 
             EndBlock();  //blocks should not cross scope boundaries.
-            var scope = _scopeManager.OpenScope(scopeType, exceptionType);
+            _ = _scopeManager.OpenScope(scopeType, exceptionType);
 
             // Exception handler scopes must have a leader block, even
             // if the exception handler is empty, and created before any

--- a/src/Compilers/Core/Portable/CodeGen/SequencePointList.cs
+++ b/src/Compilers/Core/Portable/CodeGen/SequencePointList.cs
@@ -115,18 +115,15 @@ namespace Microsoft.CodeAnalysis.CodeGen
             DebugDocumentProvider documentProvider,
             ArrayBuilder<Cci.SequencePoint> builder)
         {
-            bool lastPathIsMapped = false;
-            string lastPath = null;
-            Cci.DebugSourceDocument lastDebugDocument = null;
-
             FileLinePositionSpan? firstReal = FindFirstRealSequencePoint();
             if (!firstReal.HasValue)
             {
                 return;
             }
-            lastPath = firstReal.Value.Path;
-            lastPathIsMapped = firstReal.Value.HasMappedPath;
-            lastDebugDocument = documentProvider(lastPath, basePath: lastPathIsMapped ? this._tree.FilePath : null);
+
+            string lastPath = firstReal.Value.Path;
+            bool lastPathIsMapped = firstReal.Value.HasMappedPath;
+            Cci.DebugSourceDocument lastDebugDocument = documentProvider(lastPath, basePath: lastPathIsMapped ? _tree.FilePath : null);
 
             SequencePointList current = this;
             while (current != null)

--- a/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis
         public bool ContainsKey(K key)
         {
             V value;
-            return TryGetValue(key, out value);
+            return TryGetValue(key, out _);
         }
 
         [Conditional("DEBUG")]

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -229,11 +229,8 @@ namespace Microsoft.CodeAnalysis
             out string outputFileName,
             out string outputDirectory)
         {
-            outputFileName = null;
-            outputDirectory = null;
-            string invalidPath = null;
-
             string unquoted = RemoveQuotesAndSlashes(value);
+            string invalidPath;
             ParseAndNormalizeFile(unquoted, baseDirectory, out outputFileName, out outputDirectory, out invalidPath);
             if (outputFileName == null ||
                 !MetadataHelpers.IsValidAssemblyOrModuleName(outputFileName))
@@ -249,12 +246,11 @@ namespace Microsoft.CodeAnalysis
             IList<Diagnostic> errors,
             string baseDirectory)
         {
-            string outputFileName = null;
-            string outputDirectory = null;
             string pdbPath = null;
-            string invalidPath = null;
-
             string unquoted = RemoveQuotesAndSlashes(value);
+            string outputFileName;
+            string outputDirectory;
+            string invalidPath;
             ParseAndNormalizeFile(unquoted, baseDirectory, out outputFileName, out outputDirectory, out invalidPath);
             if (outputFileName == null ||
                 PathUtilities.ChangeExtension(outputFileName, extension: null).Length == 0)
@@ -275,11 +271,10 @@ namespace Microsoft.CodeAnalysis
             string baseDirectory,
             bool generateDiagnostic = true)
         {
-            string outputFileName = null;
-            string outputDirectory = null;
             string genericPath = null;
-            string invalidPath = null;
-
+            string outputFileName;
+            string outputDirectory;
+            string invalidPath;
             ParseAndNormalizeFile(unquoted, baseDirectory, out outputFileName, out outputDirectory, out invalidPath);
             if (string.IsNullOrWhiteSpace(outputFileName))
             {

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis
         internal SourceText TryReadFileContent(CommandLineSourceFile file, IList<DiagnosticInfo> diagnostics)
         {
             string discarded;
-            return TryReadFileContent(file, diagnostics, out discarded);
+            return TryReadFileContent(file, diagnostics, out _);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/CvtRes.cs
+++ b/src/Compilers/Core/Portable/CvtRes.cs
@@ -704,7 +704,7 @@ namespace Microsoft.CodeAnalysis
 
                 ushort cbBlock = SizeofVerString(keyValuePair.Key, keyValuePair.Value);
                 int cbKey = (keyValuePair.Key.Length + 1) * 2;     // includes terminating NUL
-                int cbVal = (keyValuePair.Value.Length + 1) * 2;     // includes terminating NUL
+                _ = (keyValuePair.Value.Length + 1) * 2;     // includes terminating NUL
 
                 var startPos = writer.BaseStream.Position;
                 Debug.Assert((startPos & 3) == 0);

--- a/src/Compilers/Core/Portable/Desktop/DesktopAssemblyIdentityComparer.cs
+++ b/src/Compilers/Core/Portable/Desktop/DesktopAssemblyIdentityComparer.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis
         private static bool IsRetargetableAssembly(AssemblyIdentity identity)
         {
             bool retargetable, portable;
-            IsRetargetableAssembly(identity, out retargetable, out portable);
+            IsRetargetableAssembly(identity, out retargetable, out _);
             return retargetable;
         }
 

--- a/src/Compilers/Core/Portable/DiaSymReader/SymUnmanagedFactory.cs
+++ b/src/Compilers/Core/Portable/DiaSymReader/SymUnmanagedFactory.cs
@@ -152,12 +152,11 @@ namespace Microsoft.DiaSymReader
 
         internal static object CreateObject(bool createReader, bool useAlternativeLoadPath, bool useComRegistry, out string moduleName, out Exception loadException)
         {
-            object instance = null;
             loadException = null;
             moduleName = null;
 
             var clsid = new Guid(createReader ? SymReaderClsid : SymWriterClsid);
-            
+            object instance;
             try
             {
                 try

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private static bool IsDiagnosticAnalyzerAttribute(PEModule peModule, CustomAttributeHandle customAttrHandle)
         {
             EntityHandle ctor;
-            return peModule.IsTargetAttribute(customAttrHandle, s_diagnosticAnalyzerAttributeNamespace, nameof(DiagnosticAnalyzerAttribute), out ctor);
+            return peModule.IsTargetAttribute(customAttrHandle, s_diagnosticAnalyzerAttributeNamespace, nameof(DiagnosticAnalyzerAttribute), out _);
         }
 
         private static string GetFullyQualifiedTypeName(TypeDefinition typeDef, PEModule peModule)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -351,8 +351,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             // Wait for all active tasks to complete.
             await WaitForActiveAnalysisTasksAsync(waitForTreeTasks: true, waitForCompilationOrNonConcurrentTask: true, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-            var diagnostics = ImmutableArray<Diagnostic>.Empty;
             var analysisScope = new AnalysisScope(_compilation, analyzers, _analysisOptions.ConcurrentAnalysis, categorizeDiagnostics: true);
             Func<AsyncQueue<CompilationEvent>> getEventQueue = () =>
                GetPendingEvents(analyzers, includeSourceEvents: true, includeNonSourceEvents: true, cancellationToken);
@@ -790,12 +788,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // Discard the returned diagnostics.
             if (analysisScope.FilterTreeOpt == null)
             {
-                var unused = _compilation.GetDiagnostics(cancellationToken);
+                _ = _compilation.GetDiagnostics(cancellationToken);
             }
             else if (!analysisScope.IsSyntaxOnlyTreeAnalysis)
             {
                 var mappedModel = _compilationData.GetOrCreateCachedSemanticModel(analysisScope.FilterTreeOpt, _compilation, cancellationToken);
-                var unused = mappedModel.GetDiagnostics(cancellationToken: cancellationToken);
+                _ = mappedModel.GetDiagnostics(cancellationToken: cancellationToken);
             }
         }
 
@@ -1120,7 +1118,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             if (eventQueue.Count > 0)
             {
                 CompilationEvent discarded;
-                while (eventQueue.TryDequeue(out discarded)) ;
+                while (eventQueue.TryDequeue(out _)) ;
             }
 
             if (!eventQueue.IsCompleted)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             SuppressMessageInfo info;
-            if (IsDiagnosticSuppressed(diagnostic, out info))
+            if (IsDiagnosticSuppressed(diagnostic, out _))
             {
                 // Attach the suppression info to the diagnostic.
                 diagnostic = diagnostic.WithIsSuppressed(true);
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Debug.Assert(id != null);
             Debug.Assert(location != null);
 
-            info = default(SuppressMessageInfo);
+            _ = default(SuppressMessageInfo);
 
             if (IsDiagnosticGloballySuppressed(id, symbolOpt: null, isImmediatelyContainingSymbol: false, info: out info))
             {
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // TODO: How should we deal with multiple SuppressMessage attributes, with different suppression info/states?
             // For now, we just pick the last attribute, if not suppressed.
             SuppressMessageInfo currentInfo;
-            if (!builder.TryGetValue(info.Id, out currentInfo))
+            if (!builder.TryGetValue(info.Id, out _))
             {
                 builder[info.Id] = info;
             }

--- a/src/Compilers/Core/Portable/InternalUtilities/CommandLineUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/CommandLineUtilities.cs
@@ -46,7 +46,7 @@ namespace Roslyn.Utilities
         public static IEnumerable<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments)
         {
             char? unused;
-            return SplitCommandLineIntoArguments(commandLine, removeHashComments, out unused);
+            return SplitCommandLineIntoArguments(commandLine, removeHashComments, out _);
         }
 
         public static IEnumerable<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, out char? illegalChar)

--- a/src/Compilers/Core/Portable/InternalUtilities/ConcurrentSet.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ConcurrentSet.cs
@@ -100,7 +100,7 @@ namespace Roslyn.Utilities
         /// <returns>true if the value was removed successfully; otherwise false.</returns>
         public bool Remove(T value)
         {
-            return _dictionary.TryRemove(value, out var b);
+            return _dictionary.TryRemove(value, out var _);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/InternalUtilities/StreamExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StreamExtensions.cs
@@ -33,7 +33,7 @@ namespace Roslyn.Utilities
             Debug.Assert(count > 0);
 
             int totalBytesRead;
-            int bytesRead = 0;
+            int bytesRead;
             for (totalBytesRead = 0; totalBytesRead < count; totalBytesRead += bytesRead)
             {
                 // Note: Don't attempt to save state in-between calls to .Read as it would

--- a/src/Compilers/Core/Portable/InternalUtilities/StringExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StringExtensions.cs
@@ -197,7 +197,7 @@ namespace Roslyn.Utilities
         /// </summary>
         internal static string Unquote(this string arg)
         {
-            return Unquote(arg, out var quoted);
+            return Unquote(arg, out var _);
         }
 
         internal static string Unquote(this string arg, out bool quoted)

--- a/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
@@ -30,7 +30,7 @@ namespace Roslyn.Utilities
             for (int i = 0; i < _items.Length; i++)
             {
                 T target;
-                if (!_items[i].TryGetTarget(out target))
+                if (!_items[i].TryGetTarget(out _))
                 {
                     if (firstDead == -1)
                     {
@@ -110,7 +110,7 @@ namespace Roslyn.Utilities
                 var item = _items[i];
 
                 T target;
-                if (item.TryGetTarget(out target))
+                if (item.TryGetTarget(out _))
                 {
                     result[j++] = item;
                 }

--- a/src/Compilers/Core/Portable/InternalUtilities/WeakReferenceExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/WeakReferenceExtensions.cs
@@ -15,7 +15,7 @@ namespace Roslyn.Utilities
 
         public static bool IsNull<T>(this WeakReference<T> reference) where T : class
         {
-            return !reference.TryGetTarget(out var target);
+            return !reference.TryGetTarget(out var _);
         }
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis
         internal TypeSymbol GetTypeOfToken(EntityHandle token)
         {
             bool isNoPiaLocalType;
-            return GetTypeOfToken(token, out isNoPiaLocalType);
+            return GetTypeOfToken(token, out _);
         }
 
         internal TypeSymbol GetTypeOfToken(EntityHandle token, out bool isNoPiaLocalType)
@@ -545,7 +545,7 @@ namespace Microsoft.CodeAnalysis
         private TypeSymbol GetTypeOfTypeDef(TypeDefinitionHandle typeDef)
         {
             bool isNoPiaLocalType;
-            return GetTypeOfTypeDef(typeDef, out isNoPiaLocalType, isContainingType: false);
+            return GetTypeOfTypeDef(typeDef, out _, isContainingType: false);
         }
 
         private TypeSymbol GetTypeOfTypeDef(TypeDefinitionHandle typeDef, out bool isNoPiaLocalType, bool isContainingType)
@@ -754,13 +754,13 @@ namespace Microsoft.CodeAnalysis
             switch (token.Kind)
             {
                 case HandleKind.TypeDefinition:
-                    type = GetTypeOfTypeDef((TypeDefinitionHandle)token, out isNoPiaLocalType, isContainingType: false);
+                    type = GetTypeOfTypeDef((TypeDefinitionHandle)token, out _, isContainingType: false);
                     // it is valid for a modifier to refer to an unconstructed type, we need to preserve this fact
                     type = SubstituteWithUnboundIfGeneric(type);
                     break;
 
                 case HandleKind.TypeReference:
-                    type = GetTypeOfTypeRef((TypeReferenceHandle)token, out isNoPiaLocalType);
+                    type = GetTypeOfTypeRef((TypeReferenceHandle)token, out _);
                     // it is valid for a modifier to refer to an unconstructed type, we need to preserve this fact
                     type = SubstituteWithUnboundIfGeneric(type);
                     break;
@@ -805,7 +805,7 @@ namespace Microsoft.CodeAnalysis
                             goto tryAgain;
 
                         case SignatureTypeCode.GenericTypeInstance:
-                            type = DecodeGenericTypeInstanceOrThrow(ref memoryReader, out refersToNoPiaLocalType);
+                            type = DecodeGenericTypeInstanceOrThrow(ref memoryReader, out _);
                             break;
 
                         default:
@@ -977,14 +977,13 @@ namespace Microsoft.CodeAnalysis
         internal void DecodeLocalConstantBlobOrThrow(ref BlobReader sigReader, out TypeSymbol type, out ConstantValue value)
         {
             SignatureTypeCode typeCode;
-
-            var customModifiers = DecodeModifiersOrThrow(ref sigReader, AllowedRequiredModifierType.None, out typeCode, out _);
+            _ = DecodeModifiersOrThrow(ref sigReader, AllowedRequiredModifierType.None, out typeCode, out _);
 
             if (typeCode == SignatureTypeCode.TypeHandle)
             {
                 // TypeDefOrRefOrSpec encoded
                 bool refersToNoPiaLocalType;
-                type = GetSymbolForTypeHandleOrThrow(sigReader.ReadTypeHandle(), out refersToNoPiaLocalType, allowTypeSpec: true, requireShortForm: true);
+                type = GetSymbolForTypeHandleOrThrow(sigReader.ReadTypeHandle(), out _, allowTypeSpec: true, requireShortForm: true);
 
                 if (type.SpecialType == SpecialType.System_Decimal)
                 {
@@ -1013,7 +1012,7 @@ namespace Microsoft.CodeAnalysis
                 if (isEnumTypeCode && sigReader.RemainingBytes > 0)
                 {
                     bool refersToNoPiaLocalType;
-                    type = GetSymbolForTypeHandleOrThrow(sigReader.ReadTypeHandle(), out refersToNoPiaLocalType, allowTypeSpec: true, requireShortForm: true);
+                    type = GetSymbolForTypeHandleOrThrow(sigReader.ReadTypeHandle(), out _, allowTypeSpec: true, requireShortForm: true);
 
                     if (GetEnumUnderlyingType(type)?.SpecialType != specialType)
                     {
@@ -1310,7 +1309,7 @@ namespace Microsoft.CodeAnalysis
 
                 SerializationTypeCode unusedElementTypeCode;
                 TypeSymbol unusedElementType;
-                DecodeCustomAttributeParameterTypeOrThrow(ref sigReader, out elementTypeCode, out elementType, out unusedElementTypeCode, out unusedElementType, isElementType: true);
+                DecodeCustomAttributeParameterTypeOrThrow(ref sigReader, out elementTypeCode, out elementType, out _, out _, isElementType: true);
                 type = GetSZArrayTypeSymbol(elementType, customModifiers: default(ImmutableArray<ModifierInfo<TypeSymbol>>));
                 typeCode = SerializationTypeCode.SZArray;
                 return;
@@ -1404,7 +1403,7 @@ namespace Microsoft.CodeAnalysis
 
                 SerializationTypeCode unusedElementTypeCode;
                 TypeSymbol unusedElementType;
-                DecodeCustomAttributeFieldOrPropTypeOrThrow(ref argReader, out elementTypeCode, out elementType, out unusedElementTypeCode, out unusedElementType, isElementType: true);
+                DecodeCustomAttributeFieldOrPropTypeOrThrow(ref argReader, out elementTypeCode, out elementType, out _, out _, isElementType: true);
                 type = GetSZArrayTypeSymbol(elementType, customModifiers: default(ImmutableArray<ModifierInfo<TypeSymbol>>));
                 return;
             }
@@ -1819,7 +1818,7 @@ namespace Microsoft.CodeAnalysis
             for (int i = 0; i < result.Length; i++)
             {
                 bool refersToNoPiaLocalType;
-                result[i] = DecodeTypeOrThrow(ref signatureReader, out refersToNoPiaLocalType);
+                result[i] = DecodeTypeOrThrow(ref signatureReader, out _);
             }
 
             return result;

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
@@ -482,7 +482,7 @@ namespace Microsoft.CodeAnalysis
         internal static int InferTypeArityFromMetadataName(string emittedTypeName)
         {
             int suffixStartsAt;
-            return InferTypeArityFromMetadataName(emittedTypeName, out suffixStartsAt);
+            return InferTypeArityFromMetadataName(emittedTypeName, out _);
         }
 
         private static short InferTypeArityFromMetadataName(string emittedTypeName, out int suffixStartsAt)

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -934,7 +934,7 @@ namespace Microsoft.CodeAnalysis
         internal bool IsNoPiaLocalType(TypeDefinitionHandle typeDef)
         {
             AttributeInfo attributeInfo;
-            return IsNoPiaLocalType(typeDef, out attributeInfo);
+            return IsNoPiaLocalType(typeDef, out _);
         }
 
         internal bool HasParamsAttribute(EntityHandle token)

--- a/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis
 
             MetadataHelpers.AssemblyQualifiedTypeName fullName = MetadataHelpers.DecodeTypeName(s);
             bool refersToNoPiaLocalType;
-            return GetTypeSymbol(fullName, out refersToNoPiaLocalType);
+            return GetTypeSymbol(fullName, out _);
         }
 
         protected TypeSymbol GetUnsupportedMetadataTypeSymbol(BadImageFormatException exception = null)

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentity.DisplayName.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentity.DisplayName.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             PooledStringBuilder sb = PooledStringBuilder.GetInstance();
-            StringBuilder builder = sb.Builder;
+            _ = sb.Builder;
             AppendKey(sb, key);
             return sb.ToStringAndFree();
         }
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             AssemblyIdentityParts parts;
-            return TryParseDisplayName(displayName, out identity, out parts);
+            return TryParseDisplayName(displayName, out identity, out _);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityComparer.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityComparer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis
         public bool ReferenceMatchesDefinition(string referenceDisplayName, AssemblyIdentity definition)
         {
             bool unificationApplied;
-            return Compare(null, referenceDisplayName, definition, out unificationApplied, ignoreVersion: false) != ComparisonResult.NotEquivalent;
+            return Compare(null, referenceDisplayName, definition, out _, ignoreVersion: false) != ComparisonResult.NotEquivalent;
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis
         public bool ReferenceMatchesDefinition(AssemblyIdentity reference, AssemblyIdentity definition)
         {
             bool unificationApplied;
-            return Compare(reference, null, definition, out unificationApplied, ignoreVersion: false) != ComparisonResult.NotEquivalent;
+            return Compare(reference, null, definition, out _, ignoreVersion: false) != ComparisonResult.NotEquivalent;
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis
         public ComparisonResult Compare(AssemblyIdentity reference, AssemblyIdentity definition)
         {
             bool unificationApplied;
-            return Compare(reference, null, definition, out unificationApplied, ignoreVersion: true);
+            return Compare(reference, null, definition, out _, ignoreVersion: true);
         }
 
         // internal for testing

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityMap.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentityMap.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
         public bool Contains(AssemblyIdentity identity, bool allowHigherVersion = true)
         {
             TValue value;
-            return TryGetValue(identity, out value, allowHigherVersion);
+            return TryGetValue(identity, out _, allowHigherVersion);
         }
 
         public bool TryGetValue(AssemblyIdentity identity, out TValue value, bool allowHigherVersion = true)

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -129,7 +129,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             }
 
             ControlFlowRegion region = root.ToImmutableRegionAndFree(blocks, localFunctions, localFunctionsMap, anonymousFunctionsMapOpt, enclosing);
-            root = null;
             MarkReachableBlocks(blocks);
 
             Debug.Assert(builder._evalStack.Count == 0);
@@ -3021,7 +3020,7 @@ oneMoreTime:
             while (true)
             {
                 testExpression = currentConditionalAccess.Operation;
-                SyntaxNode testExpressionSyntax = testExpression.Syntax;
+                _ = testExpression.Syntax;
                 ITypeSymbol testExpressionType = testExpression.Type;
 
                 PushOperand(Visit(testExpression));
@@ -3828,12 +3827,10 @@ oneMoreTime:
 
             EnterRegion(new RegionBuilder(ControlFlowRegionKind.TryAndFinally));
             EnterRegion(new RegionBuilder(ControlFlowRegionKind.Try));
-
-            IOperation lockTaken = null;
             if (!legacyMode)
             {
                 // Monitor.Enter($lock, ref $lockTaken);
-                lockTaken = new LocalReferenceExpression(baseLockStatement.LockTakenSymbol, isDeclaration: true, semanticModel: null, lockedValue.Syntax,
+                IOperation lockTaken = new LocalReferenceExpression(baseLockStatement.LockTakenSymbol, isDeclaration: true, semanticModel: null, lockedValue.Syntax,
                                                          baseLockStatement.LockTakenSymbol.Type, constantValue: default, isImplicit: true);
                 AddStatement(new InvocationExpression(enterMethod, instance: null, isVirtual: false,
                                                       ImmutableArray.Create<IArgumentOperation>(
@@ -4291,8 +4288,6 @@ oneMoreTime:
                 else
                 {
                     SpillEvalStack();
-                    RegionBuilder currentRegion = _currentRegion;
-
                     limitValueId = GetNextCaptureId(loopRegion);
                     VisitAndCapture(operation.LimitValue, limitValueId);
 
@@ -4566,11 +4561,9 @@ oneMoreTime:
                         return;
                     }
 
-                    IOperation eitherLimitOrControlVariableIsNull = null;
-
                     if (ITypeSymbolHelpers.IsNullableType(operation.LimitValue.Type))
                     {
-                        eitherLimitOrControlVariableIsNull = new BinaryOperatorExpression(BinaryOperatorKind.Or,
+                        IOperation eitherLimitOrControlVariableIsNull = new BinaryOperatorExpression(BinaryOperatorKind.Or,
                                                                                           MakeIsNullOperation(limitReference, booleanType),
                                                                                           MakeIsNullOperation(PopOperand(), booleanType),
                                                                                           isLifted: false,
@@ -5052,7 +5045,10 @@ oneMoreTime:
                         throw ExceptionUtilities.UnexpectedValue(relationalValueClause.Relation);
 
                     case CaseKind.Default:
-                        var defaultClause = (IDefaultCaseClauseOperation)caseClause;
+                        {
+                            _ = (IDefaultCaseClauseOperation)caseClause;
+                        }
+
                         if (defaultBody == null)
                         {
                             defaultBody = labeled;

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1135,7 +1135,7 @@ namespace Microsoft.Cci
         internal BlobHandle GetMethodSignatureHandle(IMethodReference methodReference)
         {
             ImmutableArray<byte> signatureBlob;
-            return GetMethodSignatureHandleAndBlob(methodReference, out signatureBlob);
+            return GetMethodSignatureHandleAndBlob(methodReference, out _);
         }
 
         internal byte[] GetMethodSignature(IMethodReference methodReference)
@@ -4113,7 +4113,7 @@ namespace Microsoft.Cci
                 Debug.Assert(!_writer._tableIndicesAreComplete);
 #if DEBUG
                 int i;
-                Debug.Assert(!this.TryGetValue(item, out i));
+                Debug.Assert(!this.TryGetValue(item, out _));
 #endif
                 int index = _firstRowId + _rows.Count;
                 this.AddItem(item, index);

--- a/src/Compilers/Core/Portable/RealParser.cs
+++ b/src/Compilers/Core/Portable/RealParser.cs
@@ -342,9 +342,7 @@ namespace Microsoft.CodeAnalysis
                     int firstExponent = i;
                     int lastExponent = i;
                     while (i < source.Length && source[i] >= '0' && source[i] <= '9') lastExponent = ++i;
-
-                    int exponentMagnitude = 0;
-
+                    int exponentMagnitude;
                     if (int.TryParse(source.Substring(firstExponent, lastExponent - firstExponent), out exponentMagnitude) &&
                         exponentMagnitude <= MAX_EXP)
                     {
@@ -680,7 +678,7 @@ namespace Microsoft.CodeAnalysis
         private static uint CountSignificantBits(BigInteger data)
         {
             byte[] dataBytes;
-            return CountSignificantBits(data, out dataBytes);
+            return CountSignificantBits(data, out _);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/RuleSet/RuleSetProcessor.cs
+++ b/src/Compilers/Core/Portable/RuleSet/RuleSetProcessor.cs
@@ -63,13 +63,12 @@ So we suppress this error until the reporting for CA3053 has been updated to acc
             // First read the file without doing any validation
             filePath = FileUtilities.NormalizeAbsolutePath(filePath);
             XmlReaderSettings settings = GetDefaultXmlReaderSettings();
-
-            XDocument ruleSetDocument = null;
             XElement ruleSetNode = null;
 
             using (Stream stream = FileUtilities.OpenRead(filePath))
             using (XmlReader xmlReader = XmlReader.Create(stream, settings))
             {
+                XDocument ruleSetDocument;
                 try
                 {
                     ruleSetDocument = XDocument.Load(xmlReader);

--- a/src/Compilers/Core/Portable/StrongName/CryptoBlobParser.cs
+++ b/src/Compilers/Core/Portable/StrongName/CryptoBlobParser.cs
@@ -251,13 +251,11 @@ namespace Microsoft.CodeAnalysis
         internal static RSAParameters ToRSAParameters(this byte[] cspBlob, bool includePrivateParameters)
         {
             BinaryReader br = new BinaryReader(new MemoryStream(cspBlob));
-
-            byte bType = br.ReadByte();    // BLOBHEADER.bType: Expected to be 0x6 (PUBLICKEYBLOB) or 0x7 (PRIVATEKEYBLOB), though there's no check for backward compat reasons. 
-            byte bVersion = br.ReadByte(); // BLOBHEADER.bVersion: Expected to be 0x2, though there's no check for backward compat reasons.
+            _ = br.ReadByte();    // BLOBHEADER.bType: Expected to be 0x6 (PUBLICKEYBLOB) or 0x7 (PRIVATEKEYBLOB), though there's no check for backward compat reasons. 
+            _ = br.ReadByte(); // BLOBHEADER.bVersion: Expected to be 0x2, though there's no check for backward compat reasons.
             br.ReadUInt16();               // BLOBHEADER.wReserved
-            int algId = br.ReadInt32();    // BLOBHEADER.aiKeyAlg
-
-            int magic = br.ReadInt32();    // RSAPubKey.magic: Expected to be 0x31415352 ('RSA1') or 0x32415352 ('RSA2') 
+            _ = br.ReadInt32();    // BLOBHEADER.aiKeyAlg
+            _ = br.ReadInt32();    // RSAPubKey.magic: Expected to be 0x31415352 ('RSA1') or 0x32415352 ('RSA2') 
             int bitLen = br.ReadInt32();   // RSAPubKey.bitLen
 
             int modulusLength = bitLen / 8;

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTreeExtensions.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTreeExtensions.cs
@@ -68,7 +68,8 @@ namespace Microsoft.CodeAnalysis
                 {
                     var position = text.Lines.GetLinePosition(index);
                     var line = text.Lines[position.Line];
-                    var allText = text.ToString(); // Entire document as string to allow inspecting the text in the debugger.
+                    string allText;
+                    _ = text.ToString(); // Entire document as string to allow inspecting the text in the debugger.
                     message = $"Unexpected difference at offset {index}: Line {position.Line + 1}, Column {position.Character + 1} \"{line.ToString()}\"  (Found: [{found}] Expected: [{expected}])";
                 }
                 else

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Text
                 for (var info = this; info != null; info = info.Previous)
                 {
                     SourceText tmp;
-                    if (info.WeakOldText.TryGetTarget(out tmp))
+                    if (info.WeakOldText.TryGetTarget(out _))
                     {
                         lastInfo = info;
                     }

--- a/src/Compilers/Core/Portable/Text/SourceTextStream.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextStream.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Text
 
                 int charsUsed, bytesUsed;
                 bool ignored;
-                _encoder.Convert(_charBuffer, _bufferOffset, _bufferUnreadChars, buffer, offset, count, flush: false, charsUsed: out charsUsed, bytesUsed: out bytesUsed, completed: out ignored);
+                _encoder.Convert(_charBuffer, _bufferOffset, _bufferUnreadChars, buffer, offset, count, flush: false, charsUsed: out charsUsed, bytesUsed: out bytesUsed, completed: out _);
                 _position += charsUsed;
                 _bufferOffset += charsUsed;
                 _bufferUnreadChars -= charsUsed;

--- a/src/Compilers/Core/Portable/Text/TextLine.cs
+++ b/src/Compilers/Core/Portable/Text/TextLine.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Text
 
                 int startLineBreak;
                 int lineBreakLength;
-                TextUtilities.GetStartAndLengthOfLineBreakEndingAt(_text, _endIncludingBreaks - 1, out startLineBreak, out lineBreakLength);
+                TextUtilities.GetStartAndLengthOfLineBreakEndingAt(_text, _endIncludingBreaks - 1, out _, out lineBreakLength);
                 return lineBreakLength;
             }
         }

--- a/src/Compilers/Core/Portable/VersionHelper.cs
+++ b/src/Compilers/Core/Portable/VersionHelper.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis
                     }
 
                     bool invalidFormat = false;
-                    System.Numerics.BigInteger number = 0;
+                    _ = 0;
 
                     //There could be an invalid character in the input so check for the presence of one and
                     //parse up to that point. examples of invalid characters are alphas and punctuation

--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Debugging
             }
 
             int offset = 0;
-            ReadGlobalHeader(customDebugInfo, ref offset, out var globalVersion, out var globalCount);
+            ReadGlobalHeader(customDebugInfo, ref offset, out var globalVersion, out var _);
 
             if (globalVersion != CustomDebugInfoConstants.Version)
             {

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -70,8 +70,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                     packageSources
                     },
                     cancellationToken).ConfigureAwait(false);
-
-                var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+                _ = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
 
                 if (result != null)
                 {
@@ -544,7 +543,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
         private ITypeSymbol GetAwaitInfo(SemanticModel semanticModel, ISyntaxFactsService syntaxFactsService, SyntaxNode node, CancellationToken cancellationToken)
         {
-            var awaitExpression = FirstAwaitExpressionAncestor(syntaxFactsService, node);
+            _ = FirstAwaitExpressionAncestor(syntaxFactsService, node);
 
             var innerExpression = syntaxFactsService.GetExpressionOfAwaitExpression(node);
 

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
@@ -97,8 +97,8 @@ namespace Microsoft.CodeAnalysis.AddImport
                 }
 
                 var project = _document.Project;
-                var projectId = project.Id;
-                var workspace = project.Solution.Workspace;
+                _ = project.Id;
+                _ = project.Solution.Workspace;
 
                 foreach (var result in results)
                 {
@@ -128,8 +128,8 @@ namespace Microsoft.CodeAnalysis.AddImport
                 }
 
                 var project = _document.Project;
-                var projectId = project.Id;
-                var workspace = project.Solution.Workspace;
+                _ = project.Id;
+                _ = project.Solution.Workspace;
 
                 foreach (var result in results)
                 {

--- a/src/Features/Core/Portable/AddPackage/AbstractAddSpecificPackageCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddPackage/AbstractAddSpecificPackageCodeFixProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.AddPackage
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            var cancellationToken = context.CancellationToken;
+            _ = context.CancellationToken;
             var assemblyName = GetAssemblyName(context.Diagnostics[0].Id);
 
             if (assemblyName != null)

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -166,8 +166,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         {
             var notificationService = context.Solution.Workspace.Services.GetService<INotificationService>();
             var changeSignatureOptionsService = context.Solution.Workspace.Services.GetService<IChangeSignatureOptionsService>();
-
-            var isExtensionMethod = context.Symbol is IMethodSymbol && (context.Symbol as IMethodSymbol).IsExtensionMethod;
+            _ = context.Symbol is IMethodSymbol && (context.Symbol as IMethodSymbol).IsExtensionMethod;
             return changeSignatureOptionsService.GetChangeSignatureOptions(context.Symbol, context.ParameterConfiguration, notificationService);
         }
 

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.GlobalSuppressMessageCodeAction.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 var suppressionsDoc = await GetOrCreateSuppressionsDocumentAsync(cancellationToken).ConfigureAwait(false);
                 var workspace = suppressionsDoc.Project.Solution.Workspace;
                 var suppressionsRoot = await suppressionsDoc.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-                var semanticModel = await suppressionsDoc.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                _ = await suppressionsDoc.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 suppressionsRoot = await Fixer.AddGlobalSuppressMessageAttributeAsync(suppressionsRoot, _targetSymbol, _diagnostic, workspace, cancellationToken).ConfigureAwait(false);
                 return suppressionsDoc.WithSyntaxRoot(suppressionsRoot);
             }

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction_Pragma.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction_Pragma.cs
@@ -64,10 +64,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 {
                     bool add = false;
                     bool toggle = false;
-
-                    int indexOfLeadingPragmaDisableToRemove = -1, indexOfTrailingPragmaEnableToRemove = -1;
+                    int indexOfTrailingPragmaEnableToRemove = -1;
+                    int indexOfLeadingPragmaDisableToRemove;
                     if (CanRemovePragmaTrivia(_suppressionTargetInfo.StartToken, _diagnostic, Fixer, isStartToken: true, indexOfTriviaToRemove: out indexOfLeadingPragmaDisableToRemove) &&
-                        CanRemovePragmaTrivia(_suppressionTargetInfo.EndToken, _diagnostic, Fixer, isStartToken: false, indexOfTriviaToRemove: out indexOfTrailingPragmaEnableToRemove))
+CanRemovePragmaTrivia(_suppressionTargetInfo.EndToken, _diagnostic, Fixer, isStartToken: false, indexOfTriviaToRemove: out indexOfTrailingPragmaEnableToRemove))
                     {
                         // Verify if there is no other trivia before the start token would again cause this diagnostic to be suppressed.
                         // If invalidated, then we just toggle existing pragma enable and disable directives before and start of the line.

--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
                 return null;
             }
 
-            var cacheService = solution.Services.CacheService;
+            _ = solution.Services.CacheService;
 
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             /// </remarks>
             internal override async Task<ImmutableArray<CodeActionOperation>> GetOperationsAsync()
             {
-                var solution = SemanticDocument.Document.Project.Solution;
+                _ = SemanticDocument.Document.Project.Solution;
 
                 // Fork, update and add as new document.
                 var projectToBeUpdated = SemanticDocument.Document.Project;

--- a/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             TextLine line,
             CancellationToken cancellationToken)
         {
-            var syntaxFactory = document.GetLanguageService<SyntaxGenerator>();
+            _ = document.GetLanguageService<SyntaxGenerator>();
             var codeGenService = document.GetLanguageService<ICodeGenerationService>();
 
             // Resolve member and type in our new, forked, solution

--- a/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
@@ -60,8 +60,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var uninitializedMembers = members.Where(m => !alreadyTypedMembers.Contains(m.Name));
 
             uninitializedMembers = uninitializedMembers.Where(m => m.IsEditorBrowsable(document.ShouldHideAdvancedMembers(), semanticModel.Compilation));
-
-            var text = await semanticModel.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            _ = await semanticModel.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (var uninitializedMember in uninitializedMembers)
             {

--- a/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
@@ -305,8 +305,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             var position = GetDescriptionPosition(item);
             var supportedPlatforms = GetSupportedPlatforms(item, workspace);
-
-            var contextDocument = FindAppropriateDocumentForDescriptionContext(document, supportedPlatforms);
+            _ = FindAppropriateDocumentForDescriptionContext(document, supportedPlatforms);
 
             if (symbols.Length != 0)
             {

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticEventTaskScheduler.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticEventTaskScheduler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             while (true)
             {
                 var task = _tasks.Take();
-                bool ret = this.TryExecuteTask(task);
+                _ = this.TryExecuteTask(task);
             }
         }
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticHelper.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 message = new LocalizableStringWithArguments(descriptor.MessageFormat, messageArgs);
             }
 
-            var warningLevel = effectiveSeverity.ToDiagnosticSeverity() ?? descriptor.DefaultSeverity;
+            _ = effectiveSeverity.ToDiagnosticSeverity() ?? descriptor.DefaultSeverity;
             return Diagnostic.Create(
                 descriptor.Id,
                 descriptor.Category,

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InMemoryStorage.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InMemoryStorage.cs
@@ -47,18 +47,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return;
                 }
 
-                analyzerMap.TryRemove(key, out var entry);
+                analyzerMap.TryRemove(key, out var _);
 
                 if (analyzerMap.IsEmpty)
                 {
-                    s_map.TryRemove(analyzer, out analyzerMap);
+                    s_map.TryRemove(analyzer, out _);
                 }
             }
 
             public static void DropCache(DiagnosticAnalyzer analyzer)
             {
                 // drop any cache related to given analyzer
-                s_map.TryRemove(analyzer, out var analyzerMap);
+                s_map.TryRemove(analyzer, out var _);
             }
 
             // make sure key is either documentId or projectId

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         return;
                     }
 
-                    _stateMap.TryRemove(projectId, out var unused);
+                    _stateMap.TryRemove(projectId, out var _);
                 }
 
                 private ImmutableDictionary<DiagnosticAnalyzer, StateSet> GetOrUpdateAnalyzerMap(Project project)

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             {
                 // remove active file state for removed document
                 var removed = false;
-                if (_activeFileStates.TryRemove(id, out var activeFileState))
+                if (_activeFileStates.TryRemove(id, out var _))
                 {
                     removed = true;
                 }

--- a/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public bool IsCompilerDiagnostic(string language, DiagnosticData diagnostic)
         {
-            var map = GetHostDiagnosticAnalyzersPerReference(language);
+            _ = GetHostDiagnosticAnalyzersPerReference(language);
             if (_compilerDiagnosticAnalyzerMap.TryGetValue(language, out var compilerAnalyzer) &&
                 _compilerDiagnosticAnalyzerDescriptorMap.TryGetValue(compilerAnalyzer, out var idMap) &&
                 idMap.Contains(diagnostic.Id))
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public DiagnosticAnalyzer GetCompilerDiagnosticAnalyzer(string language)
         {
-            var map = GetHostDiagnosticAnalyzersPerReference(language);
+            _ = GetHostDiagnosticAnalyzersPerReference(language);
             if (_compilerDiagnosticAnalyzerMap.TryGetValue(language, out var compilerAnalyzer))
             {
                 return compilerAnalyzer;
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public bool IsCompilerDiagnosticAnalyzer(string language, DiagnosticAnalyzer analyzer)
         {
-            var map = GetHostDiagnosticAnalyzersPerReference(language);
+            _ = GetHostDiagnosticAnalyzersPerReference(language);
             return _compilerDiagnosticAnalyzerMap.TryGetValue(language, out var compilerAnalyzer) && compilerAnalyzer == analyzer;
         }
 
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public string GetDiagnosticAnalyzerPackageName(string language, DiagnosticAnalyzer analyzer)
         {
-            var map = GetHostDiagnosticAnalyzersPerReference(language);
+            _ = GetHostDiagnosticAnalyzersPerReference(language);
             if (_hostDiagnosticAnalyzerPackageNameMap.TryGetValue(analyzer, out var name))
             {
                 return name;

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         private SyntaxNode FindStatement(SyntaxNode declarationBody, int position, out int statementPart)
         {
-            return FindStatementAndPartner(declarationBody, position, null, out var partner, out statementPart);
+            return FindStatementAndPartner(declarationBody, position, null, out var _, out statementPart);
         }
 
         /// <summary>
@@ -1019,7 +1019,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             for (int i = 0; i < activeNodes.Length; i++)
             {
                 int ordinal = start + i;
-                bool hasMatching = false;
                 bool isNonLeaf = oldActiveStatements[ordinal].IsNonLeaf;
                 bool isPartiallyExecuted = (oldActiveStatements[ordinal].Flags & ActiveStatementFlags.PartiallyExecuted) != 0;
                 int statementPart = activeNodes[i].StatementPart;
@@ -1031,7 +1030,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 TextSpan newSpan;
                 SyntaxNode newStatementSyntaxOpt;
                 Match<SyntaxNode> match;
-
+                bool hasMatching;
                 if (oldEnclosingLambdaBody == null)
                 {
                     match = bodyMatch;

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         internal bool HasProject(ProjectId id)
         {
-            return Projects.TryGetValue(id, out var reason);
+            return Projects.TryGetValue(id, out var _);
         }
 
         private List<(DocumentId, AsyncLazy<DocumentAnalysisResults>)> GetChangedDocumentsAnalyses(Project baseProject, Project project)

--- a/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
@@ -183,7 +183,6 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
             var compilation = semanticModel.Compilation;
             field = field.GetSymbolKey().Resolve(compilation, cancellationToken: cancellationToken).Symbol as IFieldSymbol;
 
-            var solutionNeedingProperty = solution;
 
             // We couldn't resolve field after annotating its declaration. Bail
             if (field == null)
@@ -191,7 +190,7 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
                 return null;
             }
 
-            solutionNeedingProperty = await UpdateReferencesAsync(
+            var solutionNeedingProperty = await UpdateReferencesAsync(
                 updateReferences, solution, document, field, finalFieldName, generatedPropertyName, cancellationToken).ConfigureAwait(false);
             document = solutionNeedingProperty.GetDocument(document.Id);
 
@@ -212,15 +211,14 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
             document = solution.GetDocument(document.Id);
 
             semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            compilation = semanticModel.Compilation;
+            _ = semanticModel.Compilation;
 
             var newRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var newDeclaration = newRoot.GetAnnotatedNodes<SyntaxNode>(declarationAnnotation).First();
             field = semanticModel.GetDeclaredSymbol(newDeclaration, cancellationToken) as IFieldSymbol;
 
             var generatedProperty = GenerateProperty(generatedPropertyName, finalFieldName, originalField.DeclaredAccessibility, originalField, field.ContainingType, new SyntaxAnnotation(), document, cancellationToken);
-
-            var codeGenerationService = document.GetLanguageService<ICodeGenerationService>();
+            _ = document.GetLanguageService<ICodeGenerationService>();
             var solutionWithProperty = await AddPropertyAsync(
                 document, document.Project.Solution, field, generatedProperty, cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
         private static string GetNodeName(Document document, SyntaxNode node)
         {
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
-            syntaxFacts.GetNameAndArityOfSimpleName(node, out var name, out var arity);
+            syntaxFacts.GetNameAndArityOfSimpleName(node, out var name, out var _);
             return name;
         }
 

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
@@ -238,8 +238,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                 var provider = _document.Project.Solution.Workspace.Services.GetLanguageServices(_state.TypeToGenerateIn.Language);
                 var syntaxFactory = provider.GetService<SyntaxGenerator>();
                 var codeGenerationService = provider.GetService<ICodeGenerationService>();
-
-                var syntaxTree = _document.SyntaxTree;
+                _ = _document.SyntaxTree;
                 var (fields, constructor) = syntaxFactory.CreateFieldDelegatingConstructor(
                     _document.SemanticModel.Compilation, 
                     _state.TypeToGenerateIn.Name, 

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
             }
 
             var compilation = semanticDocument.SemanticModel.Compilation;
-            var semanticFactsService = semanticDocument.Document.GetLanguageService<ISemanticFactsService>();
+            _ = semanticDocument.Document.GetLanguageService<ISemanticFactsService>();
 
             for (var i = 0; i < parameterTypes.Count; i++)
             {

--- a/src/Features/Core/Portable/GenerateMember/GenerateEnumMember/AbstractGenerateEnumMemberService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateEnumMember/AbstractGenerateEnumMemberService.CodeAction.cs
@@ -38,8 +38,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateEnumMember
                 var value = semanticFacts.LastEnumValueHasInitializer(_state.TypeToGenerateIn)
                     ? EnumValueUtilities.GetNextEnumValue(_state.TypeToGenerateIn, cancellationToken)
                     : null;
-
-                var syntaxTree = await _document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                _ = await _document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 var result = await codeGenerator.AddFieldAsync(
                     _document.Project.Solution,
                     _state.TypeToGenerateIn,

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.CodeAction.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
             protected override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
             {
                 var solution = _semanticDocument.Project.Solution;
-                var syntaxTree = _semanticDocument.SyntaxTree;
+                _ = _semanticDocument.SyntaxTree;
                 var generateUnsafe = _state.TypeMemberType.IsUnsafe() &&
                                      !_state.IsContainedInUnsafeType;
 

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
@@ -287,7 +287,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                     if (assignmentStatement != null)
                     {
                         syntaxFacts.GetPartsOfAssignmentStatement(
-                            assignmentStatement, out var left, out var right);
+                            assignmentStatement, out var left, out var _);
 
                         if (left == simpleName)
                         {
@@ -327,7 +327,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                         if (syntaxFacts.IsSimpleAssignmentStatement(siblingNode))
                         {
                             syntaxFacts.GetPartsOfAssignmentStatement(
-                                siblingNode, out var left, out var right);
+                                siblingNode, out var left, out var _);
 
                             var symbol = semanticDocument.SemanticModel.GetSymbolInfo(left, cancellationToken).Symbol;
                             if (symbol?.Kind == symbolKind &&

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.CodeAction.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 bool inNewFile,
                 bool isNested)
             {
-                var finalName = GetTypeName(state);
+                _ = GetTypeName(state);
 
                 if (inNewFile)
                 {
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 {
                     if (_intoNamespace)
                     {
-                        var namespaceToGenerateIn = string.IsNullOrEmpty(_state.NamespaceToGenerateInOpt) ? FeaturesResources.Global_Namespace : _state.NamespaceToGenerateInOpt;
+                        _ = string.IsNullOrEmpty(_state.NamespaceToGenerateInOpt) ? FeaturesResources.Global_Namespace : _state.NamespaceToGenerateInOpt;
                         return FormatDisplayText(_state, _inNewFile, isNested: false);
                     }
                     else
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                     return true;
                 }
 
-                TypeKindOptions typeKindValue = TypeKindOptions.None;
+                TypeKindOptions typeKindValue;
                 if (_service.TryGetBaseList(state.NameOrMemberAccessExpression, out typeKindValue) || _service.TryGetBaseList(state.SimpleName, out typeKindValue))
                 {
                     typeKindValueFinal = typeKindValue;

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 // True, Remove the RootNamespace
                 // False, Add Global to the Namespace
                 Debug.Assert(targetProject.Language == LanguageNames.VisualBasic);
-                IGenerateTypeService targetLanguageService = null;
+                IGenerateTypeService targetLanguageService;
                 if (_semanticDocument.Project.Language == LanguageNames.VisualBasic)
                 {
                     targetLanguageService = _service;
@@ -401,8 +401,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
                 var containers = namespaceContainersAndUsings.containers;
                 var includeUsingsOrImports = namespaceContainersAndUsings.usingOrImport;
-
-                Tuple<INamespaceSymbol, INamespaceOrTypeSymbol, Location> enclosingNamespaceGeneratedTypeToAddAndLocation = null;
+                Tuple<INamespaceSymbol, INamespaceOrTypeSymbol, Location> enclosingNamespaceGeneratedTypeToAddAndLocation;
                 if (_targetProjectChangeInLanguage == TargetProjectChangeInLanguage.NoChange)
                 {
                     enclosingNamespaceGeneratedTypeToAddAndLocation = await _service.GetOrGenerateEnclosingNamespaceSymbolAsync(
@@ -486,8 +485,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                         _targetProjectChangeInLanguage == TargetProjectChangeInLanguage.NoChange
                             ? _service.GetRootNamespace(_generateTypeOptionsResult.Project.CompilationOptions).Trim()
                             : _targetLanguageService.GetRootNamespace(_generateTypeOptionsResult.Project.CompilationOptions).Trim();
-
-                    var projectManagementService = _semanticDocument.Project.Solution.Workspace.Services.GetService<IProjectManagementService>();
+                    _ = _semanticDocument.Project.Solution.Workspace.Services.GetService<IProjectManagementService>();
                     var defaultNamespace = _generateTypeOptionsResult.DefaultNamespace;
 
                     // Case 1 : If the type is generated into the same C# project or
@@ -538,7 +536,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
             private async Task<IEnumerable<CodeActionOperation>> GetGenerateIntoTypeOperationsAsync(INamedTypeSymbol namedType)
             {
-                var codeGenService = GetCodeGenerationService();
+                _ = GetCodeGenerationService();
                 var solution = _semanticDocument.Project.Solution;
                 var codeGenResult = await CodeGenerator.AddNamedTypeDeclarationAsync(
                     solution,

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 IList<TArgumentSyntax> argumentList, ArrayBuilder<ISymbol> members, GenerateTypeOptionsResult options = null)
             {
                 var factory = _semanticDocument.Document.GetLanguageService<SyntaxGenerator>();
-                var syntaxFactsService = _semanticDocument.Document.GetLanguageService<ISyntaxFactsService>();
+                _ = _semanticDocument.Document.GetLanguageService<ISyntaxFactsService>();
 
                 var availableTypeParameters = _service.GetAvailableTypeParameters(_state, _semanticDocument.SemanticModel, _intoNamespace, _cancellationToken);
                 var parameterTypes = GetArgumentTypes(argumentList);

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
                 this.SimpleName = (TSimpleNameSyntax)node;
                 var syntaxFacts = semanticDocument.Document.GetLanguageService<ISyntaxFactsService>();
-                syntaxFacts.GetNameAndArityOfSimpleName(this.SimpleName, out var name, out var arity);
+                syntaxFacts.GetNameAndArityOfSimpleName(this.SimpleName, out var name, out var _);
 
                 this.Name = name;
                 this.NameIsVerbatim = syntaxFacts.IsVerbatimIdentifier(this.SimpleName.GetFirstToken());

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
 
                 foreach (var tuple in unimplementedMembers)
                 {
-                    var interfaceType = tuple.type;
+                    _ = tuple.type;
                     var unimplementedInterfaceMembers = tuple.members;
 
                     foreach (var unimplementedInterfaceMember in unimplementedInterfaceMembers)

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.DisposePatternCodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.DisposePatternCodeAction.cs
@@ -22,11 +22,10 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 var idisposableMembers = idisposable.GetMembers().ToArray();
 
                 // Get symbol for 'System.IDisposable.Dispose()'.
-                IMethodSymbol disposeMethod = null;
                 if ((idisposableMembers.Length == 1) && (idisposableMembers[0].Kind == SymbolKind.Method) &&
                     (idisposableMembers[0].Name == "Dispose"))
                 {
-                    disposeMethod = idisposableMembers[0] as IMethodSymbol;
+                    var disposeMethod = idisposableMembers[0] as IMethodSymbol;
                     if ((disposeMethod != null) && (!disposeMethod.IsStatic) && disposeMethod.ReturnsVoid &&
                         (disposeMethod.Arity == 0) && (disposeMethod.Parameters.Length == 0))
                     {
@@ -106,7 +105,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 CancellationToken cancellationToken)
             {
                 var result = document;
-                var compilation = await result.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+                _ = await result.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
 
                 // Add an annotation to the type declaration node so that we can find it again to append the dispose pattern implementation below.
                 result = await result.ReplaceNodeAsync(
@@ -115,7 +114,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                     cancellationToken).ConfigureAwait(false);
                 var root = await result.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 classOrStructDecl = root.GetAnnotatedNodes(s_implementingTypeAnnotation).Single();
-                compilation = await result.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+                var compilation = await result.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
                 classOrStructType = classOrStructType.GetSymbolKey().Resolve(compilation, cancellationToken: cancellationToken).Symbol as INamedTypeSymbol;
 
                 // Use the code generation service to generate all unimplemented members except those that are

--- a/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
 
             public override void RemoveProject(ProjectId projectId)
             {
-                _projectToInfo.TryRemove(projectId, out var info);
+                _projectToInfo.TryRemove(projectId, out var _);
 
                 RemoveMetadataReferences(projectId);
             }

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeMemberFromParameterCodeRefactoringProviderMemberCreation.cs
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
         }
 
         private IOperation TryFindFieldOrPropertyAssignmentStatement(IParameterSymbol parameter, IBlockOperation blockStatementOpt)
-            => TryFindFieldOrPropertyAssignmentStatement(parameter, blockStatementOpt, out var fieldOrProperty);
+            => TryFindFieldOrPropertyAssignmentStatement(parameter, blockStatementOpt, out var _);
 
         private IOperation TryFindFieldOrPropertyAssignmentStatement(
             IParameterSymbol parameter, IBlockOperation blockStatementOpt, out ISymbol fieldOrProperty)

--- a/src/Features/Core/Portable/InitializeParameter/AbstractInitializeParameterCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractInitializeParameterCodeRefactoringProvider.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
         }
 
         protected static bool IsFieldOrPropertyAssignment(IOperation statement, INamedTypeSymbol containingType, out IAssignmentOperation assignmentExpression)
-            => IsFieldOrPropertyAssignment(statement, containingType, out assignmentExpression, out var fieldOrProperty);
+            => IsFieldOrPropertyAssignment(statement, containingType, out assignmentExpression, out var _);
 
         protected static bool IsFieldOrPropertyAssignment(
             IOperation statement, INamedTypeSymbol containingType, 
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
         }
 
         protected static bool IsFieldOrPropertyReference(IOperation operation, INamedTypeSymbol containingType)
-            => IsFieldOrPropertyAssignment(operation, containingType, out var fieldOrProperty);
+            => IsFieldOrPropertyAssignment(operation, containingType, out var _);
 
         protected static bool IsFieldOrPropertyReference(
             IOperation operation, INamedTypeSymbol containingType, out ISymbol fieldOrProperty)

--- a/src/Features/Core/Portable/MoveDeclarationNearReference/AbstractMoveDeclarationNearReferenceService.cs
+++ b/src/Features/Core/Portable/MoveDeclarationNearReference/AbstractMoveDeclarationNearReferenceService.cs
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.MoveDeclarationNearReference
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
             syntaxFacts.GetPartsOfAssignmentStatement(
                 state.FirstStatementAffectedInInnermostBlock, 
-                out var left, out var operatorToken, out var right);
+                out var _, out var operatorToken, out var right);
 
             return state.DeclarationStatement.ReplaceNode(
                 state.VariableDeclarator,

--- a/src/Features/Core/Portable/Notification/SemanticChangeNotificationService.cs
+++ b/src/Features/Core/Portable/Notification/SemanticChangeNotificationService.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Notification
                 // now it runs for all workspace, make sure we get rid of entry from the map
                 // as soon as it is not needed.
                 // this whole thing will go away when workspace disable itself from solution crawler.
-                _map.TryRemove(documentId, out var unused);
+                _map.TryRemove(documentId, out var _);
             }
 
             public void RemoveProject(ProjectId projectId)

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessCodeFixprovider.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessCodeFixprovider.cs
@@ -35,8 +35,8 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
             Document document, ImmutableArray<Diagnostic> diagnostics, 
             SyntaxEditor editor, CancellationToken cancellationToken)
         {
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            _ = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            _ = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var generator = document.GetLanguageService<SyntaxGenerator>();
 
             foreach (var diagnostic in diagnostics)

--- a/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.cs
+++ b/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.cs
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.QuickInfo
             ISyntaxFactsService syntaxFactsService,
             CancellationToken cancellationToken)
         {
-            if (sections.TryGetValue(SymbolDescriptionGroups.Documentation, out var parts))
+            if (sections.TryGetValue(SymbolDescriptionGroups.Documentation, out var _))
             {
                 var documentationBuilder = new List<TaggedText>();
                 documentationBuilder.AddRange(sections[SymbolDescriptionGroups.Documentation]);

--- a/src/Features/Core/Portable/QuickInfo/IndentationHelper.cs
+++ b/src/Features/Core/Portable/QuickInfo/IndentationHelper.cs
@@ -32,14 +32,12 @@ namespace Microsoft.CodeAnalysis.QuickInfo
                 // We need to figure out the shortest indentation level of the exposed lines.  We'll
                 // then remove that indentation from all lines.
                 var indentationColumn = DetermineIndentationColumn(text, classifiedSpans, tabSize);
-
-                string spanClassificationType = null;
                 var adjustedClassifiedSpans = new List<ClassifiedSpan>();
 
                 for (var i = 0; i < classifiedSpans.Length; i++)
                 {
                     var classifiedSpan = classifiedSpans[i];
-                    spanClassificationType = classifiedSpan.ClassificationType;
+                    var spanClassificationType = classifiedSpan.ClassificationType;
                     var span = classifiedSpan.TextSpan;
 
                     var startLineNumber = text.Lines.GetLineFromPosition(span.Start).LineNumber;

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -450,8 +450,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                             AddDebuggerDisplayAttributeArguments(nestedType, builder);
                             break;
 
-                        case IPropertySymbol property:
-                        case IFieldSymbol field:
+                        case IPropertySymbol _:
+                        case IFieldSymbol _:
                             AddDebuggerDisplayAttributeArgumentsCore(member, builder);
                             break;
                     }

--- a/src/Features/Core/Portable/SimplifyTypeNames/AbstractSimplifyTypeNamesCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SimplifyTypeNames/AbstractSimplifyTypeNamesCodeFixProvider.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
             diagnosticId = null;
             if (!_analyzer.IsCandidate(node) ||
                 !_analyzer.CanSimplifyTypeNameExpression(
-                    model, node, optionSet, out var issueSpan, out diagnosticId, out var inDeclaration, cancellationToken))
+                    model, node, optionSet, out var issueSpan, out diagnosticId, out var _, cancellationToken))
             {
                 return false;
             }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -261,13 +261,12 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 internal ProjectId GetActiveProject()
                 {
-                    ProjectId activeProjectId = null;
                     if (_documentTracker != null)
                     {
                         var activeDocument = _documentTracker.TryGetActiveDocument();
                         if (activeDocument != null)
                         {
-                            activeProjectId = activeDocument.ProjectId;
+                            _ = activeDocument.ProjectId;
                         }
                     }
 
@@ -299,8 +298,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 internal void WaitUntilCompletion_ForTestingPurposesOnly(ImmutableArray<IIncrementalAnalyzer> analyzers, List<WorkItem> items)
                 {
                     _normalPriorityProcessor.WaitUntilCompletion_ForTestingPurposesOnly(analyzers, items);
-
-                    var projectItems = items.Select(i => i.With(null, i.ProjectId, EmptyAsyncToken.Instance));
+                    _ = items.Select(i => i.With(null, i.ProjectId, EmptyAsyncToken.Instance));
                     _lowPriorityProcessor.WaitUntilCompletion_ForTestingPurposesOnly(analyzers, items);
                 }
 

--- a/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionForNullableDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionForNullableDiagnosticAnalyzer.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
             }
 
             syntaxFacts.GetPartsOfMemberAccessExpression(conditionMemberAccess, out var conditionExpression, out var conditionSimpleName);
-            syntaxFacts.GetNameAndArityOfSimpleName(conditionSimpleName, out var conditionName, out var unused);
+            syntaxFacts.GetNameAndArityOfSimpleName(conditionSimpleName, out var conditionName, out var _);
 
             if (conditionName != nameof(Nullable<int>.HasValue))
             {
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
             }
 
             syntaxFacts.GetPartsOfMemberAccessExpression(whenPartMemberAccess, out var whenPartExpression, out var whenPartSimpleName);
-            syntaxFacts.GetNameAndArityOfSimpleName(whenPartSimpleName, out var whenPartName, out unused);
+            syntaxFacts.GetNameAndArityOfSimpleName(whenPartSimpleName, out var whenPartName, out _);
 
             if (whenPartName != nameof(Nullable<int>.Value))
             {

--- a/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/AbstractUseConditionalExpressionForAssignmentCodeFixProvider.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
                 return false;
             }
 
-            var variableName = variable.Name;
+            _ = variable.Name;
 
             var variableInitializer = declarator.Initializer ?? declaration.Initializer;
             if (variableInitializer?.Value != null)

--- a/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/UseConditionalExpressionForAssignmentHelpers.cs
+++ b/src/Features/Core/Portable/UseConditionalExpression/ForAssignment/UseConditionalExpressionForAssignmentHelpers.cs
@@ -13,7 +13,6 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
             out ISimpleAssignmentOperation trueAssignment,
             out ISimpleAssignmentOperation falseAssignment)
         {
-            trueAssignment = null;
             falseAssignment = null;
 
             var trueStatement = ifOperation.WhenTrue;

--- a/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameCodeFixProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.UseExplicitTupleName
             Document document, ImmutableArray<Diagnostic> diagnostics,
             SyntaxEditor editor, CancellationToken cancellationToken)
         {
-            var root = editor.OriginalRoot;
+            _ = editor.OriginalRoot;
             var generator = editor.Generator;
 
             foreach (var diagnostic in diagnostics)

--- a/src/Features/Core/Portable/Workspace/ProjectCacheService.cs
+++ b/src/Features/Core/Portable/Workspace/ProjectCacheService.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Host
 
             internal void CreateStrongReference(object key, object instance)
             {
-                if (!_cache.TryGetValue(key, out var o))
+                if (!_cache.TryGetValue(key, out var _))
                 {
                     _cache.Add(key, instance);
                 }

--- a/src/Workspaces/Core/Portable/AddImports/AbstractAddImportsService.cs
+++ b/src/Workspaces/Core/Portable/AddImports/AbstractAddImportsService.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.AddImports
 
             switch (import)
             {
-                case TExternSyntax e: return externContainer;
+                case TExternSyntax _: return externContainer;
                 case TUsingOrAliasSyntax u: return IsAlias(u) ? aliasContainer : usingContainer;
             }
 

--- a/src/Workspaces/Core/Portable/CaseCorrection/CaseCorrector.cs
+++ b/src/Workspaces/Core/Portable/CaseCorrection/CaseCorrector.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CaseCorrection
         /// </summary>
         public static async Task<Document> CaseCorrectAsync(Document document, TextSpan span, CancellationToken cancellationToken = default)
         {
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            _ = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             return await CaseCorrectAsync(document, ImmutableArray.Create(span), cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
@@ -331,7 +331,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             foreach (var span in spans)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var spanAlignedToTokens = GetSpanAlignedToTokens(syntaxFactsService, root, span, out var startToken, out var endToken);
+                _ = GetSpanAlignedToTokens(syntaxFactsService, root, span, out var startToken, out var endToken);
 
                 var previousToken = startToken.GetPreviousToken(includeZeroWidth: true, includeSkipped: true, includeDirectives: true, includeDocumentationComments: true);
                 var nextToken = endToken.GetNextToken(includeZeroWidth: true, includeSkipped: true, includeDirectives: true, includeDocumentationComments: true);

--- a/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         }
 
         public bool CanAddTo(SyntaxNode destination, Solution solution, CancellationToken cancellationToken)
-            => CanAddTo(destination, solution, cancellationToken, out var availableIndices);
+            => CanAddTo(destination, solution, cancellationToken, out var _);
 
         private bool CanAddTo(SyntaxNode destination, Solution solution, CancellationToken cancellationToken,
             out IList<bool> availableIndices, bool checkGeneratedCode = false)

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
 
                 var start = reader.ReadInt32();
                 var length = reader.ReadInt32();
-                var textSpan = new TextSpan(start, length);
+                _ = new TextSpan(start, length);
 
                 var location = ReadLocation(project, reader, document);
                 var additionalLocations = ReadAdditionalLocations(project, reader);

--- a/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
+++ b/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis.Differencing
 
                     // start point
                     int yStart = currentV[kPrev];
-                    int xStart = yStart + kPrev;
+                    _ = yStart + kPrev;
 
                     // mid point
                     int yMid = right ? yStart : yStart + 1;

--- a/src/Workspaces/Core/Portable/Differencing/Match.cs
+++ b/src/Workspaces/Core/Portable/Differencing/Match.cs
@@ -31,8 +31,8 @@ namespace Microsoft.CodeAnalysis.Differencing
             _comparer = comparer;
 
             int labelCount = comparer.LabelCount;
-            CategorizeNodesByLabels(comparer, root1, labelCount, out var nodes1, out var count1);
-            CategorizeNodesByLabels(comparer, root2, labelCount, out var nodes2, out var count2);
+            CategorizeNodesByLabels(comparer, root1, labelCount, out var nodes1, out var _);
+            CategorizeNodesByLabels(comparer, root2, labelCount, out var nodes2, out var _);
 
             _oneToTwo = new Dictionary<TNode, TNode>();
             _twoToOne = new Dictionary<TNode, TNode>();

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -47,8 +47,6 @@ namespace Microsoft.CodeAnalysis.Editing
         {
             var field = symbol as IFieldSymbol;
             var property = symbol as IPropertySymbol;
-            var method = symbol as IMethodSymbol;
-
             return new DeclarationModifiers(
                 isStatic: symbol.IsStatic,
                 isAbstract: symbol.IsAbstract,

--- a/src/Workspaces/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexLexer.cs
+++ b/src/Workspaces/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexLexer.cs
@@ -113,9 +113,6 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
             }
 
             var result = ArrayBuilder<RegexTrivia>.GetInstance();
-
-            var start = Position;
-
             while (Position < Text.Length)
             {
                 var comment = ScanComment(options);

--- a/src/Workspaces/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexParser.cs
+++ b/src/Workspaces/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexParser.cs
@@ -856,7 +856,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
         private RegexExpressionNode CheckConditionalAlternation(RegexExpressionNode result)
         {
             if (result is RegexAlternationNode topAlternation &&
-                topAlternation.Left is RegexAlternationNode innerAlternation)
+                topAlternation.Left is RegexAlternationNode _)
             {
                 return new RegexAlternationNode(
                     topAlternation.Left,
@@ -1462,7 +1462,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
             if (_currentToken.Kind == RegexKind.BackslashToken && _lexer.Position < _lexer.Text.Length)
             {
                 var backslashToken = _currentToken;
-                var afterSlash = _lexer.Position;
+                _ = _lexer.Position;
 
                 // trivia is not allowed anywhere in a character class, and definitely not between
                 // a \ and the following character.

--- a/src/Workspaces/Core/Portable/Execution/AssetStorages.cs
+++ b/src/Workspaces/Core/Portable/Execution/AssetStorages.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Execution
         public void RemoveGlobalAsset(object value, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            _globalAssets.TryRemove(value, out var asset);
+            _globalAssets.TryRemove(value, out var _);
         }
 
         public Storage CreateStorage(SolutionState solutionState)
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Execution
         public void UnregisterSnapshot(PinnedRemotableDataScope scope)
         {
             // calling it multiple times for same snapshot is not allowed.
-            if (!_storages.TryRemove(scope.SolutionInfo.ScopeId, out var dummy))
+            if (!_storages.TryRemove(scope.SolutionInfo.ScopeId, out var _))
             {
                 // this should make failure more explicit
                 FailFast.OnFatalException(new Exception("who is removing same snapshot?"));

--- a/src/Workspaces/Core/Portable/Execution/SerializerService_Asset.cs
+++ b/src/Workspaces/Core/Portable/Execution/SerializerService_Asset.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             cancellationToken.ThrowIfCancellationRequested();
 
             // REVIEW: why IDE services doesnt care about checksumAlgorithm?
-            var checksumAlgorithm = (SourceHashAlgorithm)reader.ReadInt32();
+            _ = (SourceHashAlgorithm)reader.ReadInt32();
             var encoding = _hostSerializationService.ReadEncodingFrom(reader, cancellationToken);
 
             var kind = (SerializationKinds)reader.ReadInt32();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindLiterals/FindLiteralsSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindLiterals/FindLiteralsSearchEngine.cs
@@ -59,10 +59,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     _longValue = BitConverter.DoubleToInt64Bits(f);
                     _searchKind = SearchKind.NumericLiterals;
                     break;
-                case decimal d: // unsupported
+                case decimal _: // unsupported
                     _searchKind = SearchKind.None;
                     break;
-                case char c:
+                case char _:
                     _longValue = IntegerUtilities.ToInt64(value);
                     _searchKind = SearchKind.CharacterLiterals;
                     break;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -225,8 +225,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             CancellationToken cancellationToken)
         {
             var semanticFacts = document.GetLanguageService<ISemanticFactsService>();
-
-            var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            _ = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 
             var locations = ArrayBuilder<FinderLocation>.GetInstance();
             foreach (var token in tokens)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
-            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            _ = document.GetLanguageService<ISyntaxFactsService>();
             var nameMatches = await FindReferencesInDocumentUsingSymbolNameAsync(
                 symbol,
                 document,

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -377,7 +377,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
 
             // No longer need the tmp array
-            tmp = null;
 
             var result = ArrayBuilder<Node>.GetInstance(unsortedNodes.Length);
             result.Count = unsortedNodes.Length;
@@ -510,7 +509,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             Debug.Assert(_inheritanceMap.Keys.Count == other._inheritanceMap.Keys.Count);
             var orderedKeys1 = this._inheritanceMap.Keys.Order().ToList();
-            var orderedKeys2 = other._inheritanceMap.Keys.Order().ToList();
+            _ = other._inheritanceMap.Keys.Order().ToList();
 
             for (int i = 0; i < orderedKeys1.Count; i++)
             {

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
@@ -490,7 +490,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return;
             }
 
-            var triviaInfo = tokenStream.GetTriviaData(operation.PairIndex);
+            _ = tokenStream.GetTriviaData(operation.PairIndex);
             var spanBetweenTokens = TextSpan.FromBounds(token1.Span.End, token2.SpanStart);
 
             if (operation.LineOperation != null)

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TokenStream.Changes.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TokenStream.Changes.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             public bool TryRemove(int pairIndex)
             {
-                return _map?.TryRemove(pairIndex, out var temp) ?? false;
+                return _map?.TryRemove(pairIndex, out var _) ?? false;
             }
 
             public void AddOrReplace(int key, TriviaData triviaInfo)

--- a/src/Workspaces/Core/Portable/Formatting/FormattingExtensions.cs
+++ b/src/Workspaces/Core/Portable/Formatting/FormattingExtensions.cs
@@ -173,8 +173,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             var isEmptyString = false;
             var builder = StringBuilderPool.Allocate();
-
-            var trimmedTriviaText = triviaText.TrimEnd(s_trimChars);
+            _ = triviaText.TrimEnd(s_trimChars);
             var nonWhitespaceCharIndex = GetFirstNonWhitespaceIndexInString(triviaText);
             if (nonWhitespaceCharIndex == -1)
             {

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/AbstractSyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/AbstractSyntaxFactsService.cs
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         public TSyntaxNode GetNodeWithoutLeadingBlankLines<TSyntaxNode>(TSyntaxNode node)
             where TSyntaxNode : SyntaxNode
         {
-            return GetNodeWithoutLeadingBlankLines(node, out var blankLines);
+            return GetNodeWithoutLeadingBlankLines(node, out var _);
         }
 
         public TSyntaxNode GetNodeWithoutLeadingBlankLines<TSyntaxNode>(
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             TSyntaxNode node)
             where TSyntaxNode : SyntaxNode
         {
-            return GetNodeWithoutLeadingBannerAndPreprocessorDirectives(node, out var strippedTrivia);
+            return GetNodeWithoutLeadingBannerAndPreprocessorDirectives(node, out var _);
         }
 
         public TSyntaxNode GetNodeWithoutLeadingBannerAndPreprocessorDirectives<TSyntaxNode>(

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -74,14 +74,13 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         private static IEnumerable<ISymbol> SymbolsForEnclosingInvocationExpressionWorker(SyntaxNode invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
             var symbolInfo = semanticModel.GetSymbolInfo(invocationExpression, cancellationToken);
-            IEnumerable<ISymbol> symbols = null;
             if (symbolInfo.Symbol == null)
             {
                 return null;
             }
             else
             {
-                symbols = SpecializedCollections.SingletonEnumerable(symbolInfo.Symbol);
+                var symbols = SpecializedCollections.SingletonEnumerable(symbolInfo.Symbol);
                 return symbols;
             }
         }
@@ -369,9 +368,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             {
                 return true;
             }
-
-            var index = 0;
-            index = newMetadataName.IndexOf(replacementText, 0);
+            var index = newMetadataName.IndexOf(replacementText, 0);
             StringBuilder newMetadataNameBuilder = new StringBuilder();
 
             // Every loop updates the newMetadataName to resemble the oldMetadataName

--- a/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.cs
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.SemanticModelWorkspaceService
             {
                 var versionMap = GetVersionMapFromBranch(project.Solution.Workspace, project.Solution.BranchId);
                 if (!AlreadyHasLatestCompilationSet(versionMap, project.Id, version, out var compilationSet) ||
-                    !compilationSet.Compilation.TryGetValue(out var compilation))
+                    !compilationSet.Compilation.TryGetValue(out var _))
                 {
                     var newSet = await CompilationSet.CreateAsync(project, compilationSet ?? primarySet, cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             IAssemblySymbol within,
             ITypeSymbol throughTypeOpt = null)
         {
-            return IsSymbolAccessibleCore(symbol, within, throughTypeOpt, out var failedThroughTypeCheck);
+            return IsSymbolAccessibleCore(symbol, within, throughTypeOpt, out var _);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             INamedTypeSymbol within,
             ITypeSymbol throughTypeOpt = null)
         {
-            return IsSymbolAccessible(symbol, within, throughTypeOpt, out var failedThroughTypeCheck);
+            return IsSymbolAccessible(symbol, within, throughTypeOpt, out var _);
         }
 
         /// <summary>
@@ -166,7 +166,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return true;
             }
 
-            bool unused;
             if (!type.IsDefinition)
             {
                 // All type argument must be accessible.
@@ -176,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     // worth optimizing this).
                     if (typeArg.Kind != SymbolKind.TypeParameter &&
                         typeArg.TypeKind != TypeKind.Error &&
-                        !IsSymbolAccessibleCore(typeArg, within, null, out unused))
+                        !IsSymbolAccessibleCore(typeArg, within, null, out _))
                     {
                         return false;
                     }
@@ -186,7 +185,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var containingType = type.ContainingType;
             return containingType == null
                 ? IsNonNestedTypeAccessible(type.ContainingAssembly, type.DeclaredAccessibility, within)
-                : IsMemberAccessible(type.ContainingType, type.DeclaredAccessibility, within, null, out unused);
+                : IsMemberAccessible(type.ContainingType, type.DeclaredAccessibility, within, null, out _);
         }
 
         // Is a top-level type with accessibility "declaredAccessibility" inside assembly "assembly"

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -298,10 +298,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             var getAccessibility = overriddenProperty.GetMethod.ComputeResultantAccessibility(containingType);
             var setAccessibility = overriddenProperty.SetMethod.ComputeResultantAccessibility(containingType);
-
-            SyntaxNode getBody = null;
-            SyntaxNode setBody = null;
-
+            SyntaxNode getBody;
+            SyntaxNode setBody;
             // Implement an abstract property by throwing not implemented in accessors.
             if (overriddenProperty.IsAbstract)
             {

--- a/src/Workspaces/Core/Portable/Shared/Utilities/CommonFormattingHelpers.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/CommonFormattingHelpers.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 yield break;
             }
 
-            var pairs = new List<ValueTuple<SyntaxToken, SyntaxToken>>();
+            _ = new List<ValueTuple<SyntaxToken, SyntaxToken>>();
             var previousOne = root.ConvertToTokenPair(spans[0]);
 
             // iterate through each spans and make sure each one doesn't overlap each other
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 return;
             }
 
-            var token1PartOftoken2LeadingTrivia = token1.FullSpan.Start > token2.FullSpan.Start;
+            _ = token1.FullSpan.Start > token2.FullSpan.Start;
 
             if (token1.FullSpan.End == token2.FullSpan.Start)
             {

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
@@ -148,8 +148,8 @@ namespace Microsoft.CodeAnalysis
                     // Push an null-method to our stack so that any method-type-parameters
                     // can at least be read (if not resolved) properly.
                     reader.PushMethod(methodOpt: null);
-                    var parameterTypeResolutions = reader.ReadSymbolKeyArray();
-                    var returnType = GetFirstSymbol<ITypeSymbol>(reader.ReadSymbolKey());
+                    _ = reader.ReadSymbolKeyArray();
+                    _ = GetFirstSymbol<ITypeSymbol>(reader.ReadSymbolKey());
                     reader.PopMethod(methodOpt: null);
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 int id;
-                var shouldWriteOrdinal = ShouldWriteTypeParameterOrdinal(symbol, out var methodIndex);
+                var shouldWriteOrdinal = ShouldWriteTypeParameterOrdinal(symbol, out var _);
                 if (!shouldWriteOrdinal)
                 {
                     if (_symbolToId.TryGetValue(symbol, out id))

--- a/src/Workspaces/Core/Portable/Utilities/CancellableLazy`1.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CancellableLazy`1.cs
@@ -26,7 +26,7 @@ namespace Roslyn.Utilities
         {
             get
             {
-                return this.TryGetValue(out var tmp);
+                return this.TryGetValue(out var _);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/linkedhashqueue.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/linkedhashqueue.cs
@@ -78,7 +78,7 @@ namespace Roslyn.Utilities
 
         public bool Contains(T value)
         {
-            return _map.TryGetValue(value, out var node);
+            return _map.TryGetValue(value, out var _);
         }
 
         public void Remove(T value)

--- a/src/Workspaces/Core/Portable/Utilities/SpellChecker.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SpellChecker.cs
@@ -153,7 +153,7 @@ namespace Roslyn.Utilities
             => AreSimilar(originalText, candidateText, substringsAreSimilar: false);
 
         public static bool AreSimilar(string originalText, string candidateText, bool substringsAreSimilar)
-            => AreSimilar(originalText, candidateText, substringsAreSimilar, out var unused);
+            => AreSimilar(originalText, candidateText, substringsAreSimilar, out var _);
 
         public static bool AreSimilar(string originalText, string candidateText, out double similarityWeight)
         {
@@ -180,7 +180,7 @@ namespace Roslyn.Utilities
             => value.Length <= 4 ? 1 : 2;
 
         public bool AreSimilar(string candidateText)
-            => AreSimilar(candidateText, out var similarityWeight);
+            => AreSimilar(candidateText, out var _);
 
         public bool AreSimilar(string candidateText, out double similarityWeight)
         {

--- a/src/Workspaces/Core/Portable/Utilities/ValuesSources/ValueSource.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ValuesSources/ValueSource.cs
@@ -18,7 +18,7 @@ namespace Roslyn.Utilities
         {
             get
             {
-                return this.TryGetValue(out var tmp);
+                return this.TryGetValue(out var _);
             }
         }
 


### PR DESCRIPTION
Test PR to show FixAll results from analyzer/fixer added in #30777

1. FixAll in solution seems to take an eternity and never complete, even for existing IDE diagnostics unrelated to #30777. Hence, I applied FixAll in project for couple of projects: CodeAnalysis.csproj and CSharpCodeAnalysis.csproj for this PR. I will file a separate issue to investigate FixAll in solution performance.
2. This PR shows there are still cases where we can tweak the code fix to generate slightly better code, but these seem minor, which can wait for customer feedback.
3. I personally feel unused out variables add a lot of noise and possibly need a different option, such that its default editorconfig value is prefer unused local instead of prefer discard. However, this can wait for more customer feedback.
4. I executed the analyzer added in #30777 (built after the latest commit in #30777) using AnalyzerRunner.exe on the entire Roslyn.sln, and this executed without any asserts. The performance is also comparable to the existing IDE analyzer (I confirmed against MakeFieldReadOnlyAnalyzer's execution time).