### PR TITLE
Fix couple of bugs in unused private members analyzer

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -311,6 +311,7 @@ class MyClass
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(31572, "https://github.com/dotnet/roslyn/issues/31572")]
         public async Task EntryPointMethodNotFlagged_05()
         {
             await TestDiagnosticMissingAsync(
@@ -911,6 +912,7 @@ class MyClass
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(31581, "https://github.com/dotnet/roslyn/issues/31581")]
         public async Task MethodInNameOf()
         {
             await TestDiagnosticsAsync(
@@ -923,6 +925,7 @@ class MyClass
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(31581, "https://github.com/dotnet/roslyn/issues/31581")]
         public async Task PropertyInNameOf()
         {
             await TestDiagnosticsAsync(

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -311,6 +311,18 @@ class MyClass
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task EntryPointMethodNotFlagged_05()
+        {
+            await TestDiagnosticMissingAsync(
+@"using System.Threading.Tasks;
+
+class MyClass
+{
+    private static int [|Main|]() => 0;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldIsUnused_ReadOnly()
         {
             await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -911,6 +911,30 @@ class MyClass
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task MethodInNameOf()
+        {
+            await TestDiagnosticsAsync(
+@"class MyClass
+{
+    private void [|M|]() { }
+    private string _goo = nameof(M);
+}",
+    expected: Diagnostic("IDE0052"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        public async Task PropertyInNameOf()
+        {
+            await TestDiagnosticsAsync(
+@"class MyClass
+{
+    private int [|P|] { get; }
+    private string _goo = nameof(P);
+}",
+    expected: Diagnostic("IDE0052"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FieldInDocComment()
         {
             await TestDiagnosticsAsync(

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
@@ -649,6 +649,27 @@ End Class", parameters:=Nothing,
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function MethodInNameOf() As Task
+            Await TestDiagnosticsAsync(
+"Class C
+    Private Sub [|M|]()
+    End Sub
+    Private _goo2 As String = NameOf(M)
+End Class", parameters:=Nothing,
+    Diagnostic("IDE0052"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        Public Async Function PropertyInNameOf() As Task
+            Await TestDiagnosticsAsync(
+"Class C
+    Private ReadOnly Property [|P|] As Integer
+    Private _goo2 As String = NameOf(P)
+End Class", parameters:=Nothing,
+    Diagnostic("IDE0052"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
         Public Async Function FieldInDocComment() As Task
             Await TestDiagnosticsAsync(
 "

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
@@ -649,6 +649,7 @@ End Class", parameters:=Nothing,
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        <WorkItem(31581, "https://github.com/dotnet/roslyn/issues/31581")>
         Public Async Function MethodInNameOf() As Task
             Await TestDiagnosticsAsync(
 "Class C
@@ -660,6 +661,7 @@ End Class", parameters:=Nothing,
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        <WorkItem(31581, "https://github.com/dotnet/roslyn/issues/31581")>
         Public Async Function PropertyInNameOf() As Task
             Await TestDiagnosticsAsync(
 "Class C

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticHelper.cs
@@ -86,7 +86,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var warningLevel = effectiveSeverity.ToDiagnosticSeverity() ?? descriptor.DefaultSeverity;
             return Diagnostic.Create(
                 descriptor.Id,
                 descriptor.Category,

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft.CodeAnalysis {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -40,7 +39,7 @@ namespace Microsoft.CodeAnalysis {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.CodeAnalysis.FeaturesResources", typeof(FeaturesResources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.CodeAnalysis.FeaturesResources", typeof(FeaturesResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -2795,6 +2794,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Private_member_0_is_unused {
             get {
                 return ResourceManager.GetString("Private_member_0_is_unused", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Private method &apos;{0}&apos; can be removed as it is never invoked..
+        /// </summary>
+        internal static string Private_method_0_can_be_removed_as_it_is_never_invoked {
+            get {
+                return ResourceManager.GetString("Private_method_0_can_be_removed_as_it_is_never_invoked", resourceCulture);
             }
         }
         

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1439,6 +1439,9 @@ This version used in: {2}</value>
   <data name="Private_member_0_can_be_removed_as_the_value_assigned_to_it_is_never_read" xml:space="preserve">
     <value>Private member '{0}' can be removed as the value assigned to it is never read.</value>
   </data>
+  <data name="Private_method_0_can_be_removed_as_it_is_never_invoked" xml:space="preserve">
+    <value>Private method '{0}' can be removed as it is never invoked.</value>
+  </data>
   <data name="Code_Quality" xml:space="preserve">
     <value>Code Quality</value>
   </data>

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -601,6 +601,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 => methodSymbol.Name == WellKnownMemberNames.EntryPointMethodName &&
                    methodSymbol.IsStatic &&
                    (methodSymbol.ReturnsVoid ||
+                    methodSymbol.ReturnType.SpecialType == SpecialType.System_Int32 ||
                     methodSymbol.ReturnType.OriginalDefinition == _taskType ||
                     methodSymbol.ReturnType.OriginalDefinition == _genericTaskType);
 

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -313,6 +313,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 {
                     switch (symbol.Kind)
                     {
+                        // Handle potential references to methods/properties from missing IOperation
+                        // for method group/property group.
                         case SymbolKind.Method:
                         case SymbolKind.Property:
                             OnSymbolUsage(symbol, ValueUsageInfo.NameOnly);

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Když se upraví zdrojový soubor {0}, relace ladění nebude moct pokračovat kvůli vnitřní chybě: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">Podpisy souvisejících metod nalezené v metadatech se nebudou aktualizovat.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">In Metadaten gefundene ähnliche Methodensignaturen werden nicht aktualisiert.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">Las signaturas de método relacionadas encontradas en los metadatos no se actualizarán.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">Les signatures de méthode associées trouvées dans les métadonnées ne seront pas mises à jour.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">Le firme del metodo correlate trovate nei metadati non verranno aggiornate.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">メタデータ内に検出される関連するメソッド シグネチャは更新されません。</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">메타데이터에서 찾은 관련 메서드 시그니처가 업데이트되지 않습니다.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">Sygnatury powiązanych metod znalezione w metadanych nie zostaną zaktualizowane.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">As assinaturas de método relacionadas encontradas nos metadados não serão atualizadas.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">Связанные сигнатуры методов, найденные в метаданных, не будут обновлены.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">Meta verilerde bulunan ilgili metot imzaları güncelleştirilmez.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">不更新在元数据中发现的相关方法签名。</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -162,6 +162,11 @@
         <target state="new">Invert conditional</target>
         <note />
       </trans-unit>
+      <trans-unit id="Private_method_0_can_be_removed_as_it_is_never_invoked">
+        <source>Private method '{0}' can be removed as it is never invoked.</source>
+        <target state="new">Private method '{0}' can be removed as it is never invoked.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Related_method_signatures_found_in_metadata_will_not_be_updated">
         <source>Related method signatures found in metadata will not be updated.</source>
         <target state="translated">將不會更新中繼資料中所找到的相關方法簽章。</target>


### PR DESCRIPTION
1. https://github.com/dotnet/roslyn/commit/1196711c981829ba53e4ef307cf79f25b3b0bff2: Fixes #31572. Fix detection of entry point methods to account for `int` return type.

2. https://github.com/dotnet/roslyn/commit/9cc8b0c5388bff6453c0807b2fbe96f7ef6f0dc8: Fixes #31581. Add a workaround for #19965 to detect references to method/property from method group/property group argument to `nameof` operator. We also provide a different diagnostic message for private methods that have name-only references.