### PR TITLE
Fix AddImport to not error on awaited extension methods

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -4989,5 +4989,64 @@ namespace B
     }
 }");
         }
+
+
+        [WorkItem(745490, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/745490")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestAddUsingForAwaitableReturningExtensionMethod()
+        {
+            await TestAsync(
+@"
+namespace A
+{
+    using System;
+    using System.Threading.Tasks;
+
+    class C
+    {
+        C Instance { get; } => null;
+
+        async Task M() => await Instance.[|Foo|]();
+    }
+}
+
+namespace B
+{
+    using System;
+    using System.Threading.Tasks;
+    using A;
+
+    static class Extensions
+    {
+        public static Task Foo(this C instance) => null;
+    }
+}",
+@"
+namespace A
+{
+    using System;
+    using System.Threading.Tasks;
+    using B;
+
+    class C
+    {
+        C Instance { get; } => null;
+
+        async Task M() => await Instance.Foo();
+    }
+}
+
+namespace B
+{
+    using System;
+    using System.Threading.Tasks;
+    using A;
+
+    static class Extensions
+    {
+        public static Task Foo(this C instance) => null;
+    }
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -546,7 +546,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         {
             var awaitExpression = FirstAwaitExpressionAncestor(syntaxFactsService, node);
 
-            var innerExpression = syntaxFactsService.GetExpressionOfAwaitExpression(node);
+            var innerExpression = syntaxFactsService.GetExpressionOfAwaitExpression(awaitExpression);
 
             return semanticModel.GetTypeInfo(innerExpression).Type;
         }


### PR DESCRIPTION
This fixes a typo in the `AbstractAddImportFeatureService` where it was passing the wrong node into `syntaxFactsService.GetExpressionOfAwaitExpression`. This would cause a gold bar when trying to find missing imports for an awaited extension method.

fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/745490