### PR TITLE
Add overload for AnalyzerConfig.Parse that takes a SourceText

### DIFF
--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -186,6 +186,7 @@ Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions.IncludeNullableReferenc
 override Microsoft.CodeAnalysis.FlowAnalysis.CaptureId.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.FlowAnalysis.CaptureId.GetHashCode() -> int
 static Microsoft.CodeAnalysis.AnalyzerConfig.GetAnalyzerConfigOptions<TStringList, TACList>(TStringList sourcePaths, TACList analyzerConfigs) -> Microsoft.CodeAnalysis.AnalyzerConfigOptionsResult
+static Microsoft.CodeAnalysis.AnalyzerConfig.Parse(Microsoft.CodeAnalysis.Text.SourceText text, string pathToFile) -> Microsoft.CodeAnalysis.AnalyzerConfig
 static Microsoft.CodeAnalysis.AnalyzerConfig.Parse(string text, string pathToFile) -> Microsoft.CodeAnalysis.AnalyzerConfig
 static Microsoft.CodeAnalysis.AnalyzerConfig.ReservedKeys.get -> System.Collections.Immutable.ImmutableHashSet<string>
 static Microsoft.CodeAnalysis.AnalyzerConfig.ReservedValues.get -> System.Collections.Immutable.ImmutableHashSet<string>


### PR DESCRIPTION
This is for IDE cases, so we can back the text with an ITextSnapshot instead of having to realize the entire string.