### PR TITLE
Tests for `is` declaration pattern

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -33349,8 +33349,7 @@ class C
             comp.VerifyDiagnostics();
         }
 
-        // https://github.com/dotnet/roslyn/issues/29909: Should not warn on either call to F(string).
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/29909")]
+        [Fact]
         [WorkItem(29909, "https://github.com/dotnet/roslyn/issues/29909")]
         public void IsPattern_02()
         {
@@ -33407,6 +33406,299 @@ class C
                 // (18,19): warning CS8604: Possible null reference argument for parameter 'o' in 'void C.F(object o)'.
                 //                 F(x); // null
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("o", "void C.F(object o)").WithLocation(18, 19));
+        }
+
+        [Fact]
+        public void IsDeclarationPattern_01()
+        {
+            var source =
+@"class Program
+{
+    static void F1(object x1)
+    {
+        if (x1 is string y1)
+        {
+            x1.ToString();
+            y1.ToString();
+        }
+        x1.ToString();
+    }
+    static void F2(object? x2)
+    {
+        if (x2 is string y2)
+        {
+            x2.ToString();
+            y2.ToString();
+        }
+        x2.ToString(); // 1
+    }
+    static void F3(object x3)
+    {
+        x3 = null; // 2
+        if (x3 is string y3)
+        {
+            x3.ToString();
+            y3.ToString();
+        }
+        x3.ToString(); // 3
+    }
+    static void F4(object? x4)
+    {
+        if (x4 == null) return;
+        if (x4 is string y4)
+        {
+            x4.ToString();
+            y4.ToString();
+        }
+        x4.ToString();
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (19,9): warning CS8602: Possible dereference of a null reference.
+                //         x2.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(19, 9),
+                // (23,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x3 = null; // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(23, 14),
+                // (29,9): warning CS8602: Possible dereference of a null reference.
+                //         x3.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(29, 9));
+        }
+
+        [Fact]
+        public void IsDeclarationPattern_02()
+        {
+            var source =
+@"class Program
+{
+    static void F1<T, U>(T t1)
+        where T : class
+        where U : class
+    {
+        if (t1 is U u1)
+        {
+            t1.ToString();
+            u1.ToString();
+        }
+        t1.ToString();
+    }
+    static void F2<T, U>(T t2)
+        where T : class?
+        where U : class
+    {
+        if (t2 is U u2)
+        {
+            t2.ToString();
+            u2.ToString();
+        }
+        t2.ToString(); // 1
+    }
+    static void F3<T, U>(T t3)
+        where T : class
+        where U : class
+    {
+        t3 = null; // 2
+        if (t3 is U u3)
+        {
+            t3.ToString();
+            u3.ToString();
+        }
+        t3.ToString(); // 3
+    }
+    static void F4<T, U>(T t4)
+        where T : class?
+        where U : class
+    {
+        if (t4 == null) return;
+        if (t4 is U u4)
+        {
+            t4.ToString();
+            u4.ToString();
+        }
+        t4.ToString();
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (23,9): warning CS8602: Possible dereference of a null reference.
+                //         t2.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2").WithLocation(23, 9),
+                // (29,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t3 = null; // 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(29, 14),
+                // (35,9): warning CS8602: Possible dereference of a null reference.
+                //         t3.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t3").WithLocation(35, 9));
+        }
+
+        [Fact]
+        public void IsDeclarationPattern_03()
+        {
+            var source =
+@"class Program
+{
+    static void F1<T, U>(T t1)
+    {
+        if (t1 is U u1)
+        {
+            t1.ToString();
+            u1.ToString();
+        }
+        t1.ToString(); // 1
+    }
+    static void F2<T, U>(T t2)
+    {
+        if (t2 == null) return;
+        if (t2 is U u2)
+        {
+            t2.ToString();
+            u2.ToString();
+        }
+        t2.ToString();
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         t1.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1").WithLocation(10, 9));
+        }
+
+        [Fact]
+        public void IsDeclarationPattern_Unassigned_01()
+        {
+            var source =
+@"class Program
+{
+    static void F1(object x1)
+    {
+        if (x1 is string y1)
+        {
+        }
+        else
+        {
+            x1.ToString();
+            y1.ToString(); // 1
+        }
+    }
+    static void F2(object? x2)
+    {
+        if (x2 is string y2)
+        {
+        }
+        else
+        {
+            x2.ToString(); // 2
+            y2.ToString(); // 3
+        }
+    }
+    static void F3(object x3)
+    {
+        x3 = null; // 4
+        if (x3 is string y3)
+        {
+        }
+        else
+        {
+            x3.ToString(); // 5
+            y3.ToString(); // 6
+        }
+    }
+    static void F4(object? x4)
+    {
+        if (x4 == null) return;
+        if (x4 is string y4)
+        {
+        }
+        else
+        {
+            x4.ToString();
+            y4.ToString(); // 7
+        }
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (11,13): error CS0165: Use of unassigned local variable 'y1'
+                //             y1.ToString(); // 1
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y1").WithArguments("y1").WithLocation(11, 13),
+                // (21,13): warning CS8602: Possible dereference of a null reference.
+                //             x2.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(21, 13),
+                // (22,13): error CS0165: Use of unassigned local variable 'y2'
+                //             y2.ToString(); // 3
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y2").WithArguments("y2").WithLocation(22, 13),
+                // (27,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x3 = null; // 4
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(27, 14),
+                // (33,13): warning CS8602: Possible dereference of a null reference.
+                //             x3.ToString(); // 5
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(33, 13),
+                // (34,13): error CS0165: Use of unassigned local variable 'y3'
+                //             y3.ToString(); // 6
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y3").WithArguments("y3").WithLocation(34, 13),
+                // (46,13): error CS0165: Use of unassigned local variable 'y4'
+                //             y4.ToString(); // 7
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y4").WithArguments("y4").WithLocation(46, 13));
+        }
+
+        [Fact]
+        public void IsDeclarationPattern_Unassigned_02()
+        {
+            var source =
+@"class Program
+{
+    static void F1(object x1)
+    {
+        if (x1 is string y1) { }
+        x1.ToString();
+        y1.ToString(); // 1
+    }
+    static void F2(object? x2)
+    {
+        if (x2 is string y2) { }
+        x2.ToString(); // 2
+        y2.ToString(); // 3
+    }
+    static void F3(object x3)
+    {
+        x3 = null; // 4
+        if (x3 is string y3) { }
+        x3.ToString(); // 5
+        y3.ToString(); // 6
+    }
+    static void F4(object? x4)
+    {
+        if (x4 == null) return;
+        if (x4 is string y4) { }
+        x4.ToString();
+        y4.ToString(); // 7
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (7,9): error CS0165: Use of unassigned local variable 'y1'
+                //         y1.ToString(); // 1
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y1").WithArguments("y1").WithLocation(7, 9),
+                // (12,9): warning CS8602: Possible dereference of a null reference.
+                //         x2.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(12, 9),
+                // (13,9): error CS0165: Use of unassigned local variable 'y2'
+                //         y2.ToString(); // 3
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y2").WithArguments("y2").WithLocation(13, 9),
+                // (17,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x3 = null; // 4
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(17, 14),
+                // (19,9): warning CS8602: Possible dereference of a null reference.
+                //         x3.ToString(); // 5
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(19, 9),
+                // (20,9): error CS0165: Use of unassigned local variable 'y3'
+                //         y3.ToString(); // 6
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y3").WithArguments("y3").WithLocation(20, 9),
+                // (27,9): error CS0165: Use of unassigned local variable 'y4'
+                //         y4.ToString(); // 7
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y4").WithArguments("y4").WithLocation(27, 9));
         }
 
         [Fact]


### PR DESCRIPTION
Split out from https://github.com/dotnet/roslyn/pull/31703.