### PR TITLE
Mark compiler generated files as generated for GitHub PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -63,3 +63,9 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+# Generated files
+src/Compilers/CSharp/Portable/Generated/*                  linguist-generated=true
+src/Compilers/CSharp/Portable/CSharpResources.Designer.cs  linguist-generated=true
+src/Compilers/VisualBasic/Portable/Generated/*             linguist-generated=true
+src/Compilers/VisualBasic/Portable/VBResources.Designer.vb linguist-generated=true


### PR DESCRIPTION
GitHub will recognize these attributes and collapse generated files by-default when you're doing a pull request. They're not hidden completely -- you can still expand the file if you want to see the generated code.