### PR TITLE
DeclareAsNullable should handle async returns

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -82,6 +82,28 @@ class Program
         }
 
         [Fact]
+        public async Task FixReturnType_Async()
+        {
+            await TestInRegularAndScript1Async(
+NonNullTypes + @"
+class Program
+{
+    static async System.Threading.Tasks.Task<string> M()
+    {
+        return [|null|];
+    }
+}",
+NonNullTypes + @"
+class Program
+{
+    static async System.Threading.Tasks.Task<string?> M()
+    {
+        return null;
+    }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
         public async Task FixReturnType_WithTrivia()
         {
             await TestInRegularAndScript1Async(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -104,6 +104,34 @@ class Program
         }
 
         [Fact]
+        public async Task FixReturnType_AsyncLocalFunction()
+        {
+            await TestInRegularAndScript1Async(
+NonNullTypes + @"
+class Program
+{
+    static void M()
+    {
+        async System.Threading.Tasks.Task<string> local()
+        {
+            return [|null|];
+        }
+    }
+}",
+NonNullTypes + @"
+class Program
+{
+    static void M()
+    {
+        async System.Threading.Tasks.Task<string?> local()
+        {
+            return null;
+        }
+    }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
         public async Task FixReturnType_WithTrivia()
         {
             await TestInRegularAndScript1Async(
@@ -160,7 +188,7 @@ class Program
         [WorkItem(26639, "https://github.com/dotnet/roslyn/issues/26639")]
         public async Task FixLocalFunctionReturnType()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestInRegularAndScript1Async(
 NonNullTypes + @"
 class Program
 {
@@ -169,6 +197,17 @@ class Program
         string local()
         {
             return [|null|];
+        }
+    }
+}",
+NonNullTypes + @"
+class Program
+{
+    void M()
+    {
+        string? local()
+        {
+            return null;
         }
     }
 }", parameters: s_nullableFeature);

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -95,12 +95,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
                     case MethodDeclarationSyntax method:
                         // string M() { return null; }
                         // async Task<string> M() { return null; }
-                        return tryGetMethodReturnType(method.ReturnType, method.Modifiers);
+                        return TryGetMethodReturnType(method.ReturnType, method.Modifiers);
 
                     case LocalFunctionStatementSyntax localFunction:
                         // string local() { return null; }
                         // async Task<string> local() { return null; }
-                        return tryGetMethodReturnType(localFunction.ReturnType, localFunction.Modifiers);
+                        return TryGetMethodReturnType(localFunction.ReturnType, localFunction.Modifiers);
 
                     case PropertyDeclarationSyntax property:
                         // string x { get { return null; } }
@@ -147,25 +147,25 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
 
             return null;
 
-            TypeSyntax tryGetMethodReturnType(TypeSyntax returnType, SyntaxTokenList modifiers)
+            // local functions
+            TypeSyntax TryGetMethodReturnType(TypeSyntax returnType, SyntaxTokenList modifiers)
             {
-                var asyncModifier = modifiers.FirstOrDefault(m => m.Kind() == SyntaxKind.AsyncKeyword);
-                if (asyncModifier.Kind() != SyntaxKind.None)
+                if (modifiers.Any(SyntaxKind.AsyncKeyword))
                 {
                     // async Task<string> M() { return null; }
-                    return tryGetSingleTypeArgument(returnType);
+                    return TryGetSingleTypeArgument(returnType);
                 }
 
                 // string M() { return null; }
                 return returnType;
             }
 
-            TypeSyntax tryGetSingleTypeArgument(TypeSyntax type)
+            TypeSyntax TryGetSingleTypeArgument(TypeSyntax type)
             {
                 switch (type)
                 {
                     case QualifiedNameSyntax qualified:
-                        return tryGetSingleTypeArgument(qualified.Right);
+                        return TryGetSingleTypeArgument(qualified.Right);
 
                     case GenericNameSyntax generic:
                         var typeArguments = generic.TypeArgumentList.Arguments;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/31699

Also, the compiler now produces the warning for `return null;` in local functions too, so addressed that (thanks Cyrus for pointing it out).

@dotnet/roslyn-ide for review. Thanks