### PR TITLE
Async-streams: Fix crash with async-iterator method with only throw

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8188,7 +8188,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The body of an async-iterator method must contain a &apos;yield&apos; statement. Consider removing `async` from the method declaration..
+        ///   Looks up a localized string similar to The body of an async-iterator method must contain a &apos;yield&apos; statement. Consider removing &apos;async&apos; from the method declaration or adding a &apos;yield&apos; statement..
         /// </summary>
         internal static string ERR_PossibleAsyncIteratorWithoutYieldOrAwait {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8179,6 +8179,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The return type of an async method must be a task-like type instead of &apos;{0}&apos;. The body of an async-iterator method must be an iterator block (ie. contain a &apos;yield&apos; statement)..
+        /// </summary>
+        internal static string ERR_PossibleAsyncIteratorWithoutYield {
+            get {
+                return ResourceManager.GetString("ERR_PossibleAsyncIteratorWithoutYield", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To cast a negative value, you must enclose the value in parentheses..
         /// </summary>
         internal static string ERR_PossibleBadNegCast {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8179,11 +8179,20 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The return type of an async method must be a task-like type instead of &apos;{0}&apos;. The body of an async-iterator method must be an iterator block (ie. contain a &apos;yield&apos; statement)..
+        ///   Looks up a localized string similar to The body of an async-iterator method must contain a &apos;yield&apos; statement..
         /// </summary>
         internal static string ERR_PossibleAsyncIteratorWithoutYield {
             get {
                 return ResourceManager.GetString("ERR_PossibleAsyncIteratorWithoutYield", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The body of an async-iterator method must contain a &apos;yield&apos; statement. Consider removing `async` from the method declaration..
+        /// </summary>
+        internal static string ERR_PossibleAsyncIteratorWithoutYieldOrAwait {
+            get {
+                return ResourceManager.GetString("ERR_PossibleAsyncIteratorWithoutYieldOrAwait", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2642,7 +2642,10 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'await foreach'?</value>
   </data>
   <data name="ERR_PossibleAsyncIteratorWithoutYield" xml:space="preserve">
-    <value>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</value>
+    <value>The body of an async-iterator method must contain a 'yield' statement.</value>
+  </data>
+  <data name="ERR_PossibleAsyncIteratorWithoutYieldOrAwait" xml:space="preserve">
+    <value>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</value>
   </data>
   <data name="WRN_BadXMLRefParamType" xml:space="preserve">
     <value>Invalid type for parameter {0} in XML comment cref attribute: '{1}'</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2645,7 +2645,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>The body of an async-iterator method must contain a 'yield' statement.</value>
   </data>
   <data name="ERR_PossibleAsyncIteratorWithoutYieldOrAwait" xml:space="preserve">
-    <value>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</value>
+    <value>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</value>
   </data>
   <data name="WRN_BadXMLRefParamType" xml:space="preserve">
     <value>Invalid type for parameter {0} in XML comment cref attribute: '{1}'</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2641,6 +2641,9 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
   <data name="ERR_AwaitForEachMissingMemberWrongAsync" xml:space="preserve">
     <value>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'foreach' rather than 'await foreach'?</value>
   </data>
+  <data name="ERR_PossibleAsyncIteratorWithoutYield" xml:space="preserve">
+    <value>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</value>
+  </data>
   <data name="WRN_BadXMLRefParamType" xml:space="preserve">
     <value>Invalid type for parameter {0} in XML comment cref attribute: '{1}'</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1594,6 +1594,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BadDynamicAwaitForEach = 8416,
         ERR_NoConvToIAsyncDispWrongAsync = 8417,
         ERR_NoConvToIDispWrongAsync = 8418,
+        ERR_PossibleAsyncIteratorWithoutYield = 8419,
 
         WRN_ConvertingNullableToNonNullable = 8600,
         WRN_NullReferenceAssignment = 8601,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1595,6 +1595,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_NoConvToIAsyncDispWrongAsync = 8417,
         ERR_NoConvToIDispWrongAsync = 8418,
         ERR_PossibleAsyncIteratorWithoutYield = 8419,
+        ERR_PossibleAsyncIteratorWithoutYieldOrAwait = 8420,
 
         WRN_ConvertingNullableToNonNullable = 8600,
         WRN_NullReferenceAssignment = 8601,

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(method.IteratorElementType != null);
 
                 _isEnumerable = method.IsIAsyncEnumerableReturningAsync(method.DeclaringCompilation);
+                Debug.Assert(_isEnumerable != method.IsIAsyncEnumeratorReturningAsync(method.DeclaringCompilation));
             }
 
             protected override void VerifyPresenceOfRequiredAPIs(DiagnosticBag bag)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 method.IsIAsyncEnumeratorReturningAsync(compilation);
             if (isAsyncEnumerableOrEnumerator && !method.IsIterator)
             {
-                diagnostics.Add(new CSDiagnosticInfo(ErrorCode.ERR_PossibleAsyncIteratorWithoutYield, method.ReturnType), method.Locations[0]);
+                diagnostics.Add(ErrorCode.ERR_PossibleAsyncIteratorWithoutYield, method.Locations[0], method.ReturnType);
                 stateMachineType = null;
                 return body;
             }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -153,8 +153,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
-        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
-        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_PossibleAsyncIteratorWithoutYieldOrAwait">
-        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</source>
-        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.</target>
+        <source>The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</source>
+        <target state="new">The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -152,6 +152,11 @@
         <target state="new">An out variable cannot be declared as a ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PossibleAsyncIteratorWithoutYield">
+        <source>The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</source>
+        <target state="new">The return type of an async method must be a task-like type instead of '{0}'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_RefAssignNarrower">
         <source>Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</source>
         <target state="new">Cannot ref-assign '{1}' to '{0}' because '{1}' has a narrower escape scope than '{0}'.</target>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -1228,7 +1228,7 @@ class C
                 // (4,74): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     public static async System.Collections.Generic.IAsyncEnumerable<int> M()
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(4, 74),
-                // (4,74): error CS8420: The body of an async-iterator method must contain a 'yield' statement. Consider removing `async` from the method declaration.
+                // (4,74): error CS8420: The body of an async-iterator method must contain a 'yield' statement. Consider removing 'async' from the method declaration or adding a 'yield' statement.
                 //     public static async System.Collections.Generic.IAsyncEnumerable<int> M()
                 Diagnostic(ErrorCode.ERR_PossibleAsyncIteratorWithoutYieldOrAwait, "M").WithArguments("System.Collections.Generic.IAsyncEnumerable<int>").WithLocation(4, 74)
                 );

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -1290,7 +1290,7 @@ class C
 
         [Fact]
         [WorkItem(31552, "https://github.com/dotnet/roslyn/issues/31552")]
-        public void AsyncIterator_WithoutBody()
+        public void AsyncIterator_WithEmptyBody()
         {
             string source = @"
 class C

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -1202,6 +1203,132 @@ class C
                 // (7,9): error CS1622: Cannot return a value from an iterator. Use the yield return statement to return a value, or yield break to end the iteration.
                 //         return value;
                 Diagnostic(ErrorCode.ERR_ReturnInIterator, "return").WithLocation(7, 9)
+                );
+        }
+
+        [Fact]
+        [WorkItem(31552, "https://github.com/dotnet/roslyn/issues/31552")]
+        public void AsyncIterator_WithThrowOnly()
+        {
+            string source = @"
+class C
+{
+    public static async System.Collections.Generic.IAsyncEnumerable<int> M()
+    {
+        throw new System.NotImplementedException();
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(source);
+            comp.VerifyDiagnostics(
+                // (4,74): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     public static async System.Collections.Generic.IAsyncEnumerable<int> M()
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(4, 74)
+                );
+            comp.VerifyEmitDiagnostics(
+                // (4,74): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     public static async System.Collections.Generic.IAsyncEnumerable<int> M()
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(4, 74),
+                // (4,74): error CS8419: The return type of an async method must be a task-like type instead of 'System.Collections.Generic.IAsyncEnumerable<int>'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).
+                //     public static async System.Collections.Generic.IAsyncEnumerable<int> M()
+                Diagnostic(ErrorCode.ERR_PossibleAsyncIteratorWithoutYield, "M").WithArguments("System.Collections.Generic.IAsyncEnumerable<int>").WithLocation(4, 74)
+                );
+
+            var m = comp.SourceModule.GlobalNamespace.GetMember<MethodSymbol>("C.M");
+            Assert.False(m.IsIterator);
+            Assert.True(m.IsAsync);
+        }
+
+        [Fact]
+        [WorkItem(31552, "https://github.com/dotnet/roslyn/issues/31552")]
+        public void AsyncIteratorReturningEnumerator_WithThrowOnly()
+        {
+            string source = @"
+class C
+{
+    public static async System.Collections.Generic.IAsyncEnumerator<int> M()
+    {
+        throw new System.NotImplementedException();
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(source);
+            comp.VerifyDiagnostics(
+                // (4,74): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     public static async System.Collections.Generic.IAsyncEnumerator<int> M()
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(4, 74)
+                );
+            comp.VerifyEmitDiagnostics(
+                // (4,74): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     public static async System.Collections.Generic.IAsyncEnumerator<int> M()
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(4, 74),
+                // (4,74): error CS8419: The return type of an async method must be a task-like type instead of 'System.Collections.Generic.IAsyncEnumerator<int>'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).
+                //     public static async System.Collections.Generic.IAsyncEnumerator<int> M()
+                Diagnostic(ErrorCode.ERR_PossibleAsyncIteratorWithoutYield, "M").WithArguments("System.Collections.Generic.IAsyncEnumerator<int>").WithLocation(4, 74)
+                );
+        }
+
+        [Fact]
+        [WorkItem(31552, "https://github.com/dotnet/roslyn/issues/31552")]
+        public void AsyncIteratorReturningEnumerator_WithAwaitAndThrow()
+        {
+            string source = @"
+class C
+{
+    async System.Collections.Generic.IAsyncEnumerator<int> M()
+    {
+        await System.Threading.Tasks.Task.CompletedTask;
+        throw new System.NotImplementedException();
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(source);
+            comp.VerifyDiagnostics();
+            comp.VerifyEmitDiagnostics(
+                // (4,60): error CS8419: The return type of an async method must be a task-like type instead of 'System.Collections.Generic.IAsyncEnumerator<int>'. The body of an async-iterator method must be an iterator block (ie. contain a 'yield' statement).
+                //     async System.Collections.Generic.IAsyncEnumerator<int> M()
+                Diagnostic(ErrorCode.ERR_PossibleAsyncIteratorWithoutYield, "M").WithArguments("System.Collections.Generic.IAsyncEnumerator<int>").WithLocation(4, 60)
+                );
+        }
+
+        [Fact]
+        [WorkItem(31552, "https://github.com/dotnet/roslyn/issues/31552")]
+        public void AsyncIterator_WithoutBody()
+        {
+            string source = @"
+class C
+{
+    public static async System.Collections.Generic.IAsyncEnumerable<int> M()
+    {
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(source);
+            comp.VerifyDiagnostics(
+                // (4,74): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     public static async System.Collections.Generic.IAsyncEnumerable<int> M()
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(4, 74),
+                // (4,74): error CS0161: 'C.M()': not all code paths return a value
+                //     public static async System.Collections.Generic.IAsyncEnumerable<int> M()
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "M").WithArguments("C.M()").WithLocation(4, 74)
+                );
+        }
+
+        [Fact]
+        [WorkItem(31552, "https://github.com/dotnet/roslyn/issues/31552")]
+        public void AsyncIteratorReturningEnumerator_WithoutBody()
+        {
+            string source = @"
+class C
+{
+    public static async System.Collections.Generic.IAsyncEnumerator<int> M()
+    {
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(source);
+            comp.VerifyDiagnostics(
+                // (4,74): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     public static async System.Collections.Generic.IAsyncEnumerable<int> M()
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(4, 74),
+                // (4,74): error CS0161: 'C.M()': not all code paths return a value
+                //     public static async System.Collections.Generic.IAsyncEnumerable<int> M()
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "M").WithArguments("C.M()").WithLocation(4, 74)
                 );
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/31552

For context, a method body without a `yield` is not considered an iterator.