### PR TITLE
 Editor completion: tests for non-block for completion items

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3603,8 +3603,8 @@ class C
                                                                          ' 2. Hang here as well.
                                                                          Dim completionItem = state.GetSelectedItemOpt()
                                                                      End Sub)
-                                                    Thread.Sleep(250)
                                                     task2 = Task.Run(Sub()
+                                                                         Thread.Sleep(250)
                                                                          Try
                                                                              ' 3. Check that the other task is running/hanging.
                                                                              Assert.Equal(TaskStatus.Running, task1.Status)
@@ -3655,7 +3655,7 @@ class C
             ' 7. Simulate unblocking the provider.
             ' 8. Verify that 
             ' 8.a. The old completion adds 'a' to 'Sys' and displays 'Sysa'. CommitIfUnique is canceled because it was interrupted by typing 'a'.
-            ' 8.b. The new completion completes CommitIfUnique and then add 'a'.
+            ' 8.b. The new completion completes CommitIfUnique and then adds 'a'.
             Dim tcs = New TaskCompletionSource(Of Boolean)
             Dim provider = New TaskControlledCompletionProvider(tcs.Task)
             Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
@@ -3690,8 +3690,8 @@ class C
                                                                          ' 2. Hang here as well.
                                                                          Dim completionItem = state.GetSelectedItemOpt()
                                                                      End Sub)
-                                                    Thread.Sleep(250)
                                                     task2 = Task.Run(Sub()
+                                                                         Thread.Sleep(250)
                                                                          Try
                                                                              ' 3. Check that the other task is running/hanging.
                                                                              Assert.Equal(TaskStatus.Running, task1.Status)

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3559,6 +3559,17 @@ class C
         <MemberData(NameOf(AllCompletionImplementations))>
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestNoBlockOnCompletionItems4(completionImplementation As CompletionImplementation) As Task
+            ' This test verifies a scenario with the following conditions:
+            ' a. A slow completion provider
+            ' b. The block option set to false.
+            ' Scenario:
+            ' 1. Type 'Sys'
+            ' 2. Send CommitIfUnique (Ctrl + space)
+            ' 3. Wait for 250ms.
+            ' 4. Verify that there is no completion window shown. In the new completion, we can just start the verification and check that the verification is still running.
+            ' 5. Check that the commit is not yet provided: there is 'Sys' but no 'System'
+            ' 6. Simulate unblocking the provider.
+            ' 7. Verify that the completion completes CommitIfUnique.
             Dim tcs = New TaskCompletionSource(Of Boolean)
             Dim provider = New TaskControlledCompletionProvider(tcs.Task)
             Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
@@ -3592,7 +3603,7 @@ class C
                                                                          ' 2. Hang here as well.
                                                                          Dim completionItem = state.GetSelectedItemOpt()
                                                                      End Sub)
-                                                    Task.Delay(250)
+                                                    Thread.Sleep(250)
                                                     task2 = Task.Run(Sub()
                                                                          Try
                                                                              ' 3. Check that the other task is running/hanging.
@@ -3631,6 +3642,20 @@ class C
         <MemberData(NameOf(AllCompletionImplementations))>
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestNoBlockOnCompletionItems3(completionImplementation As CompletionImplementation) As Task
+            ' This test verifies a scenario with the following conditions:
+            ' a. A slow completion provider
+            ' b. The block option set to false.
+            ' Scenario:
+            ' 1. Type 'Sys'
+            ' 2. Send CommitIfUnique (Ctrl + space)
+            ' 3. Wait for 250ms.
+            ' 4. Verify that there is no completion window shown. In the new completion, we can just start the verification and check that the verification is still running.
+            ' 5. Check that the commit is not yet provided: there is 'Sys' but no 'System'
+            ' 6. The next statement in the UI thread after CommitIfUnique is typing 'a'.
+            ' 7. Simulate unblocking the provider.
+            ' 8. Verify that 
+            ' 8.a. The old completion adds 'a' to 'Sys' and displays 'Sysa'. CommitIfUnique is canceled because it was interrupted by typing 'a'.
+            ' 8.b. The new completion completes CommitIfUnique and then add 'a'.
             Dim tcs = New TaskCompletionSource(Of Boolean)
             Dim provider = New TaskControlledCompletionProvider(tcs.Task)
             Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
@@ -3665,7 +3690,7 @@ class C
                                                                          ' 2. Hang here as well.
                                                                          Dim completionItem = state.GetSelectedItemOpt()
                                                                      End Sub)
