### PR TITLE
Simplify SetForegroundWindow

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEditAndContinue.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEditAndContinue.cs
@@ -209,7 +209,7 @@ End Module
 ");
             VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
             VisualStudio.Debugger.Go(waitForBreakMode: false);
-            VisualStudio.ActivateMainWindow(skipAttachingThreads: true);
+            VisualStudio.ActivateMainWindow();
             VisualStudio.SolutionExplorer.OpenFile(project, module1FileName);
 
             VisualStudio.SendKeys.Send(VirtualKey.T);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             return result.ToArray();
         }
 
-        public void ActivateMainWindow(bool skipAttachingThreads = false)
+        public void ActivateMainWindow()
             => InvokeOnUIThread(() =>
             {
                 var dte = GetDTE();
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                     Debug.WriteLine($"DTE.MainWindow.HWnd = {activeVisualStudioWindow}");
                 }
 
-                IntegrationHelper.SetForegroundWindow(activeVisualStudioWindow, skipAttachingThreads);
+                IntegrationHelper.SetForegroundWindow(activeVisualStudioWindow);
             });
 
         public int GetErrorListErrorCount()

--- a/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
@@ -81,15 +81,18 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         public static IntPtr GetForegroundWindow()
         {
             // Attempt to get the foreground window in a loop, as the NativeMethods function can return IntPtr.Zero
-            // in certain circumstances, such as when a window is losing activation.
+            // in certain circumstances, such as when a window is losing activation. If no foreground window is
+            // identified after a short timeout, none is returned. This only impacts the ability of the test to restore
+            // focus to a previous window, which is fine.
 
             var foregroundWindow = IntPtr.Zero;
+            var stopwatch = Stopwatch.StartNew();
 
             do
             {
                 foregroundWindow = NativeMethods.GetForegroundWindow();
             }
-            while (foregroundWindow == IntPtr.Zero);
+            while (foregroundWindow == IntPtr.Zero && stopwatch.Elapsed < TimeSpan.FromMilliseconds(250));
 
             return foregroundWindow;
         }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
@@ -195,24 +195,27 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
         public static void SetForegroundWindow(IntPtr window)
         {
-            // Make the window a top-most window so it will appear above any existing top-most windows
-            NativeMethods.SetWindowPos(window, (IntPtr)NativeMethods.HWND_TOPMOST, 0, 0, 0, 0, (NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE));
+            var activeWindow = NativeMethods.GetLastActivePopup(window);
+            NativeMethods.SwitchToThisWindow(activeWindow, true);
 
-            // Move the window into the foreground as it may not have been achieved by the 'SetWindowPos' call
-            var success = NativeMethods.SetForegroundWindow(window);
-            if (!success)
-            {
-                throw new InvalidOperationException("Setting the foreground window failed.");
-            }
+            //// Make the window a top-most window so it will appear above any existing top-most windows
+            //NativeMethods.SetWindowPos(window, (IntPtr)NativeMethods.HWND_TOPMOST, 0, 0, 0, 0, (NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE));
 
-            // Ensure the window is 'Active' as it may not have been achieved by 'SetForegroundWindow'
-            NativeMethods.SetActiveWindow(window);
+            //// Move the window into the foreground as it may not have been achieved by the 'SetWindowPos' call
+            //var success = NativeMethods.SetForegroundWindow(window);
+            //if (!success)
+            //{
+            //    throw new InvalidOperationException("Setting the foreground window failed.");
+            //}
 
-            // Give the window the keyboard focus as it may not have been achieved by 'SetActiveWindow'
-            NativeMethods.SetFocus(window);
+            //// Ensure the window is 'Active' as it may not have been achieved by 'SetForegroundWindow'
+            //NativeMethods.SetActiveWindow(window);
 
-            // Remove the 'Top-Most' qualification from the window
-            NativeMethods.SetWindowPos(window, (IntPtr)NativeMethods.HWND_NOTOPMOST, 0, 0, 0, 0, (NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE));
+            //// Give the window the keyboard focus as it may not have been achieved by 'SetActiveWindow'
+            //NativeMethods.SetFocus(window);
+
+            //// Remove the 'Top-Most' qualification from the window
+            //NativeMethods.SetWindowPos(window, (IntPtr)NativeMethods.HWND_NOTOPMOST, 0, 0, 0, 0, (NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE));
         }
 
         public static void SendInput(NativeMethods.INPUT[] inputs)

