### PR TITLE
Fix double writes of XML files during build

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -19,6 +19,12 @@
 
     <!-- Place VS insertion (CoreXT) packages to a separate directory -->
     <PackageOutputPath Condition="'$(IsVisualStudioInsertionPackage)' == 'true'">$(ArtifactsConfigurationDir)DevDivPackages\Roslyn\</PackageOutputPath>
+
+  <!-- Until we have adopted the final layout we need to ensure documentation files have the right path
+       for multi+targeted projects
+      https://github.com/dotnet/roslyn/issues/23547
+  -->
+    <DocumentationFile Condition="'$(MSBuildProjectExtension)' == '.csproj' and '$(TargetFramework)' != '' and '$(GenerateDocumentationFile)' == 'true'">$(IntermediateOutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(Language)' == 'CSharp' and '$(TargetFramework)' == 'net20'">

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -155,7 +155,7 @@
     <MicrosoftVisualStudioValidationVersion>15.3.23</MicrosoftVisualStudioValidationVersion>
     <MicrosoftVisualStudioVsInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioVsInteractiveWindowVersion>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
-    <MSBuildStructuredLoggerVersion>1.2.48</MSBuildStructuredLoggerVersion>
+    <MSBuildStructuredLoggerVersion>2.0.61</MSBuildStructuredLoggerVersion>
     <MDbgVersion>0.1.0</MDbgVersion>
     <MonoOptionsVersion>4.4.0</MonoOptionsVersion>
     <MoqVersion>4.7.99</MoqVersion>


### PR DESCRIPTION
Presently our build is writing XML documentation files to the same output location on every build. This means multi-targeted builds are stomping on each others files. Need to separate them out. 

**Note**: updating this PR in stages. First commit to make sure that the bug is caught in CI. Will upload the fix once that is verified.