### PR TITLE
Arcade bootstrapper: msbuildEngine, InitializeBuildTool

### DIFF
--- a/.vsts-dnceng.yml
+++ b/.vsts-dnceng.yml
@@ -75,7 +75,7 @@ phases:
         _configuration: Release
 
   steps:
-    - script: build/scripts/cibuild.cmd -configuration $(_configuration) -testCoreClr -buildCoreClr
+    - script: build/scripts/cibuild.cmd -configuration $(_configuration) -msbuildEngine:dotnet -testCoreClr
       displayName: Build and Test
 
     - task: PublishTestResults@1

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -144,20 +144,7 @@ function Exec-Script([string]$script, [string]$scriptArgs = "") {
 
 # Ensure the proper .NET Core SDK is available. Returns the location to the dotnet.exe.
 function Ensure-DotnetSdk() {
-  if (-not (Test-Path global:_dotNetExe)) {
-    $global:_dotNetExe = Join-Path (InitializeDotNetCli -install:$true) "dotnet.exe"
-  }
-
-  return $global:_dotNetExe
-}
-
-# Ensure the proper VS msbuild is available. Returns the locaqtion of the msbuild.exe.
-function Ensure-MSBuild() {
-  if (-not (Test-Path global:_msbuildExe)) {
-    $global:_msbuildExe = InitializeVisualStudioMSBuild
-  }
-
-  return $global:_msbuildExe
+  return Join-Path (InitializeDotNetCli -install:$true) "dotnet.exe"
 }
 
 function Get-VersionCore([string]$name, [string]$versionFile) {
@@ -230,6 +217,7 @@ function Restore-Project([string]$projectFileName, [string]$logFilePath = "") {
         $logArg = " /bl:$logFilePath"
     }
 
-    Exec-Console (Ensure-DotNetSdk) "restore --verbosity quiet $projectFilePath $logArg"
+    $buildTool = InitializeBuildTool
+    Exec-Console $buildTool.Path "$($buildTool.Command) `"$projectFilePath`" /t:Restore /m /nologo /clp:None /v:quiet /nr:false /warnaserror $logArg $args"
 }
 

--- a/build/scripts/test-determinism.ps1
+++ b/build/scripts/test-determinism.ps1
@@ -43,8 +43,8 @@ function Run-Build([string]$rootDir, [string]$logFile = $null) {
             $args += " /bl:$logFile"
         }
 
-        Write-Host "Building the Solution"
-        Exec-Console $msbuild $args
+        $buildTool = InitializeBuildTool
+        Exec-Console $buildTool.Path "$($buildTool.Command) $args"
     }
     finally {
         Pop-Location
@@ -238,8 +238,6 @@ try {
     Create-Directory $errorDirLeft
     Create-Directory $errorDirRight
 
-    $dotnet = Ensure-DotnetSdk
-    $msbuild = Ensure-MSBuild
     if (($bootstrapDir -eq "") -or (-not ([IO.Path]::IsPathRooted($script:bootstrapDir)))) {
         Write-Host "The bootstrap build path must be absolute"
         exit 1


### PR DESCRIPTION
Use more of Arcade bootstrapper functions.
Convert `buildCoreClr` to `msbuildEngine` parameter used by Arcade.
Update Initialize* functions to memoize their result.