--- a/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
@@ -197,25 +197,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         {
             var activeWindow = NativeMethods.GetLastActivePopup(window);
             NativeMethods.SwitchToThisWindow(activeWindow, true);
-
-            //// Make the window a top-most window so it will appear above any existing top-most windows
-            //NativeMethods.SetWindowPos(window, (IntPtr)NativeMethods.HWND_TOPMOST, 0, 0, 0, 0, (NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE));
-
-            //// Move the window into the foreground as it may not have been achieved by the 'SetWindowPos' call
-            //var success = NativeMethods.SetForegroundWindow(window);
-            //if (!success)
-            //{
-            //    throw new InvalidOperationException("Setting the foreground window failed.");
-            //}
-
-            //// Ensure the window is 'Active' as it may not have been achieved by 'SetForegroundWindow'
-            //NativeMethods.SetActiveWindow(window);
-
-            //// Give the window the keyboard focus as it may not have been achieved by 'SetActiveWindow'
-            //NativeMethods.SetFocus(window);
-
-            //// Remove the 'Top-Most' qualification from the window
-            //NativeMethods.SetWindowPos(window, (IntPtr)NativeMethods.HWND_NOTOPMOST, 0, 0, 0, 0, (NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOMOVE));
         }
 
         public static void SendInput(NativeMethods.INPUT[] inputs)

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
@@ -48,11 +48,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
         public const uint GW_CHILD = 5;
         public const uint GW_ENABLEDPOPUP = 6;
 
-        public const int HWND_NOTOPMOST = -2;
-        public const int HWND_TOPMOST = -1;
-        public const int HWND_TOP = 0;
-        public const int HWND_BOTTOM = 1;
-
         public const uint INPUT_MOUSE = 0;
         public const uint INPUT_KEYBOARD = 1;
         public const uint INPUT_HARDWARE = 2;
@@ -62,22 +57,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
         public const uint KEYEVENTF_KEYUP = 0x0002;
         public const uint KEYEVENTF_UNICODE = 0x0004;
         public const uint KEYEVENTF_SCANCODE = 0x0008;
-
-        public const uint SWP_NOSIZE = 0x0001;
-        public const uint SWP_NOMOVE = 0x0002;
-        public const uint SWP_NOZORDER = 0x0004;
-        public const uint SWP_NOREDRAW = 0x008;
-        public const uint SWP_NOACTIVATE = 0x0010;
-        public const uint SWP_DRAWFRAME = 0x0020;
-        public const uint SWP_FRAMECHANGED = 0x0020;
-        public const uint SWP_SHOWWINDOW = 0x0040;
-        public const uint SWP_HIDEWINDOW = 0x0080;
-        public const uint SWP_NOCOPYBITS = 0x0100;
-        public const uint SWP_NOOWNERZORDER = 0x0200;
-        public const uint SWP_NOREPOSITION = 0x0200;
-        public const uint SWP_NOSENDCHANGING = 0x0400;
-        public const uint SWP_DEFERERASE = 0x2000;
-        public const uint SWP_ASYNCWINDOWPOS = 0x4000;
 
         public const uint WM_GETTEXT = 0x000D;
         public const uint WM_GETTEXTLENGTH = 0x000E;
@@ -171,20 +150,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
 
         [DllImport(User32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern IntPtr SendMessage(IntPtr hWnd, uint uMsg, IntPtr wParam, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder lParam);
-
-        [DllImport(User32, SetLastError = true)]
-        public static extern IntPtr SetActiveWindow(IntPtr hWnd);
-
-        [DllImport(User32, SetLastError = true)]
-        public static extern IntPtr SetFocus(IntPtr hWnd);
-
-        [DllImport(User32, SetLastError = false)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool SetForegroundWindow(IntPtr hWnd);
-
-        [DllImport(User32, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool SetWindowPos(IntPtr hWnd, [Optional] IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
         [DllImport(User32, SetLastError = true)]
         public static extern IntPtr GetLastActivePopup(IntPtr hWnd);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
@@ -186,6 +186,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool SetWindowPos(IntPtr hWnd, [Optional] IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
+        [DllImport(User32, SetLastError = true)]
+        public static extern IntPtr GetLastActivePopup(IntPtr hWnd);
+
+        [DllImport(User32, SetLastError = true)]
+        public static extern void SwitchToThisWindow(IntPtr hWnd, [MarshalAs(UnmanagedType.Bool)] bool fUnknown);
+
         [DllImport(User32, CharSet = CharSet.Unicode)]
         public static extern short VkKeyScan(char ch);
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
@@ -133,10 +133,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
 
         [DllImport(User32, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, [MarshalAs(UnmanagedType.Bool)] bool fAttach);
-
-        [DllImport(User32, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool BlockInput([MarshalAs(UnmanagedType.Bool)] bool fBlockIt);
 
         [DllImport(User32, SetLastError = true)]

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -160,8 +160,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             return (T)Activator.GetObject(typeof(T), $"{_integrationService.BaseUri}/{objectUri}");
         }
 
-        public void ActivateMainWindow(bool skipAttachingThreads = false)
-            => _inProc.ActivateMainWindow(skipAttachingThreads);
+        public void ActivateMainWindow()
+            => _inProc.ActivateMainWindow();
 
         public void WaitForApplicationIdle(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Switch from `SetForegroundWindow` to `SwitchToThisWindow` to bring a window to the front. The latter is used by Task Manager's "Switch To" functionality, and doesn't have the same restrictions regarding the state of the window manager prior to the call.