### PR TITLE
Use a pair of lock files instead of an interprocess named mutex on Mono because the latter is not implemented

### DIFF
--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -344,21 +344,15 @@ class Hello
                     var source = new TaskCompletionSource<bool>();
                     var thread = new Thread(_ =>
                     {
-                        Mutex mutex = null;
                         try
                         {
-                            Assert.True(Mutex.TryOpenExisting(mutexName, out mutex));
-                            Assert.False(mutex.WaitOne(millisecondsTimeout: 0));
+                            Assert.True(BuildServerConnection.WasServerMutexOpen(mutexName));
                             source.SetResult(true);
                         }
                         catch (Exception ex)
                         {
                             source.SetException(ex);
                             throw;
-                        }
-                        finally
-                        {
-                            mutex?.Dispose();
                         }
                     });
 

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -736,6 +736,12 @@ namespace Microsoft.CodeAnalysis.CommandLine
             {
                 return Mutex.TryOpenExisting(mutexName, out m);
             }
+            catch
+            {
+                // In the case an exception occured trying to open the Mutex then 
+                // the assumption is that it's not open.
+                return false;
+            }
             finally
             {
                 m?.Dispose();
@@ -745,7 +751,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         public bool TryLock(int timeoutMs)
         {
             if (IsDisposed)
-                throw new InvalidOperationException("Mutex disposed");
+                throw new ObjectDisposedException("Mutex");
             if (IsLocked)
                 throw new InvalidOperationException("Lock already held");
             return IsLocked = Mutex.WaitOne(timeoutMs);
@@ -754,7 +760,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         public void Unlock()
         {
             if (IsDisposed)
-                throw new InvalidOperationException("Mutex disposed");
+                throw new ObjectDisposedException("Mutex");
             if (!IsLocked)
                 throw new InvalidOperationException("Lock not held");
             Mutex.ReleaseMutex();
@@ -807,14 +813,14 @@ namespace Microsoft.CodeAnalysis.CommandLine
         public bool TryLock(int timeoutMs)
         {
             if (IsDisposed)
-                throw new InvalidOperationException("Mutex disposed");
+                throw new ObjectDisposedException("Mutex");
             return HeldMutex.TryLock(timeoutMs);
         }
 
         public void Unlock()
         {
             if (IsDisposed)
-                throw new InvalidOperationException("Mutex disposed");
+                throw new ObjectDisposedException("Mutex");
             HeldMutex.Unlock();
         }
 

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -125,14 +125,14 @@ namespace Microsoft.CodeAnalysis.CommandLine
             var timeoutNewProcess = timeoutOverride ?? TimeOutMsNewProcess;
             var timeoutExistingProcess = timeoutOverride ?? TimeOutMsExistingProcess;
             Task<NamedPipeClientStream> pipeTask = null;
-            Mutex clientMutex = null;
+            IServerMutex clientMutex = null;
             var holdsMutex = false;
             try
             {
                 try
                 {
                     var clientMutexName = GetClientMutexName(pipeName);
-                    clientMutex = new Mutex(initiallyOwned: true, name: clientMutexName, out holdsMutex);
+                    clientMutex = OpenOrCreateMutex(clientMutexName, out holdsMutex);
                 }
                 catch
                 {
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 {
                     try
                     {
-                        holdsMutex = clientMutex.WaitOne(timeoutNewProcess);
+                        holdsMutex = clientMutex.TryLock(timeoutNewProcess);
 
                         if (!holdsMutex)
                         {
@@ -173,14 +173,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             }
             finally
             {
-                if (clientMutex != null)
-                {
-                    if (holdsMutex)
-                    {
-                        clientMutex.ReleaseMutex();
-                    }
-                    clientMutex.Dispose();
-                }
+                clientMutex?.Dispose();
             }
 
             if (pipeTask != null)
@@ -528,12 +521,23 @@ namespace Microsoft.CodeAnalysis.CommandLine
         {
             try
             {
-                Mutex mutex;
-                var open = Mutex.TryOpenExisting(mutexName, out mutex);
-                if (open)
+                if (PlatformInformation.IsRunningOnMono)
                 {
-                    mutex.Dispose();
-                    return true;
+                    IServerMutex mutex = null;
+                    bool createdNew = false;
+                    try
+                    {
+                        mutex = new ServerFileMutexPair(mutexName, false, out createdNew);
+                        return !createdNew;
+                    }
+                    finally
+                    {
+                        mutex?.Dispose();
+                    }
+                }
+                else
+                {
+                    return ServerNamedMutex.WasOpen(mutexName);
                 }
             }
             catch
@@ -542,8 +546,18 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 // the assumption is that it's not open. 
                 return false;
             }
+        }
 
-            return false;
+        internal static IServerMutex OpenOrCreateMutex(string name, out bool createdNew)
+        {
+            if (PlatformInformation.IsRunningOnMono)
+            {
+                return new ServerFileMutexPair(name, initiallyOwned: true, out createdNew);
+            }
+            else
+            {
+                return new ServerNamedMutex(name, out createdNew);
+            }
         }
 
         internal static string GetServerMutexName(string pipeName)
@@ -604,4 +618,223 @@ namespace Microsoft.CodeAnalysis.CommandLine
             return Environment.GetEnvironmentVariable("SYSTEMROOT");
         }
     }
+
+    internal interface IServerMutex : IDisposable
+    {
+        bool TryLock(int timeoutMs);
+        void Unlock();
+        bool IsDisposed { get; }
+    }
+
+    /// <summary>
+    /// An interprocess mutex abstraction based on OS advisory locking (FileStream.Lock/Unlock).
+    /// If multiple processes running as the same user create FileMutex instances with the same name,
+    ///  those instances will all point to the same file somewhere in a selected temporary directory.
+    /// The TryLock method can be used to attempt to acquire the mutex, with Unlock or Dispose used to release.
+    /// Unlike Win32 named mutexes, there is no mechanism for detecting an abandoned mutex. The file
+    ///  will simply revert to being unlocked but remain where it is.
+    /// </summary>
+    internal sealed class FileMutex : IDisposable
+    {
+        public readonly FileStream Stream;
+        public readonly string FilePath;
+
+        public bool IsLocked { get; private set; }
+
+        internal static string GetMutexDirectory()
+        {
+            var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (string.IsNullOrWhiteSpace(homeDirectory))
+                homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            if (string.IsNullOrWhiteSpace(homeDirectory))
+                homeDirectory = BuildServerConnection.GetTempPath(null);
+            var result = Path.Combine(homeDirectory, ".roslyn");
+            Directory.CreateDirectory(result);
+            return result;
+        }
+
+        public FileMutex(string name)
+        {
+            FilePath = Path.Combine(GetMutexDirectory(), name);
+            Stream = new FileStream(FilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+        }
+
+        public bool TryLock(int timeoutMs)
+        {
+            if (IsLocked)
+                throw new InvalidOperationException("Lock already held");
+
+            var sw = Stopwatch.StartNew();
+            do
+            {
+                try
+                {
+                    Stream.Lock(0, 0);
+                    IsLocked = true;
+                    return true;
+                }
+                catch (IOException)
+                {
+                    // Lock currently held by someone else.
+                    // We want to sleep for a short period of time to ensure that other processes
+                    //  have an opportunity to finish their work and relinquish the lock.
+                    // Spinning here (via Yield) would work but risks creating a priority
+                    //  inversion if the lock is held by a lower-priority process.
+                    Thread.Sleep(1);
+                }
+                catch (Exception)
+                {
+                    // Something else went wrong.
+                    return false;
+                }
+            } while (sw.ElapsedMilliseconds < timeoutMs);
+
+            return false;
+        }
+
+        public void Unlock()
+        {
+            if (!IsLocked)
+                return;
+            Stream.Unlock(0, 0);
+            IsLocked = false;
+        }
+
+        public void Dispose()
+        {
+            var wasLocked = IsLocked;
+            if (wasLocked)
+                Unlock();
+            Stream.Dispose();
+            // We do not delete the lock file here because there is no reliable way to perform a
+            //  'delete if no one has the file open' operation atomically on *nix. This is a leak.
+        }
+    }
+
+    internal sealed class ServerNamedMutex : IServerMutex
+    {
+        public readonly Mutex Mutex;
+
+        public bool IsDisposed { get; private set; }
+        public bool IsLocked { get; private set; }
+
+        public ServerNamedMutex(string mutexName, out bool createdNew)
+        {
+            Mutex = new Mutex(
+                initiallyOwned: true,
+                name: mutexName,
+                createdNew: out createdNew
+            );
+            if (createdNew)
+                IsLocked = true;
+        }
+
+        public static bool WasOpen(string mutexName)
+        {
+            Mutex m = null;
+            try
+            {
+                return Mutex.TryOpenExisting(mutexName, out m);
+            }
+            finally
+            {
+                m?.Dispose();
+            }
+        }
+
+        public bool TryLock(int timeoutMs)
+        {
+            if (IsDisposed)
+                throw new InvalidOperationException("Mutex disposed");
+            if (IsLocked)
+                throw new InvalidOperationException("Lock already held");
+            return IsLocked = Mutex.WaitOne(timeoutMs);
+        }
+
+        public void Unlock()
+        {
+            if (IsDisposed)
+                throw new InvalidOperationException("Mutex disposed");
+            if (!IsLocked)
+                throw new InvalidOperationException("Lock not held");
+            Mutex.ReleaseMutex();
+            IsLocked = false;
+        }
+
+        public void Dispose()
+        {
+            if (IsDisposed)
+                return;
+            IsDisposed = true;
+
+            try
+            {
+                if (IsLocked)
+                    Mutex.ReleaseMutex();
+            }
+            finally
+            {
+                Mutex.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Approximates a named mutex with 'locked', 'unlocked' and 'abandoned' states.
+    /// There is no reliable way to detect whether a mutex has been abandoned on some target platforms,
+    ///  so we use the AliveMutex to manually track whether the creator of a mutex is still running,
+    ///  while the HeldMutex represents the actual lock state of the mutex.
+    /// </summary>
+    internal sealed class ServerFileMutexPair : IServerMutex
+    {
+        public readonly FileMutex AliveMutex;
+        public readonly FileMutex HeldMutex;
+
+        public bool IsDisposed { get; private set; }
+
+        public ServerFileMutexPair(string mutexName, bool initiallyOwned, out bool createdNew)
+        {
+            AliveMutex = new FileMutex(mutexName + "-alive");
+            HeldMutex = new FileMutex(mutexName + "-held");
+            createdNew = AliveMutex.TryLock(0);
+            if (initiallyOwned && createdNew)
+            {
+                if (!TryLock(0))
+                    throw new Exception("Failed to lock mutex after creating it");
+            }
+        }
+
+        public bool TryLock(int timeoutMs)
+        {
+            if (IsDisposed)
+                throw new InvalidOperationException("Mutex disposed");
+            return HeldMutex.TryLock(timeoutMs);
+        }
+
+        public void Unlock()
+        {
+            if (IsDisposed)
+                throw new InvalidOperationException("Mutex disposed");
+            HeldMutex.Unlock();
+        }
+
+        public void Dispose()
+        {
+            if (IsDisposed)
+                return;
+            IsDisposed = true;
+
+            try
+            {
+                HeldMutex.Unlock();
+                AliveMutex.Unlock();
+            }
+            finally
+            {
+                AliveMutex.Dispose();
+                HeldMutex.Dispose();
+            }
+        }
+    }
+
 }

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -643,12 +643,8 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         internal static string GetMutexDirectory()
         {
-            var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            if (string.IsNullOrWhiteSpace(homeDirectory))
-                homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            if (string.IsNullOrWhiteSpace(homeDirectory))
-                homeDirectory = BuildServerConnection.GetTempPath(null);
-            var result = Path.Combine(homeDirectory, ".roslyn");
+            var tempPath = BuildServerConnection.GetTempPath(null);
+            var result = Path.Combine(tempPath, ".roslyn");
             Directory.CreateDirectory(result);
             return result;
         }


### PR DESCRIPTION
This is a rough attempt at using a pair of lockfiles on mono to indicate whether the compiler server is starting/running. On all platforms right now a single interprocess named mutex is used, but those are not implemented on Mono (primarily because there is no actual primitive for this on *nix - coreclr has a very elaborate implementation based on shm that can leak resources.)

My approach was to pull all the direct use of the Mutex into helper methods on BuildServerConnection, then replace the Mutex type with IDisposable. When running on Mono instead of creating a Mutex it creates a ServerFileMutexPair, which is an abstraction over a pair of file locks: one file lock represents whether the Mutex was 'alive', so we can detect an abandoned Mutex, and the other file lock represents whether it is held.

There are a bunch of debugging writelines in here because I spent a lot of time troubleshooting this, naturally those will go away during cleanup if it looks mergeable.

The Wait operation is only implemented for a timeout of 0ms - that seems to be the only one used in the code right now, so that might be okay? But in the event we actually need a blocking wait I have no idea how to do that with lockfiles.

I have only tested this on Linux w/the latest version of Mono, so if it seems viable I'll have to test it out in other environments. It would be cool if it could also be used on coreclr and netframework to unify the code, but it might be better to keep using Mutex there.

cc @jaredpar , @marek-safar 