### PR TITLE
Copy nullability of non-nullable members

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -648,6 +648,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (targetType.IsReferenceType)
                 {
+                    // https://github.com/dotnet/roslyn/issues/31395,
                     // https://github.com/dotnet/roslyn/issues/29968 We should copy all tracked state from `value`,
                     // regardless of BoundNode type, but we'll need to handle cycles. (For instance, the
                     // assignment to C.F below. See also NullableReferenceTypesTests.Members_FieldCycle_01.)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -730,36 +730,30 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (fieldOrPropertyType.IsReferenceType)
             {
-                // If statically declared as not-nullable, no need to adjust the tracking info. 
-                // Declaration information takes priority.
-                if (fieldOrPropertyType.IsNullable != false)
+                int targetMemberSlot = GetOrCreateSlot(member, targetContainerSlot);
+                NullableAnnotation value = fieldOrPropertyType.NullableAnnotation;
+                // https://github.com/dotnet/roslyn/issues/29968 Remove isByRefTarget check?
+                if (isByRefTarget)
                 {
-                    int targetMemberSlot = GetOrCreateSlot(member, targetContainerSlot);
-                    NullableAnnotation value = fieldOrPropertyType.NullableAnnotation;
-                    // https://github.com/dotnet/roslyn/issues/29968 Remove isByRefTarget check?
-                    if (isByRefTarget)
-                    {
-                        // This is a member access through a by ref entity and it isn't considered declared as not-nullable. 
-                        // Since reference can point to the heap, we cannot assume the member doesn't have null value
-                        // after this assignment, regardless of what value is being assigned.
-                    }
-                    else if (valueContainerSlot > 0)
-                    {
-                        int valueMemberSlot = VariableSlot(member, valueContainerSlot);
-                        value = valueMemberSlot > 0 && valueMemberSlot < this.State.Capacity ?
-                            this.State[valueMemberSlot] :
-                            NullableAnnotation.Unknown;
-                    }
-
-                    this.State[targetMemberSlot] = value;
+                    // This is a member access through a by ref entity and it isn't considered declared as not-nullable. 
+                    // Since reference can point to the heap, we cannot assume the member doesn't have null value
+                    // after this assignment, regardless of what value is being assigned.
                 }
+                else if (valueContainerSlot > 0)
+                {
+                    int valueMemberSlot = VariableSlot(member, valueContainerSlot);
+                    value = valueMemberSlot > 0 && valueMemberSlot < this.State.Capacity ?
+                        this.State[valueMemberSlot] :
+                        NullableAnnotation.Unknown;
+                }
+
+                this.State[targetMemberSlot] = value;
 
                 if (valueContainerSlot > 0)
                 {
                     int valueMemberSlot = VariableSlot(member, valueContainerSlot);
                     if (valueMemberSlot > 0 && valueMemberSlot <= slotWatermark)
                     {
-                        int targetMemberSlot = GetOrCreateSlot(member, targetContainerSlot);
                         InheritNullableStateOfTrackableType(targetMemberSlot, valueMemberSlot, isByRefTarget, slotWatermark);
                     }
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -56770,7 +56770,7 @@ class B<[Nullable(0)]T01,
         }
 
         [Fact]
-        public void InheritNullabilityOfNotNullableMember()
+        public void InheritNullabilityOfNonNullableClassMember()
         {
             var source =
 @"#pragma warning disable 8618
@@ -56802,6 +56802,43 @@ class Program
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "s").WithLocation(10, 40),
                 // (17,35): warning CS8601: Possible null reference assignment.
                 //         var a2 = new C<T>() { F = t };
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "t").WithLocation(17, 35));
+            comp.VerifyTypes();
+        }
+
+        [Fact]
+        public void InheritNullabilityOfNonNullableStructMember()
+        {
+            var source =
+@"#pragma warning disable 8618
+struct S<T>
+{
+    internal T F;
+}
+class Program
+{
+    static void F0(string? s)
+    {
+        var a1 = new S<string>() { F = s };
+        _ = a1.F/*T:string?*/;
+        var b1 = a1;
+        _ = b1.F/*T:string?*/;
+    }
+    static void F1<T>(T? t) where T : class
+    {
+        var a2 = new S<T>() { F = t };
+        _ = a2.F/*T:T?*/;
+        var b2 = a2;
+        _ = b2.F/*T:T?*/;
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (10,40): warning CS8601: Possible null reference assignment.
+                //         var a1 = new S<string>() { F = s };
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "s").WithLocation(10, 40),
+                // (17,35): warning CS8601: Possible null reference assignment.
+                //         var a2 = new S<T>() { F = t };
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "t").WithLocation(17, 35));
             comp.VerifyTypes();
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -56790,9 +56790,9 @@ class Program
     static void F2<T>(T? t) where T : class
     {
         var a2 = new C<T>() { F = t };
-        a2.F/*T:T?*/.ToString(); // 2
+        F(a2.F/*T:T?*/); // 2
         var b2 = a2;
-        b2.F/*T:T!*/.ToString();
+        F(b2.F/*T:T!*/);
     }
     static void F(object o)
     {
@@ -56810,9 +56810,9 @@ class Program
                 // (17,35): warning CS8601: Possible null reference assignment.
                 //         var a2 = new C<T>() { F = t };
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "t").WithLocation(17, 35),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
-                //         a2.F/*T:T?*/.ToString(); // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a2.F").WithLocation(18, 9));
+                // (18,11): warning CS8604: Possible null reference argument for parameter 'o' in 'void Program.F(object o)'.
+                //         F(a2.F/*T:T?*/); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "a2.F").WithArguments("o", "void Program.F(object o)").WithLocation(18, 11));
             comp.VerifyTypes();
         }
 


### PR DESCRIPTION
`InheritNullableStateOfMember` was skipping members with non-nullable reference types.