### PR TITLE
Add syntax classification for nullable directives

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests_Preprocessor.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests_Preprocessor.cs
@@ -773,6 +773,52 @@ aeu";
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task PP_NullableEnable()
+        {
+            var code = @"#nullable enable";
+
+            await TestAsync(code,
+                PPKeyword("#"),
+                PPKeyword("nullable"),
+                PPKeyword("enable"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task PP_NullableEnableWithComment()
+        {
+            var code = @"#nullable enable //Goo";
+
+            await TestAsync(code,
+                PPKeyword("#"),
+                PPKeyword("nullable"),
+                PPKeyword("enable"),
+                Comment("//Goo"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task PP_NullableDisable()
+        {
+            var code = @"#nullable disable";
+
+            await TestAsync(code,
+                PPKeyword("#"),
+                PPKeyword("nullable"),
+                PPKeyword("disable"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task PP_NullableDisableWithComment()
+        {
+            var code = @"#nullable disable //Goo";
+
+            await TestAsync(code,
+                PPKeyword("#"),
+                PPKeyword("nullable"),
+                PPKeyword("disable"),
+                Comment("//Goo"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task PP_PragmaChecksum1()
         {
             await TestAsync(

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -201,6 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                 case SyntaxKind.PragmaChecksumDirectiveTrivia:
                 case SyntaxKind.ReferenceDirectiveTrivia:
                 case SyntaxKind.LoadDirectiveTrivia:
+                case SyntaxKind.NullableDirectiveTrivia:
                 case SyntaxKind.BadDirectiveTrivia:
                     ClassifyPreprocessorDirective((DirectiveTriviaSyntax)trivia.GetStructure());
                     return;

--- a/src/Workspaces/CSharp/Portable/Classification/Worker_Preprocesser.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker_Preprocesser.cs
@@ -65,6 +65,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                 case SyntaxKind.LoadDirectiveTrivia:
                     ClassifyLoadDirective((LoadDirectiveTriviaSyntax)node);
                     break;
+                case SyntaxKind.NullableDirectiveTrivia:
+                    ClassifyNullableDirective((NullableDirectiveTriviaSyntax)node);
+                    break;
             }
         }
 
@@ -282,6 +285,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             AddClassification(node.HashToken, ClassificationTypeNames.PreprocessorKeyword);
             AddClassification(node.LoadKeyword, ClassificationTypeNames.PreprocessorKeyword);
             AddClassification(node.File, ClassificationTypeNames.StringLiteral);
+            ClassifyDirectiveTrivia(node);
+        }
+
+        private void ClassifyNullableDirective(NullableDirectiveTriviaSyntax node)
+        {
+            AddClassification(node.HashToken, ClassificationTypeNames.PreprocessorKeyword);
+            AddClassification(node.NullableKeyword, ClassificationTypeNames.PreprocessorKeyword);
+            AddClassification(node.SettingToken, ClassificationTypeNames.PreprocessorKeyword);
             ClassifyDirectiveTrivia(node);
         }
     }


### PR DESCRIPTION
This PR adds syntax classification support for `#nullable [enable|disable]` directives.

Left: 16.0 Preview 1, right: VS 15.9 with this PR
![nullable-directives](https://user-images.githubusercontent.com/823398/49564216-0fdb4500-f923-11e8-8b2c-ca6bb9776729.png)
