### PR TITLE
asynccompletion: number of changes when making large changes differ with the original completion

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -317,7 +317,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 // We're replacing the current buffer text with the exact same code.  If 
                 // we pass EditOptions.DefaultMinimalChange then no actual buffer change
                 // will happen.  That's problematic as it breaks features like brace-matching
-                // which want to buffer changes to properly compute their state.  In this
+                // which want to buffer changes to properly compute their state.  In this 
+                // scenario, we want the editor do nothing special with the edit.
                 return EditOptions.None;
             }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -182,8 +182,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     // Note: we only want to move the caret if the caret would have been moved 
                     // by the edit.  i.e. if the caret was actually in the mapped span that 
                     // we're replacing.
-                    if (view.GetCaretPoint(subjectBuffer) is SnapshotPoint caretPositionInBuffer &&
-                        mappedSpan.IntersectsWith(caretPositionInBuffer))
+                    var caretPositionInBuffer = view.GetCaretPoint(subjectBuffer);
+                    if (caretPositionInBuffer.HasValue && mappedSpan.IntersectsWith(caretPositionInBuffer.Value))
                     {
                         view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(subjectBuffer.CurrentSnapshot, mappedSpan.Start.Position + adjustedNewText.Length));
                     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -159,8 +159,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             var mappedSpan = triggerSnapshotSpan.TranslateTo(subjectBuffer.CurrentSnapshot, SpanTrackingMode.EdgeInclusive);
             
             var adjustedNewText = AdjustForVirtualSpace(textChange, view, _editorOperationsFactoryService);
-            var editOptions = GetEditOptions(mappedSpan, adjustedNewText);
-            using (var edit = subjectBuffer.CreateEdit(editOptions, reiteratedVersionNumber: null, editTag: null))
+
+            using (var edit = subjectBuffer.CreateEdit(EditOptions.DefaultMinimalChange, reiteratedVersionNumber: null, editTag: null))
             {
                 edit.Replace(mappedSpan.Span, change.TextChange.NewText);
 
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 {
                     view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(subjectBuffer.CurrentSnapshot, change.NewPosition.Value));
                 }
-                else if (editOptions.ComputeMinimalChange)
+                else
                 {
                     // Or, If we're doing a minimal change, then the edit that we make to the 
                     // buffer may not make the total text change that places the caret where we 
@@ -308,21 +308,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             }
 
             return newText;
-        }
-
-        internal static EditOptions GetEditOptions(SnapshotSpan spanToReplace, string adjustedNewText)
-        {
-            if (spanToReplace.GetText() == adjustedNewText)
-            {
-                // We're replacing the current buffer text with the exact same code.  If 
-                // we pass EditOptions.DefaultMinimalChange then no actual buffer change
-                // will happen.  That's problematic as it breaks features like brace-matching
-                // which want to buffer changes to properly compute their state.  In this 
-                // scenario, we want the editor do nothing special with the edit.
-                return EditOptions.None;
-            }
-
-            return EditOptions.DefaultMinimalChange;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Utilities;
 using AsyncCompletionData = Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using RoslynCompletionItem = Microsoft.CodeAnalysis.Completion.CompletionItem;
@@ -28,14 +29,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             new AsyncCompletionData.CommitResult(isHandled: false, AsyncCompletionData.CommitBehavior.None);
 
         private readonly RecentItemsManager _recentItemsManager;
+        private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
 
         public IEnumerable<char> PotentialCommitCharacters { get; }
 
-        internal CommitManager(ImmutableArray<char> potentialCommitCharacters, RecentItemsManager recentItemsManager, IThreadingContext threadingContext) : base(threadingContext)
+        internal CommitManager(ImmutableArray<char> potentialCommitCharacters, RecentItemsManager recentItemsManager, IThreadingContext threadingContext, IEditorOperationsFactoryService editorOperationsFactoryService) : base(threadingContext)
         {
             PotentialCommitCharacters = potentialCommitCharacters;
             _recentItemsManager = recentItemsManager;
-        }
+            _editorOperationsFactoryService = editorOperationsFactoryService;
+    }
 
         /// <summary>
         /// The method performs a preliminarily filtering of commit availability.
@@ -150,15 +153,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return AsyncCompletionData.CommitBehavior.None;
             }
 
