### PR TITLE
Add new analyzer API (DiagnosticSuppressor) to suppress reported comp…

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2162,11 +2162,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal ImmutableArray<Diagnostic> GetDiagnostics(CompilationStage stage, bool includeEarlierStages, CancellationToken cancellationToken)
         {
             var diagnostics = DiagnosticBag.GetInstance();
-            GetDiagnostics(stage, includeEarlierStages, diagnostics, cancellationToken);
+            GetDiagnostics(stage, includeEarlierStages, diagnostics, cancellationToken: cancellationToken);
             return diagnostics.ToReadOnlyAndFree();
         }
 
-        internal override void GetDiagnostics(CompilationStage stage, bool includeEarlierStages, DiagnosticBag diagnostics, CancellationToken cancellationToken = default)
+        internal override void GetDiagnostics(
+            CompilationStage stage,
+            bool includeEarlierStages,
+            DiagnosticBag diagnostics,
+            bool filterDiagnostics = true,
+            CancellationToken cancellationToken = default)
         {
             var builder = DiagnosticBag.GetInstance();
 
@@ -2253,7 +2258,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Before returning diagnostics, we filter warnings
             // to honor the compiler options (e.g., /nowarn, /warnaserror and /warn) and the pragmas.
-            FilterAndAppendAndFreeDiagnostics(diagnostics, ref builder);
+            FilterAndAppendAndFreeDiagnostics(diagnostics, ref builder, filterDiagnostics);
         }
 
         private static void AppendLoadDirectiveDiagnostics(DiagnosticBag builder, SyntaxAndDeclarationManager syntaxAndDeclarations, SyntaxTree syntaxTree, Func<IEnumerable<Diagnostic>, IEnumerable<Diagnostic>> locationFilterOpt = null)
@@ -2457,7 +2462,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Before returning diagnostics, we filter warnings
             // to honor the compiler options (/nowarn, /warnaserror and /warn) and the pragmas.
             var result = DiagnosticBag.GetInstance();
-            FilterAndAppendAndFreeDiagnostics(result, ref builder);
+            FilterAndAppendAndFreeDiagnostics(result, ref builder, filterDiagnostics: true);
             return result.ToReadOnlyAndFree<Diagnostic>();
         }
 
@@ -2509,11 +2514,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             IEnumerable<ResourceDescription> manifestResources,
             CompilationTestData testData,
             DiagnosticBag diagnostics,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            bool filterDiagnostics = true)
         {
             Debug.Assert(!IsSubmission || HasCodeToEmit());
 
-            string runtimeMDVersion = GetRuntimeMetadataVersion(emitOptions, diagnostics);
+            string runtimeMDVersion = GetRuntimeMetadataVersion(emitOptions, diagnostics, filterDiagnostics);
             if (runtimeMDVersion == null)
             {
                 return null;
@@ -2575,7 +2581,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool emitTestCoverageData,
             DiagnosticBag diagnostics,
             Predicate<ISymbol> filterOpt,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            bool filterDiagnostics = true)
         {
             // The diagnostics should include syntax and declaration errors. We insert these before calling Emitter.Emit, so that the emitter
             // does not attempt to emit if there are declaration errors (but we do insert all errors from method body binding...)
@@ -2585,7 +2592,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 excludeDiagnostics = PooledHashSet<int>.GetInstance();
                 excludeDiagnostics.Add((int)ErrorCode.ERR_ConcreteMissingBody);
             }
-            bool hasDeclarationErrors = !FilterAndAppendDiagnostics(diagnostics, GetDiagnostics(CompilationStage.Declare, true, cancellationToken), excludeDiagnostics);
+            bool hasDeclarationErrors = !FilterAndAppendDiagnostics(diagnostics,
+                                                                    GetDiagnostics(CompilationStage.Declare, true, cancellationToken),
+                                                                    filterDiagnostics,
+                                                                    excludeDiagnostics);
             excludeDiagnostics?.Free();
 
             // TODO (tomat): NoPIA:
@@ -2633,7 +2643,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     filterOpt: filterOpt,
                     cancellationToken: cancellationToken);
 
-                bool hasMethodBodyErrorOrWarningAsError = !FilterAndAppendAndFreeDiagnostics(diagnostics, ref methodBodyDiagnosticBag);
+                bool hasMethodBodyErrorOrWarningAsError = !FilterAndAppendAndFreeDiagnostics(diagnostics, ref methodBodyDiagnosticBag, filterDiagnostics);
 
                 if (hasDeclarationErrors || hasMethodBodyErrorOrWarningAsError)
                 {
@@ -2650,7 +2660,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Stream win32Resources,
             string outputNameOverride,
             DiagnosticBag diagnostics,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            bool filterDiagnostics = true)
         {
             // Use a temporary bag so we don't have to refilter pre-existing diagnostics.
             var resourceDiagnostics = DiagnosticBag.GetInstance();
@@ -2663,7 +2674,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 AddedModulesResourceNames(resourceDiagnostics),
                 resourceDiagnostics);
 
-            if (!FilterAndAppendAndFreeDiagnostics(diagnostics, ref resourceDiagnostics))
+            if (!FilterAndAppendAndFreeDiagnostics(diagnostics, ref resourceDiagnostics, filterDiagnostics))
             {
                 return false;
             }
@@ -2676,7 +2687,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             string assemblyName = FileNameUtilities.ChangeExtension(outputNameOverride, extension: null);
             DocumentationCommentCompiler.WriteDocumentationCommentXml(this, assemblyName, xmlDocStream, xmlDiagnostics, cancellationToken);
 
-            return FilterAndAppendAndFreeDiagnostics(diagnostics, ref xmlDiagnostics);
+            return FilterAndAppendAndFreeDiagnostics(diagnostics, ref xmlDiagnostics, filterDiagnostics);
         }
 
         private IEnumerable<string> AddedModulesResourceNames(DiagnosticBag diagnostics)
@@ -2729,7 +2740,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 cancellationToken);
         }
 
-        internal string GetRuntimeMetadataVersion(EmitOptions emitOptions, DiagnosticBag diagnostics)
+        internal string GetRuntimeMetadataVersion(EmitOptions emitOptions, DiagnosticBag diagnostics, bool filterDiagnostics = true)
         {
             string runtimeMDVersion = GetRuntimeMetadataVersion(emitOptions);
             if (runtimeMDVersion != null)
@@ -2739,7 +2750,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             DiagnosticBag runtimeMDVersionDiagnostics = DiagnosticBag.GetInstance();
             runtimeMDVersionDiagnostics.Add(ErrorCode.WRN_NoRuntimeMetadataVersion, NoLocation.Singleton);
-            if (!FilterAndAppendAndFreeDiagnostics(diagnostics, ref runtimeMDVersionDiagnostics))
+            if (!FilterAndAppendAndFreeDiagnostics(diagnostics, ref runtimeMDVersionDiagnostics, filterDiagnostics))
             {
                 return null;
             }

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -2766,7 +2766,7 @@ namespace N5
         }
 
         [Fact]
