### PR TITLE
fixed re-enterance bug in async operation listener.

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.AsyncToken.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.AsyncToken.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
             {
                 _listener = listener;
 
-                listener.Increment();
+                listener.Increment_NoLock();
             }
 
             public void Dispose()
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
                     }
 
                     _disposed = true;
-                    _listener.Decrement(this);
+                    _listener.Decrement_NoLock(this);
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.AsyncToken.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.AsyncToken.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Shared.TestHooks
 {
@@ -21,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
 
             public void Dispose()
             {
-                lock (_listener._gate)
+                using (_listener._gate.DisposableWait(CancellationToken.None))
                 {
                     if (_disposed)
                     {

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -105,11 +105,10 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
                 }
                 else
                 {
-                    // setting result of a task can cause await machinary to wake up awaited code
-                    // and run code inline. that basically means random code running at the same thread
-                    // as the thread SetResult is called. so make sure we do in another thread (basically outside of the lock).
-                    // also, to prevent re-enterance bug, use NonReentrantLock to explicitly block
-                    // re-enterance
+                    // Calling SetResult on a normal TaskCompletionSource can cause continuations to run synchronously
+                    // at that point. That's a problem as that may cause additional code to run while we're holding a lock. 
+                    // In order to prevent that, we pass along RunContinuationsAsynchronously in order to ensure that 
+                    // all continuations will run at a future point when this thread has released the lock.
                     var source = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     _pendingTasks.Add(source);
 

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -53,13 +53,13 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
             }
         }
 
-        private void Increment()
+        private void Increment_NoLock()
         {
             Contract.ThrowIfFalse(_gate.LockHeldByMe());
             _counter++;
         }
 
-        private void Decrement(AsyncToken token)
+        private void Decrement_NoLock(AsyncToken token)
         {
             Contract.ThrowIfFalse(_gate.LockHeldByMe());
 


### PR DESCRIPTION
basically we are calling SetResult inside of a lock and since we used regular lock which allows re-enterance, we sometimes ran arbitary code under lock which re-entered async operation listener and mess everything up.

changed to non re-enterance lock so that it explicitly throws if re-enterance happens.

and make sure call SetResult from other thread (out side of the lock).