### PR TITLE
Set working folder for the solution added.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectFactory.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
+using Microsoft.VisualStudio.LanguageServices.Storage;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
@@ -84,6 +85,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                             VersionStamp.Create(),
                             solutionPathToSetWithOnSolutionAdded,
                             projects: new[] { projectInfo }));
+
+                    // set working folder for the persistent service
+                    var persistenceService = w.Services.GetRequiredService<IPersistentStorageLocationService>() as VisualStudioPersistentStorageLocationService;
+                    persistenceService?.UpdateForVisualStudioWorkspace(w);
                 }
                 else
                 {

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFindReferences.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFindReferences.cs
@@ -150,5 +150,14 @@ class Program
                     }
                 });
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)]
+        public void VerifyWorkingFolder()
+        {
+            SetUpEditor(@"class EmptyContent {$$}");
+
+            // verify working folder has set
+            Assert.NotNull(VisualStudio.Workspace.GetWorkingFolder());
+        }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServices;
@@ -171,5 +172,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
                 optionService.SetOptions(optionService.GetOptions().WithChangedOption(optionKey, value));
             });
+
+        public string GetWorkingFolder()
+        {
+            var service = _visualStudioWorkspace.Services.GetRequiredService<IPersistentStorageLocationService>();
+            return service.TryGetStorageLocation(_visualStudioWorkspace.CurrentSolution.Id);
+        }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -78,5 +79,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public void SetFeatureOption(string feature, string optionName, string language, string valueString)
             => _inProc.SetFeatureOption(feature, optionName, language, valueString);
+
+        public string GetWorkingFolder() => _inProc.GetWorkingFolder();
     }
 }


### PR DESCRIPTION
persistent service requires working folder location to find out where to save its persistent file

...

user impact is 
1. FAR, Navigate To can be slow than needed at warm solution loaded
2. VS uses more memory than needed.
