### PR TITLE
Tolerate snippets where Shortcut is null.

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             var snippets = service.GetSnippetsIfAvailable();
             if (isPreProcessorContext)
             {
-                snippets = snippets.Where(snippet => snippet.Shortcut.StartsWith("#", StringComparison.Ordinal));
+                snippets = snippets.Where(snippet => snippet.Shortcut != null && snippet.Shortcut.StartsWith("#", StringComparison.Ordinal));
             }
             var text = await semanticModel.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Simple null-check for snippet.Shortcut in preprocessor context check.