### PR TITLE
Project document ordering

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/SourceFileHandlingTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/SourceFileHandlingTests.cs
@@ -67,6 +67,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
             using (var project = CreateCSharpCPSProject(environment, "project1"))
             {
                 IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
+                VersionStamp GetVersion() => environment.Workspace.CurrentSolution.Projects.Single().Version;
 
                 Assert.Empty(GetCurrentDocuments());
 
@@ -87,15 +88,27 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
                 project.RemoveSourceFile(sourceFileFullPath4);
                 project.AddSourceFile(sourceFileFullPath4);
 
-                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2, sourceFileFullPath3, sourceFileFullPath4, sourceFileFullPath5 });
+                var oldVersion = GetVersion();
+
+                project.ReorderSourceFiles(new[] { sourceFileFullPath5, sourceFileFullPath4, sourceFileFullPath3, sourceFileFullPath2, sourceFileFullPath1 });
+
+                var newVersion = GetVersion();
+
+                project.ReorderSourceFiles(new[] { sourceFileFullPath5, sourceFileFullPath4, sourceFileFullPath3, sourceFileFullPath2, sourceFileFullPath1 });
+
+                var newSameVersion = GetVersion();
+
+                // Reordering should result in a new version if the order is different. If it's the same, the version should stay the same.
+                Assert.NotEqual(oldVersion, newVersion);
+                Assert.Equal(newVersion, newSameVersion);
 
                 var documents = GetCurrentDocuments().ToArray();
 
-                Assert.Equal(documents[0].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(documents[1].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[0].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[1].FilePath, sourceFileFullPath4, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(documents[2].FilePath, sourceFileFullPath3, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(documents[3].FilePath, sourceFileFullPath4, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(documents[4].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[3].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[4].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
             }
         }
 
@@ -131,15 +144,15 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
                 // Removing path4 to test remove of a file when it was also added in a batch.
                 project.RemoveSourceFile(sourceFileFullPath4);
 
-                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath3, sourceFileFullPath5 });
+                project.ReorderSourceFiles(new[] { sourceFileFullPath5, sourceFileFullPath3, sourceFileFullPath1 });
 
                 project.EndBatch();
 
                 var documents = GetCurrentDocuments().ToArray();
 
-                Assert.Equal(documents[0].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[0].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(documents[1].FilePath, sourceFileFullPath3, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(documents[2].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[2].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
             }
         }
 
@@ -175,7 +188,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
                 // Removing path4 to test remove of a file when it was also added in a batch.
                 project.RemoveSourceFile(sourceFileFullPath4);
 
-                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath3, sourceFileFullPath5 });
+                project.ReorderSourceFiles(new[] { sourceFileFullPath5, sourceFileFullPath3, sourceFileFullPath1 });
 
                 // Re-adding / re-removing / re-adding again.
                 project.AddSourceFile(sourceFileFullPath2);
@@ -185,17 +198,17 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
                 project.AddSourceFile(sourceFileFullPath2);
                 project.AddSourceFile(sourceFileFullPath4);
 
-                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2, sourceFileFullPath3, sourceFileFullPath4, sourceFileFullPath5 });
+                project.ReorderSourceFiles(new[] { sourceFileFullPath5, sourceFileFullPath4, sourceFileFullPath3, sourceFileFullPath2, sourceFileFullPath1 });
 
                 project.EndBatch();
 
                 var documents = GetCurrentDocuments().ToArray();
 
-                Assert.Equal(documents[0].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(documents[1].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[0].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[1].FilePath, sourceFileFullPath4, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(documents[2].FilePath, sourceFileFullPath3, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(documents[3].FilePath, sourceFileFullPath4, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(documents[4].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[3].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[4].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
             }
         }
 
@@ -221,7 +234,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
                 project.AddSourceFile(sourceFileFullPath1);
                 project.AddSourceFile(sourceFileFullPath2);
 
-                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2 });
+                project.ReorderSourceFiles(new[] { sourceFileFullPath2, sourceFileFullPath1 });
 
                 project.AddSourceFile(sourceFileFullPath3);
                 project.AddSourceFile(sourceFileFullPath4);
@@ -229,15 +242,15 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
 
                 project.EndBatch();
 
-                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2, sourceFileFullPath3, sourceFileFullPath4, sourceFileFullPath5 });
+                project.ReorderSourceFiles(new[] { sourceFileFullPath5, sourceFileFullPath4, sourceFileFullPath3, sourceFileFullPath2, sourceFileFullPath1 });
 
                 var documents = GetCurrentDocuments().ToArray();
 