-        private void TestSymbolStartAnalyzer_MultipleAnalyzers_AllSymbolKinds()
+        public void TestSymbolStartAnalyzer_MultipleAnalyzers_AllSymbolKinds()
         {
             testCore("SymbolStartTopLevelRuleId", topLevel: true);
             testCore("SymbolStartRuleId", topLevel: false);

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticSuppressorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticSuppressorTests.cs
@@ -1,0 +1,406 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Diagnostics.CSharp;
+using Microsoft.CodeAnalysis.FlowAnalysis;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+using static Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public partial class DiagnosticSuppressorTests : CompilingTestBase
+    {
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestSuppression_CompilerSyntaxWarning()
+        {
+            // NOTE: Empty switch block warning is reported by the C# language parser
+            string source = @"
+class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+        }
+    }
+}";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            var expectedDiagnostic =
+                // (7,9): warning CS1522: Empty switch block
+                //         {
+                Diagnostic(ErrorCode.WRN_EmptySwitch, "{").WithLocation(7, 9);
+
+            compilation.VerifyDiagnostics(expectedDiagnostic);
+
+            var analyzers = new DiagnosticAnalyzer[] { new DiagnosticSuppressorForId("CS1522") };
+            compilation.VerifySuppressedDiagnostics(analyzers, null, null, true, expectedDiagnostic);
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestSuppression_CompilerSemanticWarning()
+        {
+            string source = @"
+class C
+{
+    // warning CS0169: The field 'C.f' is never used
+    private readonly int f;
+}";
+            var expectedDiagnostic =
+                // (5,26): warning CS0169: The field 'C.f' is never used
+                //     private readonly int f;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "f").WithArguments("C.f").WithLocation(5, 26);
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics(expectedDiagnostic);
+
+            var analyzers = new DiagnosticAnalyzer[] { new DiagnosticSuppressorForId("CS0169") };
+            compilation.VerifySuppressedDiagnostics(analyzers, null, null, true, expectedDiagnostic);
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestNoSuppression_CompilerSyntaxError()
+        {
+            string source = @"
+class { }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+
+            compilation.VerifyDiagnostics(
+                // (2,7): error CS1001: Identifier expected
+                // class { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(2, 7));
+
+            // Verify compiler syntax error cannot be suppressed.
+            var analyzers = new DiagnosticAnalyzer[] { new DiagnosticSuppressorForId("CS1001") };
+            compilation.VerifySuppressedDiagnostics(analyzers);
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestNoSuppression_CompilerSemanticError()
+        {
+            string source = @"
+class C
+{
+    void M(UndefinedType x) { }
+}";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+
+            compilation.VerifyDiagnostics(
+                // (4,12): error CS0246: The type or namespace name 'UndefinedType' could not be found (are you missing a using directive or an assembly reference?)
+                //     void M(UndefinedType x) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UndefinedType").WithArguments("UndefinedType").WithLocation(4, 12));
+
+            // Verify compiler semantic error cannot be suppressed.
+            var analyzers = new DiagnosticAnalyzer[] { new DiagnosticSuppressorForId("CS0246") };
+            compilation.VerifySuppressedDiagnostics(analyzers);
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestSuppression_MultipleDiagnostics()
+        {
+            string source = @"
+class C
+{
+    // warning CS0169: The field 'C.f' is never used
+    private readonly int f;
+    // warning CS0169: The field 'C.f2' is never used
+    private readonly int f2;
+}";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // (5,26): warning CS0169: The field 'C.f' is never used
+                //     private readonly int f;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "f").WithArguments("C.f").WithLocation(5, 26),
+                // (7,26): warning CS0169: The field 'C.f2' is never used
+                //     private readonly int f2;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "f2").WithArguments("C.f2").WithLocation(7, 26)
+            };
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics(expectedDiagnostics);
+
+            var analyzers = new DiagnosticAnalyzer[] { new DiagnosticSuppressorForId("CS0169") };
+            compilation.VerifySuppressedDiagnostics(analyzers, null, null, true, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestSuppression_MultipleSuppressors_SameDiagnostic()
+        {
+            string source = @"
+class C
+{
+    // warning CS0169: The field 'C.f' is never used
+    private readonly int f;
+}";
+            var expectedDiagnostic =
+                // (5,26): warning CS0169: The field 'C.f' is never used
+                //     private readonly int f;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "f").WithArguments("C.f").WithLocation(5, 26);
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics(expectedDiagnostic);
+
+            var analyzers = new DiagnosticAnalyzer[] { new DiagnosticSuppressorForId("CS0169"), new DiagnosticSuppressorForId("CS0169") };
+            compilation.VerifySuppressedDiagnostics(analyzers, null, null, true, expectedDiagnostic);
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestSuppression_MultipleSuppressors_DifferentDiagnostic()
+        {
+            string source = @"
+class C
+{
+    // warning CS0169: The field 'C.f' is never used
+    private readonly int f;
+}";
+            var expectedCompilerDiagnostic =
+                // (5,26): warning CS0169: The field 'C.f' is never used
+                //     private readonly int f;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "f").WithArguments("C.f").WithLocation(5, 26);
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics(expectedCompilerDiagnostic);
+
+            var expectedAnalyzerDiagnostic =
+                Diagnostic("ID1000", @"class C
+{
+    // warning CS0169: The field 'C.f' is never used
+    private readonly int f;
+}").WithLocation(2, 1);
+
+            var analyzer = new CompilationAnalyzerWithSeverity(DiagnosticSeverity.Warning, configurable: true);
+            compilation.VerifyAnalyzerDiagnostics(new DiagnosticAnalyzer[] { analyzer }, null, null, true,
+                expectedAnalyzerDiagnostic);
+
+            var suppressor1 = new DiagnosticSuppressorForId("CS0169");
+            var suppresor2 = new DiagnosticSuppressorForId(analyzer.Descriptor.Id);
+
+            var analyzers = new DiagnosticAnalyzer[] { analyzer, suppressor1, suppresor2 };
+            compilation.VerifySuppressedDiagnostics(analyzers, null, null, true,
+                expectedCompilerDiagnostic,
+                expectedAnalyzerDiagnostic);
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestNoSuppression_SpecificOptionsTurnsOffSuppressor()
+        {
+            string source = @"
+class C
+{
+    // warning CS0169: The field 'C.f' is never used
+    private readonly int f;
+}";
+            var expectedDiagnostic =
+                // (5,26): warning CS0169: The field 'C.f' is never used
+                //     private readonly int f;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "f").WithArguments("C.f").WithLocation(5, 26);
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics(expectedDiagnostic);
+
+            const string suppressionId = "SPR1001";
+            var analyzers = new DiagnosticAnalyzer[] { new DiagnosticSuppressorForId("CS0169", suppressionId) };
+            compilation.VerifySuppressedDiagnostics(analyzers, null, null, true, expectedDiagnostic);
+
+            var specificDiagnosticOptions = compilation.Options.SpecificDiagnosticOptions.Add(suppressionId, ReportDiagnostic.Suppress);
+            compilation = compilation.WithOptions(compilation.Options.WithSpecificDiagnosticOptions(specificDiagnosticOptions));
+            compilation.VerifySuppressedDiagnostics(analyzers);
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestSuppression_AnalyzerDiagnostics_SeveritiesAndConfigurableMatrix()
+        {
+            string source = @"
+class C { }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var configurations = new[] { false, true };
+            var severities = Enum.GetValues(typeof(DiagnosticSeverity));
+            var originalSpecificDiagnosticOptions = compilation.Options.SpecificDiagnosticOptions;
+
+            foreach (var configurable in configurations)
+            {
+                foreach (DiagnosticSeverity defaultSeverity in severities)
+                {
+                    foreach (DiagnosticSeverity effectiveSeverity in severities)
+                    {
+                        var diagnostic = Diagnostic("ID1000", "class C { }")
+                                            .WithLocation(2, 1)
+                                            .WithDefaultSeverity(defaultSeverity)
+                                            .WithEffectiveSeverity(configurable ? effectiveSeverity : defaultSeverity);
+
+                        if (defaultSeverity == DiagnosticSeverity.Warning &&
+                            effectiveSeverity == DiagnosticSeverity.Error &&
+                            configurable)
+                        {
+                            diagnostic = diagnostic.WithWarningAsError(true);
+                        }
+
+                        var analyzer = new CompilationAnalyzerWithSeverity(defaultSeverity, configurable);
+                        var suppressor = new DiagnosticSuppressorForId(analyzer.Descriptor.Id);
+                        var analyzersWithoutSuppressor = new DiagnosticAnalyzer[] { analyzer };
+                        var analyzersWithSuppressor = new DiagnosticAnalyzer[] { analyzer, suppressor };
+
+                        var specificDiagnosticOptions = originalSpecificDiagnosticOptions.Add(
+                            key: analyzer.Descriptor.Id,
+                            value: DiagnosticDescriptor.MapSeverityToReport(effectiveSeverity));
+                        compilation = compilation.WithOptions(compilation.Options.WithSpecificDiagnosticOptions(specificDiagnosticOptions));
+                        
+                        // Verify analyzer diagnostic without suppressor, also verify no suppressions.
+                        compilation.VerifyAnalyzerDiagnostics(analyzersWithoutSuppressor, null, null, true, diagnostic);
+                        compilation.VerifySuppressedDiagnostics(analyzersWithoutSuppressor);
+
+                        // Verify suppressed analyzer diagnostic, except when default severity is Error or diagnostic is not-configurable.
+                        if (defaultSeverity == DiagnosticSeverity.Error || !configurable)
+                        {
+                            compilation.VerifySuppressedDiagnostics(analyzersWithSuppressor);
+                        }
+                        else
+                        {
+                            compilation.VerifySuppressedDiagnostics(analyzersWithSuppressor, null, null, true, diagnostic);
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestExceptionFromSuppressor()
+        {
+            string source = @"
+class C { }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzer = new CompilationAnalyzerWithSeverity(DiagnosticSeverity.Warning, configurable: true);
+            testCore(new DiagnosticSuppressorThrowsExceptionFromSupportedSuppressions());
+            testCore(new DiagnosticSuppressorThrowsExceptionFromReportedSuppressions(analyzer.Descriptor.Id));
+            return;
+
+            // Local functions.
+            void testCore(DiagnosticSuppressor suppressor)
+            {
+                var analyzers = new DiagnosticAnalyzer[] { analyzer, suppressor };
+                compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                    Diagnostic("AD0001").WithArguments(suppressor.ToString(),
+                                                       typeof(NotImplementedException).FullName,
+                                                       "The method or operation is not implemented.")
+                                        .WithLocation(1, 1),
+                    Diagnostic("ID1000", "class C { }").WithLocation(2, 1));
+
+                compilation.VerifySuppressedDiagnostics(analyzers);
+            }
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestUnsupportedSuppressionReported()
+        {
+            string source = @"
+class C { }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            const string supportedSuppressionId = "supportedId";
+            const string unsupportedSuppressionId = "unsupportedId";
+            var analyzer = new CompilationAnalyzerWithSeverity(DiagnosticSeverity.Warning, configurable: true);
+            var suppressor = new DiagnosticSuppressor_UnsupportedSuppressionReported(analyzer.Descriptor.Id, supportedSuppressionId, unsupportedSuppressionId);
+            var analyzers = new DiagnosticAnalyzer[] { analyzer, suppressor };
+
+            // "Reported suppression with ID '{0}' is not supported by the suppressor."
+            var exceptionMessage = string.Format(CodeAnalysisResources.UnsupportedSuppressionReported, unsupportedSuppressionId);
+
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                Diagnostic("AD0001").WithArguments(suppressor.ToString(),
+                                                   typeof(ArgumentException).FullName,
+                                                   exceptionMessage)
+                                    .WithLocation(1, 1),
+                Diagnostic("ID1000", "class C { }").WithLocation(2, 1));
+
+            compilation.VerifySuppressedDiagnostics(analyzers);
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestInvalidDiagnosticSuppressionReported()
+        {
+            string source = @"
+class C { }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            const string unsupportedSuppressedId = "UnsupportedId";
+            var analyzer = new CompilationAnalyzerWithSeverity(DiagnosticSeverity.Warning, configurable: true);
+            var suppressor = new DiagnosticSuppressor_InvalidDiagnosticSuppressionReported(analyzer.Descriptor.Id, unsupportedSuppressedId);
+            var analyzers = new DiagnosticAnalyzer[] { analyzer, suppressor };
+
+            // "Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor."
+            var exceptionMessage = string.Format(CodeAnalysisResources.InvalidDiagnosticSuppressionReported, analyzer.Descriptor.Id, unsupportedSuppressedId);
+
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                Diagnostic("AD0001").WithArguments(suppressor.ToString(),
+                                                   typeof(System.ArgumentException).FullName,
+                                                   exceptionMessage)
+                                    .WithLocation(1, 1),
+                Diagnostic("ID1000", "class C { }").WithLocation(2, 1));
+
+            compilation.VerifySuppressedDiagnostics(analyzers);
+        }
+
+        [Fact, WorkItem(20242, "https://github.com/dotnet/roslyn/issues/20242")]
+        public void TestNonReportedDiagnosticCannotBeSuppressed()
+        {
+            string source = @"
+class C { }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            const string nonReportedDiagnosticId = "NonReportedId";
+            var analyzer = new CompilationAnalyzerWithSeverity(DiagnosticSeverity.Warning, configurable: true);
+            var suppressor = new DiagnosticSuppressor_NonReportedDiagnosticCannotBeSuppressed(analyzer.Descriptor.Id, nonReportedDiagnosticId);
+            var analyzers = new DiagnosticAnalyzer[] { analyzer, suppressor };
+
+            // "Non-reported diagnostic with ID '{0}' cannot be suppressed."
+            var exceptionMessage = string.Format(CodeAnalysisResources.NonReportedDiagnosticCannotBeSuppressed, nonReportedDiagnosticId);
+
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                Diagnostic("AD0001").WithArguments(suppressor.ToString(),
+                                                   typeof(System.ArgumentException).FullName,
+                                                   exceptionMessage)
+                                    .WithLocation(1, 1),
+                Diagnostic("ID1000", "class C { }").WithLocation(2, 1));
+
+            compilation.VerifySuppressedDiagnostics(analyzers);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft.CodeAnalysis {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -40,7 +39,7 @@ namespace Microsoft.CodeAnalysis {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.CodeAnalysis.CodeAnalysisResources", typeof(CodeAnalysisResources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.CodeAnalysis.CodeAnalysisResources", typeof(CodeAnalysisResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -767,6 +766,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Suppressed diagnostic ID &apos;{0}&apos; does not match suppressable ID &apos;{1}&apos; for the given suppression descriptor..
+        /// </summary>
+        internal static string InvalidDiagnosticSuppressionReported {
+            get {
+                return ResourceManager.GetString("InvalidDiagnosticSuppressionReported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid hash..
         /// </summary>
         internal static string InvalidHash {
@@ -1042,6 +1050,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string NodeOrTokenOutOfSequence {
             get {
                 return ResourceManager.GetString("NodeOrTokenOutOfSequence", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Non-reported diagnostic with ID &apos;{0}&apos; cannot be suppressed..
+        /// </summary>
+        internal static string NonReportedDiagnosticCannotBeSuppressed {
+            get {
+                return ResourceManager.GetString("NonReportedDiagnosticCannotBeSuppressed", resourceCulture);
             }
         }
         
@@ -1397,6 +1414,24 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Analyzer &apos;{0}&apos; contains a null descriptor in its &apos;SupportedSuppressions&apos;..
+        /// </summary>
+        internal static string SupportedSuppressionsHasNullDescriptor {
+            get {
+                return ResourceManager.GetString("SupportedSuppressionsHasNullDescriptor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space..
+        /// </summary>
+        internal static string SuppressionIdCantBeNullOrWhitespace {
+            get {
+                return ResourceManager.GetString("SuppressionIdCantBeNullOrWhitespace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Windows PDB writer doesn&apos;t support SourceLink feature: &apos;{0}&apos;.
         /// </summary>
         internal static string SymWriterDoesNotSupportSourceLink {
@@ -1573,6 +1608,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string UnsupportedHashAlgorithm {
             get {
                 return ResourceManager.GetString("UnsupportedHashAlgorithm", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reported suppression with ID &apos;{0}&apos; is not supported by the suppressor..
+        /// </summary>
+        internal static string UnsupportedSuppressionReported {
+            get {
+                return ResourceManager.GetString("UnsupportedSuppressionReported", resourceCulture);
             }
         }
         

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -419,6 +419,9 @@
   <data name="DiagnosticIdCantBeNullOrWhitespace" xml:space="preserve">
     <value>A DiagnosticDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</value>
   </data>
+  <data name="SuppressionIdCantBeNullOrWhitespace" xml:space="preserve">
+    <value>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</value>
+  </data>
   <data name="RuleSetHasDuplicateRules" xml:space="preserve">
     <value>The rule set file has duplicate rules for '{0}' with differing actions '{1}' and '{2}'.</value>
   </data>
@@ -443,6 +446,15 @@
   <data name="UnsupportedDiagnosticReported" xml:space="preserve">
     <value>Reported diagnostic with ID '{0}' is not supported by the analyzer.</value>
   </data>
+  <data name="UnsupportedSuppressionReported" xml:space="preserve">
+    <value>Reported suppression with ID '{0}' is not supported by the suppressor.</value>
+  </data>
+  <data name="InvalidDiagnosticSuppressionReported" xml:space="preserve">
+    <value>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</value>
+  </data>
+  <data name="NonReportedDiagnosticCannotBeSuppressed" xml:space="preserve">
+    <value>Non-reported diagnostic with ID '{0}' cannot be suppressed.</value>
+  </data>
   <data name="InvalidDiagnosticIdReported" xml:space="preserve">
     <value>Reported diagnostic has an ID '{0}', which is not a valid identifier.</value>
   </data>
@@ -451,6 +463,9 @@
   </data>
   <data name="SupportedDiagnosticsHasNullDescriptor" xml:space="preserve">
     <value>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</value>
+  </data>
+  <data name="SupportedSuppressionsHasNullDescriptor" xml:space="preserve">
+    <value>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</value>
   </data>
   <data name="The_type_0_is_not_understood_by_the_serialization_binder" xml:space="preserve">
     <value>The type '{0}' is not understood by the serialization binder.</value>

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
@@ -215,7 +215,8 @@ namespace Microsoft.CodeAnalysis
             return effectiveDiagnostic != null ? MapSeverityToReport(effectiveDiagnostic.Severity) : ReportDiagnostic.Suppress;
         }
 
-        private static ReportDiagnostic MapSeverityToReport(DiagnosticSeverity severity)
+        // internal for testing purposes.
+        internal static ReportDiagnostic MapSeverityToReport(DiagnosticSeverity severity)
         {
             switch (severity)
             {

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.FixedLocalizableString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.FixedLocalizableString.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis
 
             private readonly string _fixedString;
 
-            public static FixedLocalizableString Create(string fixedResource)
+            public static new FixedLocalizableString Create(string fixedResource)
             {
                 if (string.IsNullOrEmpty(fixedResource))
                 {

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
@@ -39,6 +39,11 @@ namespace Microsoft.CodeAnalysis
 
         public static implicit operator LocalizableString(string fixedResource)
         {
+            return Create(fixedResource);
+        }
+
+        internal static LocalizableString Create(string fixedResource)
+        {
             return FixedLocalizableString.Create(fixedResource);
         }
 

--- a/src/Compilers/Core/Portable/Diagnostic/SuppressionDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SuppressionDescriptor.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Provides a description about a programmatic suppression of a <see cref="Diagnostic"/> by a <see cref="DiagnosticSuppressor"/>.
+    /// </summary>
+    public sealed class SuppressionDescriptor : IEquatable<SuppressionDescriptor>
+    {
+        /// <summary>
+        /// An unique identifier for the suppression.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// Identifier of the suppressed diagnostic, i.e. <see cref="Diagnostic.Id"/>.
+        /// </summary>
+        public string SuppressedDiagnosticId { get; }
+
+        /// <summary>
+        /// A localizable description about the suppression.
+        /// </summary>
+        public LocalizableString Description { get; }
+
+        /// <summary>
+        /// Create a SuppressionDescriptor, which provides description about a programmatic suppression of a <see cref="Diagnostic"/>.
+        /// NOTE: For localizable <paramref name="description"/>,
+        /// use constructor overload .
+        /// </summary>
+        /// <param name="id">A unique identifier for the suppression. For example, suppression ID "SP1001".</param>
+        /// <param name="suppressedDiagnosticId">Identifier of the suppressed diagnostic, i.e. <see cref="Diagnostic.Id"/>. For example, compiler warning Id "CS0649".</param>
+        /// <param name="description">Description of the suppression. For example: "Suppress CS0649 on fields marked with YYY attribute as they are implicitly assigned.".</param>
+        public SuppressionDescriptor(
+            string id,
+            string suppressedDiagnosticId,
+            string description)
+            : this(id, suppressedDiagnosticId,
+                   LocalizableString.Create(description ?? throw new ArgumentNullException(nameof(description))))
+        {
+        }
+
+        /// <summary>
+        /// Create a SuppressionDescriptor, which provides description about a programmatic suppression of a <see cref="Diagnostic"/>.
+        /// </summary>
+        /// <param name="id">A unique identifier for the suppression. For example, suppression ID "SP1001".</param>
+        /// <param name="suppressedDiagnosticId">Identifier of the suppressed diagnostic, i.e. <see cref="Diagnostic.Id"/>. For example, compiler warning Id "CS0649".</param>
+        /// <param name="description">Description of the suppression. For example: "Suppress CS0649 on fields marked with YYY attribute as they are implicitly assigned.".</param>
+        public SuppressionDescriptor(
+            string id,
+            string suppressedDiagnosticId,
+            LocalizableString description)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException(CodeAnalysisResources.SuppressionIdCantBeNullOrWhitespace, nameof(id));
+            }
+
+            if (string.IsNullOrWhiteSpace(suppressedDiagnosticId))
+            {
+                throw new ArgumentException(CodeAnalysisResources.DiagnosticIdCantBeNullOrWhitespace, nameof(suppressedDiagnosticId));
+            }
+
+            this.Id = id;
+            this.SuppressedDiagnosticId = suppressedDiagnosticId;
+            this.Description = description ?? throw new ArgumentNullException(nameof(description));
+        }
+
+        public bool Equals(SuppressionDescriptor other)
+        {
+            return
+                other != null &&
+                this.Id == other.Id &&
+                this.SuppressedDiagnosticId == other.SuppressedDiagnosticId &&
+                this.Description.Equals(other.Description);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as SuppressionDescriptor);
+        }
+
+        public override int GetHashCode()
+        {
+            return Hash.Combine(this.Id.GetHashCode(),
+                   Hash.Combine(this.SuppressedDiagnosticId.GetHashCode(), this.Description.GetHashCode()));
+        }
+
+        /// <summary>
+        /// Flag indicating if the suppression is disabled for the given <see cref="CompilationOptions"/>.
+        /// </summary>
+        /// <param name="compilationOptions">Compilation options</param>
+        internal bool IsDisabled(CompilationOptions compilationOptions)
+        {
+            if (compilationOptions == null)
+            {
+                throw new ArgumentNullException(nameof(compilationOptions));
+            }
+
+            return compilationOptions.SpecificDiagnosticOptions.TryGetValue(Id, out var reportDiagnostic) &&
+                reportDiagnostic == ReportDiagnostic.Suppress;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -48,9 +48,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             private Dictionary<ISymbol, Task<HostSymbolStartAnalysisScope>> _lazySymbolScopeTasks;
 
             /// <summary>
-            /// Supported descriptors for diagnostic analyzer.
+            /// Supported diagnostic descriptors for diagnostic analyzer, if any.
             /// </summary>
-            private ImmutableArray<DiagnosticDescriptor> _lazyDescriptors = default(ImmutableArray<DiagnosticDescriptor>);
+            private ImmutableArray<DiagnosticDescriptor> _lazyDiagnosticDescriptors = default(ImmutableArray<DiagnosticDescriptor>);
+
+            /// <summary>
+            /// Supported suppression descriptors for diagnostic suppressor, if any.
+            /// </summary>
+            private ImmutableArray<SuppressionDescriptor> _lazySuppressionDescriptors = default(ImmutableArray<SuppressionDescriptor>);
 
             public Task<HostSessionStartAnalysisScope> GetSessionAnalysisScopeTask(AnalyzerExecutor analyzerExecutor)
             {
@@ -210,32 +215,43 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             }
 
-            public ImmutableArray<DiagnosticDescriptor> GetOrComputeDescriptors(DiagnosticAnalyzer analyzer, AnalyzerExecutor analyzerExecutor)
+            public ImmutableArray<DiagnosticDescriptor> GetOrComputeDiagnosticDescriptors(DiagnosticAnalyzer analyzer, AnalyzerExecutor analyzerExecutor)
+                => GetOrComputeDescriptors(ref _lazyDiagnosticDescriptors, ComputeDiagnosticDescriptors, _gate, analyzer, analyzerExecutor);
+
+            public ImmutableArray<SuppressionDescriptor> GetOrComputeSuppressionDescriptors(DiagnosticSuppressor suppressor, AnalyzerExecutor analyzerExecutor)
+                => GetOrComputeDescriptors(ref _lazySuppressionDescriptors, ComputeSuppressionDescriptors, _gate, suppressor, analyzerExecutor);
+
+            private static ImmutableArray<TDescriptor> GetOrComputeDescriptors<TDescriptor>(
+                ref ImmutableArray<TDescriptor> lazyDescriptors,
+                Func<DiagnosticAnalyzer, AnalyzerExecutor, ImmutableArray<TDescriptor>> computeDescriptors,
+                object gate,
+                DiagnosticAnalyzer analyzer,
+                AnalyzerExecutor analyzerExecutor)
             {
-                lock (_gate)
+                lock (gate)
                 {
-                    if (!_lazyDescriptors.IsDefault)
+                    if (!lazyDescriptors.IsDefault)
                     {
-                        return _lazyDescriptors;
+                        return lazyDescriptors;
                     }
                 }
 
                 // Otherwise, compute the value.
                 // We do so outside the lock statement as we are calling into user code, which may be a long running operation.
-                var descriptors = ComputeDescriptors(analyzer, analyzerExecutor);
+                var descriptors = computeDescriptors(analyzer, analyzerExecutor);
 
-                lock (_gate)
+                lock (gate)
                 {
                     // Check if another thread already stored the computed value.
-                    if (!_lazyDescriptors.IsDefault)
+                    if (!lazyDescriptors.IsDefault)
                     {
                         // If so, we return the stored value.
-                        descriptors = _lazyDescriptors;
+                        descriptors = lazyDescriptors;
                     }
                     else
                     {
                         // Otherwise, store the value computed here.
-                        _lazyDescriptors = descriptors;
+                        lazyDescriptors = descriptors;
                     }
                 }
 
@@ -245,7 +261,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             /// <summary>
             /// Compute <see cref="DiagnosticAnalyzer.SupportedDiagnostics"/> and exception handler for the given <paramref name="analyzer"/>.
             /// </summary>
-            private static ImmutableArray<DiagnosticDescriptor> ComputeDescriptors(
+            private static ImmutableArray<DiagnosticDescriptor> ComputeDiagnosticDescriptors(
                 DiagnosticAnalyzer analyzer,
                 AnalyzerExecutor analyzerExecutor)
             {
@@ -292,6 +308,40 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
 
                 return supportedDiagnostics;
+            }
+
+            private static ImmutableArray<SuppressionDescriptor> ComputeSuppressionDescriptors(
+                DiagnosticAnalyzer analyzer,
+                AnalyzerExecutor analyzerExecutor)
+            {
+                var descriptors = ImmutableArray<SuppressionDescriptor>.Empty;
+
+                if (analyzer is DiagnosticSuppressor suppressor)
+                {
+                    // Catch Exception from suppressor.SupportedSuppressions
+                    analyzerExecutor.ExecuteAndCatchIfThrows(
+                        analyzer,
+                        _ =>
+                        {
+                            var descriptorsLocal = suppressor.SupportedSuppressions;
+                            if (!descriptorsLocal.IsDefaultOrEmpty)
+                            {
+                                foreach (var descriptor in descriptorsLocal)
+                                {
+                                    if (descriptor == null)
+                                    {
+                                        // Disallow null descriptors.
+                                        throw new ArgumentException(string.Format(CodeAnalysisResources.SupportedSuppressionsHasNullDescriptor, analyzer.ToString()), nameof(DiagnosticSuppressor.SupportedSuppressions));
+                                    }
+                                }
+
+                                descriptors = descriptorsLocal;
+                            }
+                        },
+                        argument: default(object));
+                }
+
+                return descriptors;
             }
 
             public bool TryProcessCompletedMemberAndGetPendingSymbolEndActionsForContainer(

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -235,7 +235,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             AnalyzerExecutor analyzerExecutor)
         {
             var analyzerExecutionContext = GetAnalyzerExecutionContext(analyzer);
-            return analyzerExecutionContext.GetOrComputeDescriptors(analyzer, analyzerExecutor);
+            return analyzerExecutionContext.GetOrComputeDiagnosticDescriptors(analyzer, analyzerExecutor);
+        }
+
+        /// <summary>
+        /// Return <see cref="DiagnosticSuppressor.SupportedSuppressions"/> of given <paramref name="suppressor"/>.
+        /// </summary>
+        public ImmutableArray<SuppressionDescriptor> GetSupportedSuppressionDescriptors(
+            DiagnosticSuppressor suppressor,
+            AnalyzerExecutor analyzerExecutor)
+        {
+            var analyzerExecutionContext = GetAnalyzerExecutionContext(suppressor);
+            return analyzerExecutionContext.GetOrComputeSuppressionDescriptors(suppressor, analyzerExecutor);
         }
 
         internal bool IsSupportedDiagnostic(DiagnosticAnalyzer analyzer, Diagnostic diagnostic, Func<DiagnosticAnalyzer, bool> isCompilerAnalyzer, AnalyzerExecutor analyzerExecutor)
@@ -306,6 +317,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (!isSuppressed)
                 {
                     return false;
+                }
+            }
+
+            if (analyzer is DiagnosticSuppressor suppressor)
+            {
+                foreach (var suppressionDescriptor in GetSupportedSuppressionDescriptors(suppressor, analyzerExecutor))
+                {
+                    if (!suppressionDescriptor.IsDisabled(options))
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerTelemetry.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerTelemetry.cs
@@ -90,6 +90,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Telemetry
         public int OperationBlockActionsCount { get; set; } = 0;
 
         /// <summary>
+        /// Count of registered suppression actions.
+        /// This is the same as count of <see cref="DiagnosticSuppressor"/>s as each suppressor
+        /// has a single suppression action, i.e. <see cref="DiagnosticSuppressor.ReportSuppressions(SuppressionAnalysisContext)"/>.
+        /// </summary>
+        public int SuppressionActionsCount { get; set; } = 0;
+
+        /// <summary>
         /// Total execution time.
         /// </summary>
         public TimeSpan ExecutionTime { get; set; } = TimeSpan.Zero;
@@ -99,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Telemetry
         /// </summary>
         public bool Concurrent { get; set; }
 
-        internal AnalyzerTelemetryInfo(AnalyzerActionCounts actionCounts, TimeSpan executionTime)
+        internal AnalyzerTelemetryInfo(AnalyzerActionCounts actionCounts, int suppressionActionCounts, TimeSpan executionTime)
         {
             CompilationStartActionsCount = actionCounts.CompilationStartActionsCount;
             CompilationEndActionsCount = actionCounts.CompilationEndActionsCount;
@@ -120,6 +127,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Telemetry
             OperationBlockStartActionsCount = actionCounts.OperationBlockStartActionsCount;
             OperationBlockEndActionsCount = actionCounts.OperationBlockEndActionsCount;
             OperationBlockActionsCount = actionCounts.OperationBlockActionsCount;
+
+            SuppressionActionsCount = suppressionActionCounts;
 
             ExecutionTime = executionTime;
             Concurrent = actionCounts.Concurrent;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -420,7 +420,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
                 Func<DiagnosticAnalyzer, AnalyzerActionCounts> getAnalyzerActionCounts = analyzer => analyzerActionCounts[analyzer];
 
-                _analysisResultBuilder.StoreAnalysisResult(analysisScope, driver, compilation, getAnalyzerActionCounts, fullAnalysisResultForAnalyzersInScope: true);
+                _analysisResultBuilder.ApplySuppressionsAndStoreAnalysisResult(analysisScope, driver, compilation, getAnalyzerActionCounts, fullAnalysisResultForAnalyzersInScope: true);
             }
             finally
             {
@@ -450,7 +450,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Force compilation diagnostics and wait for analyzer execution to complete.
                 var compDiags = compilation.GetDiagnostics(cancellationToken);
                 var analyzerDiags = await driver.GetDiagnosticsAsync(compilation).ConfigureAwait(false);
-                return compDiags.AddRange(analyzerDiags);
+                var reportedDiagnostics = compDiags.AddRange(analyzerDiags);
+                return driver.ApplyAnalyzerSuppressions(reportedDiagnostics, compilation);
             }
             finally
             {
@@ -898,7 +899,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     finally
                     {
                         // Update the diagnostic results based on the diagnostics reported on the driver.
-                        _analysisResultBuilder.StoreAnalysisResult(analysisScope, driver, _compilation, _analysisState.GetAnalyzerActionCounts, fullAnalysisResultForAnalyzersInScope: false);
+                        _analysisResultBuilder.ApplySuppressionsAndStoreAnalysisResult(analysisScope, driver, _compilation, _analysisState.GetAnalyzerActionCounts, fullAnalysisResultForAnalyzersInScope: false);
                     }
                 }
             }
@@ -1227,8 +1228,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             try
             {
                 var actionCounts = await GetAnalyzerActionCountsAsync(analyzer, cancellationToken).ConfigureAwait(false);
+                var suppressionActionCounts = analyzer is DiagnosticSuppressor ? 1 : 0;
                 var executionTime = GetAnalyzerExecutionTime(analyzer);
-                return new AnalyzerTelemetryInfo(actionCounts, executionTime);
+                return new AnalyzerTelemetryInfo(actionCounts, suppressionActionCounts, executionTime);
             }
             catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticSuppressor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticSuppressor.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    /// <summary>
+    /// The base type for diagnostic suppressors that can programmatically suppress diagnostics.
+    /// </summary>
+    public abstract class DiagnosticSuppressor : DiagnosticAnalyzer
+    {
+        // Disallow suppressors from reporting diagnostics or registering analysis actions.
+        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
+
+        public sealed override void Initialize(AnalysisContext context) { }
+
+        /// <summary>
+        /// Returns a set of descriptors for the suppressions that this suppressor is capable of producing.
+        /// </summary>
+        public abstract ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; }
+
+        /// <summary>
+        /// Suppress analyzer and/or compiler diagnostics reported for the compilation.
+        /// This may be a subset of the full set of reported diagnostics, as an optimization for
+        /// supporting incremental and partial analysis scenarios.
+        /// A diagnostic is considered suppressible by analyzers if *all* of the following conditions are met:
+        ///     1. Diagnostic is not already suppressed in source via pragma/suppress message attribute.
+        ///     2. Diagnostic's <see cref="Diagnostic.DefaultSeverity"/> is not <see cref="DiagnosticSeverity.Error"/>.
+        ///     3. Diagnostic is not tagged with <see cref="WellKnownDiagnosticTags.NotConfigurable"/> custom tag.
+        /// </summary>
+        public abstract void ReportSuppressions(SuppressionAnalysisContext context);
+    }
+}

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/Suppression.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/Suppression.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    /// <summary>
+    /// Programmatic suppression of a <see cref="Diagnostic"/> by a <see cref="DiagnosticSuppressor"/>.
+    /// </summary>
+    public struct Suppression
+    {
+        private Suppression(SuppressionDescriptor descriptor, Diagnostic suppressedDiagnostic)
+        {
+            Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+            SuppressedDiagnostic = suppressedDiagnostic ?? throw new ArgumentNullException(nameof(suppressedDiagnostic));
+
+            if (descriptor.SuppressedDiagnosticId != suppressedDiagnostic.Id)
+            {
+                // Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.
+                var message = string.Format(CodeAnalysisResources.InvalidDiagnosticSuppressionReported, suppressedDiagnostic.Id, descriptor.SuppressedDiagnosticId);
+                throw new ArgumentException(message);
+            }
+        }
+
+        /// <summary>
+        /// Creates a suppression of a <see cref="Diagnostic"/> with the given <see cref="SuppressionDescriptor"/>.
+        /// </summary>
+        /// <param name="descriptor">
+        /// Descriptor for the suppression, which must be from <see cref="DiagnosticSuppressor.SupportedSuppressions"/>
+        /// for the <see cref="DiagnosticSuppressor"/> creating this suppression.
+        /// </param>
+        /// <param name="suppressedDiagnostic">
+        /// <see cref="Diagnostic"/> to be suppressed, which must be from <see cref="SuppressionAnalysisContext.ReportedDiagnostics"/>
+        /// for the suppression context in which this suppression is being created.</param>
+        public static Suppression Create(SuppressionDescriptor descriptor, Diagnostic suppressedDiagnostic)
+            => new Suppression(descriptor, suppressedDiagnostic);
+
+        /// <summary>
+        /// Descriptor for this suppression.
+        /// </summary>
+        public SuppressionDescriptor Descriptor { get; }
+
+        /// <summary>
+        /// Diagnostic suppressed by this suppression.
+        /// </summary>
+        public Diagnostic SuppressedDiagnostic { get; }
+    }
+}

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,15 +1,38 @@
 *REMOVED*Microsoft.CodeAnalysis.Operations.IEventAssignmentOperation.EventReference.get -> Microsoft.CodeAnalysis.Operations.IEventReferenceOperation
+Microsoft.CodeAnalysis.Diagnostics.DiagnosticSuppressor
+Microsoft.CodeAnalysis.Diagnostics.DiagnosticSuppressor.DiagnosticSuppressor() -> void
+Microsoft.CodeAnalysis.Diagnostics.Suppression
+Microsoft.CodeAnalysis.Diagnostics.Suppression.Descriptor.get -> Microsoft.CodeAnalysis.SuppressionDescriptor
+Microsoft.CodeAnalysis.Diagnostics.Suppression.SuppressedDiagnostic.get -> Microsoft.CodeAnalysis.Diagnostic
+Microsoft.CodeAnalysis.Diagnostics.SuppressionAnalysisContext
+Microsoft.CodeAnalysis.Diagnostics.SuppressionAnalysisContext.CancellationToken.get -> System.Threading.CancellationToken
+Microsoft.CodeAnalysis.Diagnostics.SuppressionAnalysisContext.Compilation.get -> Microsoft.CodeAnalysis.Compilation
+Microsoft.CodeAnalysis.Diagnostics.SuppressionAnalysisContext.GetSemanticModel(Microsoft.CodeAnalysis.SyntaxTree syntaxTree) -> Microsoft.CodeAnalysis.SemanticModel
+Microsoft.CodeAnalysis.Diagnostics.SuppressionAnalysisContext.Options.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions
+Microsoft.CodeAnalysis.Diagnostics.SuppressionAnalysisContext.ReportSuppression(Microsoft.CodeAnalysis.Diagnostics.Suppression suppression) -> void
+Microsoft.CodeAnalysis.Diagnostics.SuppressionAnalysisContext.ReportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>
+Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.SuppressionActionsCount.get -> int
+Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.SuppressionActionsCount.set -> void
 Microsoft.CodeAnalysis.IFieldSymbol.IsFixedSizeBuffer.get -> bool
 Microsoft.CodeAnalysis.OperationKind.Binary = 32 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.ConstructorBody = 89 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.FromEndIndex = 100 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.MethodBody = 88 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.Range = 99 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.SuppressionDescriptor
+Microsoft.CodeAnalysis.SuppressionDescriptor.Description.get -> Microsoft.CodeAnalysis.LocalizableString
+Microsoft.CodeAnalysis.SuppressionDescriptor.Equals(Microsoft.CodeAnalysis.SuppressionDescriptor other) -> bool
+Microsoft.CodeAnalysis.SuppressionDescriptor.Id.get -> string
+Microsoft.CodeAnalysis.SuppressionDescriptor.SuppressedDiagnosticId.get -> string
+Microsoft.CodeAnalysis.SuppressionDescriptor.SuppressionDescriptor(string id, string suppressedDiagnosticId, Microsoft.CodeAnalysis.LocalizableString description) -> void
+Microsoft.CodeAnalysis.SuppressionDescriptor.SuppressionDescriptor(string id, string suppressedDiagnosticId, string description) -> void
 Microsoft.CodeAnalysis.OperationKind.TupleBinary = 87 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.Unary = 31 -> Microsoft.CodeAnalysis.OperationKind
 abstract Microsoft.CodeAnalysis.Compilation.ClassifyCommonConversion(Microsoft.CodeAnalysis.ITypeSymbol source, Microsoft.CodeAnalysis.ITypeSymbol destination) -> Microsoft.CodeAnalysis.Operations.CommonConversion
 abstract Microsoft.CodeAnalysis.Compilation.ContainsSymbolsWithName(string name, Microsoft.CodeAnalysis.SymbolFilter filter = Microsoft.CodeAnalysis.SymbolFilter.TypeAndMember, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> bool
 abstract Microsoft.CodeAnalysis.Compilation.GetSymbolsWithName(string name, Microsoft.CodeAnalysis.SymbolFilter filter = Microsoft.CodeAnalysis.SymbolFilter.TypeAndMember, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ISymbol>
+abstract Microsoft.CodeAnalysis.Diagnostics.DiagnosticSuppressor.ReportSuppressions(Microsoft.CodeAnalysis.Diagnostics.SuppressionAnalysisContext context) -> void
+abstract Microsoft.CodeAnalysis.Diagnostics.DiagnosticSuppressor.SupportedSuppressions.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.SuppressionDescriptor>
 abstract Microsoft.CodeAnalysis.Diagnostics.SymbolStartAnalysisContext.RegisterCodeBlockAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.CodeBlockAnalysisContext> action) -> void
 abstract Microsoft.CodeAnalysis.Diagnostics.SymbolStartAnalysisContext.RegisterCodeBlockStartAction<TLanguageKindEnum>(System.Action<Microsoft.CodeAnalysis.Diagnostics.CodeBlockStartAnalysisContext<TLanguageKindEnum>> action) -> void
 abstract Microsoft.CodeAnalysis.Diagnostics.SymbolStartAnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.OperationKind> operationKinds) -> void
@@ -169,6 +192,11 @@ const Microsoft.CodeAnalysis.WellKnownMemberNames.GetAsyncEnumeratorMethodName =
 const Microsoft.CodeAnalysis.WellKnownMemberNames.MoveNextAsyncMethodName = "MoveNextAsync" -> string
 override Microsoft.CodeAnalysis.FlowAnalysis.CaptureId.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.FlowAnalysis.CaptureId.GetHashCode() -> int
+override Microsoft.CodeAnalysis.SuppressionDescriptor.Equals(object obj) -> bool
+override Microsoft.CodeAnalysis.SuppressionDescriptor.GetHashCode() -> int
+override sealed Microsoft.CodeAnalysis.Diagnostics.DiagnosticSuppressor.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext context) -> void
+override sealed Microsoft.CodeAnalysis.Diagnostics.DiagnosticSuppressor.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor>
+static Microsoft.CodeAnalysis.Diagnostics.Suppression.Create(Microsoft.CodeAnalysis.SuppressionDescriptor descriptor, Microsoft.CodeAnalysis.Diagnostic suppressedDiagnostic) -> Microsoft.CodeAnalysis.Diagnostics.Suppression
 static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph.Create(Microsoft.CodeAnalysis.Operations.IBlockOperation body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph
 static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph.Create(Microsoft.CodeAnalysis.Operations.IConstructorBodyOperation constructorBody, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph
 static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph.Create(Microsoft.CodeAnalysis.Operations.IFieldInitializerOperation initializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
@@ -9,6 +9,11 @@
 {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">Blok dané operace nepatří do aktuálního analytického kontextu.</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata() musí vracet instanci {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
@@ -9,6 +9,11 @@
 "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">Der angegebene Operationsblock gehört nicht zum aktuellen Analysekontext.</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata() muss eine Instanz von {1} zurückgeben.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
@@ -9,6 +9,11 @@
 "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">El bloque de operaciones dado no pertenece al contexto de análisis actual.</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata() debe devolver una instancia de {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
@@ -9,6 +9,11 @@
 '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">Le bloc d'opérations donné n'appartient pas au contexte d'analyse actuel.</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata() doit retourner une instance de {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
@@ -9,6 +9,11 @@
 '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">Il blocco operazioni specificato non appartiene al contesto di analisi corrente.</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata() deve restituire un'istanza di {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
@@ -9,6 +9,11 @@
 '{1}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">指定した操作ブロックが現在の分析コンテストに属していません。</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata() は {1} のインスタンスを返す必要があります。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
@@ -9,6 +9,11 @@
 '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">지정한 작업 블록이 현재 분석 컨텍스트에 속하지 않습니다.</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata()는 {1}의 인스턴스를 반환해야 합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
@@ -9,6 +9,11 @@
 „{1}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">Dany blok operacji nie należy do bieżącego kontekstu analizy.</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">Metoda {0}.GetMetadata() musi zwrócić wystąpienie {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
@@ -9,6 +9,11 @@
 '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">O bloqueio de operação fornecido não pertence ao contexto de análise atual.</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata() deve retornar uma instância de {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
@@ -9,6 +9,11 @@
 "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">Заданный блок операции не принадлежит текущему контексту анализа.</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata() должен возвращать экземпляр {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
@@ -9,6 +9,11 @@
 '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">Belirtilen işlem bloğu geçerli analiz bağlamına ait değil.</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata() bir {1} örneği döndürmelidir.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
@@ -9,6 +9,11 @@
 “{1}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">给定操作块不属于当前的分析上下文。</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata() 必须返回 {1} 的实例。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
@@ -9,6 +9,11 @@
 '{1}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidDiagnosticSuppressionReported">
+        <source>Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</source>
+        <target state="new">Suppressed diagnostic ID '{0}' does not match suppressable ID '{1}' for the given suppression descriptor.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidOperationBlockForAnalysisContext">
         <source>Given operation block does not belong to the current analysis context.</source>
         <target state="translated">指定的作業區塊不屬於目前的分析內容。</target>
@@ -22,6 +27,11 @@
       <trans-unit id="IsSymbolAccessibleWrongAssembly">
         <source>Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</source>
         <target state="new">Parameter '{0}' must be a symbol from this compilation or some referenced assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonReportedDiagnosticCannotBeSuppressed">
+        <source>Non-reported diagnostic with ID '{0}' cannot be suppressed.</source>
+        <target state="new">Non-reported diagnostic with ID '{0}' cannot be suppressed.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotARootOperation">
@@ -62,6 +72,16 @@
       <trans-unit id="SupportedDiagnosticsHasNullDescriptor">
         <source>Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</source>
         <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedDiagnostics'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SupportedSuppressionsHasNullDescriptor">
+        <source>Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</source>
+        <target state="new">Analyzer '{0}' contains a null descriptor in its 'SupportedSuppressions'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SuppressionIdCantBeNullOrWhitespace">
+        <source>A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</source>
+        <target state="new">A SuppressionDescriptor must have an Id that is neither null nor an empty string nor a string that only contains white space.</target>
         <note />
       </trans-unit>
       <trans-unit id="Unresolved">
@@ -192,6 +212,11 @@
       <trans-unit id="GetMetadataMustReturnInstance">
         <source>{0}.GetMetadata() must return an instance of {1}.</source>
         <target state="translated">{0}.GetMetadata() 必須傳回 {1} 的執行個體。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedSuppressionReported">
+        <source>Reported suppression with ID '{0}' is not supported by the suppressor.</source>
+        <target state="new">Reported suppression with ID '{0}' is not supported by the suppressor.</target>
         <note />
       </trans-unit>
       <trans-unit id="Value_too_large_to_be_represented_as_a_30_bit_unsigned_integer">

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -1989,7 +1989,7 @@ class MyClass
                 Dim project = workspace.CurrentSolution.Projects.Single()
 
                 ' Add analyzer
-                Dim analyzer = New HiddenDiagnosticsCompilationAnalyzer()
+                Dim analyzer = New CompilationAnalyzerWithSeverity(DiagnosticSeverity.Hidden, configurable:=False)
                 Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))
                 project = project.AddAnalyzerReference(analyzerReference)
 
@@ -2002,7 +2002,7 @@ class MyClass
                 Assert.Equal(1, descriptorsMap.Count)
                 Dim descriptors = descriptorsMap.First().Value
                 Assert.Equal(1, descriptors.Length)
-                Assert.Equal(HiddenDiagnosticsCompilationAnalyzer.Descriptor.Id, descriptors.Single().Id)
+                Assert.Equal(analyzer.Descriptor.Id, descriptors.Single().Id)
 
                 ' Force project analysis
                 incrementalAnalyzer.AnalyzeProjectAsync(project, semanticsChanged:=True, reasons:=InvocationReasons.Empty, cancellationToken:=CancellationToken.None).Wait()
@@ -2018,7 +2018,7 @@ class MyClass
                 ' Get diagnostics explicitly
                 Dim hiddenDiagnostics = diagnosticService.GetDiagnosticsAsync(project.Solution, project.Id).WaitAndGetResult(CancellationToken.None)
                 Assert.Equal(1, hiddenDiagnostics.Count())
-                Assert.Equal(HiddenDiagnosticsCompilationAnalyzer.Descriptor.Id, hiddenDiagnostics.Single().Id)
+                Assert.Equal(analyzer.Descriptor.Id, hiddenDiagnostics.Single().Id)
             End Using
         End Sub
 

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -356,6 +356,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Contract.ThrowIfFalse(project.SupportsCompilation);
             AssertCompilation(project, compilation);
 
+            // Always run diagnostic suppressors.
+            analyzers = AppendDiagnosticSuppressors(analyzers, allAnalyzersAndSuppressors: service.GetDiagnosticAnalyzers(project));
+
             // Create driver that holds onto compilation and associated analyzers
             return compilation.WithAnalyzers(filteredAnalyzers, GetAnalyzerOptions());
 
@@ -785,6 +788,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // in the error list
                 return null;
             }
+        }
+
+        public static IEnumerable<DiagnosticAnalyzer> AppendDiagnosticSuppressors(IEnumerable<DiagnosticAnalyzer> analyzers, IEnumerable<DiagnosticAnalyzer> allAnalyzersAndSuppressors)
+        {
+            // Append while ensuring no duplicates are added.
+            var diagnosticSuppressors = allAnalyzersAndSuppressors.OfType<DiagnosticSuppressor>();
+            return !diagnosticSuppressors.Any()
+                ? analyzers
+                : analyzers.Concat(diagnosticSuppressors).Distinct();
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticResultSerializer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticResultSerializer.cs
@@ -180,6 +180,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             writer.WriteInt32(telemetryInfo.OperationBlockActionsCount);
             writer.WriteInt32(telemetryInfo.OperationBlockStartActionsCount);
             writer.WriteInt32(telemetryInfo.OperationBlockEndActionsCount);
+            writer.WriteInt32(telemetryInfo.SuppressionActionsCount);
             writer.WriteInt64(telemetryInfo.ExecutionTime.Ticks);
             writer.WriteBoolean(telemetryInfo.Concurrent);
         }
@@ -204,6 +205,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var operationBlockActionsCount = reader.ReadInt32();
             var operationBlockStartActionsCount = reader.ReadInt32();
             var operationBlockEndActionsCount = reader.ReadInt32();
+            var suppressionActionsCount = reader.ReadInt32();
             var executionTime = new TimeSpan(reader.ReadInt64());
             var concurrent = reader.ReadBoolean();
 
@@ -228,6 +230,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 OperationBlockStartActionsCount = operationBlockStartActionsCount,
                 OperationBlockEndActionsCount = operationBlockEndActionsCount,
                 OperationBlockActionsCount = operationBlockActionsCount,
+
+                SuppressionActionsCount = suppressionActionsCount,
 
                 ExecutionTime = executionTime,
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -191,6 +191,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return null;
                 }
 
+                // Always run diagnostic suppressors.
+                analyzers = AnalyzerHelper.AppendDiagnosticSuppressors(analyzers, allAnalyzersAndSuppressors: analyzerDriver.Analyzers).ToImmutableArray();
+
                 return analyzerDriver.Compilation.WithAnalyzers(analyzers, analyzerDriver.AnalysisOptions);
             }
 

--- a/src/Features/Core/Portable/Diagnostics/Log/DiagnosticLogAggregator.cs
+++ b/src/Features/Core/Portable/Diagnostics/Log/DiagnosticLogAggregator.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Log
             "Analyzer.OperationBlockStart",
             "Analyzer.SymbolEnd",
             "Analyzer.SymbolStart",
+            "Analyzer.Suppression",
         };
 
         private readonly DiagnosticAnalyzerService _owner;
@@ -87,6 +88,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Log
                 Counts[13] = analyzerTelemetryInfo.OperationBlockStartActionsCount;
                 Counts[14] = analyzerTelemetryInfo.SymbolStartActionsCount;
                 Counts[15] = analyzerTelemetryInfo.SymbolEndActionsCount;
+                Counts[16] = analyzerTelemetryInfo.SuppressionActionsCount;
             }
         }
     }

--- a/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -703,16 +703,24 @@ namespace Microsoft.CodeAnalysis
         }
 
         [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-        public class HiddenDiagnosticsCompilationAnalyzer : DiagnosticAnalyzer
+        public class CompilationAnalyzerWithSeverity : DiagnosticAnalyzer
         {
-            public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
-                "ID1000",
-                "Description1",
-                string.Empty,
-                "Analysis",
-                DiagnosticSeverity.Hidden,
-                true,
-                customTags: WellKnownDiagnosticTags.NotConfigurable);
+            public CompilationAnalyzerWithSeverity(
+                DiagnosticSeverity severity,
+                bool configurable)
+            {
+                var customTags = !configurable ? new[] { WellKnownDiagnosticTags.NotConfigurable } : Array.Empty<string>();
+                Descriptor = new DiagnosticDescriptor(
+                    "ID1000",
+                    "Description1",
+                    string.Empty,
+                    "Analysis",
+                    severity,
+                    true,
+                    customTags: customTags);
+            }
+
+            public DiagnosticDescriptor Descriptor { get; }
 
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
 
@@ -723,7 +731,7 @@ namespace Microsoft.CodeAnalysis
 
             private void OnCompilation(CompilationAnalysisContext context)
             {
-                // Report the hidden diagnostic on all trees in compilation.
+                // Report the diagnostic on all trees in compilation.
                 foreach (var tree in context.Compilation.SyntaxTrees)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(Descriptor, tree.GetRoot().GetLocation()));
@@ -1659,6 +1667,163 @@ namespace Microsoft.CodeAnalysis
                         }
                     }
                 }
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class DiagnosticSuppressorForId: DiagnosticSuppressor
+        {
+            private readonly SuppressionDescriptor _suppressionDescriptor;
+            public DiagnosticSuppressorForId(string suppressedDiagnosticId, string suppressionId = null)
+            {
+                _suppressionDescriptor = new SuppressionDescriptor(
+                    id: suppressionId ?? "SPR0001",
+                    suppressedDiagnosticId: suppressedDiagnosticId,
+                    description: $"Suppress {suppressedDiagnosticId}");
+            }
+
+            public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions
+                => ImmutableArray.Create(_suppressionDescriptor);
+
+            public override void ReportSuppressions(SuppressionAnalysisContext context)
+            {
+                foreach (var diagnostic in context.ReportedDiagnostics)
+                {
+                    Assert.Equal(_suppressionDescriptor.SuppressedDiagnosticId, diagnostic.Id);
+                    context.ReportSuppression(Suppression.Create(_suppressionDescriptor, diagnostic));
+                }
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class DiagnosticSuppressorThrowsExceptionFromSupportedSuppressions : DiagnosticSuppressor
+        {
+            public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions
+                => throw new NotImplementedException();
+
+            public override void ReportSuppressions(SuppressionAnalysisContext context)
+            {
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class DiagnosticSuppressorThrowsExceptionFromReportedSuppressions : DiagnosticSuppressor
+        {
+            private readonly SuppressionDescriptor _descriptor;
+            public DiagnosticSuppressorThrowsExceptionFromReportedSuppressions(string suppressedDiagnosticId)
+            {
+                _descriptor = new SuppressionDescriptor(
+                    "SPR0001",
+                    suppressedDiagnosticId,
+                    $"Suppress {suppressedDiagnosticId}");
+            }
+
+            public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions
+                => ImmutableArray.Create(_descriptor);
+
+            public override void ReportSuppressions(SuppressionAnalysisContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class DiagnosticSuppressor_UnsupportedSuppressionReported : DiagnosticSuppressor
+        {
+            private readonly SuppressionDescriptor _supportedDescriptor;
+            private readonly SuppressionDescriptor _unsupportedDescriptor;
+
+            public DiagnosticSuppressor_UnsupportedSuppressionReported(string suppressedDiagnosticId, string supportedSuppressionId, string unsupportedSuppressionId)
+            {
+                _supportedDescriptor = new SuppressionDescriptor(
+                    supportedSuppressionId,
+                    suppressedDiagnosticId,
+                    $"Suppress {suppressedDiagnosticId}");
+
+                _unsupportedDescriptor = new SuppressionDescriptor(
+                    unsupportedSuppressionId,
+                    suppressedDiagnosticId,
+                    $"Suppress {suppressedDiagnosticId}");
+            }
+
+            public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions
+                => ImmutableArray.Create(_supportedDescriptor);
+
+            public override void ReportSuppressions(SuppressionAnalysisContext context)
+            {
+                foreach (var diagnostic in context.ReportedDiagnostics)
+                {
+                    Assert.Equal(_unsupportedDescriptor.SuppressedDiagnosticId, diagnostic.Id);
+                    context.ReportSuppression(Suppression.Create(_unsupportedDescriptor, diagnostic));
+                }
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class DiagnosticSuppressor_InvalidDiagnosticSuppressionReported : DiagnosticSuppressor
+        {
+            private readonly SuppressionDescriptor _supportedDescriptor;
+            private readonly SuppressionDescriptor _unsupportedDescriptor;
+
+            public DiagnosticSuppressor_InvalidDiagnosticSuppressionReported(string suppressedDiagnosticId, string unsupportedSuppressedDiagnosticId)
+            {
+                _supportedDescriptor = new SuppressionDescriptor(
+                    "SPR0001",
+                    suppressedDiagnosticId,
+                    $"Suppress {suppressedDiagnosticId}");
+
+                _unsupportedDescriptor = new SuppressionDescriptor(
+                    "SPR0002",
+                    unsupportedSuppressedDiagnosticId,
+                    $"Suppress {unsupportedSuppressedDiagnosticId}");
+            }
+
+            public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions
+                => ImmutableArray.Create(_supportedDescriptor);
+
+            public override void ReportSuppressions(SuppressionAnalysisContext context)
+            {
+                foreach (var diagnostic in context.ReportedDiagnostics)
+                {
+                    Assert.Equal(_supportedDescriptor.SuppressedDiagnosticId, diagnostic.Id);
+                    context.ReportSuppression(Suppression.Create(_unsupportedDescriptor, diagnostic));
+                }
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class DiagnosticSuppressor_NonReportedDiagnosticCannotBeSuppressed : DiagnosticSuppressor
+        {
+            private readonly SuppressionDescriptor _descriptor1, _descriptor2;
+            private readonly string _nonReportedDiagnosticId;
+
+            public DiagnosticSuppressor_NonReportedDiagnosticCannotBeSuppressed(string reportedDiagnosticId, string nonReportedDiagnosticId)
+            {
+                _descriptor1 = new SuppressionDescriptor(
+                    "SPR0001",
+                    reportedDiagnosticId,
+                    $"Suppress {reportedDiagnosticId}");
+                _descriptor2 = new SuppressionDescriptor(
+                    "SPR0002",
+                    nonReportedDiagnosticId,
+                    $"Suppress {nonReportedDiagnosticId}");
+                _nonReportedDiagnosticId = nonReportedDiagnosticId;
+            }
+
+            public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions
+                => ImmutableArray.Create(_descriptor1, _descriptor2);
+
+            public override void ReportSuppressions(SuppressionAnalysisContext context)
+            {
+                var nonReportedDiagnostic = Diagnostic.Create(
+                    id: _nonReportedDiagnosticId,
+                    category: "Category",
+                    message: "Message",
+                    severity: DiagnosticSeverity.Warning,
+                    defaultSeverity: DiagnosticSeverity.Warning,
+                    isEnabledByDefault: true,
+                    warningLevel: 1);
+                context.ReportSuppression(Suppression.Create(_descriptor2, nonReportedDiagnostic));
             }
         }
     }

--- a/src/Test/Utilities/Portable/Diagnostics/DiagnosticDescription.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/DiagnosticDescription.cs
@@ -28,6 +28,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         private readonly bool _argumentOrderDoesNotMatter;
         private readonly Type _errorCodeType;
         private readonly bool _ignoreArgumentsWhenComparing;
+        private readonly DiagnosticSeverity? _defaultSeverityOpt;
+        private readonly DiagnosticSeverity? _effectiveSeverityOpt;
 
         // fields for DiagnosticDescriptions constructed via factories
         private readonly Func<SyntaxNode, bool> _syntaxPredicate;
@@ -64,7 +66,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             LinePosition? startLocation,
             Func<SyntaxNode, bool> syntaxNodePredicate,
             bool argumentOrderDoesNotMatter,
-            Type errorCodeType = null)
+            Type errorCodeType = null,
+            DiagnosticSeverity? defaultSeverityOpt = null,
+            DiagnosticSeverity? effectiveSeverityOpt = null)
         {
             _code = code;
             _isWarningAsError = isWarningAsError;
@@ -74,6 +78,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             _syntaxPredicate = syntaxNodePredicate;
             _argumentOrderDoesNotMatter = argumentOrderDoesNotMatter;
             _errorCodeType = errorCodeType ?? code.GetType();
+            _defaultSeverityOpt = defaultSeverityOpt;
+            _effectiveSeverityOpt = effectiveSeverityOpt;
         }
 
         public DiagnosticDescription(
@@ -83,7 +89,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             LinePosition? startLocation,
             Func<SyntaxNode, bool> syntaxNodePredicate,
             bool argumentOrderDoesNotMatter,
-            Type errorCodeType = null)
+            Type errorCodeType = null,
+            DiagnosticSeverity? defaultSeverityOpt = null,
+            DiagnosticSeverity? effectiveSeverityOpt = null)
         {
             _code = code;
             _isWarningAsError = false;
@@ -93,13 +101,17 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             _syntaxPredicate = syntaxNodePredicate;
             _argumentOrderDoesNotMatter = argumentOrderDoesNotMatter;
             _errorCodeType = errorCodeType ?? code.GetType();
+            _defaultSeverityOpt = defaultSeverityOpt;
+            _effectiveSeverityOpt = effectiveSeverityOpt;
         }
 
-        public DiagnosticDescription(Diagnostic d, bool errorCodeOnly)
+        public DiagnosticDescription(Diagnostic d, bool errorCodeOnly, bool includeDefaultSeverity = false, bool includeEffectiveSeverity = false)
         {
             _code = d.Code;
             _isWarningAsError = d.IsWarningAsError;
             _location = d.Location;
+            _defaultSeverityOpt = includeDefaultSeverity ? d.DefaultSeverity : (DiagnosticSeverity?)null;
+            _effectiveSeverityOpt = includeEffectiveSeverity ? d.Severity : (DiagnosticSeverity?)null;
 
             DiagnosticWithInfo dinfo = null;
             if (d.Code == 0)
@@ -160,17 +172,27 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public DiagnosticDescription WithArguments(params string[] arguments)
         {
-            return new DiagnosticDescription(_code, _isWarningAsError, _squiggledText, arguments, _startPosition, _syntaxPredicate, false, _errorCodeType);
+            return new DiagnosticDescription(_code, _isWarningAsError, _squiggledText, arguments, _startPosition, _syntaxPredicate, false, _errorCodeType, _defaultSeverityOpt, _effectiveSeverityOpt);
         }
 
         public DiagnosticDescription WithArgumentsAnyOrder(params string[] arguments)
         {
-            return new DiagnosticDescription(_code, _isWarningAsError, _squiggledText, arguments, _startPosition, _syntaxPredicate, true, _errorCodeType);
+            return new DiagnosticDescription(_code, _isWarningAsError, _squiggledText, arguments, _startPosition, _syntaxPredicate, true, _errorCodeType, _defaultSeverityOpt, _effectiveSeverityOpt);
         }
 
         public DiagnosticDescription WithWarningAsError(bool isWarningAsError)
         {
-            return new DiagnosticDescription(_code, isWarningAsError, _squiggledText, _arguments, _startPosition, _syntaxPredicate, true, _errorCodeType);
+            return new DiagnosticDescription(_code, isWarningAsError, _squiggledText, _arguments, _startPosition, _syntaxPredicate, true, _errorCodeType, _defaultSeverityOpt, _effectiveSeverityOpt);
+        }
+
+        public DiagnosticDescription WithDefaultSeverity(DiagnosticSeverity defaultSeverity)
+        {
+            return new DiagnosticDescription(_code, _isWarningAsError, _squiggledText, _arguments, _startPosition, _syntaxPredicate, true, _errorCodeType, defaultSeverity, _effectiveSeverityOpt);
+        }
+
+        public DiagnosticDescription WithEffectiveSeverity(DiagnosticSeverity effectiveSeverity)
+        {
+            return new DiagnosticDescription(_code, _isWarningAsError, _squiggledText, _arguments, _startPosition, _syntaxPredicate, true, _errorCodeType, _defaultSeverityOpt, effectiveSeverity);
         }
 
         /// <summary>
@@ -178,7 +200,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         /// </summary>
         public DiagnosticDescription WithLocation(int line, int column)
         {
-            return new DiagnosticDescription(_code, _isWarningAsError, _squiggledText, _arguments, new LinePosition(line - 1, column - 1), _syntaxPredicate, _argumentOrderDoesNotMatter, _errorCodeType);
+            return new DiagnosticDescription(_code, _isWarningAsError, _squiggledText, _arguments, new LinePosition(line - 1, column - 1), _syntaxPredicate, _argumentOrderDoesNotMatter, _errorCodeType, _defaultSeverityOpt, _effectiveSeverityOpt);
         }
 
         /// <summary>
@@ -187,10 +209,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         /// <param name="syntaxPredicate">The argument to syntaxPredicate will be the nearest SyntaxNode whose Span contains first squiggled character.</param>
         public DiagnosticDescription WhereSyntax(Func<SyntaxNode, bool> syntaxPredicate)
         {
-            return new DiagnosticDescription(_code, _isWarningAsError, _squiggledText, _arguments, _startPosition, syntaxPredicate, _argumentOrderDoesNotMatter, _errorCodeType);
+            return new DiagnosticDescription(_code, _isWarningAsError, _squiggledText, _arguments, _startPosition, syntaxPredicate, _argumentOrderDoesNotMatter, _errorCodeType, _defaultSeverityOpt, _effectiveSeverityOpt);
         }
 
         public object Code => _code;
+        public bool IsWarningAsError => _isWarningAsError;
+        public DiagnosticSeverity? DefaultSeverity => _defaultSeverityOpt;
+        public DiagnosticSeverity? EffectiveSeverity => _effectiveSeverityOpt;
 
         public override bool Equals(object obj)
         {
@@ -279,6 +304,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 }
             }
 
+            if (_defaultSeverityOpt != d._defaultSeverityOpt ||
+                _effectiveSeverityOpt != d._effectiveSeverityOpt)
+            {
+                return false;
+            }
+
             return true;
         }
 
@@ -293,6 +324,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             hashCode = Hash.Combine(_arguments, hashCode);
             if (_startPosition != null)
                 hashCode = Hash.Combine(hashCode, _startPosition.Value.GetHashCode());
+            if (_defaultSeverityOpt != null)
+                hashCode = Hash.Combine(hashCode, _defaultSeverityOpt.Value.GetHashCode());
+            if (_effectiveSeverityOpt != null)
+                hashCode = Hash.Combine(hashCode, _effectiveSeverityOpt.Value.GetHashCode());
             return hashCode;
         }
 
@@ -361,6 +396,16 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 sb.Append(".WithWarningAsError(true)");
             }
 
+            if (_defaultSeverityOpt != null)
+            {
+                sb.Append($".WithDefaultSeverity(DiagnosticSeverity.{_defaultSeverityOpt.Value.ToString()})");
+            }
+
+            if (_effectiveSeverityOpt != null)
+            {
+                sb.Append($".WithEffectiveSeverity(DiagnosticSeverity.{_effectiveSeverityOpt.Value.ToString()})");
+            }
+
             if (_syntaxPredicate != null && _showPredicate)
             {
                 sb.Append(".WhereSyntax(...)");
@@ -376,6 +421,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var language = actual.Any() && actual.First().Id.StartsWith("CS", StringComparison.Ordinal) ? CSharp : VisualBasic;
             var includeDiagnosticMessagesAsComments = (language == CSharp);
             int indentDepth = (language == CSharp) ? 4 : 1;
+            var includeDefaultSeverity = expected.Any() && expected.All(d => d.DefaultSeverity != null);
+            var includeEffectiveSeverity = expected.Any() && expected.All(d => d.EffectiveSeverity != null);
 
             if (IsSortedOrEmpty(expected))
             {
@@ -429,7 +476,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     }
                 }
 
-                var description = new DiagnosticDescription(d, errorCodeOnly: false);
+                var description = new DiagnosticDescription(d, errorCodeOnly: false, includeDefaultSeverity, includeEffectiveSeverity);
                 var diffDescription = description;
                 var idx = Array.IndexOf(expected, description);
                 if (idx != -1)

--- a/src/Test/Utilities/Portable/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/DiagnosticExtensions.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
@@ -69,7 +70,10 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentException("Must specify expected errors.", nameof(expected));
             }
 
-            var unmatched = actual.Select(d => new DiagnosticDescription(d, errorCodeOnly)).ToList();
+            var includeDefaultSeverity = expected.Any() && expected.All(e => e.DefaultSeverity != null);
+            var includeEffectiveSeverity = expected.Any() && expected.All(e => e.EffectiveSeverity != null);
+            var unmatched = actual.Select(d => new DiagnosticDescription(d, errorCodeOnly, includeDefaultSeverity, includeEffectiveSeverity))
+                                  .ToList();
 
             // Try to match each of the 'expected' errors to one of the 'actual' ones.
             // If any of the expected errors don't appear, fail test.
@@ -162,7 +166,9 @@ namespace Microsoft.CodeAnalysis
                 params DiagnosticDescription[] expected)
             where TCompilation : Compilation
         {
-            c = c.GetAnalyzerDiagnostics(analyzers, options, onAnalyzerException, logAnalyzerExceptionAsDiagnostics, reportSuppressedDiagnostics, diagnostics: out var diagnostics);
+            c = c.GetCompilationWithAnalyzerDiagnostics(analyzers, options, onAnalyzerException,
+                logAnalyzerExceptionAsDiagnostics, reportSuppressedDiagnostics,
+                includeCompilerDiagnostics: false, diagnostics: out var diagnostics);
             diagnostics.Verify(expected);
             return c; // note this is a new compilation
         }
@@ -187,17 +193,106 @@ namespace Microsoft.CodeAnalysis
             bool logAnalyzerExceptionAsDiagnostics = true)
             where TCompilation : Compilation
         {
-            c = GetAnalyzerDiagnostics(c, analyzers, options, onAnalyzerException, logAnalyzerExceptionAsDiagnostics, reportSuppressedDiagnostics, out var diagnostics);
+            c = GetCompilationWithAnalyzerDiagnostics(c, analyzers, options, onAnalyzerException,
+                logAnalyzerExceptionAsDiagnostics, reportSuppressedDiagnostics,
+                includeCompilerDiagnostics: false, out var diagnostics);
             return diagnostics;
         }
 
-        private static TCompilation GetAnalyzerDiagnostics<TCompilation>(
+        public static TCompilation VerifySuppressedDiagnostics<TCompilation>(
+            this TCompilation c,
+            DiagnosticAnalyzer[] analyzers,
+            AnalyzerOptions options = null,
+            Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null,
+            bool logAnalyzerExceptionAsDiagnostics = true,
+            params DiagnosticDescription[] expected)
+            where TCompilation : Compilation
+        {
+            // Verify suppression is unaffected by toggling /warnaserror.
+            // Only perform this additional verification if the caller hasn't
+            // explicitly overridden specific or general diagnostic options.
+            if (c.Options.GeneralDiagnosticOption == ReportDiagnostic.Default &&
+                c.Options.SpecificDiagnosticOptions.IsEmpty)
+            {
+                _ = c.VerifySuppressedDiagnostics(toggleWarnAsError: true,
+                    analyzers, options, onAnalyzerException, logAnalyzerExceptionAsDiagnostics,
+                    expected);
+            }
+
+            return c.VerifySuppressedDiagnostics(toggleWarnAsError: false,
+                analyzers, options, onAnalyzerException, logAnalyzerExceptionAsDiagnostics,
+                expected);
+        }
+
+        private static TCompilation VerifySuppressedDiagnostics<TCompilation>(
+            this TCompilation c,
+            bool toggleWarnAsError,
+            DiagnosticAnalyzer[] analyzers,
+            AnalyzerOptions options,
+            Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException,
+            bool logAnalyzerExceptionAsDiagnostics,
+            DiagnosticDescription[] expectedDiagnostics)
+            where TCompilation : Compilation
+        {
+            if (toggleWarnAsError)
+            {
+                var toggledOption = c.Options.GeneralDiagnosticOption == ReportDiagnostic.Error ?
+                    ReportDiagnostic.Default :
+                    ReportDiagnostic.Error;
+                c = (TCompilation)c.WithOptions(c.Options.WithGeneralDiagnosticOption(toggledOption));
+
+                var builder = ArrayBuilder<DiagnosticDescription>.GetInstance(expectedDiagnostics.Length);
+                foreach (var expected in expectedDiagnostics)
+                {
+                    // Toggle warnaserror and effective severity if following are true:
+                    //  1. Default severity is not specified or specified as Warning
+                    //  2. Effective severity is not specified or specified as Warning or Error
+                    var defaultSeverityCheck = !expected.DefaultSeverity.HasValue ||
+                        expected.DefaultSeverity.Value == DiagnosticSeverity.Warning;
+                    var effectiveSeverityCheck = !expected.EffectiveSeverity.HasValue ||
+                         expected.EffectiveSeverity.Value == DiagnosticSeverity.Warning ||
+                         expected.EffectiveSeverity.Value == DiagnosticSeverity.Error;
+
+                    DiagnosticDescription newExpected;
+                    if (defaultSeverityCheck && effectiveSeverityCheck)
+                    {
+                        newExpected = expected.WithWarningAsError(!expected.IsWarningAsError);
+
+                        if (expected.EffectiveSeverity.HasValue)
+                        {
+                            var newEffectiveSeverity = expected.EffectiveSeverity.Value == DiagnosticSeverity.Error ?
+                                DiagnosticSeverity.Warning :
+                                DiagnosticSeverity.Error;
+                            newExpected = newExpected.WithEffectiveSeverity(newEffectiveSeverity);
+                        }
+                    }
+                    else
+                    {
+                        newExpected = expected;
+                    }
+
+                    builder.Add(newExpected);
+                }
+
+                expectedDiagnostics = builder.ToArrayAndFree();
+            }
+
+            c = c.GetCompilationWithAnalyzerDiagnostics(analyzers, options, onAnalyzerException,
+                logAnalyzerExceptionAsDiagnostics, reportSuppressedDiagnostics: true,
+                    includeCompilerDiagnostics: true, diagnostics: out var diagnostics);
+            diagnostics = diagnostics.WhereAsArray(d => d.IsSuppressed);
+            diagnostics.Verify(expectedDiagnostics);
+            return c; // note this is a new compilation
+        }
+
+    private static TCompilation GetCompilationWithAnalyzerDiagnostics<TCompilation>(
                 this TCompilation c,
                 DiagnosticAnalyzer[] analyzers,
                 AnalyzerOptions options,
                 Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException,
                 bool logAnalyzerExceptionAsDiagnostics,
                 bool reportSuppressedDiagnostics,
+                bool includeCompilerDiagnostics,
                 out ImmutableArray<Diagnostic> diagnostics)
             where TCompilation : Compilation
         {
@@ -228,8 +323,14 @@ namespace Microsoft.CodeAnalysis
 
             var analyzerManager = new AnalyzerManager(analyzersArray);
             var driver = AnalyzerDriver.CreateAndAttachToCompilation(c, analyzersArray, options, analyzerManager, onAnalyzerException, null, false, out var newCompilation, CancellationToken.None);
-            var discarded = newCompilation.GetDiagnostics();
-            diagnostics = driver.GetDiagnosticsAsync(newCompilation).Result.AddRange(exceptionDiagnostics);
+            var compilerDiagnostics = newCompilation.GetDiagnostics();
+            diagnostics = driver.GetDiagnosticsAsync(newCompilation).Result;
+            if (includeCompilerDiagnostics)
+            {
+                diagnostics = diagnostics.AddRange(compilerDiagnostics);
+            }
+
+            diagnostics = driver.ApplyAnalyzerSuppressions(diagnostics, newCompilation).AddRange(exceptionDiagnostics);
 
             if (!reportSuppressedDiagnostics)
             {

--- a/src/Tools/AnalyzerRunner/Extensions.cs
+++ b/src/Tools/AnalyzerRunner/Extensions.cs
@@ -24,6 +24,7 @@ namespace AnalyzerRunner
             analyzerTelemetryInfo.SymbolEndActionsCount += addendum.SymbolEndActionsCount;
             analyzerTelemetryInfo.SyntaxNodeActionsCount += addendum.SyntaxNodeActionsCount;
             analyzerTelemetryInfo.SyntaxTreeActionsCount += addendum.SyntaxTreeActionsCount;
+            analyzerTelemetryInfo.SuppressionActionsCount += addendum.SuppressionActionsCount;
         }
     }
 }

--- a/src/Tools/AnalyzerRunner/Program.cs
+++ b/src/Tools/AnalyzerRunner/Program.cs
@@ -505,6 +505,8 @@ namespace AnalyzerRunner
             WriteLine($"Symbol End Actions:             {telemetry.SymbolEndActionsCount}", ConsoleColor.White);
             WriteLine($"Syntax Node Actions:            {telemetry.SyntaxNodeActionsCount}", ConsoleColor.White);
             WriteLine($"Syntax Tree Actions:            {telemetry.SyntaxTreeActionsCount}", ConsoleColor.White);
+
+            WriteLine($"Suppression Actions:            {telemetry.SuppressionActionsCount}", ConsoleColor.White);
         }
 
         private static void WriteExecutionTimes(string analyzerName, int longestAnalyzerName, AnalyzerTelemetryInfo telemetry)


### PR DESCRIPTION
…iler/analyzer diagnostics

Fixes #20242 and #30172

Added public APIs with documentation comments:
```cs
namespace Microsoft.CodeAnalysis.Diagnostics
{
    /// <summary>
    /// The base type for diagnostic suppressors that can programmatically suppress diagnostics.
    /// </summary>
    public abstract class DiagnosticSuppressor : DiagnosticAnalyzer
    {
        // Disallow suppressors from reporting diagnostics or registering analysis actions.
        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;

        public sealed override void Initialize(AnalysisContext context) { }

        /// <summary>
        /// Returns a set of descriptors for the suppressions that this suppressor is capable of producing.
        /// </summary>
        public abstract ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; }

        /// <summary>
        /// Suppress analyzer and/or compiler diagnostics reported for the compilation.
        /// This may be a subset of the full set of reported diagnostics, as an optimization for
        /// supporting incremental and partial analysis scenarios.
        /// A diagnostic is considered suppressible by analyzers if *all* of the following conditions are met:
        ///     1. Diagnostic is not already suppressed in source via pragma/suppress message attribute.
        ///     2. Diagnostic's <see cref="Diagnostic.DefaultSeverity"/> is not <see cref="DiagnosticSeverity.Error"/>.
        ///     3. Diagnostic is not tagged with <see cref="WellKnownDiagnosticTags.NotConfigurable"/> custom tag.
        /// </summary>
        public abstract void ReportSuppressions(SuppressionAnalysisContext context);
    }

    /// <summary>
    /// Provides a description about a programmatic suppression of a <see cref="Diagnostic"/> by a <see cref="DiagnosticSuppressor"/>.
    /// </summary>
    public sealed class SuppressionDescriptor : IEquatable<SuppressionDescriptor>
    {
        /// <summary>
        /// An unique identifier for the suppression.
        /// </summary>
        public string Id { get; }

        /// <summary>
        /// Identifier of the suppressed diagnostic, i.e. <see cref="Diagnostic.Id"/>.
        /// </summary>
        public string SuppressedDiagnosticId { get; }

        /// <summary>
        /// A localizable description about the suppression.
        /// </summary>
        public LocalizableString Description { get; }
    }

    /// <summary>
    /// Context for suppressing analyzer and/or compiler diagnostics reported for the compilation.
    /// </summary>
    public struct SuppressionAnalysisContext
    {
        /// <summary>
        /// Suppressible analyzer and/or compiler diagnostics reported for the compilation.
        /// This may be a subset of the full set of reported diagnostics, as an optimization for
        /// supporting incremental and partial analysis scenarios.
        /// A diagnostic is considered suppressible by analyzers if *all* of the following conditions are met:
        ///     1. Diagnostic is not already suppressed in source via pragma/suppress message attribute.
        ///     2. Diagnostic's <see cref="Diagnostic.DefaultSeverity"/> is not <see cref="DiagnosticSeverity.Error"/>.
        ///     3. Diagnostic is not tagged with <see cref="WellKnownDiagnosticTags.NotConfigurable"/> custom tag.
        /// </summary>
        public ImmutableArray<Diagnostic> ReportedDiagnostics { get; }

        /// <summary>
        /// Report a <see cref="Suppression"/> for a reported diagnostic.
        /// </summary>
        public void ReportSuppression(Suppression suppression);

        /// <summary>
        /// Gets a <see cref="SemanticModel"/> for the given <see cref="SyntaxTree"/>, which is shared across all analyzers.
        /// </summary>
        public SemanticModel GetSemanticModel(SyntaxTree syntaxTree);

        /// <summary>
        /// <see cref="CodeAnalysis.Compilation"/> for the context.
        /// </summary>
        public Compilation Compilation { get; }

        /// <summary>
        /// Options specified for the analysis.
        /// </summary>
        public AnalyzerOptions Options { get; }

        /// <summary>
        /// Token to check for requested cancellation of the analysis.
        /// </summary>
        public CancellationToken CancellationToken { get; }
    }

    /// <summary>
    /// Programmatic suppression of a <see cref="Diagnostic"/> by a <see cref="DiagnosticSuppressor"/>.
    /// </summary>
    public struct Suppression
    {
        /// <summary>
        /// Creates a suppression of a <see cref="Diagnostic"/> with the given <see cref="SuppressionDescriptor"/>.
        /// </summary>
        /// <param name="descriptor">
        /// Descriptor for the suppression, which must be from <see cref="DiagnosticSuppressor.SupportedSuppressions"/>
        /// for the <see cref="DiagnosticSuppressor"/> creating this suppression.
        /// </param>
        /// <param name="suppressedDiagnostic">
        /// <see cref="Diagnostic"/> to be suppressed, which must be from <see cref="SuppressionAnalysisContext.ReportedDiagnostics"/>
        /// for the suppression context in which this suppression is being created.</param>
        public static Suppression Create(SuppressionDescriptor descriptor, Diagnostic suppressedDiagnostic);

        /// <summary>
        /// Descriptor for this suppression.
        /// </summary>
        public SuppressionDescriptor Descriptor { get; }

        /// <summary>
        /// Diagnostic suppressed by this suppression.
        /// </summary>
        public Diagnostic SuppressedDiagnostic { get; }
    }
}
```

For batch compilation, suppressors always run after all the compiler and analyzer diagnostics have been computed.
For IDE partial/incremental analysis scenario, we may run the suppressors with partial diagnostics.
Suppressed diagnostics from diagnostic suppressors are equivalent to source suppressed diagnostics: they show up in the error list with "Suppression State" column as "Suppressed" and are also output to errorlog as suppressed diagnostics.

Note that this API has been approved at the IDE/analyzer design meeting.