### PR TITLE
Fix procdump support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ phases:
         _testKind: Test64
 
   steps:
-    - script: build/scripts/cibuild.cmd -configuration $(_configuration) -testDesktop -$(_testKind)
+    - script: build/scripts/cibuild.cmd -configuration $(_configuration) -testDesktop -$(_testKind) -procdump
       displayName: Build and Test
 
     - task: PublishTestResults@1

--- a/src/Tools/Source/RunTests/Options.cs
+++ b/src/Tools/Source/RunTests/Options.cs
@@ -176,7 +176,7 @@ namespace RunTests
                     opt.ProcDumpDirectory = value;
                     index++;
                 }
-                else if (comparer.Equals(current, "-procdump"))
+                else if (comparer.Equals(current, "-useprocdump"))
                 {
                     opt.UseProcDump = false;
                     index++;


### PR DESCRIPTION
Makes two changes:

- Fixes the parsing of useprocdump option in RunTests. This was blocking
our official builds.
- Enables proc dump during normal desktop CI runs. This appears to have
been lost when moving our tests to Azure DevOps