### PR TITLE
More Test Hook Fixes

### DIFF
--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.RegionBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.RegionBuilder.cs
@@ -226,12 +226,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             public void ExtendToInclude(BasicBlockBuilder block)
             {
+                Debug.Assert(block != null);
                 Debug.Assert((Kind != ControlFlowRegionKind.FilterAndHandler &&
                               Kind != ControlFlowRegionKind.TryAndCatch &&
                               Kind != ControlFlowRegionKind.TryAndFinally) ||
                               Regions.Last().LastBlock == block);
-
-                Debug.Assert(block != null);
 
                 if (FirstBlock == null)
                 {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.RegionBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.RegionBuilder.cs
@@ -231,6 +231,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                               Kind != ControlFlowRegionKind.TryAndFinally) ||
                               Regions.Last().LastBlock == block);
 
+                Debug.Assert(block != null);
+
                 if (FirstBlock == null)
                 {
                     Debug.Assert(LastBlock == null);

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -1671,9 +1671,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     // This region can be empty in certain error scenarios, such as `new T {}`, where T does not
                     // have a class constraint. There are no arguments or initializers, so nothing will have
                     // been put into the region at this point
-                    if (toMerge.LastBlock is null)
+                    if (toMerge.FirstBlock is null)
                     {
-                        Debug.Assert(toMerge.FirstBlock is null);
+                        Debug.Assert(toMerge.LastBlock is null);
                     }
                     else
                     {

--- a/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
@@ -1011,14 +1011,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 {
                     case LanguageNames.CSharp:
                         {
-                            CSharpSyntaxNode syntax = applyParenthesizedIfAnyCS((CSharpSyntaxNode)captureReferenceSyntax);
-
-                            if (syntax.Parent?.Parent is CSharp.Syntax.UsingStatementSyntax usingStmt &&
-                                usingStmt.Declaration == syntax.Parent)
-                            {
-                                return true;
-                            }
-
+                            var syntax = (CSharpSyntaxNode)captureReferenceSyntax;
                             switch (syntax.Kind())
                             {
                                 case CSharp.SyntaxKind.ObjectCreationExpression:
@@ -1027,6 +1020,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                                         return true;
                                     }
                                     break;
+                            }
+
+                            syntax = applyParenthesizedIfAnyCS((CSharpSyntaxNode)captureReferenceSyntax);
+
+                            if (syntax.Parent?.Parent is CSharp.Syntax.UsingStatementSyntax usingStmt &&
+                                usingStmt.Declaration == syntax.Parent)
+                            {
+                                return true;
                             }
 
                             CSharpSyntaxNode parent = syntax.Parent;

--- a/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
@@ -1022,7 +1022,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                                     break;
                             }
 
-                            syntax = applyParenthesizedIfAnyCS((CSharpSyntaxNode)captureReferenceSyntax);
+                            syntax = applyParenthesizedIfAnyCS(syntax);
 
                             if (syntax.Parent?.Parent is CSharp.Syntax.UsingStatementSyntax usingStmt &&
                                 usingStmt.Declaration == syntax.Parent)


### PR DESCRIPTION
This fixes another couple of bugs with the test hook. There are only 2 tests left that need to be fixed before we can enable the test hook in ADO for https://github.com/dotnet/roslyn/issues/31450.

Each commit is an isolated bug fix and test addition.