### PR TITLE
Remove the Code Style dependency on Hash.cs

### DIFF
--- a/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
+++ b/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
@@ -32,7 +32,6 @@
   <ItemGroup>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\EnumerableExtensions.cs" Link="Formatting\EnumerableExtensions.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\ExceptionUtilities.cs" Link="InternalUtilities\ExceptionUtilities.cs" />
-    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\Hash.cs" Link="InternalUtilities\Hash.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\IReadOnlySet.cs" Link="InternalUtilities\IReadOnlySet.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\KeyValuePairUtil.cs" Link="InternalUtilities\KeyValuePairUtil.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.cs" Link="InternalUtilities\SpecializedCollections.cs" />

--- a/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
+++ b/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
@@ -57,6 +57,7 @@
     <Compile Include="..\..\..\Workspaces\Core\Portable\CodeStyle\CodeStyleHelpers.cs" Link="Options\CodeStyleHelpers.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\CodeStyle\CodeStyleOption.cs" Link="Options\CodeStyleOption.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\CodeStyle\NotificationOption.cs" Link="Options\NotificationOption.cs" />
+    <Compile Include="..\..\..\Workspaces\Core\Portable\CodeStyle\UnusedValuePreference.cs" Link="Options\UnusedValuePreference.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Diagnostics\Extensions_SharedWithCodeStyle.cs" Link="Options\Extensions_SharedWithCodeStyle.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Extensions\NotificationOptionExtensions.cs" Link="Options\NotificationOptionExtensions.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Formatting\AbstractSyntaxFormattingService.cs" Link="Formatting\AbstractSyntaxFormattingService.cs" />

--- a/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
@@ -171,7 +171,6 @@ namespace Roslyn.Utilities
             return hashCode;
         }
 
-#if !CODE_STYLE
         /// <summary>
         /// Compute the FNV-1a hash of a sequence of bytes and determines if the byte
         /// sequence is valid ASCII and hence the hash code matches a char sequence
@@ -197,7 +196,6 @@ namespace Roslyn.Utilities
             isAscii = (asciiMask & 0x80) == 0;
             return hashCode;
         }
-#endif
 
         /// <summary>
         /// Compute the FNV-1a hash of a sequence of bytes

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOption.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOption.cs
@@ -189,6 +189,6 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                Equals(option);
 
         public override int GetHashCode()
-            => Hash.Combine(Value.GetHashCode(), Notification.GetHashCode());
+            => unchecked((Notification.GetHashCode() * (int)0xA5555529) + Value.GetHashCode());
     }
 }

--- a/src/Workspaces/Core/Portable/Options/OptionKey.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionKey.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Options
 
             if (Language != null)
             {
-                hash = Hash.Combine(Language.GetHashCode(), hash);
+                hash = unchecked((hash * (int)0xA5555529) + Language.GetHashCode());
             }
 
             return hash;


### PR DESCRIPTION
* Fixes a build error from an indirect merge conflict between #31276 and #30777 
* Reverts the changes to **Hash.cs** introduced in #31276 and unlinks it from the Code Style layer (see https://github.com/dotnet/roslyn/pull/31276#discussion_r236864512)