### PR TITLE
Always use procdump on test timeout

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -397,9 +397,10 @@ function Test-XUnit() {
         $args += " -xml -timeout:75"
     }
 
+    $procdumpPath = Ensure-ProcDump
+    $args += " -procdumppath:$procDumpPath"
     if ($procdump) {
-        $procdumpPath = Ensure-ProcDump
-        $args += " -procdumppath:$procDumpPath"
+        $args += " -useprocdump";
     }
 
     if ($test64) {

--- a/src/Tools/Source/RunTests/Options.cs
+++ b/src/Tools/Source/RunTests/Options.cs
@@ -64,6 +64,11 @@ namespace RunTests
         public TimeSpan? Timeout { get; set; }
 
         /// <summary>
+        /// Whether or not to use proc dump to monitor running processes for failures.
+        /// </summary>
+        public bool UseProcDump { get; set; }
+
+        /// <summary>
         /// The directory which contains procdump.exe. 
         /// </summary>
         public string ProcDumpDirectory { get; set; }
@@ -171,6 +176,11 @@ namespace RunTests
                     opt.ProcDumpDirectory = value;
                     index++;
                 }
+                else if (comparer.Equals(current, "-procdump"))
+                {
+                    opt.UseProcDump = false;
+                    index++;
+                }
                 else
                 {
                     break;
@@ -192,6 +202,12 @@ namespace RunTests
             if (!File.Exists(opt.XunitPath))
             {
                 Console.WriteLine($"The file '{opt.XunitPath}' does not exist.");
+                return null;
+            }
+
+            if (opt.UseProcDump && string.IsNullOrEmpty(opt.ProcDumpDirectory))
+            {
+                Console.WriteLine($"The option 'useprocdump' was specified but 'procdumppath' was not provided");
                 return null;
             }
 

--- a/src/Tools/Source/RunTests/ProcDumpUtil.cs
+++ b/src/Tools/Source/RunTests/ProcDumpUtil.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 namespace RunTests
 {
-    internal struct ProcDumpInfo
+    internal readonly struct ProcDumpInfo
     {
         private const string KeyProcDumpFilePath = "ProcDumpFilePath";
         private const string KeyProcDumpDirectory = "ProcDumpOutputPath";

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -351,7 +351,7 @@ namespace RunTests
         {
             var testExecutionOptions = new TestExecutionOptions(
                 xunitPath: options.XunitPath,
-                procDumpInfo: GetProcDumpInfo(options),
+                procDumpInfo: options.UseProcDump ? GetProcDumpInfo(options) : null,
                 logsDirectory: options.LogsDirectory,
                 trait: options.Trait,
                 noTrait: options.NoTrait,


### PR DESCRIPTION
This changes RunTests to always use procdump when tests timeout.

Previously there was a single option, procdumppath, which controlled
both monitoring xunit processes with procdump and using procdump on time
out. The former causes stability issues at times with test execution and
has to be disabled in a couple of places (spanish and integration
tests). The latter has no stability issues and hence should always be
used.