### PR TITLE
 Rename an enum member to be clearer, and add docs as well. 

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -162,7 +162,7 @@ class C
 
             public DiagnosticAnalyzerCategory GetAnalyzerCategory()
             {
-                return DiagnosticAnalyzerCategory.SyntaxAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis | DiagnosticAnalyzerCategory.ProjectAnalysis;
+                return DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis | DiagnosticAnalyzerCategory.ProjectAnalysis;
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingDiagnosticAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingDiagnosticAnalyzer.cs
@@ -19,12 +19,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
         internal const string RenameToPropertyKey = "RenameTo";
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptor);
-        public bool OpenFileOnly(Workspace workspace) => true;
+
+        public DiagnosticAnalyzerCategory GetAnalyzerCategory()
+            => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
+
+        public bool OpenFileOnly(Workspace workspace) 
+            => true;
 
         public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
-        }
+            => context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
 
         private void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
         {
@@ -35,8 +38,5 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 context.ReportDiagnostic(diagnostic);
             }
         }
-
-        public DiagnosticAnalyzerCategory GetAnalyzerCategory()
-            => DiagnosticAnalyzerCategory.SyntaxAnalysis;
     }
 }

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -430,7 +430,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
             public DiagnosticAnalyzerCategory GetAnalyzerCategory()
             {
-                return DiagnosticAnalyzerCategory.SyntaxAnalysis;
+                return DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
             }
 
             public bool OpenFileOnly(Workspace workspace)

--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractSuppressionAllCodeTests.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractSuppressionAllCodeTests.cs
@@ -151,9 +151,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             }
 
             public DiagnosticAnalyzerCategory GetAnalyzerCategory()
-            {
-                return DiagnosticAnalyzerCategory.SyntaxAnalysis;
-            }
+                => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
 
             public override void Initialize(AnalysisContext analysisContext)
             {

--- a/src/Features/Core/Portable/AddAccessibilityModifiers/AbstractAddAccessibilityModifiersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/AddAccessibilityModifiers/AbstractAddAccessibilityModifiersDiagnosticAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.AddAccessibilityModifiers
         }
 
         public sealed override DiagnosticAnalyzerCategory GetAnalyzerCategory()
-            => DiagnosticAnalyzerCategory.SyntaxAnalysis;
+            => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
 
         public sealed override bool OpenFileOnly(Workspace workspace)
             => false;

--- a/src/Features/Core/Portable/ConvertAnonymousTypeToTuple/AbstractConvertAnonymousTypeToTupleDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/ConvertAnonymousTypeToTuple/AbstractConvertAnonymousTypeToTupleDiagnosticAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.ConvertAnonymousTypeToTuple
         protected abstract int GetInitializerCount(TAnonymousObjectCreationExpressionSyntax anonymousType);
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
-            => DiagnosticAnalyzerCategory.SyntaxAnalysis;
+            => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
         public override bool OpenFileOnly(Workspace workspace)
             => false;

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerCategory.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerCategory.cs
@@ -14,8 +14,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         /// <summary>
         /// Analyzer reports syntax diagnostics (i.e. registers a SyntaxTree action).
+        /// Note: an <see cref="DiagnosticAnalyzer"/> that uses this will not work properly if
+        /// it registers a <see cref="AnalysisContext.RegisterSyntaxNodeAction{TLanguageKindEnum}(Action{SyntaxNodeAnalysisContext}, TLanguageKindEnum[])"/> and then ends
+        /// up needing to use the <see cref="SyntaxNodeAnalysisContext.SemanticModel"/>.  If a
+        /// <see cref="SemanticModel"/> is needed, use <see cref="SemanticSpanAnalysis"/> or
+        /// <see cref="SemanticDocumentAnalysis"/>.
         /// </summary>
-        SyntaxAnalysis = 0x0001,
+        SyntaxTreeWithoutSemanticsAnalysis = 0x0001,
 
         /// <summary>
         /// Analyzer reports semantic diagnostics and also supports incremental span based method body analysis.

--- a/src/Features/Core/Portable/Formatting/FormattingDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Formatting/FormattingDiagnosticAnalyzer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         }
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
-            => DiagnosticAnalyzerCategory.SyntaxAnalysis;
+            => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
 
         public override bool OpenFileOnly(Workspace workspace)
             => false;

--- a/src/Features/Core/Portable/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
@@ -28,13 +28,14 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
             _helpers = helpers;
         }
 
-        public override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SyntaxAnalysis;
-        public override bool OpenFileOnly(Workspace workspace) => false;
+        public override DiagnosticAnalyzerCategory GetAnalyzerCategory() 
+            => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
+
+        public override bool OpenFileOnly(Workspace workspace)
+            => false;
 
         protected override void InitializeWorker(AnalysisContext context)
-        {
-            context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
-        }
+            => context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
 
         private void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
         {

--- a/src/Features/Core/Portable/Shared/Extensions/DiagnosticAnalyzerExtensions.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/DiagnosticAnalyzerExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             if (analyzer is DocumentDiagnosticAnalyzer)
             {
-                category |= DiagnosticAnalyzerCategory.SyntaxAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
+                category |= DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
             }
             else if (analyzer is ProjectDiagnosticAnalyzer)
             {
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 {
                     // It is not possible to know the categorization for a public analyzer,
                     // so return a worst-case categorization.
-                    category = (DiagnosticAnalyzerCategory.SyntaxAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis | DiagnosticAnalyzerCategory.ProjectAnalysis);
+                    category = (DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis | DiagnosticAnalyzerCategory.ProjectAnalysis);
                 }
             }
 
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static bool SupportsSyntaxDiagnosticAnalysis(this DiagnosticAnalyzer analyzer)
         {
             var category = analyzer.GetDiagnosticAnalyzerCategory();
-            return (category & DiagnosticAnalyzerCategory.SyntaxAnalysis) != 0;
+            return (category & DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis) != 0;
         }
 
         public static bool SupportsSemanticDiagnosticAnalysis(this DiagnosticAnalyzer analyzer)


### PR DESCRIPTION
Note: i decided against SyntaxTreeAnalysis as i really wanted the member to be very visible asnot being appropriate if you do anything the semantic model.  With this name, my hope is that PRs are easier because someone would see this and then more readily notice if the semantic model was used.