### PR TITLE
make sure we don't load assembly too early for vsix installed analyze…

### DIFF
--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -242,6 +242,8 @@ namespace Microsoft.CodeAnalysis.Execution
                 // 2 can be different if analyzer loader used for the reference do something like shadow copying
                 // otherwise, use reference.FullPath. we use usePathFromAssembly == false for vsix installed analyzer dlls
                 // to make sure we don't load them up front and they don't get shadow copied.
+                // TryGetAnalyzerAssemblyPath will load the given assembly to find out actual location where CLR
+                // picked up the dll
                 var assemblyPath = usePathFromAssembly ? TryGetAnalyzerAssemblyPath(file) : file.FullPath;
 
                 using (var stream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))

--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -238,8 +238,10 @@ namespace Microsoft.CodeAnalysis.Execution
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                // use actual assembly path rather than one returned from reference.FullPath
+                // use actual assembly path rather than one returned from reference.FullPath if asked (usePathFromAssembly)
                 // 2 can be different if analyzer loader used for the reference do something like shadow copying
+                // otherwise, use reference.FullPath. we use usePathFromAssembly == false for vsix installed analyzer dlls
+                // to make sure we don't load them up front and they don't get shadow copied.
                 var assemblyPath = usePathFromAssembly ? TryGetAnalyzerAssemblyPath(file) : file.FullPath;
 
                 using (var stream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))

--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Execution
             throw ExceptionUtilities.UnexpectedValue(reference.GetType());
         }
 
