### PR TITLE
Hide AnalyzerConfig section matching implementation

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -272,180 +272,180 @@ RoOt = TruE");
         [Fact]
         public void SimpleNameMatch()
         {
-            string regex = TryCompileSectionNameToRegEx("abc");
-            Assert.Equal("^.*/abc$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("abc").Value;
+            Assert.Equal("^.*/abc$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/abc");
-            Assert.DoesNotMatch(regex, "/aabc");
-            Assert.DoesNotMatch(regex, "/ abc");
-            Assert.DoesNotMatch(regex, "/cabc");
+            Assert.True(matcher.IsMatch("/abc"));
+            Assert.False(matcher.IsMatch("/aabc"));
+            Assert.False(matcher.IsMatch("/ abc"));
+            Assert.False(matcher.IsMatch("/cabc"));
         }
 
         [Fact]
         public void StarOnlyMatch()
         {
-            string regex = TryCompileSectionNameToRegEx("*");
-            Assert.Equal("^.*/[^/]*$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("*").Value;
+            Assert.Equal("^.*/[^/]*$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/abc");
-            Assert.Matches(regex, "/123");
-            Assert.Matches(regex, "/abc/123");
+            Assert.True(matcher.IsMatch("/abc"));
+            Assert.True(matcher.IsMatch("/123"));
+            Assert.True(matcher.IsMatch("/abc/123"));
         }
 
         [Fact]
         public void StarNameMatch()
         {
-            string regex = TryCompileSectionNameToRegEx("*.cs");
-            Assert.Equal("^.*/[^/]*\\.cs$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("*.cs").Value;
+            Assert.Equal("^.*/[^/]*\\.cs$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/abc.cs");
-            Assert.Matches(regex, "/123.cs");
-            Assert.Matches(regex, "/dir/subpath.cs");
+            Assert.True(matcher.IsMatch("/abc.cs"));
+            Assert.True(matcher.IsMatch("/123.cs"));
+            Assert.True(matcher.IsMatch("/dir/subpath.cs"));
             // Only '/' is defined as a directory separator, so the caller
             // is responsible for converting any other machine directory
             // separators to '/' before matching
-            Assert.Matches(regex, "/dir\\subpath.cs");
+            Assert.True(matcher.IsMatch("/dir\\subpath.cs"));
 
-            Assert.DoesNotMatch(regex, "/abc.vb");
+            Assert.False(matcher.IsMatch("/abc.vb"));
         }
 
         [Fact]
         public void StarStarNameMatch()
         {
-            string regex = TryCompileSectionNameToRegEx("**.cs");
-            Assert.Equal("^.*/.*\\.cs$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("**.cs").Value;
+            Assert.Equal("^.*/.*\\.cs$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/abc.cs");
-            Assert.Matches(regex, "/dir/subpath.cs");
+            Assert.True(matcher.IsMatch("/abc.cs"));
+            Assert.True(matcher.IsMatch("/dir/subpath.cs"));
         }
 
         [Fact]
         public void EscapeDot()
         {
-            string regex = TryCompileSectionNameToRegEx("...");
-            Assert.Equal("^.*/\\.\\.\\.$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("...").Value;
+            Assert.Equal("^.*/\\.\\.\\.$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/...");
-            Assert.Matches(regex, "/subdir/...");
-            Assert.DoesNotMatch(regex, "/aaa");
-            Assert.DoesNotMatch(regex, "/???");
-            Assert.DoesNotMatch(regex, "/abc");
+            Assert.True(matcher.IsMatch("/..."));
+            Assert.True(matcher.IsMatch("/subdir/..."));
+            Assert.False(matcher.IsMatch("/aaa"));
+            Assert.False(matcher.IsMatch("/???"));
+            Assert.False(matcher.IsMatch("/abc"));
         }
 
         [Fact]
         public void BadEscapeMatch()
         {
-            string regex = TryCompileSectionNameToRegEx("abc\\d.cs");
-            Assert.Null(regex);
+            SectionNameMatcher? matcher = TryCreateSectionNameMatcher("abc\\d.cs");
+            Assert.Null(matcher);
         }
 
         [Fact]
         public void EndBackslashMatch()
         {
-            string regex = TryCompileSectionNameToRegEx("abc\\");
-            Assert.Null(regex);
+            SectionNameMatcher? matcher = TryCreateSectionNameMatcher("abc\\");
+            Assert.Null(matcher);
         }
 
         [Fact]
         public void QuestionMatch()
         {
-            string regex = TryCompileSectionNameToRegEx("ab?def");
-            Assert.Equal("^.*/ab.def$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("ab?def").Value;
+            Assert.Equal("^.*/ab.def$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/abcdef");
-            Assert.Matches(regex, "/ab?def");
-            Assert.Matches(regex, "/abzdef");
-            Assert.Matches(regex, "/ab/def");
-            Assert.Matches(regex, "/ab\\def");
+            Assert.True(matcher.IsMatch("/abcdef"));
+            Assert.True(matcher.IsMatch("/ab?def"));
+            Assert.True(matcher.IsMatch("/abzdef"));
+            Assert.True(matcher.IsMatch("/ab/def"));
+            Assert.True(matcher.IsMatch("/ab\\def"));
         }
 
         [Fact]
         public void LiteralBackslash()
         {
-            string regex = TryCompileSectionNameToRegEx("ab\\\\c");
-            Assert.Equal("^.*/ab\\\\c$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("ab\\\\c").Value;
+            Assert.Equal("^.*/ab\\\\c$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/ab\\c");
-            Assert.DoesNotMatch(regex, "/ab/c");
-            Assert.DoesNotMatch(regex, "/ab\\\\c");
+            Assert.True(matcher.IsMatch("/ab\\c"));
+            Assert.False(matcher.IsMatch("/ab/c"));
+            Assert.False(matcher.IsMatch("/ab\\\\c"));
         }
 
         [Fact]
         public void LiteralStars()
         {
-            string regex = TryCompileSectionNameToRegEx("\\***\\*\\**");
-            Assert.Equal("^.*/\\*.*\\*\\*[^/]*$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("\\***\\*\\**").Value;
+            Assert.Equal("^.*/\\*.*\\*\\*[^/]*$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/*ab/cd**efg*");
-            Assert.DoesNotMatch(regex, "/ab/cd**efg*");
-            Assert.DoesNotMatch(regex, "/*ab/cd*efg*");
-            Assert.DoesNotMatch(regex, "/*ab/cd**ef/gh");
+            Assert.True(matcher.IsMatch("/*ab/cd**efg*"));
+            Assert.False(matcher.IsMatch("/ab/cd**efg*"));
+            Assert.False(matcher.IsMatch("/*ab/cd*efg*"));
+            Assert.False(matcher.IsMatch("/*ab/cd**ef/gh"));
         }
 
         [Fact]
         public void LiteralQuestions()
         {
-            string regex = TryCompileSectionNameToRegEx("\\??\\?*\\??");
-            Assert.Equal("^.*/\\?.\\?[^/]*\\?.$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("\\??\\?*\\??").Value;
+            Assert.Equal("^.*/\\?.\\?[^/]*\\?.$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/?a?cde?f");
-            Assert.Matches(regex, "/???????f");
-            Assert.DoesNotMatch(regex, "/aaaaaaaa");
-            Assert.DoesNotMatch(regex, "/aa?cde?f");
-            Assert.DoesNotMatch(regex, "/?a?cdexf");
-            Assert.DoesNotMatch(regex, "/?axcde?f");
+            Assert.True(matcher.IsMatch("/?a?cde?f"));
+            Assert.True(matcher.IsMatch("/???????f"));
+            Assert.False(matcher.IsMatch("/aaaaaaaa"));
+            Assert.False(matcher.IsMatch("/aa?cde?f"));
+            Assert.False(matcher.IsMatch("/?a?cdexf"));
+            Assert.False(matcher.IsMatch("/?axcde?f"));
         }
 
         [Fact]
         public void LiteralBraces()
         {
-            string regex = TryCompileSectionNameToRegEx("abc\\{\\}def");
-            Assert.Equal("^.*/abc\\{\\}def$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("abc\\{\\}def").Value;
+            Assert.Equal("^.*/abc\\{\\}def$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/abc{}def");
-            Assert.Matches(regex, "/subdir/abc{}def");
-            Assert.DoesNotMatch(regex, "/abcdef");
-            Assert.DoesNotMatch(regex, "/abc}{def");
+            Assert.True(matcher.IsMatch("/abc{}def"));
+            Assert.True(matcher.IsMatch("/subdir/abc{}def"));
+            Assert.False(matcher.IsMatch("/abcdef"));
+            Assert.False(matcher.IsMatch("/abc}{def"));
         }
 
         [Fact]
         public void LiteralComma()
         {
-            string regex = TryCompileSectionNameToRegEx("abc\\,def");
-            Assert.Equal("^.*/abc,def$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("abc\\,def").Value;
+            Assert.Equal("^.*/abc,def$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/abc,def");
-            Assert.Matches(regex, "/subdir/abc,def");
-            Assert.DoesNotMatch(regex, "/abcdef");
-            Assert.DoesNotMatch(regex, "/abc\\,def");
-            Assert.DoesNotMatch(regex, "/abc`def");
+            Assert.True(matcher.IsMatch("/abc,def"));
+            Assert.True(matcher.IsMatch("/subdir/abc,def"));
+            Assert.False(matcher.IsMatch("/abcdef"));
+            Assert.False(matcher.IsMatch("/abc\\,def"));
+            Assert.False(matcher.IsMatch("/abc`def"));
         }
 
         [Fact]
         public void SimpleChoice()
         {
-            string regex = TryCompileSectionNameToRegEx("*.{cs,vb,fs}");
-            Assert.Equal("^.*/[^/]*\\.(?:cs|vb|fs)$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("*.{cs,vb,fs}").Value;
+            Assert.Equal("^.*/[^/]*\\.(?:cs|vb|fs)$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/abc.cs");
-            Assert.Matches(regex, "/abc.vb");
-            Assert.Matches(regex, "/abc.fs");
-            Assert.Matches(regex, "/subdir/abc.cs");
-            Assert.Matches(regex, "/subdir/abc.vb");
-            Assert.Matches(regex, "/subdir/abc.fs");
+            Assert.True(matcher.IsMatch("/abc.cs"));
+            Assert.True(matcher.IsMatch("/abc.vb"));
+            Assert.True(matcher.IsMatch("/abc.fs"));
+            Assert.True(matcher.IsMatch("/subdir/abc.cs"));
+            Assert.True(matcher.IsMatch("/subdir/abc.vb"));
+            Assert.True(matcher.IsMatch("/subdir/abc.fs"));
 
-            Assert.DoesNotMatch(regex, "/abcxcs");
-            Assert.DoesNotMatch(regex, "/abcxvb");
-            Assert.DoesNotMatch(regex, "/abcxfs");
-            Assert.DoesNotMatch(regex, "/subdir/abcxcs");
-            Assert.DoesNotMatch(regex, "/subdir/abcxcb");
-            Assert.DoesNotMatch(regex, "/subdir/abcxcs");
+            Assert.False(matcher.IsMatch("/abcxcs"));
+            Assert.False(matcher.IsMatch("/abcxvb"));
+            Assert.False(matcher.IsMatch("/abcxfs"));
+            Assert.False(matcher.IsMatch("/subdir/abcxcs"));
+            Assert.False(matcher.IsMatch("/subdir/abcxcb"));
+            Assert.False(matcher.IsMatch("/subdir/abcxcs"));
         }
 
         [Fact]
         public void OneChoiceHasSlashes()
         {
-            string regex = TryCompileSectionNameToRegEx("{*.cs,subdir/test.vb}");
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("{*.cs,subdir/test.vb}").Value;
             // This is an interesting case that may be counterintuitive.  A reasonable understanding
             // of the section matching could interpret the choice as generating multiple identical
             // sections, so [{a, b, c}] would be equivalent to [a] ... [b] ... [c] with all of the
@@ -455,101 +455,101 @@ RoOt = TruE");
             // [*.cs] usually translates into '**/*.cs' because it contains no slashes, the slashes in
             // the second choice make this into '/*.cs', effectively matching only files in the root
             // directory of the match, instead of all subdirectories.
-            Assert.Equal("^/(?:[^/]*\\.cs|subdir/test\\.vb)$", regex);
+            Assert.Equal("^/(?:[^/]*\\.cs|subdir/test\\.vb)$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/test.cs");
-            Assert.Matches(regex, "/subdir/test.vb");
+            Assert.True(matcher.IsMatch("/test.cs"));
+            Assert.True(matcher.IsMatch("/subdir/test.vb"));
 
-            Assert.DoesNotMatch(regex, "/subdir/test.cs");
-            Assert.DoesNotMatch(regex, "/subdir/subdir/test.vb");
-            Assert.DoesNotMatch(regex, "/test.vb");
+            Assert.False(matcher.IsMatch("/subdir/test.cs"));
+            Assert.False(matcher.IsMatch("/subdir/subdir/test.vb"));
+            Assert.False(matcher.IsMatch("/test.vb"));
         }
 
         [Fact]
         public void EmptyChoice()
         {
-            string regex = TryCompileSectionNameToRegEx("{}");
-            Assert.Equal("^.*/(?:)$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("{}").Value;
+            Assert.Equal("^.*/(?:)$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/");
-            Assert.Matches(regex, "/subdir/");
-            Assert.DoesNotMatch(regex, "/.");
-            Assert.DoesNotMatch(regex, "/anything");
+            Assert.True(matcher.IsMatch("/"));
+            Assert.True(matcher.IsMatch("/subdir/"));
+            Assert.False(matcher.IsMatch("/."));
+            Assert.False(matcher.IsMatch("/anything"));
         }
 
         [Fact]
         public void SingleChoice()
         {
-            string regex = TryCompileSectionNameToRegEx("{*.cs}");
-            Assert.Equal("^.*/(?:[^/]*\\.cs)$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("{*.cs}").Value;
+            Assert.Equal("^.*/(?:[^/]*\\.cs)$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/test.cs");
-            Assert.Matches(regex, "/subdir/test.cs");
-            Assert.DoesNotMatch(regex, "test.vb");
-            Assert.DoesNotMatch(regex, "testxcs");
+            Assert.True(matcher.IsMatch("/test.cs"));
+            Assert.True(matcher.IsMatch("/subdir/test.cs"));
+            Assert.False(matcher.IsMatch("test.vb"));
+            Assert.False(matcher.IsMatch("testxcs"));
         }
 
         [Fact]
         public void UnmatchedBraces()
         {
-            string regex = TryCompileSectionNameToRegEx("{{{{}}");
-            Assert.Null(regex);
+            SectionNameMatcher? matcher = TryCreateSectionNameMatcher("{{{{}}");
+            Assert.Null(matcher);
         }
 
         [Fact]
         public void CommaOutsideBraces()
         {
-            string regex = TryCompileSectionNameToRegEx("abc,def");
-            Assert.Null(regex);
+            SectionNameMatcher? matcher = TryCreateSectionNameMatcher("abc,def");
+            Assert.Null(matcher);
         }
 
         [Fact]
         public void RecursiveChoice()
         {
-            string regex = TryCompileSectionNameToRegEx("{test{.cs,.vb},other.{a{bb,cc}}}");
-            Assert.Equal("^.*/(?:test(?:\\.cs|\\.vb)|other\\.(?:a(?:bb|cc)))$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("{test{.cs,.vb},other.{a{bb,cc}}}").Value;
+            Assert.Equal("^.*/(?:test(?:\\.cs|\\.vb)|other\\.(?:a(?:bb|cc)))$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/test.cs");
-            Assert.Matches(regex, "/test.vb");
-            Assert.Matches(regex, "/subdir/test.cs");
-            Assert.Matches(regex, "/subdir/test.vb");
-            Assert.Matches(regex, "/other.abb");
-            Assert.Matches(regex, "/other.acc");
+            Assert.True(matcher.IsMatch("/test.cs"));
+            Assert.True(matcher.IsMatch("/test.vb"));
+            Assert.True(matcher.IsMatch("/subdir/test.cs"));
+            Assert.True(matcher.IsMatch("/subdir/test.vb"));
+            Assert.True(matcher.IsMatch("/other.abb"));
+            Assert.True(matcher.IsMatch("/other.acc"));
 
-            Assert.DoesNotMatch(regex, "/test.fs");
-            Assert.DoesNotMatch(regex, "/other.bbb");
-            Assert.DoesNotMatch(regex, "/other.ccc");
-            Assert.DoesNotMatch(regex, "/subdir/other.bbb");
-            Assert.DoesNotMatch(regex, "/subdir/other.ccc");
+            Assert.False(matcher.IsMatch("/test.fs"));
+            Assert.False(matcher.IsMatch("/other.bbb"));
+            Assert.False(matcher.IsMatch("/other.ccc"));
+            Assert.False(matcher.IsMatch("/subdir/other.bbb"));
+            Assert.False(matcher.IsMatch("/subdir/other.ccc"));
         }
 
         [Fact]
         public void DashChoice()
         {
-            string regex = TryCompileSectionNameToRegEx("ab{-}cd{-,}ef");
-            Assert.Equal("^.*/ab(?:-)cd(?:-|)ef$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("ab{-}cd{-,}ef").Value;
+            Assert.Equal("^.*/ab(?:-)cd(?:-|)ef$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/ab-cd-ef");
-            Assert.Matches(regex, "/ab-cdef");
+            Assert.True(matcher.IsMatch("/ab-cd-ef"));
+            Assert.True(matcher.IsMatch("/ab-cdef"));
 
-            Assert.DoesNotMatch(regex, "/abcdef");
-            Assert.DoesNotMatch(regex, "/ab--cd-ef");
-            Assert.DoesNotMatch(regex, "/ab--cd--ef");
+            Assert.False(matcher.IsMatch("/abcdef"));
+            Assert.False(matcher.IsMatch("/ab--cd-ef"));
+            Assert.False(matcher.IsMatch("/ab--cd--ef"));
         }
 
         [Fact]
         public void MiddleMatch()
         {
-            string regex = TryCompileSectionNameToRegEx("ab{cs,vb,fs}cd");
-            Assert.Equal("^.*/ab(?:cs|vb|fs)cd$", regex);
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("ab{cs,vb,fs}cd").Value;
+            Assert.Equal("^.*/ab(?:cs|vb|fs)cd$", matcher.Regex.ToString());
 
-            Assert.Matches(regex, "/abcscd");
-            Assert.Matches(regex, "/abvbcd");
-            Assert.Matches(regex, "/abfscd");
+            Assert.True(matcher.IsMatch("/abcscd"));
+            Assert.True(matcher.IsMatch("/abvbcd"));
+            Assert.True(matcher.IsMatch("/abfscd"));
 
-            Assert.DoesNotMatch(regex, "/abcs");
-            Assert.DoesNotMatch(regex, "/abcd");
-            Assert.DoesNotMatch(regex, "/vbcd");
+            Assert.False(matcher.IsMatch("/abcs"));
+            Assert.False(matcher.IsMatch("/abcd"));
+            Assert.False(matcher.IsMatch("/vbcd"));
         }
 
         [Fact]
@@ -593,6 +593,33 @@ dotnet_diagnostic.cs000.severity = error", "/.editorconfig"));
 
             Assert.Equal(new[] {
                 CreateImmutableDictionary(("cs000", ReportDiagnostic.Error)),
+                CreateImmutableDictionary(("cs000", ReportDiagnostic.Error)),
+                null
+            }, options.TreeOptions);
+        }
+
+        [Fact]
+        public void BadSectionInConfigIgnored()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+dotnet_diagnostic.cs000.severity = suppress
+
+[*.vb]
+dotnet_diagnostic.cs000.severity = error
+
+[{test.*]
+dotnet_diagnostic.cs000.severity = info"
+, "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/test.cs", "/test.vb", "/test" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[] {
+                CreateImmutableDictionary(("cs000", ReportDiagnostic.Suppress)),
                 CreateImmutableDictionary(("cs000", ReportDiagnostic.Error)),
                 null
             }, options.TreeOptions);

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -8,12 +8,24 @@ namespace Microsoft.CodeAnalysis
 {
     public sealed partial class AnalyzerConfig
     {
+        public readonly struct SectionNameMatcher
+        {
+            internal Regex Regex { get; }
+
+            internal SectionNameMatcher(Regex regex)
+            {
+                Regex = regex;
+            }
+
+            public bool IsMatch(string s) => Regex.IsMatch(s);
+        }
+
         /// <summary>
-        /// Takes a <see cref="Section.Name"/> and compiles the file glob
-        /// inside to a regex which recognizes the given language. Returns
-        /// null if the section name is invalid.
+        /// Takes a <see cref="Section.Name"/> and creates a matcher that
+        /// matches the the given language. Returns null if the section name is
+        /// invalid.
         /// </summary>
-        public static string TryCompileSectionNameToRegEx(string sectionName)
+        public static SectionNameMatcher? TryCreateSectionNameMatcher(string sectionName)
         {
             // An editorconfig section name is a language for recognizing file paths
             // defined by the following grammar:
@@ -60,7 +72,7 @@ namespace Microsoft.CodeAnalysis
                 return null;
             }
             sb.Append('$');
-            return sb.ToString();
+            return new SectionNameMatcher(new Regex(sb.ToString(), RegexOptions.Compiled));
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis
         public string NormalizedDirectory { get; }
 
         /// <summary>
-        /// The path passed to <see cref="AnalyzerConfig.Parse(string, string)"/> during construction.
+        /// The path passed to <see cref="Parse(string, string)"/> during construction.
         /// </summary>
         public string PathToFile { get; }
 
@@ -91,17 +91,17 @@ namespace Microsoft.CodeAnalysis
         /// Takes a list of paths to source files and a list of AnalyzeConfigs and produces a
         /// resultant dictionary of diagnostic configurations for each of the source paths.
         /// Source paths are matched by checking if they are members of the language recognized by
-        /// <see cref="AnalyzerConfig.Section.Name"/>s.
+        /// <see cref="Section.Name"/>s.
         /// </summary>
         /// <param name="sourcePaths">
         /// Absolute, normalized paths to source files. These paths are expected to be normalized
         /// using the same mechanism used to normalize the path passed to the path parameter of
-        /// <see cref="AnalyzerConfig.Parse(string, string)"/>. Source files will only be considered
+        /// <see cref="Parse(string, string)"/>. Source files will only be considered
         /// applicable for a given <see cref="AnalyzerConfig"/> if the config path is an ordinal
         /// prefix of the source path.
         /// </param>
         /// <param name="analyzerConfigs">
-        /// Parsed AnalyzerConfig files. The <see cref="AnalyzerConfig.NormalizedDirectory"/>
+        /// Parsed AnalyzerConfig files. The <see cref="NormalizedDirectory"/>
         /// must be an ordinal prefix of a source file path to be considered applicable.
         /// </param>
         /// <returns>
@@ -127,24 +127,24 @@ namespace Microsoft.CodeAnalysis
             var allTreeOptions = ArrayBuilder<TreeOptions>.GetInstance(sourcePaths.Count);
             var allAnalyzerOptions = ArrayBuilder<AnalyzerOptions>.GetInstance(sourcePaths.Count);
 
-            var allRegexes = PooledDictionary<AnalyzerConfig, ImmutableArray<Regex>>.GetInstance();
+            var allMatchers = PooledDictionary<AnalyzerConfig, ImmutableArray<SectionNameMatcher?>>.GetInstance();
             foreach (var config in analyzerConfigs)
             {
                 // Create an array of regexes with each entry corresponding to the same index
                 // in <see cref="EditorConfig.NamedSections"/>.
-                var builder = ArrayBuilder<Regex>.GetInstance(config.NamedSections.Length);
+                var builder = ArrayBuilder<SectionNameMatcher?>.GetInstance(config.NamedSections.Length);
                 foreach (var section in config.NamedSections)
                 {
-                    string regex = AnalyzerConfig.TryCompileSectionNameToRegEx(section.Name);
-                    builder.Add(new Regex(regex, RegexOptions.Compiled));
+                    SectionNameMatcher? matcher = AnalyzerConfig.TryCreateSectionNameMatcher(section.Name);
+                    builder.Add(matcher);
                 }
 
                 Debug.Assert(builder.Count == config.NamedSections.Length);
 
-                allRegexes.Add(config, builder.ToImmutableAndFree());
+                allMatchers.Add(config, builder.ToImmutableAndFree());
             }
 
-            Debug.Assert(allRegexes.Count == analyzerConfigs.Count);
+            Debug.Assert(allMatchers.Count == analyzerConfigs.Count);
 
             var treeOptionsBuilder = ImmutableDictionary.CreateBuilder<string, ReportDiagnostic>(
                 CaseInsensitiveComparison.Comparer);
@@ -169,10 +169,10 @@ namespace Microsoft.CodeAnalysis
                         }
                         string relativePath = normalizedPath.Substring(dirLength);
 
-                        ImmutableArray<Regex> regexes = allRegexes[config];
-                        for (int sectionIndex = 0; sectionIndex < regexes.Length; sectionIndex++)
+                        ImmutableArray<SectionNameMatcher?> matchers = allMatchers[config];
+                        for (int sectionIndex = 0; sectionIndex < matchers.Length; sectionIndex++)
                         {
-                            if (regexes[sectionIndex].IsMatch(relativePath))
+                            if (matchers[sectionIndex]?.IsMatch(relativePath) == true)
                             {
                                 var section = config.NamedSections[sectionIndex];
                                 addOptions(section, treeOptionsBuilder, analyzerOptionsBuilder, config.PathToFile);
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis
                 analyzerOptionsBuilder.Clear();
             }
 
-            allRegexes.Free();
+            allMatchers.Free();
             Debug.Assert(allTreeOptions.Count == allAnalyzerOptions.Count);
             Debug.Assert(allTreeOptions.Count == sourcePaths.Count);
 
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis
                 diagnosticBuilder.ToImmutableAndFree());
 
             void addOptions(
-                AnalyzerConfig.Section section,
+                Section section,
                 TreeOptions.Builder treeBuilder,
                 AnalyzerOptions.Builder analyzerBuilder,
                 string analyzerConfigPath)
@@ -427,8 +427,8 @@ namespace Microsoft.CodeAnalysis
             /// <summary>
             /// Keys and values for this section. All keys are lower-cased according to the
             /// EditorConfig specification and keys are compared case-insensitively. Values are
-            /// lower-cased if the value appears in <see cref="AnalyzerConfig.ReservedValues" />
-            /// or if the corresponding key is in <see cref="AnalyzerConfig.ReservedKeys" />. Otherwise,
+            /// lower-cased if the value appears in <see cref="ReservedValues" />
+            /// or if the corresponding key is in <see cref="ReservedKeys" />. Otherwise,
             /// the values are the literal values present in the source.
             /// </summary>
             public ImmutableDictionary<string, string> Properties { get; }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -24,6 +24,8 @@ Microsoft.CodeAnalysis.AnalyzerConfig.Section
 Microsoft.CodeAnalysis.AnalyzerConfig.Section.Name.get -> string
 Microsoft.CodeAnalysis.AnalyzerConfig.Section.Properties.get -> System.Collections.Immutable.ImmutableDictionary<string, string>
 Microsoft.CodeAnalysis.AnalyzerConfig.Section.Section(string name, System.Collections.Immutable.ImmutableDictionary<string, string> properties) -> void
+Microsoft.CodeAnalysis.AnalyzerConfig.SectionNameMatcher
+Microsoft.CodeAnalysis.AnalyzerConfig.SectionNameMatcher.IsMatch(string s) -> bool
 Microsoft.CodeAnalysis.AnalyzerConfigOptionsResult
 Microsoft.CodeAnalysis.AnalyzerConfigOptionsResult.AnalyzerOptions.get -> System.Collections.Immutable.ImmutableArray<System.Collections.Immutable.ImmutableDictionary<string, string>>
 Microsoft.CodeAnalysis.AnalyzerConfigOptionsResult.Diagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>
@@ -194,7 +196,7 @@ static Microsoft.CodeAnalysis.AnalyzerConfig.ReservedKeys.get -> System.Collecti
 static Microsoft.CodeAnalysis.AnalyzerConfig.ReservedValues.get -> System.Collections.Immutable.ImmutableHashSet<string>
 static Microsoft.CodeAnalysis.AnalyzerConfig.Section.NameComparer.get -> System.StringComparison
 static Microsoft.CodeAnalysis.AnalyzerConfig.Section.PropertiesKeyComparer.get -> System.StringComparer
-static Microsoft.CodeAnalysis.AnalyzerConfig.TryCompileSectionNameToRegEx(string sectionName) -> string
+static Microsoft.CodeAnalysis.AnalyzerConfig.TryCreateSectionNameMatcher(string sectionName) -> Microsoft.CodeAnalysis.AnalyzerConfig.SectionNameMatcher?
 static Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions.KeyComparer.get -> System.StringComparer
 static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph.Create(Microsoft.CodeAnalysis.Operations.IBlockOperation body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph
 static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph.Create(Microsoft.CodeAnalysis.Operations.IConstructorBodyOperation constructorBody, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph


### PR DESCRIPTION
The existing API publicly exposes that we match AnalyzerConfig sections
using a Regex compilation strategy. There are numerous reasons why we
may want to change this implementation strategy in the future, so this
changes the API to return an opaque "matcher" struct instead of a regex
string.