-                                                    Task.Delay(250)
+                                                    Thread.Sleep(250)
                                                     task2 = Task.Run(Sub()
                                                                          Try
                                                                              ' 3. Check that the other task is running/hanging.

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3572,7 +3572,7 @@ class C
                 state.SendTypeChars("Sys")
                 state.SendCommitUniqueCompletionListItem()
                 Await Task.Delay(250)
-                Await state.AssertNoCompletionSession(block:=False)
+                state.AssertNoCompletionSessionWithNoBlock()
                 Assert.Contains("Sys", state.GetLineTextFromCaretPosition())
                 Assert.DoesNotContain("System", state.GetLineTextFromCaretPosition())
 
@@ -3600,7 +3600,7 @@ class C
                 state.SendTypeChars("Sys")
                 state.SendCommitUniqueCompletionListItem()
                 Await Task.Delay(250)
-                Await state.AssertNoCompletionSession(block:=False)
+                state.AssertNoCompletionSessionWithNoBlock()
                 Assert.Contains("Sys", state.GetLineTextFromCaretPosition())
                 Assert.DoesNotContain("System", state.GetLineTextFromCaretPosition())
 

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -438,7 +438,7 @@ End Class
 
                 ' We should not have a session now.  Note: do not block as this will just hang things
                 ' since the provider will not return.
-                Await state.AssertNoCompletionSession(block:=False)
+                state.AssertNoCompletionSessionWithNoBlock()
 
                 ' Now, navigate back.
                 state.SendBackspace()
@@ -476,7 +476,7 @@ End Class
 
                 ' We should not have a session now.  Note: do not block as this will just hang things
                 ' since the provider will not return.
-                Await state.AssertNoCompletionSession(block:=False)
+                state.AssertNoCompletionSessionWithNoBlock()
 
                 ' Now, navigate using the caret.
                 state.SendMoveToPreviousCharacter()
@@ -2176,7 +2176,7 @@ End Class]]></Document>)
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSelectedCompletionItem("Sub")
                 state.SendSave()
-                Await state.AssertNoCompletionSession(block:=True)
+                Await state.AssertNoCompletionSession()
                 state.AssertMatchesTextStartingAtLine(2, "    Su")
             End Using
         End Function

--- a/src/EditorFeatures/TestUtilities2/Intellisense/LegacyTestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/LegacyTestState.vb
@@ -137,12 +137,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             CurrentCompletionPresenterSession.SetSelectedItem(item)
         End Sub
 
-        Public Overrides Async Function AssertNoCompletionSession(Optional block As Boolean = True) As Task
-            If block Then
-                Await WaitForAsynchronousOperationsAsync()
-            End If
+        Public Overrides Async Function AssertNoCompletionSession() As Task
+            Await WaitForAsynchronousOperationsAsync()
             Assert.Null(Me.CurrentCompletionPresenterSession)
         End Function
+
+        Public Overrides Sub AssertNoCompletionSessionWithNoBlock()
+            Assert.Null(Me.CurrentCompletionPresenterSession)
+        End Sub
 
         Public Overrides Async Function AssertCompletionSessionAfterTypingHash() As Task
             ' The legacy completion implementation was not updated to treat # as an IntelliSense trigger

--- a/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
@@ -135,6 +135,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             End If
 
             Dim completionItems = session.GetComputedItems(CancellationToken.None)
