### PR TITLE
Increase severity of local function naming style to Warning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -103,7 +103,7 @@ dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
 dotnet_naming_style.camel_case_style.capitalization = camel_case
 
 # Local functions are PascalCase
-dotnet_naming_rule.local_functions_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = warning
 dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
 dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
 


### PR DESCRIPTION
Helps prevent missed cases like occurred in #31708.