### PR TITLE
Implement host object support for .editorconfig files

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -535,6 +535,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     CheckHostObjectSupport(param = nameof(AdditionalFiles), analyzerHostObject.SetAdditionalFiles(AdditionalFiles));
                 }
 
+                // For host objects which support it, set the analyzer config files and potential config files.
+                if (cscHostObject is IAnalyzerConfigFilesHostObject analyzerConfigFilesHostObject)
+                {
+                    CheckHostObjectSupport(param = nameof(AnalyzerConfigFiles), analyzerConfigFilesHostObject.SetAnalyzerConfigFiles(AnalyzerConfigFiles));
+                    CheckHostObjectSupport(param = nameof(PotentialAnalyzerConfigFiles), analyzerConfigFilesHostObject.SetPotentialAnalyzerConfigFiles(PotentialAnalyzerConfigFiles));
+                }
+
                 ICscHostObject5 cscHostObject5 = cscHostObject as ICscHostObject5;
                 if (cscHostObject5 != null)
                 {

--- a/src/Compilers/Core/MSBuildTask/DiscoverEditorConfigFiles.cs
+++ b/src/Compilers/Core/MSBuildTask/DiscoverEditorConfigFiles.cs
@@ -21,8 +21,17 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         [Required]
         public ITaskItem[] InputFiles { get; set; }
 
+        /// <summary>
+        /// The set of applicable .editorconfig files.
+        /// </summary>
         [Output]
         public ITaskItem[] EditorConfigFiles { get; private set; }
+
+        /// <summary>
+        /// Paths we considered that did *not* have a existing .editorconfig file.
+        /// </summary>
+        [Output]
+        public ITaskItem[] PotentialEditorConfigFiles { get; private set; }
 
         static DiscoverEditorConfigFiles()
         {
@@ -57,6 +66,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             var directoriesAddedToQueue = new HashSet<string>(StringComparer.Ordinal);
             var directoriesToVisit = new Queue<DirectoryInfo>();
             var editorConfigFiles = new List<ITaskItem>();
+            var potentialEditorConfigFiles = new List<ITaskItem>();
 
             void addNewDirectoryIfNotAlreadyAdded(DirectoryInfo directory)
             {
@@ -92,6 +102,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                         isRootEditorConfig = FileIsRootEditorConfig(editorConfigFilePath);
                     }
+                    else
+                    {
+                        potentialEditorConfigFiles.Add(new TaskItem(editorConfigFilePath));
+                    }
                 }
                 catch (IOException exception)
                 {
@@ -106,6 +120,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
 
             EditorConfigFiles = editorConfigFiles.ToArray();
+            PotentialEditorConfigFiles = potentialEditorConfigFiles.ToArray();
         }
 
         internal static bool FileIsRootEditorConfig(string editorConfigFilePath)

--- a/src/Compilers/Core/MSBuildTask/IAnalyzerConfigFilesHostObject.cs
+++ b/src/Compilers/Core/MSBuildTask/IAnalyzerConfigFilesHostObject.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.CodeAnalysis.BuildTasks
+{
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("31891ED8-BEB5-43BF-A90D-9E7E1CE9BA84")]
+    public interface IAnalyzerConfigFilesHostObject
+    {
+        bool SetAnalyzerConfigFiles(ITaskItem[] analyzerConfigFiles);
+        bool SetPotentialAnalyzerConfigFiles(ITaskItem[] potentialAnalyzerConfigfiles);
+    }
+}

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -256,6 +256,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return (string)_store[nameof(Platform)]; }
         }
 
