### PR TITLE
Move package reference to RoslynTools.ModifyVsixManifest from Tools to VSIX project

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -58,7 +58,7 @@ jobs:
   - task: PowerShell@2
     displayName: Publish Assets
     inputs:
-      arguments: '-config $(BuildConfiguration) -branchName "$(Build.SourceBranch)" -mygetApiKey $(Roslyn.MyGetApiKey) -nugetApiKey $(Roslyn.NuGetApiKey) -gitHubUserName $(Roslyn.GitHubUserName) -gitHubToken $(Roslyn.GitHubToken) -gitHubEmail $(Roslyn.GitHubEmail)'
+      arguments: '-configuration $(BuildConfiguration) -branchName "$(Build.SourceBranch)" -mygetApiKey $(Roslyn.MyGetApiKey) -nugetApiKey $(Roslyn.NuGetApiKey) -gitHubUserName $(Roslyn.GitHubUserName) -gitHubToken $(Roslyn.GitHubToken) -gitHubEmail $(Roslyn.GitHubEmail)'
       filePath: 'build\scripts\publish-assets.ps1'
     condition: succeeded()
 

--- a/build/Targets/RepoToolset/BuildTasks.props
+++ b/build/Targets/RepoToolset/BuildTasks.props
@@ -8,4 +8,7 @@
     <RoslynToolsBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(NuGetPackageRoot)roslyntools.buildtasks\$(RoslynToolsBuildTasksVersion)\tools\net472\RoslynTools.BuildTasks.dll</RoslynToolsBuildTasksAssembly>
     <RoslynToolsBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)roslyntools.buildtasks\$(RoslynToolsBuildTasksVersion)\tools\netcoreapp2.1\RoslynTools.BuildTasks.dll</RoslynToolsBuildTasksAssembly>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="RoslynTools.BuildTasks" Version="$(RoslynToolsBuildTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+  </ItemGroup>
 </Project>

--- a/build/Targets/RepoToolset/Tools.proj
+++ b/build/Targets/RepoToolset/Tools.proj
@@ -49,7 +49,6 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" Condition="'$(PublishingToBlobStorage)' == 'true'" IsImplicitlyDefined="true" />
     <PackageReference Include="RoslynTools.NuGetRepack.BuildTasks" Version="$(RoslynToolsNuGetRepackVersion)" Condition="'$(UsingToolNuGetRepack)' == 'true'" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.DotNet.SignTool" Version="$(MicrosoftDotNetSignToolVersion)" IsImplicitlyDefined="true" />
-    <PackageReference Include="RoslynTools.ModifyVsixManifest" Version="$(RoslynToolsModifyVsixManifestVersion)" Condition="'$(UsingToolVSSDK)' == 'true'" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.SymbolUploader.Build.Task" Version="$(MicrosoftSymbolUploaderBuildTaskVersion)" Condition="'$(UsingToolSymbolUploader)' == 'true'" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.DotNet.Maestro.Tasks" Version="$(MicrosoftDotNetMaestroTasksVersion)" Condition="'$(PublishBuildAssets)' == 'true'" IsImplicitlyDefined="true" />  
   </ItemGroup>

--- a/build/Targets/RepoToolset/VisualStudio.props
+++ b/build/Targets/RepoToolset/VisualStudio.props
@@ -20,6 +20,7 @@
 
   <ItemGroup Condition="'$(IsVsixProject)' == 'true'">
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="RoslynTools.ModifyVsixManifest" Version="$(RoslynToolsModifyVsixManifestVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(IsVsixProject)' == 'true'">

--- a/build/Targets/Tools.props
+++ b/build/Targets/Tools.props
@@ -17,7 +17,6 @@
   -->
 
   <ItemGroup>
-    <PackageReference Include="RoslynTools.BuildTasks" Version="$(RoslynToolsBuildTasksVersion)" ExcludeAssets="all" />
     <PackageReference Include="RoslynDependencies.OptimizationData" Version="$(RoslynDependenciesOptimizationDataVersion)" ExcludeAssets="all" />
     <PackageReference Include="RoslynTools.OptProf" Version="$(RoslynToolsOptProfVersion)" ExcludeAssets="all" />
     <PackageReference Include="Roslyn.OptProf.RunSettings.Generator" Version="$(RoslynOptProfRunSettingsGeneratorVersion)" ExcludeAssets="all" />

--- a/build/scripts/publish-assets.ps1
+++ b/build/scripts/publish-assets.ps1
@@ -9,7 +9,7 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
     # Standard options
-    [string]$config = "",
+    [string]$configuration = "",
     [string]$branchName = "",
     [string]$releaseName = "",
     [switch]$test,
@@ -143,14 +143,15 @@ function Normalize-BranchName([string]$branchName) {
 }
 
 try {
-    . (Join-Path $PSScriptRoot "build-utils.ps1")
-    $dotnet = Ensure-DotnetSdk
-    $nugetDir = Join-Path $BinariesConfigDir "NuGet"
-
-    if ($config -eq "") {
+    if ($configuration -eq "") {
         Write-Host "Must provide the build configuration with -config"
         exit 1
     }
+
+    . (Join-Path $PSScriptRoot "build-utils.ps1")
+
+    $dotnet = Ensure-DotnetSdk
+    $nugetDir = Join-Path $BinariesConfigDir "NuGet"
 
     Write-Host "Downloading PublishData.json"
     $publishFileContent = (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/roslyn/master/build/config/PublishData.json" -UseBasicParsing).Content


### PR DESCRIPTION
RoslynTools.ModifyVsixManifest and RoslynTools.BuildTasks are used by targets that execute on Build and thus must be restored when the project is restored, not when the CI tools are restored.

Fixes https://github.com/dotnet/roslyn/issues/31630