### PR TITLE
Add test to show that pointers are disallowed.

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
@@ -2369,5 +2369,21 @@ public class C {
                 //         Expression<Func<string>> e0 = () => x ??= null;
                 Diagnostic(ErrorCode.ERR_ExpressionTreeCantContainNullCoalescingAssignment, "x ??= null").WithLocation(7, 45));
         }
+
+        [Fact]
+        public void PointersDisallowed()
+        {
+            CreateCompilation(@"
+class C
+{
+    unsafe void M(int* i1, int* i2)
+    {
+        i1 ??= i2;
+    }
+}", options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+                // (6,9): error CS0019: Operator '??=' cannot be applied to operands of type 'int*' and 'int*'
+                //         i1 ??= i2;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "i1 ??= i2").WithArguments("??=", "int*", "int*").WithLocation(6, 9));
+        }
     }
 }


### PR DESCRIPTION
Followup from https://github.com/dotnet/roslyn/issues/31238. The only other missing test was demonstrating that pointers are not allowed in ??= expressions. @dotnet/roslyn-compiler for review.