### PR TITLE
Fix classification for comments after "#pragma warning" directives

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests_Preprocessor.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests_Preprocessor.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.Editor.UnitTests.Classification.FormattedClassifications;
 
@@ -838,6 +839,20 @@ aeu";
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [WorkItem(30783, "https://github.com/dotnet/roslyn/issues/30783")]
+        public async Task PP_PragmaWarningDisableAllWithComment()
+        {
+            var code = @"#pragma warning disable //Goo";
+
+            await TestAsync(code,
+                PPKeyword("#"),
+                PPKeyword("pragma"),
+                PPKeyword("warning"),
+                PPKeyword("disable"),
+                Comment("//Goo"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task PP_PragmaWarningRestoreOne()
         {
             var code = @"#pragma warning restore 100";
@@ -861,6 +876,20 @@ aeu";
                 PPKeyword("warning"),
                 PPKeyword("restore"),
                 Number("100"),
+                Comment("//Goo"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [WorkItem(30783, "https://github.com/dotnet/roslyn/issues/30783")]
+        public async Task PP_PragmaWarningRestoreAllWithComment()
+        {
+            var code = @"#pragma warning restore //Goo";
+
+            await TestAsync(code,
+                PPKeyword("#"),
+                PPKeyword("pragma"),
+                PPKeyword("warning"),
+                PPKeyword("restore"),
                 Comment("//Goo"));
         }
 

--- a/src/Workspaces/CSharp/Portable/Classification/Worker_Preprocesser.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker_Preprocesser.cs
@@ -263,20 +263,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             AddClassification(node.WarningKeyword, ClassificationTypeNames.PreprocessorKeyword);
             AddClassification(node.DisableOrRestoreKeyword, ClassificationTypeNames.PreprocessorKeyword);
 
-            // Comments after a "#pragma warning" directive without any error codes are trailing trivia of the "disable"/"restore" token.
-            foreach (var syntaxTrivia in node.DisableOrRestoreKeyword.TrailingTrivia)
-            {
-                if (syntaxTrivia.Kind() == SyntaxKind.WhitespaceTrivia)
-                {
-                    // Skip the initial whitespace
-                    continue;
-                }
-                ClassifyToken(syntaxTrivia.Token);
-            }
-
             foreach (var nodeOrToken in node.ErrorCodes.GetWithSeparators())
             {
                 ClassifyNodeOrToken(nodeOrToken);
+            }
+
+            if (node.ErrorCodes.Count == 0)
+            {
+                // When there are no error codes, we need to classify the directive's trivia.
+                // (When there are error codes, ClassifyNodeOrToken above takes care of that.)
+                ClassifyDirectiveTrivia(node);
             }
         }
 

--- a/src/Workspaces/CSharp/Portable/Classification/Worker_Preprocesser.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker_Preprocesser.cs
@@ -263,6 +263,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             AddClassification(node.WarningKeyword, ClassificationTypeNames.PreprocessorKeyword);
             AddClassification(node.DisableOrRestoreKeyword, ClassificationTypeNames.PreprocessorKeyword);
 
+            // Comments after a "#pragma warning" directive without any error codes are trailing trivia of the "disable"/"restore" token.
+            foreach (var syntaxTrivia in node.DisableOrRestoreKeyword.TrailingTrivia)
+            {
+                if (syntaxTrivia.Kind() == SyntaxKind.WhitespaceTrivia)
+                {
+                    // Skip the initial whitespace
+                    continue;
+                }
+                ClassifyToken(syntaxTrivia.Token);
+            }
+
             foreach (var nodeOrToken in node.ErrorCodes.GetWithSeparators())
             {
                 ClassifyNodeOrToken(nodeOrToken);


### PR DESCRIPTION
Fixes #30783.

Single-line comments after the `disable`/`restore` keyword are part of the trailing trivia of the keyword token. This PR adds support for classifying those comments.

Block comments are not supported in preprocessor directives, so they are not classified.