### PR TITLE
close sqlite connection when solution is closed

### DIFF
--- a/src/VisualStudio/Core/Def/Storage/VisualStudioPersistentStorageLocationService.cs
+++ b/src/VisualStudio/Core/Def/Storage/VisualStudioPersistentStorageLocationService.cs
@@ -152,6 +152,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Storage
                 _service.UpdateForVisualStudioWorkspace(_visualStudioWorkspace);
             }
 
+            int IVsSolutionEvents.OnAfterCloseSolution(object pUnkReserved)
+            {
+                _service.ProcessChangeToIVsSolutionChange(_visualStudioWorkspace);
+                return VSConstants.S_OK;
+            }
+
             int IVsSolutionEvents.OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
             {
                 return VSConstants.E_NOTIMPL;
@@ -193,11 +199,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Storage
             }
 
             int IVsSolutionEvents.OnBeforeCloseSolution(object pUnkReserved)
-            {
-                return VSConstants.E_NOTIMPL;
-            }
-
-            int IVsSolutionEvents.OnAfterCloseSolution(object pUnkReserved)
             {
                 return VSConstants.E_NOTIMPL;
             }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFindReferences.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFindReferences.cs
@@ -158,6 +158,11 @@ class Program
 
             // verify working folder has set
             Assert.NotNull(VisualStudio.Workspace.GetWorkingFolder());
+
+            VisualStudio.SolutionExplorer.CloseSolution();
+
+            // verify working folder has not set
+            Assert.Null(VisualStudio.Workspace.GetWorkingFolder());
         }
     }
 }


### PR DESCRIPTION
previously, we didn't close the db when a solution is closed, but when a new solution is opened. this makes sure that we release the db when solution is closed.

user visible outcome of this is that once solution is closed, user can now delete .vs folder. previously, the user wouldn't be able to delete the folder right after solution is closed.

while looking at this 2 other issues are found. 
one is issue on IVsSolution - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/746630
the other issue is - https://github.com/dotnet/roslyn/issues/31686

this fix is needed regardless of the above 2 issues. but without fixing those 2, persistent service can still get into wrong state where either persistent service becomes noop or connection stay alive until next new solution is opened.

