### PR TITLE
Fix brace placement for destructor in "Implement interface with Dispose pattern"

### DIFF
--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
@@ -6368,7 +6368,8 @@ partial class C
     }}
 
     // {CSharpFeaturesResources.TODO_colon_override_a_finalizer_only_if_Dispose_bool_disposing_above_has_code_to_free_unmanaged_resources}
-    // ~{className}() {{
+    // ~{className}()
+    // {{
     //   // {CSharpFeaturesResources.Do_not_change_this_code_Put_cleanup_code_in_Dispose_bool_disposing_above}
     //   Dispose(false);
     // }}

--- a/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementInterfaceService.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementInterfaceService.cs
@@ -108,7 +108,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
     }}
 
     // {CSharpFeaturesResources.TODO_colon_override_a_finalizer_only_if_Dispose_bool_disposing_above_has_code_to_free_unmanaged_resources}
-    // ~{classDecl.Identifier.Value}() {{
+    // ~{classDecl.Identifier.Value}()
+    // {{
     //   // {CSharpFeaturesResources.Do_not_change_this_code_Put_cleanup_code_in_Dispose_bool_disposing_above}
     //   Dispose(false);
     // }}


### PR DESCRIPTION
When implementing the full IDisposable pattern, the auto-generated destructor would have its opening brace on the same line as the method identifier.

This PR moves the brace to its own line, to match the default C# code style.