### PR TITLE
WIP: Dont warn about the deprecated lincseUrl property

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -216,6 +216,13 @@
   </ItemGroup>
 
   <!--
+    Add licens to packable projects 
+  -->
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="$(LicenseFilePath)" PackagePath="License.txt" Visible="false" Pack="true"/>
+  </ItemGroup>
+
+  <!--
     Append common text to package specific PackageDescription.
   -->
   <Target Name="_AppendCommonPackageDescription" 

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -216,7 +216,7 @@
   </ItemGroup>
 
   <!--
-    Add licens to packable projects 
+    Add license to packable projects 
   -->
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <None Include="$(LicenseFilePath)" PackagePath="License.txt" Visible="false" Pack="true"/>

--- a/build/Targets/RepoToolset/ProjectDefaults.props
+++ b/build/Targets/RepoToolset/ProjectDefaults.props
@@ -18,7 +18,6 @@
     <Serviceable>true</Serviceable>
     <DevelopmentDependency>false</DevelopmentDependency>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkId=529443</PackageLicenseUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
     <!-- Disable the message indicating we are using a preview SDK. That is understood and by design -->

--- a/build/Targets/RepoToolset/Workarounds.targets
+++ b/build/Targets/RepoToolset/Workarounds.targets
@@ -98,7 +98,6 @@
       <NuspecProperty Include="Serviceable=$(Serviceable)"/>
       <NuspecProperty Include="DevelopmentDependency=$(DevelopmentDependency)"/>
       <NuspecProperty Include="RequireLicenseAcceptance=$(PackageRequireLicenseAcceptance)"/>
-      <NuspecProperty Include="PackageLicenseUrl=$(PackageLicenseUrl)"/>
       <NuspecProperty Include="PackageProjectUrl=$(PackageProjectUrl)"/>
       <NuspecProperty Include="PackageIconUrl=$(PackageIconUrl)" Condition="'$(PackageIconUrl)' != ''" />
       <NuspecProperty Include="PackageReleaseNotes=$(PackageReleaseNotes)" Condition="'$(PackageReleaseNotes)' != ''" />

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -13,6 +13,7 @@
     <PackageProjectUrl>https://github.com/dotnet/roslyn</PackageProjectUrl>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Parser Scanner Lexer Emit CodeGeneration Metadata IL Compilation Scripting Syntax Semantics</PackageTags>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <NoWarn>$(NoWarn);NU5125</NoWarn>
   </PropertyGroup>
 
   <Import Project="RepoToolset\ProjectLayout.props" />

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -8,12 +8,12 @@
   
   <PropertyGroup>
     <RepositoryUrl>https://github.com/dotnet/roslyn</RepositoryUrl>
-    <PackageLicenseUrl>$(RepositoryUrl)/blob/master/License.txt</PackageLicenseUrl>
+    <PackageLicenseFile>License.txt</PackageLicenseFile>
+    <LicenseFilePath>$(MSBuildThisFileDirectory)..\..\License.txt</LicenseFilePath>
     <RepositoryRawUrl>https://raw.githubusercontent.com/dotnet/roslyn</RepositoryRawUrl>
-    <PackageProjectUrl>https://github.com/dotnet/roslyn</PackageProjectUrl>
+    <!-- <PackageProjectUrl>https://github.com/dotnet/roslyn</PackageProjectUrl> -->
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Parser Scanner Lexer Emit CodeGeneration Metadata IL Compilation Scripting Syntax Semantics</PackageTags>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
-    <NoWarn>$(NoWarn);NU5125</NoWarn>
   </PropertyGroup>
 
   <Import Project="RepoToolset\ProjectLayout.props" />
@@ -147,6 +147,8 @@
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(MicrosoftNetCoreAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="$(RoslynDiagnosticsAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(MicrosoftVisualStudioThreadingAnalyzersVersion)" PrivateAssets="all" />
+
+    <Content Include="$(MSBuildThisFileDirectory)..\..\License.txt" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!--

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -11,7 +11,6 @@
     <PackageLicenseFile>License.txt</PackageLicenseFile>
     <LicenseFilePath>$(MSBuildThisFileDirectory)..\..\License.txt</LicenseFilePath>
     <RepositoryRawUrl>https://raw.githubusercontent.com/dotnet/roslyn</RepositoryRawUrl>
-    <!-- <PackageProjectUrl>https://github.com/dotnet/roslyn</PackageProjectUrl> -->
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Parser Scanner Lexer Emit CodeGeneration Metadata IL Compilation Scripting Syntax Semantics</PackageTags>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
   </PropertyGroup>

--- a/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.nuspec
+++ b/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.nuspec
@@ -6,7 +6,6 @@
     <version>$Version$</version>
     <authors>$Authors$</authors>
     <requireLicenseAcceptance>$RequireLicenseAcceptance$</requireLicenseAcceptance>
-    <licenseUrl>$PackageLicenseUrl$</licenseUrl>
     <projectUrl>$PackageProjectUrl$</projectUrl>
     <copyright>$Copyright$</copyright>
     <developmentDependency>$DevelopmentDependency$</developmentDependency>

--- a/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.nuspec
+++ b/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.nuspec
@@ -6,7 +6,6 @@
     <version>$Version$</version>
     <authors>$Authors$</authors>
     <requireLicenseAcceptance>$RequireLicenseAcceptance$</requireLicenseAcceptance>
-    <licenseUrl>$PackageLicenseUrl$</licenseUrl>
     <projectUrl>$PackageProjectUrl$</projectUrl>
     <copyright>$Copyright$</copyright>
     <developmentDependency>$DevelopmentDependency$</developmentDependency>


### PR DESCRIPTION
Command line builds can fail with a warning like below. This removes that warning for all projects. Based on the fix provided in [project-system](https://github.com/dotnet/project-system/pull/4320)

To repro, run `build/scripts/cibuild.cmd -configuration Debug -testDesktop -Test32 `

```
C:\Program Files\dotnet\sdk\2.1.500\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(202,5): error NU51
25: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. [C:\Users\ryzng\Source\R
epos\roslyn\src\NuGet\Microsoft.Net.Compilers\Microsoft.Net.Compilers.Package.csproj]

Build FAILED.

C:\Program Files\dotnet\sdk\2.1.500\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(202,5): error NU51
25: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. [C:\Users\ryzng\Source\R
epos\roslyn\src\NuGet\Microsoft.Net.Compilers\Microsoft.Net.Compilers.Package.csproj]
    0 Warning(s)
    1 Error(s)
```