### PR TITLE
Update CompilerServerLogger.cs

### DIFF
--- a/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
+++ b/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     // Otherwise, assume that the environment variable specifies the name of the log file.
                     if (Directory.Exists(loggingFileName))
                     {
-                        loggingFileName = Path.Combine(loggingFileName, $"server.{loggingFileName}.{GetCurrentProcessId()}.log");
+                        loggingFileName = Path.Combine(loggingFileName, $"server.{GetCurrentProcessId()}.log");
                     }
 
                     // Open allowing sharing. We allow multiple processes to log to the same file, so we use share mode to allow that.


### PR DESCRIPTION
[CHANGED] Removed the filepath from the filename of the log. The loggingFileName could be "C:\Users\user\build" which means that the second string in Path.Combine generates to "server.C:\Users\user\build.log" and that will be combined with the path once again leading to a full file path of: "C:\Users\user\build\server.C:\Users\user\build.log" and I dont think thats legal on Windows.