### PR TITLE
Use release bootstrap compiler

### DIFF
--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -12,6 +12,7 @@ $PackagesDir = Join-Path $ArtifactsDir "packages\$configuration"
 $binaryLog = if (Test-Path variable:binaryLog) { $binaryLog } else { $false }
 $nodeReuse = if (Test-Path variable:nodeReuse) { $nodeReuse } else { $false }
 $bootstrapDir = if (Test-Path variable:bootstrapDir) { $bootstrapDir } else { "" }
+$bootstrapConfiguration = if (Test-Path variable:bootstrapConfiguration) { $bootstrapConfiguration } else { "Release" }
 $properties = if (Test-Path variable:properties) { $properties } else { @() }
 
 function GetProjectOutputBinary([string]$fileName, [string]$projectName = "", [string]$configuration = $script:configuration, [string]$tfm = "net472", [string]$rid = "", [bool]$published = $false) {
@@ -192,7 +193,7 @@ function Restore-Project([string]$projectFileName, [string]$logFilePath = "") {
     Exec-Console $buildTool.Path "$($buildTool.Command) `"$projectFilePath`" /t:Restore /m /nologo /clp:None /v:quiet /nr:false /warnaserror $logArg $args"
 }
 
-function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]$logFileName = "", [switch]$parallel = $true, [switch]$summary = $true, [switch]$warnAsError = $true) {
+function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]$logFileName = "", [switch]$parallel = $true, [switch]$summary = $true, [switch]$warnAsError = $true, [string]$configuration = $script:configuration) {
     # Because we override the C#/VB toolset to build against our LKG package, it is important
     # that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise,
     # we'll run into issues such as https://github.com/dotnet/roslyn/issues/6211.
@@ -261,7 +262,7 @@ function Make-BootstrapBuild() {
     $packageName = if ($msbuildEngine -eq 'dotnet') { "Microsoft.NETCore.Compilers" } else { "Microsoft.Net.Compilers" }
     $projectPath = "src\NuGet\$packageName\$packageName.Package.csproj"
 
-    Run-MSBuild $projectPath "/restore /t:Pack /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP /p:PackageOutputPath=`"$dir`" /p:ApplyPartialNgenOptimization=false" -logFileName "Bootstrap"
+    Run-MSBuild $projectPath "/restore /t:Pack /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP /p:PackageOutputPath=`"$dir`" /p:ApplyPartialNgenOptimization=false" -logFileName "Bootstrap" -configuration $bootstrapConfiguration
     $packageFile = Get-ChildItem -Path $dir -Filter "$packageName.*.nupkg"
     Unzip "$dir\$packageFile" $dir
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -32,6 +32,7 @@ param (
 
     # Options
     [switch]$bootstrap,
+    [string]$bootstrapConfiguration = "Release",
     [switch][Alias('bl')]$binaryLog,
     [switch]$ci,
     [switch]$official,
@@ -83,6 +84,7 @@ function Print-Usage() {
     Write-Host "  -ci                       Set when running on CI server"
     Write-Host "  -official                 Set when building an official build"
     Write-Host "  -bootstrap                Build using a bootstrap compilers"
+    Write-Host "  -bootstrapConfiguration   Build configuration for bootstrap compiler: 'Debug' or 'Release'"
     Write-Host "  -msbuildEngine <value>    Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
     Write-Host "  -procdump                 Monitor test runs with procdump"
     Write-Host "  -skipAnalyzers            Do not run analyzers during build operations"

--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -2,6 +2,7 @@
 param([string]$configuration = "Debug",
       [string]$msbuildEngine = "vs",
       [string]$bootstrapDir = "",
+      [string]$bootstrapConfiguration = "Debug",
       [string]$altRootDrive = "q:",
       [switch]$help)
 


### PR DESCRIPTION
The point of using the bootstrap compiler is validating that we can
build the C# code base with the latest C# compiler. Unfortunately the
debug version of the compiler is significantly slower than the Release
version and it slows down our Debug unit test runs accordingly.

This change causes us to prefer a release version of the bootstrap
compiler. The debug bootstrap compiler is still used in the determinism
leg hence we wont't lose coverage here. This should bring our Release
and Debug desktop tests back to the same run time.