+            ' During the computation we can explicitly dismiss the session or we can return no items.
+            ' Each of these conditions mean that there is no active completion.
             Assert.True(session.IsDismissed OrElse completionItems.Items.Count() = 0)
         End Function
 
@@ -150,13 +152,17 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             ' If completionItems cannot be calculated in 5 seconds, no session exists.
             Dim task1 = Task.Delay(5000)
-            Dim task2 = Task.Run(Sub()
-                                     Dim completionItems = session.GetComputedItems(CancellationToken.None)
-                                     ' In the non blocking mode, we are not interested for a session appeared later than in 5 seconds.
-                                     If task1.Status = TaskStatus.Running Then
-                                         Assert.True(session.IsDismissed OrElse completionItems.Items.Count() = 0)
-                                     End If
-                                 End Sub)
+            Dim task2 = Task.Run(
+                Sub()
+                    Dim completionItems = session.GetComputedItems(CancellationToken.None)
+
+                    ' In the non blocking mode, we are not interested for a session appeared later than in 5 seconds.
+                    If task1.Status = TaskStatus.Running Then
+                        ' During the computation we can explicitly dismiss the session or we can return no items.
+                        ' Each of these conditions mean that there is no active completion.
+                        Assert.True(session.IsDismissed OrElse completionItems.Items.Count() = 0)
+                    End If
+                End Sub)
 
             Task.WaitAny(task1, task2)
         End Sub

--- a/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             MyBase.New(
                 workspaceElement,
                 extraCompletionProviders,
-                excludedTypes:=Nothing,
+                excludedTypes:=excludedTypes,
                 extraExportedTypes,
                 includeFormatCommandHandler,
                 workspaceKind:=workspaceKind)
@@ -265,7 +265,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Await WaitForAsynchronousOperationsAsync()
             Dim session = GetExportedValue(Of IAsyncCompletionBroker)().GetSession(TextView)
             If Not session Is Nothing Then
-                Assert.False(CompletionItemsContainsAny({"ClassLibrary1"}))
+                Assert.False(CompletionItemsContainsAny({text}))
             End If
         End Function
 

--- a/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
@@ -150,14 +150,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             ' If completionItems cannot be calculated in 5 seconds, no session exists.
             Dim task1 = Task.Delay(5000)
-            Dim task2 = New Task(Sub()
+            Dim task2 = Task.Run(Sub()
                                      Dim completionItems = session.GetComputedItems(CancellationToken.None)
                                      ' In the non blocking mode, we are not interested for a session appeared later than in 5 seconds.
                                      If task1.Status = TaskStatus.Running Then
                                          Assert.True(session.IsDismissed OrElse completionItems.Items.Count() = 0)
                                      End If
                                  End Sub)
-            task2.Start()
+
             Task.WaitAny(task1, task2)
         End Sub
 

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestStateBase.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestStateBase.vb
@@ -158,7 +158,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         Public MustOverride Overloads Sub SendSelectCompletionItemThroughPresenterSession(item As CompletionItem)
 
-        Public MustOverride Function AssertNoCompletionSession(Optional block As Boolean = True) As Task
+        Public MustOverride Function AssertNoCompletionSession() As Task
+
+        Public MustOverride Sub AssertNoCompletionSessionWithNoBlock()
 
         Public MustOverride Function AssertCompletionSessionAfterTypingHash() As Task
 


### PR DESCRIPTION
Fixes #29112 
Fixes #31287 

Tagging @AmadeusW as well

Let us agree how BlockForCompletionItems = false works in the new completion:
1. It does not block GetCompletionContextAsync, Update and Filter.
2. It blocks UIThread when executing CommitIfUnique

Please review TestNoBlockOnCompletionItems* (1-4) tests and let me know if either scenario or tests should be corrected.

Please let me know if you see a better approach for validation rather than one thread waiting for another.

Let us agree here and then include TypeScript and F# for review as well.