-            using (var edit = subjectBuffer.CreateEdit())
+            var change = completionService.GetChangeAsync(document, roslynItem, commitCharacter, cancellationToken).WaitAndGetResult(cancellationToken);
+            var textChange = change.TextChange;
+            var triggerSnapshotSpan = new SnapshotSpan(triggerSnapshot, textChange.Span.ToSpan());
+            var mappedSpan = triggerSnapshotSpan.TranslateTo(subjectBuffer.CurrentSnapshot, SpanTrackingMode.EdgeInclusive);
+            
+            var adjustedNewText = AdjustForVirtualSpace(textChange, view, _editorOperationsFactoryService);
+            var editOptions = GetEditOptions(mappedSpan, adjustedNewText);
+            using (var edit = subjectBuffer.CreateEdit(editOptions, reiteratedVersionNumber: null, editTag: null))
             {
-                var change = completionService.GetChangeAsync(document, roslynItem, commitCharacter, cancellationToken).WaitAndGetResult(cancellationToken);
-
-                var textChange = change.TextChange;
-
-                var triggerSnapshotSpan = new SnapshotSpan(triggerSnapshot, textChange.Span.ToSpan());
-                var mappedSpan = triggerSnapshotSpan.TranslateTo(subjectBuffer.CurrentSnapshot, SpanTrackingMode.EdgeInclusive);
-
                 edit.Replace(mappedSpan.Span, change.TextChange.NewText);
 
                 // The edit updates the snapshot however other extensions may make changes there.
@@ -168,6 +171,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 if (change.NewPosition.HasValue)
                 {
                     view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(subjectBuffer.CurrentSnapshot, change.NewPosition.Value));
+                }
+                else if (editOptions.ComputeMinimalChange)
+                {
+                    // Or, If we're doing a minimal change, then the edit that we make to the 
+                    // buffer may not make the total text change that places the caret where we 
+                    // would expect it to go based on the requested change. In this case, 
+                    // determine where the item should go and set the care manually.
+
+                    // Note: we only want to move the caret if the caret would have been moved 
+                    // by the edit.  i.e. if the caret was actually in the mapped span that 
+                    // we're replacing.
+                    if (view.GetCaretPoint(subjectBuffer) is SnapshotPoint caretPositionInBuffer &&
+                        mappedSpan.IntersectsWith(caretPositionInBuffer))
+                    {
+                        view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(subjectBuffer.CurrentSnapshot, mappedSpan.Start.Position + adjustedNewText.Length));
+                    }
                 }
 
                 includesCommitCharacter = change.IncludesCommitCharacter;
@@ -267,6 +286,42 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 case EnterKeyRule.AfterFullyTypedWord:
                     return item.GetEntireDisplayText() == textTypedSoFar;
             }
+        }
+
+        internal static string AdjustForVirtualSpace(TextChange textChange, ITextView textView, IEditorOperationsFactoryService editorOperationsFactoryService)
+        {
+            var newText = textChange.NewText;
+
+            var caretPoint = textView.Caret.Position.BufferPosition;
+            var virtualCaretPoint = textView.Caret.Position.VirtualBufferPosition;
+
+            if (textChange.Span.IsEmpty &&
+                textChange.Span.Start == caretPoint &&
+                virtualCaretPoint.IsInVirtualSpace)
+            {
+                // They're in virtual space and the text change is specified against the cursor
+                // position that isn't in virtual space.  In this case, add the virtual spaces to the
+                // thing we're adding.
+                var editorOperations = editorOperationsFactoryService.GetEditorOperations(textView);
+                var whitespace = editorOperations.GetWhitespaceForVirtualSpace(virtualCaretPoint);
+                return whitespace + newText;
+            }
+
+            return newText;
+        }
+
+        internal static EditOptions GetEditOptions(SnapshotSpan spanToReplace, string adjustedNewText)
+        {
+            if (spanToReplace.GetText() == adjustedNewText)
+            {
+                // We're replacing the current buffer text with the exact same code.  If 
+                // we pass EditOptions.DefaultMinimalChange then no actual buffer change
+                // will happen.  That's problematic as it breaks features like brace-matching
+                // which want to buffer changes to properly compute their state.  In this
+                return EditOptions.None;
+            }
+
+            return EditOptions.DefaultMinimalChange;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManagerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManagerProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
@@ -18,13 +19,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
     {
         private readonly IThreadingContext _threadingContext;
         private readonly RecentItemsManager _recentItemsManager;
+        private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CommitManagerProvider(IThreadingContext threadingContext, RecentItemsManager recentItemsManager)
+        public CommitManagerProvider(IThreadingContext threadingContext, RecentItemsManager recentItemsManager, IEditorOperationsFactoryService editorOperationsFactoryService)
         {
             _threadingContext = threadingContext;
             _recentItemsManager = recentItemsManager;
+            _editorOperationsFactoryService = editorOperationsFactoryService;
         }
 
         IAsyncCompletionCommitManager IAsyncCompletionCommitManagerProvider.GetOrCreate(ITextView textView)
@@ -35,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 potentialCommitCharacters = ImmutableArray<char>.Empty;
             }
 
-            return new CommitManager(potentialCommitCharacters, _recentItemsManager, _threadingContext);
+            return new CommitManager(potentialCommitCharacters, _recentItemsManager, _threadingContext, _editorOperationsFactoryService);
         }
     }
 }

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3834,31 +3834,17 @@ class C
 }", finalText)
 
                 Dim changes = snapshotBeforeCommit.Version.Changes
