### PR TITLE
Fix up VisualStudioWorkspace.GetFileCodeModel

### DIFF
--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -29,15 +29,18 @@ namespace Microsoft.VisualStudio.LanguageServices
     internal class RoslynVisualStudioWorkspace : VisualStudioWorkspaceImpl
     {
         private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _streamingPresenters;
+        private readonly Lazy<ProjectCodeModelFactory> _projectCodeModelFactory;
 
         [ImportingConstructor]
         private RoslynVisualStudioWorkspace(
             ExportProvider exportProvider,
             [ImportMany] IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters,
-            [ImportMany] IEnumerable<IDocumentOptionsProviderFactory> documentOptionsProviderFactories)
+            [ImportMany] IEnumerable<IDocumentOptionsProviderFactory> documentOptionsProviderFactories,
+            Lazy<ProjectCodeModelFactory> projectCodeModelFactory)
             : base(exportProvider, AsyncServiceProvider.GlobalProvider) // TODO: switch to the cleaner MEF import
         {
             _streamingPresenters = streamingPresenters;
+            _projectCodeModelFactory = projectCodeModelFactory;
 
             foreach (var providerFactory in documentOptionsProviderFactories)
             {
@@ -52,28 +55,21 @@ namespace Microsoft.VisualStudio.LanguageServices
                 throw new ArgumentNullException(nameof(documentId));
             }
 
-/*
-
-            var project = DeferredState.ProjectTracker.GetProject(documentId.ProjectId);
+            var project = CurrentSolution.GetProject(documentId.ProjectId);
             if (project == null)
             {
                 throw new ArgumentException(ServicesVSResources.The_given_DocumentId_did_not_come_from_the_Visual_Studio_workspace, nameof(documentId));
             }
 
-            var document = project.GetDocumentOrAdditionalDocument(documentId);
-            if (document == null)
+            var documentFilePath = GetFilePath(documentId);
+            if (documentFilePath == null)
             {
                 throw new ArgumentException(ServicesVSResources.The_given_DocumentId_did_not_come_from_the_Visual_Studio_workspace, nameof(documentId));
             }
 
-            if (project.ProjectCodeModel != null)
-            {
-                return project.ProjectCodeModel.GetOrCreateFileCodeModel(document.FilePath);
-            }
+            IProjectCodeModel projectCodeModel = _projectCodeModelFactory.Value.GetProjectCodeModel(project.Id);
 
-    */
-
-            return null;
+            return projectCodeModel.GetOrCreateFileCodeModel(documentFilePath);
         }
 
         internal override IInvisibleEditor OpenInvisibleEditor(DocumentId documentId)

--- a/src/VisualStudio/TestUtilities2/CodeModel/Mocks/MockVisualStudioWorkspace.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/Mocks/MockVisualStudioWorkspace.vb
@@ -42,10 +42,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.Mocks
             SetCurrentSolution(_workspace.CurrentSolution)
         End Sub
 
-        Public Overrides Function GetFilePath(documentId As DocumentId) As String
-            Return _workspace.CurrentSolution.GetDocument(documentId).FilePath
-        End Function
-
         Public Overrides Function GetHierarchy(projectId As ProjectId) As Microsoft.VisualStudio.Shell.Interop.IVsHierarchy
             Return Nothing
         End Function


### PR DESCRIPTION
The implementation was commented out and not restored prior to merging the project system refactoring.

I attempted to write a unit test for this but it's icky: everything we have for Code Model tests is using a mock of VisualStudioWorkspace instead of the real one, and moving the code in question down to the base version runs into issues because the Code Model implementation lives in our special Implementation assembly. I could do it with a huge amount of churn, or by breaking encapsulation in a few ways that I like that we have it now. Given this was a silly mistake on my part, I'm not terribly worried about new regressions here.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/718880