### PR TITLE
Upload all VSIXes to drop, not just those that are inserted

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -182,7 +182,7 @@ steps:
 - task: PowerShell@2
   displayName: Publish Drop - VSSetup
   inputs:
-    arguments: '-Source Binaries\VSSetup\$(BuildConfiguration)\Insertion -Target $(DropRoot)\Roslyn-Signed\$(Build.SourceBranchName)\$(BuildConfiguration)\$(Build.BuildNumber)\Insertion -ParallelCount 8'
+    arguments: '-Source Binaries\VSSetup\$(BuildConfiguration) -Target $(DropRoot)\Roslyn-Signed\$(Build.SourceBranchName)\$(BuildConfiguration)\$(Build.BuildNumber)\VSSetup -ParallelCount 8'
     filePath: 'build\scripts\vsts-robocopy.ps1'
   condition: succeededOrFailed()
 


### PR DESCRIPTION
Temporary measure to make the vsixes available.
Long term we will want to remove dependency on cpvsbuild completely.