### PR TITLE
Lookup dispose methods on the underlying type for nullable value types:

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -742,7 +742,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // this emulates the same behavior as x?.Dispose(); 
             if (expr.Type.IsNullableType())
             {
-                expr = CreateConversion(expr, expr.Type.GetNullableUnderlyingType(), diagnostics);
+                expr = new BoundDisposableValuePlaceholder(expr.Syntax, expr.Type.GetNullableUnderlyingType());
             }
 
             var result = FindPatternMethodRelaxed(expr,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -736,7 +736,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal MethodSymbol TryFindDisposePatternMethod(BoundExpression expr, SyntaxNode syntaxNode, bool hasAwait, DiagnosticBag diagnostics)
         {
             Debug.Assert(!(expr is null));
-                                
+            Debug.Assert(!(expr.Type is null));
+            
             // For dispose on nullable value types, we always perform lookup on the underlying type, as we'll never actually call in the null case
             // this emulates the same behavior as x?.Dispose(); 
             if (expr.Type.IsNullableType())

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -710,7 +710,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!iDisposableConversion.IsImplicit)
                 {
-                    var declarationLocal = new BoundLocal(declaration.Syntax, declaration.LocalSymbol, null, declType);
+                    var declarationLocal = new BoundLocal(declaration.Syntax, declaration.LocalSymbol, null, declType) { WasCompilerGenerated = true };
 
                     disposeMethod = TryFindDisposePatternMethod(declarationLocal, declarationSyntax, hasAwait, diagnostics);
                     if (disposeMethod is null)
@@ -736,9 +736,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal MethodSymbol TryFindDisposePatternMethod(BoundExpression expr, SyntaxNode syntaxNode, bool hasAwait, DiagnosticBag diagnostics)
         {
             Debug.Assert(!(expr is null));
-            if (expr.Type is null)
+                                
+            // For dispose on nullable value types, we always perform lookup on the underlying type, as we'll never actually call in the null case
+            // this emulates the same behavior as x?.Dispose(); 
+            if (expr.Type.IsNullableType())
             {
-                return null;
+                expr = CreateConversion(expr, expr.Type.GetNullableUnderlyingType(), diagnostics);
             }
 
             var result = FindPatternMethodRelaxed(expr,

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -103,6 +103,13 @@
   <Node Name="BoundAwaitableValuePlaceholder" Base="BoundValuePlaceholderBase">
   </Node>
 
+  <!--
+  This node is used to represent an expression returning value of a certain type.
+  It is used to perform intermediate binding, and will not survive the local rewriting.
+  -->
+  <Node Name="BoundDisposableValuePlaceholder" Base="BoundValuePlaceholderBase">
+  </Node>
+
   <!-- only used by codegen -->
   <Node Name="BoundDup" Base="BoundExpression">
     <!-- when duplicating a local or parameter, must remember original ref kind -->

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -890,6 +890,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
+            public override BoundNode VisitDisposableValuePlaceholder(BoundDisposableValuePlaceholder node)
+            {
+                Fail(node);
+                return null;
+            }
+
             public override BoundNode VisitAwaitableValuePlaceholder(BoundAwaitableValuePlaceholder node)
             {
                 Fail(node);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -1784,6 +1784,151 @@ class C2
         }
 
         [Fact]
+        public void UsingPatternExtensionMethodWithNullableValue()
+        {
+            var source = @"
+static class C1 
+{
+    internal static void Dispose(this int x)
+    {
+        System.Console.Write($""Dispose {x}; "");
+    }
+}
+ class C2
+{
+    static void Main()
+    {
+        using (int? i1 = 1)
+        {
+            // Dispose 1
+        }
+        
+        int? i2 = 2;
+        using (i2) 
+        {
+            // Dispose 2
+        }       
+        
+        using (int? i3 = null)
+        {
+            // no dispose, null
+        }
+        
+        int? i4 = null;
+        using (i4) 
+        {
+            // no dispose, null
+        }
+    }
+}";
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe).VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "Dispose 1; Dispose 2; ");
+        }
+
+        [Fact]
+        public void UsingPatternExtensionMethodWithNullableValueTargetAndValueTarget()
+        {
+            var source = @"
+static class C2 
+{
+    internal static void Dispose(this int? c1)
+    {
+        System.Console.Write($""Dispose? {c1}; "");
+    }        
+    
+    internal static void Dispose(this int c1)
+    { 
+        System.Console.Write($""Dispose {c1}; "");
+    }
+}
+ class C3
+{
+    static void Main()
+    {
+        using (int? i1 = 1)
+        {
+            // Dispose 1
+        }
+        
+        int? i2 = 2;
+        using (i2)
+        {
+            // Dispose 2
+        }
+      
+        using (int i3 = 3)
+        {
+            // Dispose 3
+        }
+        
+        int i4 = 4;
+        using (i4)
+        {
+            // Dipose 4        
+        }
+    }
+}";
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe).VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "Dispose 1; Dispose 2; Dispose 3; Dispose 4;");
+        }
+
+        [Fact]
+        public void UsingPatternExtensionMethodWithNullRecevier()
+        {
+            var source = @"
+static class C2 
+{
+   internal static void Dispose(this object c1) { System.Console.Write($""Dispose; "");}
+}
+ class C3
+{
+    static void Main()
+    {
+        using (object o = null)
+        {
+            // Not called
+        }
+
+        object o2 = null;
+        using (o2) 
+        {
+            // not called
+        }
+    }
+}";
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe).VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "");
+        }
+
+        [Fact]
+        public void UsingPatternWithNullableReferenceType()
+        {
+            var source = @"
+struct S1
+{
+   internal void Dispose() { System.Console.Write($""Dispose; "");}
+}
+ class C3
+{
+    static void Main()
+    {
+        using (S1? s1 = new S1())
+        {
+            // Dispose
+        }
+
+        S1? s2 = new S1();
+        using (s2) 
+        {
+            // Dispose
+        }
+    }
+}";
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe).VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "Dispose; Dispose; ");
+        }
+
+        [Fact]
         public void Lambda()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -1833,7 +1833,7 @@ static class C2
 {
     internal static void Dispose(this int? c1)
     {
-        System.Console.Write($""Dispose? {c1}; "");
+        throw new System.Exception(""Nullable extension should not be called"");
     }        
     
     internal static void Dispose(this int c1)
@@ -1929,7 +1929,7 @@ static class C2
 {
    internal static void Dispose(this object c1) { System.Console.Write($""Dispose; "");}
 }
- class C3
+class C3
 {
     static void Main()
     {


### PR DESCRIPTION
 - Create a conversion from the NVT to the underlying type before searching for dispose
- Add tests to cover behavior