### PR TITLE
Put Binaries in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 [Aa]rtifacts/
 [Dd]ebug/
 [Rr]elease/
+[Bb]inaries/
 x64/
 [Bb]in/
 [Oo]bj/


### PR DESCRIPTION
Even though we don't build a Binaries directory anymore lots of
developers will have this on their machine. To avoid any accidentally
adding of Binarise to our history putting it in the ignore list. Can
remove this some time down the road when it's unlikely anyone has
Binaries directories remaining on their machine.