### PR TITLE
Switch to using a single-string for some regexes in our code.

### DIFF
--- a/src/Compilers/Core/MSBuildTask/CanonicalError.cs
+++ b/src/Compilers/Core/MSBuildTask/CanonicalError.cs
@@ -72,68 +72,68 @@ namespace Microsoft.CodeAnalysis.BuildTasks
              );
 
         // Matches and extracts filename and location from an 'origin' element.
-        private static readonly Regex s_filenameLocationFromOrigin = new Regex(
-                @"^                                           # Beginning of line
-                  (\d+>)?                                     # Optional ddd> project number prefix
-                  (?<FILENAME>.*)                             # Match anything.
-                  \(                                          # Find a parenthesis.
-                  (?<LOCATION>[\,,0-9,-]*)                    # Match any combination of numbers and ',' and '-'
-                  \)\s*                                       # Find the closing paren then any amount of spaces.
-                  $                                           # End-of-line",
+        private static readonly Regex s_filenameLocationFromOrigin = new Regex(@"
+                ^                                           # Beginning of line
+                (\d+>)?                                     # Optional ddd> project number prefix
+                (?<FILENAME>.*)                             # Match anything.
+                \(                                          # Find a parenthesis.
+                (?<LOCATION>[\,,0-9,-]*)                    # Match any combination of numbers and ',' and '-'
+                \)\s*                                       # Find the closing paren then any amount of spaces.
+                $                                           # End-of-line",
                 RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         // Matches location that is a simple number.
         // Example: line
-        private static readonly Regex s_lineFromLocation = new Regex(
-                @"^                                           # Beginning of line
-                  (?<LINE>[0-9]*)                             # Match any number.
-                  $                                           # End-of-line",
+        private static readonly Regex s_lineFromLocation = new Regex(@"
+                ^                                           # Beginning of line
+                (?<LINE>[0-9]*)                             # Match any number.
+                $                                           # End-of-line",
                 RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         // Matches location that is a range of lines.
         // Example: line-line
-        private static readonly Regex s_lineLineFromLocation = new Regex(
-                @"^                                           # Beginning of line
-                  (?<LINE>[0-9]*)                             # Match any number.
-                  -                                           # Dash
-                  (?<ENDLINE>[0-9]*)                          # Match any number.
-                  $                                           # End-of-line",
+        private static readonly Regex s_lineLineFromLocation = new Regex(@"
+                ^                                           # Beginning of line
+                (?<LINE>[0-9]*)                             # Match any number.
+                -                                           # Dash
+                (?<ENDLINE>[0-9]*)                          # Match any number.
+                $                                           # End-of-line",
                 RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         // Matches location that is a line and column
         // Example: line,col
-        private static readonly Regex s_lineColFromLocation = new Regex(
-                @"^                                           # Beginning of line
-                  (?<LINE>[0-9]*)                             # Match any number.
-                  ,                                           # Comma
-                  (?<COLUMN>[0-9]*)                           # Match any number.
-                  $                                           # End-of-line",
+        private static readonly Regex s_lineColFromLocation = new Regex(@"
+                ^                                           # Beginning of line
+                (?<LINE>[0-9]*)                             # Match any number.
+                ,                                           # Comma
+                (?<COLUMN>[0-9]*)                           # Match any number.
+                $                                           # End-of-line",
                 RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         // Matches location that is a line and column-range
         // Example: line,col-col
-        private static readonly Regex s_lineColColFromLocation = new Regex(
-                @"^                                           # Beginning of line
-                  (?<LINE>[0-9]*)                             # Match any number.
-                  ,                                           # Comma
-                  (?<COLUMN>[0-9]*)                           # Match any number.
-                  -                                           # Dash
-                  (?<ENDCOLUMN>[0-9]*)                        # Match any number.
-                  $                                           # End-of-line",
+        private static readonly Regex s_lineColColFromLocation = new Regex(@"
+                ^                                           # Beginning of line
+                (?<LINE>[0-9]*)                             # Match any number.
+                ,                                           # Comma
+                (?<COLUMN>[0-9]*)                           # Match any number.
+                -                                           # Dash
+                (?<ENDCOLUMN>[0-9]*)                        # Match any number.
+                $                                           # End-of-line",
                 RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         // Matches location that is line,col,line,col
         // Example: line,col,line,col
-        private static readonly Regex s_lineColLineColFromLocation = new Regex(
-                @"^                                           # Beginning of line
-                  (?<LINE>[0-9]*)                             # Match any number.
-                  ,                                           # Comma
-                  (?<COLUMN>[0-9]*)                           # Match any number.
-                  ,                                           # Dash
-                  (?<ENDLINE>[0-9]*)                          # Match any number.
-                  ,                                           # Dash
-                  (?<ENDCOLUMN>[0-9]*)                        # Match any number.
-                  $                                           # End-of-line",
+        private static readonly Regex s_lineColLineColFromLocation = new Regex(@"
+                ^                                           # Beginning of line
+                (?<LINE>[0-9]*)                             # Match any number.
+                ,                                           # Comma
+                (?<COLUMN>[0-9]*)                           # Match any number.
+                ,                                           # Dash
+                (?<ENDLINE>[0-9]*)                          # Match any number.
+                ,                                           # Dash
+                (?<ENDCOLUMN>[0-9]*)                        # Match any number.
+                $                                           # End-of-line",
                 RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         /// <summary>

--- a/src/Compilers/Core/MSBuildTask/CanonicalError.cs
+++ b/src/Compilers/Core/MSBuildTask/CanonicalError.cs
@@ -72,76 +72,69 @@ namespace Microsoft.CodeAnalysis.BuildTasks
              );
 
         // Matches and extracts filename and location from an 'origin' element.
-        private static readonly Regex s_filenameLocationFromOrigin = new Regex
-             (
-                 "^"                                             // Beginning of line
-                 + @"(\d+>)?"                                     // Optional ddd> project number prefix
-                 + "(?<FILENAME>.*)"                              // Match anything.
-                 + @"\("                                          // Find a parenthesis.
-                 + @"(?<LOCATION>[\,,0-9,-]*)"                    // Match any combination of numbers and ',' and '-'
-                 + @"\)\s*"                                       // Find the closing paren then any amount of spaces.
-                 + "$",                                           // End-of-line
-                 RegexOptions.IgnoreCase
-             );
+        private static readonly Regex s_filenameLocationFromOrigin = new Regex(
+                @"^                                           # Beginning of line
+                  (\d+>)?                                     # Optional ddd> project number prefix
+                  (?<FILENAME>.*)                             # Match anything.
+                  \(                                          # Find a parenthesis.
+                  (?<LOCATION>[\,,0-9,-]*)                    # Match any combination of numbers and ',' and '-'
+                  \)\s*                                       # Find the closing paren then any amount of spaces.
+                  $                                           # End-of-line",
+                RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         // Matches location that is a simple number.
-        private static readonly Regex s_lineFromLocation = new Regex        // Example: line
-            (
-                "^"                                              // Beginning of line
-                + "(?<LINE>[0-9]*)"                               // Match any number.
-                + "$",                                            // End-of-line
-                RegexOptions.IgnoreCase
-            );
+        // Example: line
+        private static readonly Regex s_lineFromLocation = new Regex(
+                @"^                                           # Beginning of line
+                  (?<LINE>[0-9]*)                             # Match any number.
+                  $                                           # End-of-line",
+                RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         // Matches location that is a range of lines.
-        private static readonly Regex s_lineLineFromLocation = new Regex    // Example: line-line
-            (
-                "^"                                              // Beginning of line
-                + "(?<LINE>[0-9]*)"                               // Match any number.
-                + "-"                                             // Dash
-                + "(?<ENDLINE>[0-9]*)"                            // Match any number.
-                + "$",                                            // End-of-line
-                RegexOptions.IgnoreCase
-            );
+        // Example: line-line
+        private static readonly Regex s_lineLineFromLocation = new Regex(
+                @"^                                           # Beginning of line
+                  (?<LINE>[0-9]*)                             # Match any number.
+                  -                                           # Dash
+                  (?<ENDLINE>[0-9]*)                          # Match any number.
+                  $                                           # End-of-line",
+                RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         // Matches location that is a line and column
-        private static readonly Regex s_lineColFromLocation = new Regex     // Example: line,col
-            (
-                "^"                                              // Beginning of line
-                + "(?<LINE>[0-9]*)"                               // Match any number.
-                + ","                                             // Comma
-                + "(?<COLUMN>[0-9]*)"                             // Match any number.
-                + "$",                                            // End-of-line
-                RegexOptions.IgnoreCase
-            );
+        // Example: line,col
+        private static readonly Regex s_lineColFromLocation = new Regex(
+                @"^                                           # Beginning of line
+                  (?<LINE>[0-9]*)                             # Match any number.
+                  ,                                           # Comma
+                  (?<COLUMN>[0-9]*)                           # Match any number.
+                  $                                           # End-of-line",
+                RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         // Matches location that is a line and column-range
-        private static readonly Regex s_lineColColFromLocation = new Regex  // Example: line,col-col
-            (
-                "^"                                              // Beginning of line
-                + "(?<LINE>[0-9]*)"                               // Match any number.
-                + ","                                             // Comma
-                + "(?<COLUMN>[0-9]*)"                             // Match any number.
-                + "-"                                             // Dash
-                + "(?<ENDCOLUMN>[0-9]*)"                          // Match any number.
-                + "$",                                            // End-of-line
-                RegexOptions.IgnoreCase
-            );
+        // Example: line,col-col
+        private static readonly Regex s_lineColColFromLocation = new Regex(
+                @"^                                           # Beginning of line
+                  (?<LINE>[0-9]*)                             # Match any number.
+                  ,                                           # Comma
+                  (?<COLUMN>[0-9]*)                           # Match any number.
+                  -                                           # Dash
+                  (?<ENDCOLUMN>[0-9]*)                        # Match any number.
+                  $                                           # End-of-line",
+                RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         // Matches location that is line,col,line,col
-        private static readonly Regex s_lineColLineColFromLocation = new Regex      // Example: line,col,line,col
-            (
-                "^"                                              // Beginning of line
-                + "(?<LINE>[0-9]*)"                               // Match any number.
-                + ","                                             // Comma
-                + "(?<COLUMN>[0-9]*)"                             // Match any number.
-                + ","                                             // Dash
-                + "(?<ENDLINE>[0-9]*)"                            // Match any number.
-                + ","                                             // Dash
-                + "(?<ENDCOLUMN>[0-9]*)"                          // Match any number.
-                + "$",                                            // End-of-line
-                RegexOptions.IgnoreCase
-            );
+        // Example: line,col,line,col
+        private static readonly Regex s_lineColLineColFromLocation = new Regex(
+                @"^                                           # Beginning of line
+                  (?<LINE>[0-9]*)                             # Match any number.
+                  ,                                           # Comma
+                  (?<COLUMN>[0-9]*)                           # Match any number.
+                  ,                                           # Dash
+                  (?<ENDLINE>[0-9]*)                          # Match any number.
+                  ,                                           # Dash
+                  (?<ENDCOLUMN>[0-9]*)                        # Match any number.
+                  $                                           # End-of-line",
+                RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         /// <summary>
         /// Represents the parts of a decomposed canonical message.


### PR DESCRIPTION
This is more idiomatic.  It also means that the IDE lights up well now and shows the regex in a much easier to understand form like:

![image](https://user-images.githubusercontent.com/4564579/49721420-0863b680-fc17-11e8-8909-ecc83aeb27ad.png)

Instead of the more opaque form:

![image](https://user-images.githubusercontent.com/4564579/49721549-52e53300-fc17-11e8-9564-efe097e405b9.png)


