### PR TITLE
make sure VS to not crash when analyzer.initialize throws

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return analyzerPerf.Select(kv => new AnalyzerPerformanceInfo(kv.analyzer.GetAnalyzerId(), DiagnosticAnalyzerLogger.AllowsTelemetry(kv.analyzer, serviceOpt), kv.timeSpan));
         }
 
-        public static bool IsCompilationEndAnalyzer(this DiagnosticAnalyzer analyzer, Project project, Compilation compilation)
+        public static bool? IsCompilationEndAnalyzer(this DiagnosticAnalyzer analyzer, Project project, Compilation compilation)
         {
             if (!project.SupportsCompilation)
             {
@@ -301,16 +301,26 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             Contract.ThrowIfNull(compilation);
 
-            // currently, this is only way to see whether analyzer has compilation end analysis or not.
-            // also, analyzer being compilation end analyzer or not is dynamic. so this can return different value based on
-            // given compilation or options.
-            //
-            // but for now, this is what we decided in design meeting until we decide how to deal with compilation end analyzer
-            // long term
-            var context = new CollectCompilationActionsContext(compilation, project.AnalyzerOptions);
-            analyzer.Initialize(context);
+            try
+            {
+                // currently, this is only way to see whether analyzer has compilation end analysis or not.
+                // also, analyzer being compilation end analyzer or not is dynamic. so this can return different value based on
+                // given compilation or options.
+                //
+                // but for now, this is what we decided in design meeting until we decide how to deal with compilation end analyzer
+                // long term
+                var context = new CollectCompilationActionsContext(compilation, project.AnalyzerOptions);
+                analyzer.Initialize(context);
 
-            return context.IsCompilationEndAnalyzer;
+                return context.IsCompilationEndAnalyzer;
+            }
+            catch
+            {
+                // analyzer.initialize can throw. when that happens, we will try again next time.
+                // we are not logging anything here since it will be logged by CompilationWithAnalyzer later
+                // in the error list
+                return null;
+            }
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -265,7 +265,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
 
                 // running this multiple time is fine
-                _compilationEndAnalyzer = _analyzer.IsCompilationEndAnalyzer(project, compilation) ? 1 : 0;
+                var result = _analyzer.IsCompilationEndAnalyzer(project, compilation);
+                if (!result.HasValue)
+                {
+                    // try again next time.
+                    return;
+                }
+
+                _compilationEndAnalyzer = result.Value ? 1 : 0;
             }
 
             public bool IsCompilationEndAnalyzer(Project project, Compilation compilation)


### PR DESCRIPTION
we are supposed to guard all calls to analyzers from exceptions. the new code I added in preview 1 I forgot to guard against it, causing VS to crash if an analyzer throws on Initialize

now, if analyzer throws, it will retry to see whether the analyzer has compilation end analyzer again next time. here next time means, next time a user executes "Build" command or project analysis runs.

Guard against situation like https://github.com/dotnet/roslyn/issues/31490