### PR TITLE
Update Compiler Server.md

### DIFF
--- a/docs/compilers/Compiler Server.md
+++ b/docs/compilers/Compiler Server.md
@@ -54,8 +54,11 @@ To diagnose problems with the server compilation, you can enable an
 environment variable that writes a diagnostic log file:
 
 ```
-export RoslynCommandLineLogFile=/path/to/log/file
+(UNIX): export RoslynCommandLineLogFile=/path/to/log/file
+(Windows CMD, using directory path): setx RoslynCommandLineLogFile="C:\path\to\log"
+(Windows CMD, using file path): setx RoslynCommandLineLogFile="C:\path\to\log\file.log"
 ```
+
 
 This file contains diagnostic logging for both the client and server,
 which you can distinguish using the `PID` tag for each diagnostic line.


### PR DESCRIPTION
[ADDED] Description on how to set the environment variable on Windows. This is directly related to my PR https://github.com/dotnet/roslyn/pull/31433 because currently only file paths are supported on windows, although directory paths should also be supported.