+        public ITaskItem[] PotentialAnalyzerConfigFiles
+        {
+            set { _store[nameof(PotentialAnalyzerConfigFiles)] = value; }
+            get { return (ITaskItem[])_store[nameof(PotentialAnalyzerConfigFiles)]; }
+        }
+
         public bool Prefer32Bit
         {
             set { _store[nameof(Prefer32Bit)] = value; }

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -19,7 +19,8 @@
                   $(ResolvedCodeAnalysisRuleSet);
                   @(AdditionalFiles);
                   @(EmbeddedFiles);
-                  @(EditorConfigFiles)"
+                  @(EditorConfigFiles);
+                  @(PotentialEditorConfigFiles)"
           Outputs="@(DocFileItem);
                    @(IntermediateAssembly);
                    @(IntermediateRefAssembly);
@@ -99,6 +100,7 @@
          OutputRefAssembly="@(IntermediateRefAssembly)"
          PdbFile="$(PdbFile)"
          Platform="$(PlatformTarget)"
+         PotentialAnalyzerConfigFiles="@(PotentialEditorConfigFiles)"
          Prefer32Bit="$(Prefer32Bit)"
          PreferredUILang="$(PreferredUILang)"
          ProvideCommandLineArgs="$(ProvideCommandLineArgs)"

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -56,8 +56,12 @@
   <Target Name="DiscoverEditorConfigFiles" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" BeforeTargets="CoreCompile">
     <DiscoverEditorConfigFiles InputFiles="@(Compile);@(AdditionalFile)">
       <Output TaskParameter="EditorConfigFiles" ItemName="EditorConfigFiles" />
+      <Output TaskParameter="PotentialEditorConfigFiles" ItemName="PotentialEditorConfigFiles" />
     </DiscoverEditorConfigFiles>
   </Target>
+  
+  <!-- Find and return the files paths where we looked for .editorconfig files but did not find one. -->
+  <Target Name="GetPotentialAnalyzerConfigFiles" DependsOnTargets="DiscoverEditorConfigFiles" Returns="@(PotentialEditorConfigFiles)" />
 
   <!--
     ========================

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -19,7 +19,8 @@
                   $(ResolvedCodeAnalysisRuleSet);
                   @(AdditionalFiles);
                   @(EmbeddedFiles);
-                  @(EditorConfigFiles)"
+                  @(EditorConfigFiles);
+                  @(PotentialEditorConfigFiles)"
           Outputs="@(DocFileItem);
                    @(IntermediateAssembly);
                    @(IntermediateRefAssembly);
@@ -90,6 +91,7 @@
          OutputRefAssembly="@(IntermediateRefAssembly)"
          PdbFile="$(PdbFile)"
          Platform="$(PlatformTarget)"
+         PotentialAnalyzerConfigFiles="@(PotentialEditorConfigFiles)"
          Prefer32Bit="$(Prefer32Bit)"
          PreferredUILang="$(PreferredUILang)"
          ProvideCommandLineArgs="$(ProvideCommandLineArgs)"

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -827,6 +827,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     CheckHostObjectSupport(param = nameof(AdditionalFiles), analyzerHostObject.SetAdditionalFiles(AdditionalFiles));
                 }
 
+                // For host objects which support them, set analyzer config files and potential analyzer config files
+                if (vbcHostObject is IAnalyzerConfigFilesHostObject analyzerConfigFilesHostObject)
+                {
+                    CheckHostObjectSupport(param = nameof(AnalyzerConfigFiles), analyzerConfigFilesHostObject.SetAnalyzerConfigFiles(AnalyzerConfigFiles));
+                    CheckHostObjectSupport(param = nameof(PotentialAnalyzerConfigFiles), analyzerConfigFilesHostObject.SetPotentialAnalyzerConfigFiles(PotentialAnalyzerConfigFiles));
+                }
+
                 CheckHostObjectSupport(param = nameof(BaseAddress), vbcHostObject.SetBaseAddress(TargetType, GetBaseAddressInHex()));
                 CheckHostObjectSupport(param = nameof(CodePage), vbcHostObject.SetCodePage(CodePage));
                 CheckHostObjectSupport(param = nameof(DebugType), vbcHostObject.SetDebugType(EmitDebugInformation, DebugType));


### PR DESCRIPTION
Define a new host object interface and pass the .editorconfig (and potential .editorconfig) files through to it.

Also define a target that will provide access to the potential .editorconfig files in places where we don't use the host object.