### PR TITLE
Add support for number range matching

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -553,6 +553,71 @@ RoOt = TruE");
         }
 
         [Fact]
+        public void NumberMatch()
+        {
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("{0..10}").Value;
+            Assert.Equal("^.*/(-?[0-9]+)$", matcher.Regex.ToString());
+
+            Assert.True(matcher.IsMatch("/0"));
+            Assert.True(matcher.IsMatch("/10"));
+            Assert.True(matcher.IsMatch("/5"));
+            Assert.True(matcher.IsMatch("/000005"));
+            Assert.False(matcher.IsMatch("/-1"));
+            Assert.False(matcher.IsMatch("/-00000001"));
+            Assert.False(matcher.IsMatch("/11"));
+        }
+
+        [Fact]
+        public void NumberMatchNegativeRange()
+        {
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("{-10..0}").Value;
+            Assert.Equal("^.*/(-?[0-9]+)$", matcher.Regex.ToString());
+
+            Assert.True(matcher.IsMatch("/0"));
+            Assert.True(matcher.IsMatch("/-10"));
+            Assert.True(matcher.IsMatch("/-5"));
+            Assert.False(matcher.IsMatch("/1"));
+            Assert.False(matcher.IsMatch("/-11"));
+            Assert.False(matcher.IsMatch("/--0"));
+        }
+
+        [Fact]
+        public void NumberMatchNegToPos()
+        {
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("{-10..10}").Value;
+            Assert.Equal("^.*/(-?[0-9]+)$", matcher.Regex.ToString());
+
+            Assert.True(matcher.IsMatch("/0"));
+            Assert.True(matcher.IsMatch("/-5"));
+            Assert.True(matcher.IsMatch("/5"));
+            Assert.True(matcher.IsMatch("/-10"));
+            Assert.True(matcher.IsMatch("/10"));
+            Assert.False(matcher.IsMatch("/-11"));
+            Assert.False(matcher.IsMatch("/11"));
+            Assert.False(matcher.IsMatch("/--0"));
+        }
+
+        [Fact]
+        public void MultipleNumberRanges()
+        {
+            SectionNameMatcher matcher = TryCreateSectionNameMatcher("a{-10..0}b{0..10}").Value;
+
+            Assert.True(matcher.IsMatch("/a0b0"));
+            Assert.True(matcher.IsMatch("/a-5b0"));
+            Assert.True(matcher.IsMatch("/a-5b5"));
+            Assert.True(matcher.IsMatch("/a-5b10"));
+            Assert.True(matcher.IsMatch("/a-10b10"));
+            Assert.True(matcher.IsMatch("/a-10b0"));
+            Assert.True(matcher.IsMatch("/a-0b0"));
+            Assert.True(matcher.IsMatch("/a-0b-0"));
+
+            Assert.False(matcher.IsMatch("/a-11b10"));
+            Assert.False(matcher.IsMatch("/a-11b10"));
+            Assert.False(matcher.IsMatch("/a-10b11"));
+        }
+
+
+        [Fact]
         public void EditorConfigToDiagnostics()
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -10,14 +14,39 @@ namespace Microsoft.CodeAnalysis
     {
         public readonly struct SectionNameMatcher
         {
+            private readonly ImmutableArray<(int minValue, int maxValue)> _numberRangePairs;
             internal Regex Regex { get; }
 
-            internal SectionNameMatcher(Regex regex)
+            internal SectionNameMatcher(
+                Regex regex,
+                ImmutableArray<(int minValue, int maxValue)> numberRangePairs)
             {
+                Debug.Assert(regex.GetGroupNumbers().Length - 1 == numberRangePairs.Length);
                 Regex = regex;
+                _numberRangePairs = numberRangePairs;
             }
 
-            public bool IsMatch(string s) => Regex.IsMatch(s);
+            public bool IsMatch(string s)
+            {
+                var match = Regex.Match(s);
+                if (!match.Success)
+                {
+                    return false;
+                }
+                Debug.Assert(match.Groups.Count - 1 == _numberRangePairs.Length);
+                for (int i = 0; i < _numberRangePairs.Length; i++)
+                {
+                    var expectedRange = _numberRangePairs[i];
+                    // Index 0 is the whole regex
+                    if (!int.TryParse(match.Groups[i + 1].Value, out int matchedNum) ||
+                        matchedNum < expectedRange.minValue ||
+                        matchedNum > expectedRange.maxValue)
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
         }
 
         /// <summary>
@@ -36,9 +65,6 @@ namespace Microsoft.CodeAnalysis
             // <char> ::= any unicode character
             // <choice> ::= "{" <choice-list> "}"
             // <choice-list> ::= <path-list> | <path-list> "," <choice-list>
-            //
-            // PROTOTYPE(editorconfig): Below remains unimplemented
-            //
             // <range> ::= "{" <integer> ".." <integer> "}"
             // <integer> ::= "-" <digit-list> | <digit-list>
             // <digit-list> ::= <digit> | <digit> <digit-list>
@@ -67,12 +93,15 @@ namespace Microsoft.CodeAnalysis
             }
 
             var lexer = new SectionNameLexer(sectionName);
-            if (!TryCompilePathList(ref lexer, sb))
+            var numberRangePairs = ArrayBuilder<(int minValue, int maxValue)>.GetInstance();
+            if (!TryCompilePathList(ref lexer, sb, parsingChoice: false, numberRangePairs))
             {
                 return null;
             }
             sb.Append('$');
-            return new SectionNameMatcher(new Regex(sb.ToString(), RegexOptions.Compiled));
+            return new SectionNameMatcher(
+                new Regex(sb.ToString(), RegexOptions.Compiled),
+                numberRangePairs.ToImmutableAndFree());
         }
 
         /// <summary>
@@ -87,7 +116,8 @@ namespace Microsoft.CodeAnalysis
         private static bool TryCompilePathList(
             ref SectionNameLexer lexer,
             StringBuilder sb,
-            bool parsingChoice = false)
+            bool parsingChoice,
+            ArrayBuilder<(int minValue, int maxValue)> numberRangePairs)
         {
             while (!lexer.IsDone)
             {
@@ -120,11 +150,11 @@ namespace Microsoft.CodeAnalysis
                         // This is ambiguous between {num..num} and {item1,item2}
                         // We need to look ahead to disambiguate. Looking for {num..num}
                         // is easier because it can't be recursive.
-                        var range = TryParseNumberRange(ref lexer);
-                        if (range is null)
+                        (string numStart, string numEnd)? rangeOpt = TryParseNumberRange(ref lexer);
+                        if (rangeOpt is null)
                         {
                             // Not a number range. Try a choice expression
-                            if (!TryCompileChoice(ref lexer, sb))
+                            if (!TryCompileChoice(ref lexer, sb, numberRangePairs))
                             {
                                 return false;
                             }
@@ -133,7 +163,20 @@ namespace Microsoft.CodeAnalysis
                         }
                         else
                         {
-                            // PROTOTYPE: Implement number range compilation
+                            (string numStart, string numEnd) = rangeOpt.GetValueOrDefault();
+                            if (int.TryParse(numStart, out var intStart) && int.TryParse(numEnd, out var intEnd))
+                            {
+                                var pair = intStart < intEnd ? (intStart, intEnd) : (intEnd, intStart);
+                                numberRangePairs.Add(pair);
+                                // Start the capturing group
+                                sb.Append('(');
+                                // Allow any digit sequence. The validity will be checked outside of the regex
+                                sb.Append("-?[0-9]+");
+                                // Close capturing group
+                                sb.Append(')');
+                                // Keep looping
+                                break;
+                            }
                             return false;
                         }
                     case TokenKind.CloseCurly:
@@ -177,7 +220,10 @@ namespace Microsoft.CodeAnalysis
         /// <choice-list> ::= <path-list> | <path-list> "," <choice-list>
         /// ]]>
         /// </summary>
-        private static bool TryCompileChoice(ref SectionNameLexer lexer, StringBuilder sb)
+        private static bool TryCompileChoice(
+            ref SectionNameLexer lexer,
+            StringBuilder sb,
+            ArrayBuilder<(int,int)> numberRangePairs)
         {
             if (lexer.Lex() != TokenKind.OpenCurly)
             {
@@ -189,7 +235,7 @@ namespace Microsoft.CodeAnalysis
 
             // We start immediately after a '{'
             // Try to compile the nested <path-list>
-            while (TryCompilePathList(ref lexer, sb, parsingChoice: true))
+            while (TryCompilePathList(ref lexer, sb, parsingChoice: true, numberRangePairs))
             {
                 // If we've succesfully compiled a <path-list> the last token should
                 // have been a ',' or a '}'
@@ -359,6 +405,8 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
+            public char CurrentCharacter => _sectionName[Position];
+
             /// <summary>
             /// Call after getting <see cref="TokenKind.SimpleCharacter" /> from <see cref="Lex()" />
             /// </summary>
@@ -387,7 +435,6 @@ namespace Microsoft.CodeAnalysis
             /// <summary>
             /// Returns the string representation of a decimal integer, or null if
             /// the current lexeme is not an integer.
-            /// PROTOTYPE: parsing numbers is not completed.
             /// </summary>
             public string TryLexNumber()
             {
@@ -396,13 +443,15 @@ namespace Microsoft.CodeAnalysis
 
                 while (!IsDone)
                 {
-                    char currentChar = EatCurrentCharacter();
+                    char currentChar = CurrentCharacter;
                     if (start && currentChar == '-')
                     {
+                        Position++;
                         sb.Append('-');
                     }
                     else if (char.IsDigit(currentChar))
                     {
+                        Position++;
                         sb.Append(currentChar);
                     }
                     else


### PR DESCRIPTION
The EditorConfig spec supports a matching construct '{number..number}'
in the section header language which matches any number between the
two given numbers.

It turns out that this is a rather obnoxious thing to encode in a regex
(although possible). Instead, I've decided to store the number range in
a side list and match any number in the regex, comparing the ranges
after the fact.