### PR TITLE
Fix procdump support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
   timeoutInMinutes: 90
 
   steps:
-    - script: build/scripts/cibuild.cmd -configuration $(_configuration) -prepareMachine -testDesktop -$(_testKind)
+    - script: build/scripts/cibuild.cmd -configuration $(_configuration) -prepareMachine -testDesktop -$(_testKind) -procdump
       displayName: Build and Test
 
     - task: PublishTestResults@1

--- a/src/Tools/Source/RunTests/Options.cs
+++ b/src/Tools/Source/RunTests/Options.cs
@@ -187,7 +187,7 @@ namespace RunTests
                     opt.ProcDumpDirectory = value;
                     index++;
                 }
-                else if (comparer.Equals(current, "-procdump"))
+                else if (comparer.Equals(current, "-useprocdump"))
                 {
                     opt.UseProcDump = false;
                     index++;


### PR DESCRIPTION
This picks Jared's procdump fix (#31491) back into master.

Makes two changes:

- Fixes the parsing of useprocdump option in RunTests. This was blocking
our official builds.
- Enables proc dump during normal desktop CI runs. This appears to have
been lost when moving our tests to Azure DevOps