-        public Checksum CreateChecksum(AnalyzerReference reference, CancellationToken cancellationToken)
+        public Checksum CreateChecksum(AnalyzerReference reference, bool usePathFromAssembly, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Execution
                 switch (reference)
                 {
                     case AnalyzerFileReference file:
-                        WriteAnalyzerFileReferenceMvid(file, writer, cancellationToken);
+                        WriteAnalyzerFileReferenceMvid(file, writer, usePathFromAssembly, cancellationToken);
                         break;
 
                     case UnresolvedAnalyzerReference unresolved:
@@ -231,13 +231,16 @@ namespace Microsoft.CodeAnalysis.Execution
             throw ExceptionUtilities.UnexpectedValue(type);
         }
 
-        private void WriteAnalyzerFileReferenceMvid(AnalyzerFileReference reference, ObjectWriter writer, CancellationToken cancellationToken)
+        private void WriteAnalyzerFileReferenceMvid(
+            AnalyzerFileReference file, ObjectWriter writer, bool usePathFromAssembly, CancellationToken cancellationToken)
         {
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 // use actual assembly path rather than one returned from reference.FullPath
                 // 2 can be different if analyzer loader used for the reference do something like shadow copying
-                var assemblyPath = TryGetAnalyzerAssemblyPath(reference) ?? reference.FullPath;
+                var assemblyPath = usePathFromAssembly ? TryGetAnalyzerAssemblyPath(file) : file.FullPath;
 
                 using (var stream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
                 using (var peReader = new PEReader(stream))
@@ -254,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Execution
             {
                 // we can't load the assembly analyzer file reference is pointing to.
                 // rather than crashing, handle it gracefully
-                WriteUnresolvedAnalyzerReferenceTo(reference, writer);
+                WriteUnresolvedAnalyzerReferenceTo(file, writer);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Execution
     {
         // host analyzer is not shadow copied, no need to load assembly to get real path
         // this also prevent us from loading assemblies for all vsix analyzers preemptively
-        const bool usePathFromAssembly = false;
+        private const bool usePathFromAssembly = false;
 
         private readonly AnalyzerReference _reference;
         private readonly ISerializerService _serializer;

--- a/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
@@ -69,15 +69,21 @@ namespace Microsoft.CodeAnalysis.Execution
         private readonly AnalyzerReference _reference;
         private readonly ISerializerService _serializer;
 
-        public WorkspaceAnalyzerReferenceAsset(
+        public static WorkspaceAnalyzerReferenceAsset Create(
             AnalyzerReference reference,
             ISerializerService serializer,
-            IReferenceSerializationService hostSerializationService) :
-            base(
-                Checksum.Create(
-                    WellKnownSynchronizationKind.AnalyzerReference,
-                    hostSerializationService.CreateChecksum(reference, usePathFromAssembly, CancellationToken.None)),
-                WellKnownSynchronizationKind.AnalyzerReference)
+            IReferenceSerializationService hostSerializationService,
+            CancellationToken cancellationToken)
+        {
+            var checksum = Checksum.Create(
+                WellKnownSynchronizationKind.AnalyzerReference,
+                hostSerializationService.CreateChecksum(reference, usePathFromAssembly, cancellationToken));
+
+            return new WorkspaceAnalyzerReferenceAsset(reference, serializer, checksum);
+        }
+
+        private WorkspaceAnalyzerReferenceAsset(AnalyzerReference reference, ISerializerService serializer, Checksum checksum) :
+            base(checksum, WellKnownSynchronizationKind.AnalyzerReference)
         {
             _reference = reference;
             _serializer = serializer;

--- a/src/Workspaces/Core/Portable/Execution/CustomAssetBuilder.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAssetBuilder.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Execution
     internal class CustomAssetBuilder
     {
         private readonly ISerializerService _serializer;
+        private readonly IReferenceSerializationService _hostSerializationService;
 
         public CustomAssetBuilder(Solution solution) : this(solution.Workspace)
         {
@@ -26,6 +27,7 @@ namespace Microsoft.CodeAnalysis.Execution
         public CustomAssetBuilder(HostWorkspaceServices services)
         {
             _serializer = services.GetService<ISerializerService>();
+            _hostSerializationService = services.GetService<IReferenceSerializationService>();
         }
 
         public CustomAsset Build(OptionSet options, string language, CancellationToken cancellationToken)
@@ -39,7 +41,9 @@ namespace Microsoft.CodeAnalysis.Execution
 
         public CustomAsset Build(AnalyzerReference reference, CancellationToken cancellationToken)
         {
-            return new WorkspaceAnalyzerReferenceAsset(reference, _serializer);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return new WorkspaceAnalyzerReferenceAsset(reference, _serializer, _hostSerializationService);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Execution/CustomAssetBuilder.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAssetBuilder.cs
@@ -41,9 +41,7 @@ namespace Microsoft.CodeAnalysis.Execution
 
         public CustomAsset Build(AnalyzerReference reference, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            return new WorkspaceAnalyzerReferenceAsset(reference, _serializer, _hostSerializationService);
+            return WorkspaceAnalyzerReferenceAsset.Create(reference, _serializer, _hostSerializationService, cancellationToken);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Execution/IReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/IReferenceSerializationService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Execution
     internal interface IReferenceSerializationService : IWorkspaceService
     {
         Checksum CreateChecksum(MetadataReference reference, CancellationToken cancellationToken);
-        Checksum CreateChecksum(AnalyzerReference reference, CancellationToken cancellationToken);
+        Checksum CreateChecksum(AnalyzerReference reference, bool usePathFromAssembly, CancellationToken cancellationToken);
 
         void WriteTo(Encoding encoding, ObjectWriter writer, CancellationToken cancellationToken);
         void WriteTo(MetadataReference reference, ObjectWriter writer, CancellationToken cancellationToken);

--- a/src/Workspaces/Core/Portable/Execution/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Execution/SerializerService.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Serialization
                         return Checksum.Create(kind, _hostSerializationService.CreateChecksum((MetadataReference)value, cancellationToken));
 
                     case WellKnownSynchronizationKind.AnalyzerReference:
-                        return Checksum.Create(kind, _hostSerializationService.CreateChecksum((AnalyzerReference)value, cancellationToken));
+                        return Checksum.Create(kind, _hostSerializationService.CreateChecksum((AnalyzerReference)value, usePathFromAssembly: true, cancellationToken));
 
                     case WellKnownSynchronizationKind.SourceText:
                         return Checksum.Create(kind, ((SourceText)value).GetChecksum());


### PR DESCRIPTION
…r dlls.

we had special code around vsix installed analyzers dlls to make sure it doesn't get loaded until it is actually used. that got broken when I made this fix - https://github.com/dotnet/roslyn/pull/31438

this puts that special behavior back to make RPS happy.