-                Assert.Equal(documents[0].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(documents[1].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[0].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[1].FilePath, sourceFileFullPath4, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(documents[2].FilePath, sourceFileFullPath3, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(documents[3].FilePath, sourceFileFullPath4, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(documents[4].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[3].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[4].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
             }
         }
 
@@ -266,7 +279,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
                 project.AddSourceFile(sourceFileFullPath4);
                 project.AddSourceFile(sourceFileFullPath5);
 
-                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2, sourceFileFullPath3, sourceFileFullPath4, sourceFileFullPath5 });
+                project.ReorderSourceFiles(new[] { sourceFileFullPath5, sourceFileFullPath4, sourceFileFullPath3, sourceFileFullPath2, sourceFileFullPath1 });
 
                 project.RemoveSourceFile(sourceFileFullPath3);
                 project.RemoveSourceFile(sourceFileFullPath4);
@@ -274,12 +287,12 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
 
                 project.EndBatch();
 
-                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2 });
+                project.ReorderSourceFiles(new[] { sourceFileFullPath2, sourceFileFullPath1 });
 
                 var documents = GetCurrentDocuments().ToArray();
 
-                Assert.Equal(documents[0].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(documents[1].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[0].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[1].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/SourceFileHandlingTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/SourceFileHandlingTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -55,6 +56,351 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
                 // Remove additional file
                 project.RemoveAdditionalFile(additionalFileFullPath);
                 Assert.Empty(GetCurrentAdditionalDocuments());
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void ReorderSourceFiles_CPS()
+        {
+            using (var environment = new TestEnvironment())
+            using (var project = CreateCSharpCPSProject(environment, "project1"))
+            {
+                IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
+
+                Assert.Empty(GetCurrentDocuments());
+
+                var sourceFileFullPath1 = @"c:\source1.cs";
+                var sourceFileFullPath2 = @"c:\source2.cs";
+                var sourceFileFullPath3 = @"c:\source3.cs";
+                var sourceFileFullPath4 = @"c:\source4.cs";
+                var sourceFileFullPath5 = @"c:\source5.cs";
+                project.AddSourceFile(sourceFileFullPath1);
+                project.AddSourceFile(sourceFileFullPath2);
+                project.AddSourceFile(sourceFileFullPath3);
+                project.AddSourceFile(sourceFileFullPath4);
+                project.AddSourceFile(sourceFileFullPath5);
+
+                project.RemoveSourceFile(sourceFileFullPath2);
+                project.AddSourceFile(sourceFileFullPath2);
+
+                project.RemoveSourceFile(sourceFileFullPath4);
+                project.AddSourceFile(sourceFileFullPath4);
+
+                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2, sourceFileFullPath3, sourceFileFullPath4, sourceFileFullPath5 });
+
+                var documents = GetCurrentDocuments().ToArray();
+
+                Assert.Equal(documents[0].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[1].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[2].FilePath, sourceFileFullPath3, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[3].FilePath, sourceFileFullPath4, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[4].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void ReorderSourceFilesBatch_CPS()
+        {
+            using (var environment = new TestEnvironment())
+            using (var project = CreateCSharpCPSProject(environment, "project1"))
+            {
+                IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
+
+                Assert.Empty(GetCurrentDocuments());
+
+                var sourceFileFullPath1 = @"c:\source1.cs";
+                var sourceFileFullPath2 = @"c:\source2.cs";
+                var sourceFileFullPath3 = @"c:\source3.cs";
+                var sourceFileFullPath4 = @"c:\source4.cs";
+                var sourceFileFullPath5 = @"c:\source5.cs";
+
+                // Add a file outside the batch.
+                project.AddSourceFile(sourceFileFullPath2);
+
+                project.StartBatch();
+                project.AddSourceFile(sourceFileFullPath1);
+                project.AddSourceFile(sourceFileFullPath3);
+                project.AddSourceFile(sourceFileFullPath4);
+                project.AddSourceFile(sourceFileFullPath5);
+
+                // Removing path2 to test removal of a file the actual internal project state has changed outside of the batch.
+                project.RemoveSourceFile(sourceFileFullPath2);
+
+                // Removing path4 to test remove of a file when it was also added in a batch.
+                project.RemoveSourceFile(sourceFileFullPath4);
+
+                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath3, sourceFileFullPath5 });
+
+                project.EndBatch();
+
+                var documents = GetCurrentDocuments().ToArray();
+
+                Assert.Equal(documents[0].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[1].FilePath, sourceFileFullPath3, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[2].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void ReorderSourceFilesBatchWithReAdding_CPS()
+        {
+            using (var environment = new TestEnvironment())
+            using (var project = CreateCSharpCPSProject(environment, "project1"))
+            {
+                IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
+
+                Assert.Empty(GetCurrentDocuments());
+
+                var sourceFileFullPath1 = @"c:\source1.cs";
+                var sourceFileFullPath2 = @"c:\source2.cs";
+                var sourceFileFullPath3 = @"c:\source3.cs";
+                var sourceFileFullPath4 = @"c:\source4.cs";
+                var sourceFileFullPath5 = @"c:\source5.cs";
+
+                // Add a file outside the batch.
+                project.AddSourceFile(sourceFileFullPath2);
+
+                project.StartBatch();
+                project.AddSourceFile(sourceFileFullPath1);
+                project.AddSourceFile(sourceFileFullPath3);
+                project.AddSourceFile(sourceFileFullPath4);
+                project.AddSourceFile(sourceFileFullPath5);
+
+                // Removing path2 to test removal of a file the actual internal project state has changed outside of the batch.
+                project.RemoveSourceFile(sourceFileFullPath2);
+
+                // Removing path4 to test remove of a file when it was also added in a batch.
+                project.RemoveSourceFile(sourceFileFullPath4);
+
+                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath3, sourceFileFullPath5 });
+
+                // Re-adding / re-removing / re-adding again.
+                project.AddSourceFile(sourceFileFullPath2);
+                project.AddSourceFile(sourceFileFullPath4);
+                project.RemoveSourceFile(sourceFileFullPath2);
+                project.RemoveSourceFile(sourceFileFullPath4);
+                project.AddSourceFile(sourceFileFullPath2);
+                project.AddSourceFile(sourceFileFullPath4);
+
+                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2, sourceFileFullPath3, sourceFileFullPath4, sourceFileFullPath5 });
+
+                project.EndBatch();
+
+                var documents = GetCurrentDocuments().ToArray();
+
+                Assert.Equal(documents[0].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[1].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[2].FilePath, sourceFileFullPath3, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[3].FilePath, sourceFileFullPath4, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[4].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void ReorderSourceFilesBatchAddAfterReorder_CPS()
+        {
+            using (var environment = new TestEnvironment())
+            using (var project = CreateCSharpCPSProject(environment, "project1"))
+            {
+                IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
+
+                Assert.Empty(GetCurrentDocuments());
+
+                var sourceFileFullPath1 = @"c:\source1.cs";
+                var sourceFileFullPath2 = @"c:\source2.cs";
+                var sourceFileFullPath3 = @"c:\source3.cs";
+                var sourceFileFullPath4 = @"c:\source4.cs";
+                var sourceFileFullPath5 = @"c:\source5.cs";
+
+                project.StartBatch();
+
+                project.AddSourceFile(sourceFileFullPath1);
+                project.AddSourceFile(sourceFileFullPath2);
+
+                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2 });
+
+                project.AddSourceFile(sourceFileFullPath3);
+                project.AddSourceFile(sourceFileFullPath4);
+                project.AddSourceFile(sourceFileFullPath5);
+
+                project.EndBatch();
+
+                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2, sourceFileFullPath3, sourceFileFullPath4, sourceFileFullPath5 });
+
+                var documents = GetCurrentDocuments().ToArray();
+
+                Assert.Equal(documents[0].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[1].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[2].FilePath, sourceFileFullPath3, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[3].FilePath, sourceFileFullPath4, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[4].FilePath, sourceFileFullPath5, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void ReorderSourceFilesBatchRemoveAfterReorder_CPS()
+        {
+            using (var environment = new TestEnvironment())
+            using (var project = CreateCSharpCPSProject(environment, "project1"))
+            {
+                IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
+
+                Assert.Empty(GetCurrentDocuments());
+
+                var sourceFileFullPath1 = @"c:\source1.cs";
+                var sourceFileFullPath2 = @"c:\source2.cs";
+                var sourceFileFullPath3 = @"c:\source3.cs";
+                var sourceFileFullPath4 = @"c:\source4.cs";
+                var sourceFileFullPath5 = @"c:\source5.cs";
+
+                project.StartBatch();
+
+                project.AddSourceFile(sourceFileFullPath1);
+                project.AddSourceFile(sourceFileFullPath2);
+                project.AddSourceFile(sourceFileFullPath3);
+                project.AddSourceFile(sourceFileFullPath4);
+                project.AddSourceFile(sourceFileFullPath5);
+
+                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2, sourceFileFullPath3, sourceFileFullPath4, sourceFileFullPath5 });
+
+                project.RemoveSourceFile(sourceFileFullPath3);
+                project.RemoveSourceFile(sourceFileFullPath4);
+                project.RemoveSourceFile(sourceFileFullPath5);
+
+                project.EndBatch();
+
+                project.ReorderSourceFiles(new[] { sourceFileFullPath1, sourceFileFullPath2 });
+
+                var documents = GetCurrentDocuments().ToArray();
+
+                Assert.Equal(documents[0].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal(documents[1].FilePath, sourceFileFullPath2, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void ReorderSourceFilesExceptions_CPS()
+        {
+            using (var environment = new TestEnvironment())
+            using (var project = CreateCSharpCPSProject(environment, "project1"))
+            {
+                IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
+
+                Assert.Empty(GetCurrentDocuments());
+
+                var sourceFileFullPath1 = @"c:\source1.cs";
+                var sourceFileFullPath2 = @"c:\source2.cs";
+                var sourceFileFullPath3 = @"c:\source3.cs";
+                var sourceFileFullPath4 = @"c:\source4.cs";
+                var sourceFileFullPath5 = @"c:\source5.cs";
+                project.AddSourceFile(sourceFileFullPath1);
+                project.AddSourceFile(sourceFileFullPath2);
+                project.AddSourceFile(sourceFileFullPath3);
+                project.AddSourceFile(sourceFileFullPath4);
+                project.AddSourceFile(sourceFileFullPath5);
+
+                project.RemoveSourceFile(sourceFileFullPath2);
+                project.AddSourceFile(sourceFileFullPath2);
+
+                project.RemoveSourceFile(sourceFileFullPath4);
+                project.AddSourceFile(sourceFileFullPath4);
+
+                // This should throw due to not passing all of the files.
+                Assert.Throws<ArgumentException>(() => project.ReorderSourceFiles(new[] { sourceFileFullPath4, sourceFileFullPath5 }));
+
+                // This should throw because the path does not exist in the project.
+                Assert.Throws<InvalidOperationException>(() => project.ReorderSourceFiles(new[] { @"C:\invalid source file", sourceFileFullPath2, sourceFileFullPath3, sourceFileFullPath4, sourceFileFullPath5 }));
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => project.ReorderSourceFiles(new List<string>()));
+                Assert.Throws<ArgumentOutOfRangeException>(() => project.ReorderSourceFiles(null));
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void ReorderSourceFilesBatchExceptions_CPS()
+        {
+            using (var environment = new TestEnvironment())
+            using (var project = CreateCSharpCPSProject(environment, "project1"))
+            {
+                IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
+
+                Assert.Empty(GetCurrentDocuments());
+
+                var sourceFileFullPath1 = @"c:\source1.cs";
+                var sourceFileFullPath2 = @"c:\source2.cs";
+                var sourceFileFullPath3 = @"c:\source3.cs";
+                var sourceFileFullPath4 = @"c:\source4.cs";
+                var sourceFileFullPath5 = @"c:\source5.cs";
+
+                project.StartBatch();
+
+                Assert.Throws<ArgumentException>(() => project.ReorderSourceFiles(new[] { sourceFileFullPath4, sourceFileFullPath5 }));
+                Assert.Throws<ArgumentException>(() => project.ReorderSourceFiles(new[] { @"C:\invalid source file" })); // no files were added, therefore we should get an argument exception
+                Assert.Throws<ArgumentOutOfRangeException>(() => project.ReorderSourceFiles(new List<string>()));
+                Assert.Throws<ArgumentOutOfRangeException>(() => project.ReorderSourceFiles(null));
+
+                project.AddSourceFile(sourceFileFullPath1);
+
+                // Test before we add/remove the rest of source files in the batch.
+                Assert.Throws<ArgumentException>(() => project.ReorderSourceFiles(new[] { sourceFileFullPath4, sourceFileFullPath5 }));
+                Assert.Throws<InvalidOperationException>(() => project.ReorderSourceFiles(new[] { @"C:\invalid source file" }));
+                Assert.Throws<ArgumentOutOfRangeException>(() => project.ReorderSourceFiles(new List<string>()));
+                Assert.Throws<ArgumentOutOfRangeException>(() => project.ReorderSourceFiles(null));
+
+                project.AddSourceFile(sourceFileFullPath2);
+                project.AddSourceFile(sourceFileFullPath3);
+                project.AddSourceFile(sourceFileFullPath4);
+                project.AddSourceFile(sourceFileFullPath5);
+
+                project.RemoveSourceFile(sourceFileFullPath2);
+                project.AddSourceFile(sourceFileFullPath2);
+
+                project.RemoveSourceFile(sourceFileFullPath4);
+                project.AddSourceFile(sourceFileFullPath4);
+
+                Assert.Throws<ArgumentException>(() => project.ReorderSourceFiles(new[] { sourceFileFullPath4, sourceFileFullPath5 }));
+                Assert.Throws<InvalidOperationException>(() => project.ReorderSourceFiles(new[] { @"C:\invalid source file", sourceFileFullPath2, sourceFileFullPath3, sourceFileFullPath4, sourceFileFullPath5 }));
+                Assert.Throws<ArgumentOutOfRangeException>(() => project.ReorderSourceFiles(new List<string>()));
+                Assert.Throws<ArgumentOutOfRangeException>(() => project.ReorderSourceFiles(null));
+
+                project.EndBatch();
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void ReorderSourceFilesBatchExceptionRemoveFile_CPS()
+        {
+            using (var environment = new TestEnvironment())
+            using (var project = CreateCSharpCPSProject(environment, "project1"))
+            {
+                IEnumerable<Document> GetCurrentDocuments() => environment.Workspace.CurrentSolution.Projects.Single().Documents;
+
+                Assert.Empty(GetCurrentDocuments());
+
+                var sourceFileFullPath1 = @"c:\source1.cs";
+                var sourceFileFullPath2 = @"c:\source2.cs";
+
+                project.AddSourceFile(sourceFileFullPath1);
+                project.AddSourceFile(sourceFileFullPath2);
+
+                project.StartBatch();
+
+                project.RemoveSourceFile(sourceFileFullPath2);
+                Assert.Throws<InvalidOperationException>(() => project.ReorderSourceFiles(new[] { sourceFileFullPath2 }));
+
+                project.EndBatch();
+
+                var documents = GetCurrentDocuments().ToArray();
+
+                Assert.Equal(documents[0].FilePath, sourceFileFullPath1, StringComparer.OrdinalIgnoreCase);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/IWorkspaceProjectContext.cs
@@ -45,5 +45,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
 
         void StartBatch();
         void EndBatch();
+
+        void ReorderSourceFiles(IEnumerable<string> filePaths);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -1082,7 +1082,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             /// <summary>
             /// The current list of document file paths that will be ordered in a batch.
             /// </summary>
-            private List<string> _orderedFilesInBatch = null;
+            private ImmutableList<DocumentId> _orderedDocumentsInBatch = null;
 
             private readonly Func<Solution, DocumentId, bool> _documentAlreadyInWorkspace;
             private readonly Action<Workspace, DocumentInfo> _documentAddAction;
@@ -1124,8 +1124,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         throw new ArgumentException($"'{fullPath}' has already been added to this project.", nameof(fullPath));
                     }
 
-                    // If we have an ordered files batch, we need to add the file to the end of it as well.
-                    _orderedFilesInBatch?.Add(fullPath);
+                    // If we have an ordered document ids batch, we need to add the document id to the end of it as well.
+                    _orderedDocumentsInBatch = _orderedDocumentsInBatch?.Add(documentId);
 
                     _documentPathsToDocumentIds.Add(fullPath, documentId);
                     _project._documentFileWatchingTokens.Add(documentId, _project._documentFileChangeContext.EnqueueWatchingFile(fullPath));
@@ -1213,8 +1213,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         throw new ArgumentException($"'{filePath}' has already been added to this project.", nameof(filePath));
                     }
 
-                    // If we have an ordered files batch, we need to add the file to the end of it as well.
-                    _orderedFilesInBatch?.Add(filePath);
+                    // If we have an ordered document ids batch, we need to add the document id to the end of it as well.
+                    _orderedDocumentsInBatch = _orderedDocumentsInBatch?.Add(documentId);
 
                     _documentPathsToDocumentIds.Add(filePath, documentId);
 
@@ -1284,18 +1284,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             private void RemoveFileInternal(DocumentId documentId, string fullPath)
             {
-                // If we have an ordered files batch, we need to remove the file from the batch.
-                if (_orderedFilesInBatch != null)
-                {
-                    for (var i = 0; i < _orderedFilesInBatch.Count; i++)
-                    {
-                        if (_orderedFilesInBatch[i].Equals(fullPath, StringComparison.OrdinalIgnoreCase))
-                        {
-                            _orderedFilesInBatch.RemoveAt(i);
-                        }
-                    }
-                }
-
+                _orderedDocumentsInBatch = _orderedDocumentsInBatch?.Remove(documentId);
                 _documentPathsToDocumentIds.Remove(fullPath);
 
                 // There are two cases:
@@ -1490,13 +1479,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         }
                     }
 
+                    var documentIds = filePaths.Select(x => _documentPathsToDocumentIds[x]).ToImmutableList();
+
                     if (_project._activeBatchScopes > 0)
                     {
-                        _orderedFilesInBatch = new List<string>(filePaths);
+                        _orderedDocumentsInBatch = documentIds;
                     }
                     else
                     {
-                        _project._workspace.ApplyBatchChangeToProject(_project.Id, oldSolution => UpdateProjectDocumentsOrder(oldSolution, filePaths));
+                        _project._workspace.ApplyBatchChangeToProject(_project.Id, solution => solution.WithProjectDocumentsOrder(_project.Id, documentIds));
                     }
                 }
             }
@@ -1532,25 +1523,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 ClearAndZeroCapacity(_documentsRemovedInBatch);
 
                 // Update project's order of documents.
-                if (_orderedFilesInBatch != null)
+                if (_orderedDocumentsInBatch != null)
                 {
-                    var orderedFiles = _orderedFilesInBatch;
-
-                    _orderedFilesInBatch = null;
-
-                    solution = UpdateProjectDocumentsOrder(solution, orderedFiles);
+                    solution = solution.WithProjectDocumentsOrder(_project.Id, _orderedDocumentsInBatch);
+                    _orderedDocumentsInBatch = null;
                 }
 
                 return solution;
-            }
-
-            private Solution UpdateProjectDocumentsOrder(Solution solution, IEnumerable<string> filePaths)
-            {
-                var projectId = _project.Id;
-                var documentIds =
-                    filePaths.Select(x => _documentPathsToDocumentIds[x]);
-
-                return solution.WithProjectDocumentsOrder(projectId, documentIds.ToImmutableList());
             }
 
             private DocumentInfo CreateDocumentInfoFromFileInfo(DynamicFileInfo fileInfo, IEnumerable<string> folders)

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -227,6 +227,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             scope.Dispose();
         }
 
+        public void ReorderSourceFiles(IEnumerable<string> filePaths)
+        {
+            _visualStudioProject.ReorderSourceFiles(filePaths.ToImmutableArrayOrEmpty());
+        }
+
         internal VisualStudioProject GetProject_TestOnly()
         {
             return _visualStudioProject;

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.CodeAnalysis.Solution.WithProjectDocumentsOrder(Microsoft.CodeAnalysis.ProjectId projectId, System.Collections.Immutable.ImmutableList<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Solution
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AliasImportDeclaration(string aliasIdentifierName, Microsoft.CodeAnalysis.SyntaxNode name) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NameExpression(Microsoft.CodeAnalysis.INamespaceOrTypeSymbol namespaceOrTypeSymbol) -> Microsoft.CodeAnalysis.SyntaxNode
 const Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.RegexAlternation = "regex - alternation" -> string

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -673,11 +673,6 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectState UpdateDocumentsOrder(ImmutableList<DocumentId> documentIds)
         {
-            if (documentIds == null)
-            {
-                throw new ArgumentNullException(nameof(documentIds));
-            }
-
             if (documentIds.IsEmpty)
             {
                 throw new ArgumentOutOfRangeException("The specified documents are empty.", nameof(documentIds));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -683,15 +683,30 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentException($"The specified documents do not equal the project document count.", nameof(documentIds));
             }
 
-            foreach (var documentId in documentIds)
+            var hasOrderChanged = false;
+
+            for (var i = 0; i < documentIds.Count; ++i)
             {
-                if (!this.ContainsDocument(documentId))
+                var documentId = documentIds[i];
+
+                if (!ContainsDocument(documentId))
                 {
                     throw new InvalidOperationException($"The document '{documentId}' does not exist in the project.");
                 }
+
+                if (DocumentIds[i] != documentId)
+                {
+                    hasOrderChanged = true;
+                }
+            }
+
+            if (!hasOrderChanged)
+            {
+                return this;
             }
 
             return this.With(
+                projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
                 documentIds: documentIds);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -671,6 +671,35 @@ namespace Microsoft.CodeAnalysis
                 latestDocumentTopLevelChangeVersion: dependentSemanticVersion);
         }
 
+        public ProjectState UpdateDocumentsOrder(ImmutableList<DocumentId> documentIds)
+        {
+            if (documentIds == null)
+            {
+                throw new ArgumentNullException(nameof(documentIds));
+            }
+
+            if (documentIds.IsEmpty)
+            {
+                throw new ArgumentOutOfRangeException("The specified documents are empty.", nameof(documentIds));
+            }
+
+            if (documentIds.Count != _documentIds.Count)
+            {
+                throw new ArgumentException($"The specified documents do not equal the project document count.", nameof(documentIds));
+            }
+
+            foreach (var documentId in documentIds)
+            {
+                if (!this.ContainsDocument(documentId))
+                {
+                    throw new InvalidOperationException($"The document '{documentId}' does not exist in the project.");
+                }
+            }
+
+            return this.With(
+                documentIds: documentIds);
+        }
+
         private void GetLatestDependentVersions(
             IImmutableDictionary<DocumentId, DocumentState> newDocumentStates,
             IImmutableDictionary<DocumentId, TextDocumentState> newAdditionalDocumentStates,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -470,6 +470,21 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Creates a new solution instance with the project documents in the order by the specified document ids.
+        /// The specified document ids must be the same as what is already in the project; no adding or removing is allowed.
+        /// </summary>
+        public Solution WithProjectDocumentsOrder(ProjectId projectId, ImmutableList<DocumentId> documentIds)
+        {
+            var newState = _state.WithProjectDocumentsOrder(projectId, documentIds);
+            if (newState == _state)
+            {
+                return this;
+            }
+
+            return new Solution(newState);
+        }
+
+        /// <summary>
         /// Create a new solution instance with the project specified updated to include the 
         /// specified metadata reference.
         /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -946,7 +946,12 @@ namespace Microsoft.CodeAnalysis
             var oldProject = this.GetProjectState(projectId);
             var newProject = oldProject.UpdateDocumentsOrder(documentIds);
 
-            return this.ForkProject(newProject);
+            if (oldProject == newProject)
+            {
+                return this;
+            }
+
+            return this.ForkProject(newProject, CompilationTranslationAction.ProjectParseOptions(newProject));
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -926,6 +926,30 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Creates a new solution instance with the project documents in the order by the specified document ids.
+        /// The specified document ids must be the same as what is already in the project; no adding or removing is allowed.
+        /// </summary>
+        public SolutionState WithProjectDocumentsOrder(ProjectId projectId, ImmutableList<DocumentId> documentIds)
+        {
+            if (projectId == null)
+            {
+                throw new ArgumentNullException(nameof(projectId));
+            }
+
+            if (documentIds == null)
+            {
+                throw new ArgumentNullException(nameof(documentIds));
+            }
+
+            CheckContainsProject(projectId);
+
+            var oldProject = this.GetProjectState(projectId);
+            var newProject = oldProject.UpdateDocumentsOrder(documentIds);
+
+            return this.ForkProject(newProject);
+        }
+
+        /// <summary>
         /// Create a new solution instance with the project specified updated to include the 
         /// specified metadata reference.
         /// </summary>

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -1520,6 +1520,83 @@ public class C : A {
             var root = newTree.GetRoot();
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestUpdateDocumentsOrder()
+        {
+            var solution = CreateSolution();
+            var pid = ProjectId.CreateNewId();
+
+            Func<ImmutableArray<Document>> GetDocuments = () => solution.GetProject(pid).Documents.ToImmutableArray();
+
+            solution = solution.AddProject(pid, "test", "test.dll", LanguageNames.CSharp);
+
+            var text1 = "public class Test1 {}";
+            var did1 = DocumentId.CreateNewId(pid);
+            solution = solution.AddDocument(did1, "test1.cs", text1);
+
+            var text2 = "public class Test2 {}";
+            var did2 = DocumentId.CreateNewId(pid);
+            solution = solution.AddDocument(did2, "test2.cs", text2);
+
+            var text3 = "public class Test3 {}";
+            var did3 = DocumentId.CreateNewId(pid);
+            solution = solution.AddDocument(did3, "test3.cs", text3);
+
+            var text4 = "public class Test4 {}";
+            var did4 = DocumentId.CreateNewId(pid);
+            solution = solution.AddDocument(did4, "test4.cs", text4);
+
+            var text5 = "public class Test5 {}";
+            var did5 = DocumentId.CreateNewId(pid);
+            solution = solution.AddDocument(did5, "test5.cs", text5);
+
+            solution = solution.WithProjectDocumentsOrder(pid, ImmutableList.CreateRange(new[] { did5, did4, did3, did2, did1 }));
+
+            var documents = GetDocuments();
+
+            Assert.Equal("test5.cs", documents[0].Name, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("test4.cs", documents[1].Name, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("test3.cs", documents[2].Name, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("test2.cs", documents[3].Name, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("test1.cs", documents[4].Name, StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestUpdateDocumentsOrderExceptions()
+        {
+            var solution = CreateSolution();
+            var pid = ProjectId.CreateNewId();
+
+            solution = solution.AddProject(pid, "test", "test.dll", LanguageNames.CSharp);
+
+            var text1 = "public class Test1 {}";
+            var did1 = DocumentId.CreateNewId(pid);
+            solution = solution.AddDocument(did1, "test1.cs", text1);
+
+            var text2 = "public class Test2 {}";
+            var did2 = DocumentId.CreateNewId(pid);
+            solution = solution.AddDocument(did2, "test2.cs", text2);
+
+            var text3 = "public class Test3 {}";
+            var did3 = DocumentId.CreateNewId(pid);
+            solution = solution.AddDocument(did3, "test3.cs", text3);
+
+            var text4 = "public class Test4 {}";
+            var did4 = DocumentId.CreateNewId(pid);
+            solution = solution.AddDocument(did4, "test4.cs", text4);
+
+            var text5 = "public class Test5 {}";
+            var did5 = DocumentId.CreateNewId(pid);
+            solution = solution.AddDocument(did5, "test5.cs", text5);
+
+            solution = solution.RemoveDocument(did5);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => solution = solution.WithProjectDocumentsOrder(pid, ImmutableList.Create<DocumentId>()));
+            Assert.Throws<ArgumentNullException>(() => solution = solution.WithProjectDocumentsOrder(pid, null));
+            Assert.Throws<InvalidOperationException>(() => solution = solution.WithProjectDocumentsOrder(pid, ImmutableList.CreateRange(new[] { did5, did3, did2, did1 })));
+            Assert.Throws<ArgumentException>(() => solution = solution.WithProjectDocumentsOrder(pid, ImmutableList.CreateRange(new[] { did3, did2, did1 })));
+        }
+
         private static void GetMultipleProjects(
             out Project csBrokenProject,
             out Project vbNormalProject,

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -1528,11 +1528,9 @@ public class C : A {
 
             Func<VersionStamp> GetVersion = () => solution.GetProject(pid).Version;
             Func<ImmutableArray<DocumentId>> GetDocumentIds = () => solution.GetProject(pid).DocumentIds.ToImmutableArray();
-            Func<DocumentId, Document> GetDocument = documentId => solution.GetProject(pid).GetDocument(documentId);
             Func<ImmutableArray<SyntaxTree>> GetSyntaxTrees = () =>
                 {
-                    var cancellationToken = new CancellationToken();
-                    return solution.State.GetCompilationAsync(solution.GetProject(pid).State, cancellationToken).Result.SyntaxTrees.ToImmutableArray();
+                    return solution.GetProject(pid).GetCompilationAsync().Result.SyntaxTrees.ToImmutableArray();
                 };
 
             solution = solution.AddProject(pid, "test", "test.dll", LanguageNames.CSharp);


### PR DESCRIPTION
This adds a new method, `ReorderSourceFiles`, to `IWorkspaceProjectContext`.

This is to support scenarios, such as F#, where the order of documents matter when retrieved using `Project.Documents`.