-                Select Case completionImplementation
-                    Case CompletionImplementation.Legacy ' Specific of the legacy implementation
-                        ' This should have happened as two text changes to the buffer.
-                        Assert.Equal(2, changes.Count)
+                ' This should have happened as two text changes to the buffer.
+                Assert.Equal(2, changes.Count)
 
-                        Dim actualChanges = changes.ToArray()
-                        Dim firstChange = actualChanges(0)
-                        Assert.Equal(New Span(0, 0), firstChange.OldSpan)
-                        Assert.Equal("using NewUsing;", firstChange.NewText)
+                Dim actualChanges = changes.ToArray()
+                Dim firstChange = actualChanges(0)
+                Assert.Equal(New Span(0, 0), firstChange.OldSpan)
+                Assert.Equal("using NewUsing;", firstChange.NewText)
 
-                        Dim secondChange = actualChanges(1)
-                        Assert.Equal(New Span(testDocument.CursorPosition.Value, 0), secondChange.OldSpan)
-                        Assert.Equal("InsertedItem", secondChange.NewText)
-                    Case CompletionImplementation.Modern
-                        Assert.Equal(1, changes.Count)
-                        Dim actualChanges = changes.ToArray()
-                        Dim firstChange = actualChanges(0)
-                        Assert.Equal(New Span(0, testDocument.CursorPosition.Value), firstChange.OldSpan)
-                        Assert.Equal("using NewUsing;
-using System;
-class C
-{
-    void goo() {
-        return InsertedItem", firstChange.NewText)
-                End Select
+                Dim secondChange = actualChanges(1)
+                Assert.Equal(New Span(testDocument.CursorPosition.Value, 0), secondChange.OldSpan)
+                Assert.Equal("InsertedItem", secondChange.NewText)
 
                 ' Make sure new edits happen after the text that was inserted.
                 state.SendTypeChars("1")
@@ -3914,33 +3900,17 @@ class C
 }", finalText)
 
                 Dim changes = snapshotBeforeCommit.Version.Changes
-                Select Case completionImplementation
-                    Case CompletionImplementation.Legacy ' Specific of the legacy implementation
-                        ' This should have happened as two text changes to the buffer.
+                ' This should have happened as two text changes to the buffer.
+                Assert.Equal(2, changes.Count)
 
-                        Assert.Equal(2, changes.Count)
+                Dim actualChanges = changes.ToArray()
+                Dim firstChange = actualChanges(0)
+                Assert.Equal(New Span(0, 0), firstChange.OldSpan)
+                Assert.Equal("using NewUsing;", firstChange.NewText)
 
-                        Dim actualChanges = changes.ToArray()
-                        Dim firstChange = actualChanges(0)
-                        Assert.Equal(New Span(0, 0), firstChange.OldSpan)
-                        Assert.Equal("using NewUsing;", firstChange.NewText)
-
-                        Dim secondChange = actualChanges(1)
-                        Assert.Equal(New Span(testDocument.CursorPosition.Value - "Custom".Length, "Custom".Length), secondChange.OldSpan)
-                        Assert.Equal("InsertedItem", secondChange.NewText)
-                    Case CompletionImplementation.Modern
-                        Assert.Equal(1, changes.Count)
-                        Dim actualChanges = changes.ToArray()
-                        Dim firstChange = actualChanges(0)
-                        Assert.Equal(New Span(0, testDocument.CursorPosition.Value), firstChange.OldSpan)
-                        Assert.Equal(
-"using NewUsing;
-using System;
-class C
-{
-    void goo() {
-        return InsertedItem", firstChange.NewText)
-                End Select
+                Dim secondChange = actualChanges(1)
+                Assert.Equal(New Span(testDocument.CursorPosition.Value - "Custom".Length, "Custom".Length), secondChange.OldSpan)
+                Assert.Equal("InsertedItem", secondChange.NewText)
 
                 ' Make sure new edits happen after the text that was inserted.
                 state.SendTypeChars("1")


### PR DESCRIPTION
Fixes #30972