### PR TITLE
added Telemetry dumper to roslyn diagnostic tool window

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/CodeFixSuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/CodeFixSuggestedAction.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Globalization;
-using System.Linq;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
@@ -27,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             object provider,
             CodeAction action,
             SuggestedActionSet fixAllFlavors)
-            : base(threadingContext, sourceProvider, workspace, subjectBuffer, 
+            : base(threadingContext, sourceProvider, workspace, subjectBuffer,
                    provider, action, fixAllFlavors)
         {
             _fix = fix;
@@ -35,16 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
         public string GetDiagnosticID()
         {
-            var diagnostic = _fix.PrimaryDiagnostic;
-
-            // we log diagnostic id as it is if it is from us
-            if (diagnostic.Descriptor.CustomTags.Any(t => t == WellKnownDiagnosticTags.Telemetry))
-            {
-                return diagnostic.Id;
-            }
-
-            // if it is from third party, we use hashcode
-            return diagnostic.GetHashCode().ToString(CultureInfo.InvariantCulture);
+            return _fix.PrimaryDiagnostic.GetTelemetryDiagnosticID();
         }
 
         protected override DiagnosticData GetDiagnostic()

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/FixAllSuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/FixAllSuggestedAction.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             // We get the telemetry id for the original code action we are fixing,
             // not the special 'FixAllCodeAction'.  that is the .CodeAction this
             // SuggestedAction is pointing at.
-            telemetryId = _originalCodeAction.GetType().GetTelemetryId(_fixAllState.Scope.GetTelemetryScope());
+            telemetryId = _originalCodeAction.GetType().GetTelemetryId(_fixAllState.Scope.GetScopeIdForTelemetry());
             return true;
         }
 

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/FixAllSuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/FixAllSuggestedAction.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
-using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -52,33 +51,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             // We get the telemetry id for the original code action we are fixing,
             // not the special 'FixAllCodeAction'.  that is the .CodeAction this
             // SuggestedAction is pointing at.
-            var prefix = GetTelemetryPrefix(_originalCodeAction);
-            var scope = GetTelemetryScope();
-            telemetryId = new Guid(prefix, scope, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            telemetryId = _originalCodeAction.GetType().GetTelemetryId(_fixAllState.Scope.GetTelemetryScope());
             return true;
-        }
-
-        private short GetTelemetryScope()
-        {
-            switch (_fixAllState.Scope)
-            {
-                case FixAllScope.Document: return 1;
-                case FixAllScope.Project: return 2;
-                case FixAllScope.Solution: return 3;
-                default: return 4;
-            }
         }
 
         public string GetDiagnosticID()
         {
-            // we log diagnostic id as it is if it is from us
-            if (_fixedDiagnostic.Descriptor.CustomTags.Any(t => t == WellKnownDiagnosticTags.Telemetry))
-            {
-                return _fixedDiagnostic.Id;
-            }
-
-            // if it is from third party, we use hashcode
-            return _fixedDiagnostic.GetHashCode().ToString(CultureInfo.InvariantCulture);
+            return _fixedDiagnostic.GetTelemetryDiagnosticID();
         }
 
         protected override void InnerInvoke(

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -55,17 +56,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
         internal virtual CodeActionPriority Priority => CodeAction.Priority;
 
-        protected static int GetTelemetryPrefix(CodeAction codeAction)
-        {
-            // AssemblyQualifiedName will change across version numbers, FullName won't
-            var type = codeAction.GetType();
-            type = type.IsConstructedGenericType ? type.GetGenericTypeDefinition() : type;
-            return type.FullName.GetHashCode();
-        }
-
         public virtual bool TryGetTelemetryId(out Guid telemetryId)
         {
-            telemetryId = new Guid(GetTelemetryPrefix(CodeAction), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            telemetryId = CodeAction.GetType().GetTelemetryId();
             return true;
         }
 

--- a/src/EditorFeatures/Core/Shared/Extensions/TelemetryExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/TelemetryExtensions.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 
 namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
@@ -19,12 +16,18 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
 
         public static int GetTelemetryPrefix(this Type type)
         {
+            type = GetTypeForTelemetry(type);
+
             // AssemblyQualifiedName will change across version numbers, FullName won't
-            type = type.IsConstructedGenericType ? type.GetGenericTypeDefinition() : type;
             return type.FullName.GetHashCode();
         }
 
-        public static short GetTelemetryScope(this FixAllScope scope)
+        public static Type GetTypeForTelemetry(this Type type)
+        {
+            return type.IsConstructedGenericType ? type.GetGenericTypeDefinition() : type;
+        }
+
+        public static short GetScopeIdForTelemetry(this FixAllScope scope)
         {
             switch (scope)
             {

--- a/src/EditorFeatures/Core/Shared/Extensions/TelemetryExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/TelemetryExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
+{
+    internal static class TelemetryExtensions
+    {
+        public static Guid GetTelemetryId(this Type type, short scope = 0)
+        {
+            return new Guid(type.GetTelemetryPrefix(), scope, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        }
+
+        public static int GetTelemetryPrefix(this Type type)
+        {
+            // AssemblyQualifiedName will change across version numbers, FullName won't
+            type = type.IsConstructedGenericType ? type.GetGenericTypeDefinition() : type;
+            return type.FullName.GetHashCode();
+        }
+
+        public static short GetTelemetryScope(this FixAllScope scope)
+        {
+            switch (scope)
+            {
+                case FixAllScope.Document: return 1;
+                case FixAllScope.Project: return 2;
+                case FixAllScope.Solution: return 3;
+                default: return 4;
+            }
+        }
+
+        public static string GetTelemetryDiagnosticID(this Diagnostic diagnostic)
+        {
+            // we log diagnostic id as it is if it is from us
+            if (diagnostic.Descriptor.CustomTags.Any(t => t == WellKnownDiagnosticTags.Telemetry))
+            {
+                return diagnostic.Id;
+            }
+
+            // if it is from third party, we use hashcode
+            return diagnostic.GetHashCode().ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/DiagnosticsWindow.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/DiagnosticsWindow.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.Shell;
 using Roslyn.Hosting.Diagnostics.PerfMargin;
 using Roslyn.Hosting.Diagnostics.RemoteHost;
+using Roslyn.VisualStudio.DiagnosticsWindow.Telemetry;
 
 namespace Roslyn.VisualStudio.DiagnosticsWindow
 {
@@ -45,10 +46,16 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow
                 Content = new PerfMarginPanel()
             };
 
-            var remoteHost = new TabItem()
+            var remoteHostPanel = new TabItem()
             {
                 Header = "Remote",
                 Content = new RemoteHostPanel(workspace)
+            };
+
+            var telemetryPanel = new TabItem()
+            {
+                Header = "Telemetry",
+                Content = new TelemetryPanel()
             };
 
             var tabControl = new TabControl
@@ -57,7 +64,8 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow
             };
 
             tabControl.Items.Add(perfMarginPanel);
-            tabControl.Items.Add(remoteHost);
+            tabControl.Items.Add(remoteHostPanel);
+            tabControl.Items.Add(telemetryPanel);
 
             base.Content = tabControl;
         }

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Roslyn.VisualStudio.DiagnosticsWindow.csproj
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Roslyn.VisualStudio.DiagnosticsWindow.csproj
@@ -77,6 +77,10 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Update="Telemetry\TelemetryPanel.xaml.cs">
+      <DependentUpon>TelemetryPanel.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Update="VenusMargin\ProjectionBufferMargin.xaml.cs">
       <DependentUpon>ProjectionBufferMargin.xaml</DependentUpon>
     </Compile>
@@ -107,6 +111,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Telemetry\TelemetryPanel.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="VenusMargin\ProjectionBufferMargin.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Telemetry/TelemetryPanel.xaml
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Telemetry/TelemetryPanel.xaml
@@ -1,0 +1,27 @@
+﻿<UserControl x:Class="Roslyn.VisualStudio.DiagnosticsWindow.Telemetry.TelemetryPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Roslyn.VisualStudio.DiagnosticsWindow.Telemetry"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Visible" >
+            <StackPanel Orientation="Vertical" >
+                <ProgressBar x:Name="GenerationProgresBar" IsIndeterminate="False" />
+                <TextBox x:Name="Result" IsReadOnly="True" TextWrapping="Wrap" />
+            </StackPanel>
+        </ScrollViewer>
+        <StackPanel Grid.Row="1" Orientation="Horizontal">
+            <Label Content="Telemetry Info" />
+            <Button Content="Dump" x:Name="DumpButton" Click="OnDump"/>
+            <Label Content="Copy To Clipboard" />
+            <Button Content="Copy" x:Name="CopyButton" Click="OnCopy"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Telemetry/TelemetryPanel.xaml.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Telemetry/TelemetryPanel.xaml.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+
+namespace Roslyn.VisualStudio.DiagnosticsWindow.Telemetry
+{
+    /// <summary>
+    /// Interaction logic for TelemetryPanel.xaml
+    /// </summary>
+    public partial class TelemetryPanel : UserControl
+    {
+        public TelemetryPanel()
+        {
+            InitializeComponent();
+        }
+
+        private async void OnDump(object sender, RoutedEventArgs e)
+        {
+            using (Disable(DumpButton))
+            using (Disable(CopyButton))
+            {
+                GenerationProgresBar.IsIndeterminate = true;
+
+                var text = await Task.Run(() => GetTelemetryString()).ConfigureAwait(true);
+                this.Result.Text = text;
+
+                GenerationProgresBar.IsIndeterminate = false;
+            }
+        }
+
+        private void OnCopy(object sender, RoutedEventArgs e)
+        {
+            Clipboard.SetText(this.Result.Text);
+        }
+
+        private string GetTelemetryString()
+        {
+            var fixAllScopeValues = Enum.GetValues(typeof(FixAllScope));
+
+            var sb = new StringBuilder();
+            var seenType = new HashSet<Type>();
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var result = ScanAssembly(assembly);
+                if (result.Length > 0)
+                {
+                    sb.AppendLine($"Searching: {assembly.FullName}");
+                    sb.AppendLine(result);
+                }
+            }
+
+            return sb.ToString();
+
+            string ScanAssembly(Assembly assembly)
+            {
+                var typeDiscovered = new StringBuilder();
+                try
+                {
+                    foreach (var module in assembly.GetModules())
+                    {
+                        foreach (var type in module.GetTypes())
+                        {
+                            ScanType(type, typeDiscovered);
+                        }
+                    }
+                }
+                catch
+                {
+                    // ignore
+                }
+
+                return typeDiscovered.ToString();
+            }
+
+            void ScanType(Type type, StringBuilder typeDiscovered)
+            {
+                type = type.GetTypeForTelemetry();
+
+                if (!seenType.Add(type))
+                {
+                    return;
+                }
+
+                RecordIfCodeAction(type, typeDiscovered);
+
+                foreach (var nestedTypeInfo in type.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    ScanType(nestedTypeInfo, typeDiscovered);
+                }
+            }
+
+            void RecordIfCodeAction(Type type, StringBuilder typeDiscovered)
+            {
+                if (!IsCodeAction(type))
+                {
+                    return;
+                }
+
+                var telemetryId = type.GetTelemetryId();
+
+                typeDiscovered.AppendLine($"Found: {type.FullName}: {telemetryId.ToString()}");
+            }
+
+            bool IsCodeAction(Type type)
+            {
+                if (type == null)
+                {
+                    return false;
+                }
+
+                var codeActionType = typeof(CodeAction);
+                return codeActionType.IsAssignableFrom(type);
+            }
+        }
+
+        private IDisposable Disable(UIElement control)
+        {
+            control.IsEnabled = false;
+            return new RAII(() => control.IsEnabled = true);
+        }
+
+        private sealed class RAII : IDisposable
+        {
+            private readonly Action _action;
+
+            public RAII(Action disposeAction)
+            {
+                _action = disposeAction;
+            }
+            public void Dispose()
+            {
+                _action?.Invoke();
+            }
+        }
+    }
+}


### PR DESCRIPTION
people are asking how to get telemetry ID we record on code fix.

so added a tool to dump that info on roslyn diagnostic tool window

you can get it from View -> Other Windows -> Roslyn Diagnostics
![image](https://user-images.githubusercontent.com/1333179/49678015-bbc18500-fa36-11e8-9bb9-17d8f8d17d00.png)

which will give you this
![image](https://user-images.githubusercontent.com/1333179/49678036-d85dbd00-fa36-11e8-978c-609cc04d6aee.png)

click dump to get all telemetry guid
