### PR TITLE
Don't warn about deprecated licenseUrl property

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -13,6 +13,10 @@
     <PackageProjectUrl>https://github.com/dotnet/roslyn</PackageProjectUrl>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Parser Scanner Lexer Emit CodeGeneration Metadata IL Compilation Scripting Syntax Semantics</PackageTags>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    
+    <!--
+      NU5125 should be removed. See https://github.com/dotnet/roslyn/issues/31589 for details
+    -->
     <NoWarn>$(NoWarn);NU5125</NoWarn>
   </PropertyGroup>
 

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -13,6 +13,7 @@
     <PackageProjectUrl>https://github.com/dotnet/roslyn</PackageProjectUrl>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Parser Scanner Lexer Emit CodeGeneration Metadata IL Compilation Scripting Syntax Semantics</PackageTags>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <NoWarn>$(NoWarn);NU5125</NoWarn>
   </PropertyGroup>
 
   <Import Project="RepoToolset\ProjectLayout.props" />


### PR DESCRIPTION
This property is deprecated but we can't quite fix it yet. See #31589 to track when we can undo this change and fix completely 