### PR TITLE
make sure to VS and OOP to use same file to get mvid of analyzer file…

### DIFF
--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -235,7 +235,11 @@ namespace Microsoft.CodeAnalysis.Execution
         {
             try
             {
-                using (var stream = new FileStream(reference.FullPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
+                // use actual assembly path rather than one returned from reference.FullPath
+                // 2 can be different if analyzer loader used for the reference do something like shadow copying
+                var assemblyPath = TryGetAnalyzerAssemblyPath(reference) ?? reference.FullPath;
+
+                using (var stream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
                 using (var peReader = new PEReader(stream))
                 {
                     var metadataReader = peReader.GetMetadataReader();


### PR DESCRIPTION
… reference when creating checksum for both VS and OOP

the problem is that the OOP always used the actual file that got used for analyzer (in other words, shadow copied file in VS), but VS used original file to get MVID.

based on shadow copying logic, 2 (with same assembly identity) might actually be 2 different files by sharing a shadow copied file between 2 original files with same assembly identitis causing MVID to be different.

this make sure all use same file for MVID so that regardless of host implementation of analyzer loader (who is the actual thing that control what file will be used to get analyzers), we get consistent MVID

...

when this situation happens, functionality wise, OOP and features that run on OOP will still work as expected. just less efficiently since OOP will pull in those mismatching analyzer references on each request and create a new solution with those analyzers updated.

this should stop us from doing that and reuse the same solution for all requests.