### PR TITLE
Add guard to DisposeAsync

### DIFF
--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -118,7 +118,7 @@ See more details about those types at https://blogs.msdn.microsoft.com/dotnet/20
 
 Compared to the state machine for a regular async method, the `MoveNext()` for an async-iterator method adds logic:
 - to support handling a `yield return` statement, which saves the current value and fulfills the promise with result `true`,
-- to support handling a `yield break` statement, which sets the dispose mode on and jumps to the closest `finally` or exit,
+- to support handling a `yield break` statement, which sets the dispose mode on and jumps to the enclosing `finally` or exit,
 - to dispatch execution to `finally` blocks (when disposing),
 - to exit the method, which fulfills the promise with result `false`,
 - to catch exceptions, which set the exception into the promise.
@@ -156,12 +156,13 @@ IAsyncEnumerator<T> GetAsyncEnumerator()
     {StateMachineType} result;
     if (initialThreadId == /*managedThreadId*/ && state == StateMachineStates.FinishedStateMachine)
     {
-        state = StateMachineStates.NotStartedStateMachine;
+        state = InitialState; // -3
+        disposeMode = false;
         result = this;
     }
     else
     {
-        result = new {StateMachineType}(StateMachineStates.NotStartedStateMachine);
+        result = new {StateMachineType}(InitialState);
     }
     /* copy all of the parameter proxies */
 }
@@ -185,26 +186,26 @@ In contrast, async methods continue running autonomously until they are done. Th
 
 In summary, disposal of an async-iterator works based on four design elements:
 - `yield return` (jumps to finally when resuming in dispose mode)
-- `yield break` (enters dispose mode and jumps to finally)
-- `finally` (after a `finally` we jump to the next one)
+- `yield break` (enters dispose mode and jumps to enclosing finally)
+- `finally` (after a `finally` we jump to the next enclosing one)
 - `DisposeAsync` (enters dispose mode and resumes execution)
 
 The caller of an async-iterator method should only call `DisposeAsync()` when the method completed or was suspended by a `yield return`.
 `DisposeAsync` sets a flag on the state machine ("dispose mode") and (if the method wasn't completed) resumes the execution from the current state.
 The state machine can resume execution from a given state (even those located within a `try`).
-When the execution is resumed in dispose mode, it jumps straight to the relevant `finally`.
+When the execution is resumed in dispose mode, it jumps straight to the enclosing `finally`.
 `finally` blocks may involve pauses and resumes, but only for `await` expressions. As a result of the restrictions imposed on `yield return` (described above), dispose mode never runs into a `yield return`.
-Once a `finally` block completes, the execution in dispose mode jumps to the next relevant `finally`, or the end of the method once we reach the top-level.
+Once a `finally` block completes, the execution in dispose mode jumps to the next enclosing `finally`, or the end of the method once we reach the top-level.
 
-Reaching a `yield break` also sets the dispose mode flag and jumps to the next relevant `finally` (or end of the method).
+Reaching a `yield break` also sets the dispose mode flag and jumps to the enclosing `finally` (or end of the method).
 By the time we return control to the caller (completing the promise as `false` by reaching the end of the method) all disposal was completed,
 and the state machine is left in finished state. So `DisposeAsync()` has no work left to do.
 
 Looking at disposal from the perspective of a given `finally` block, the code in that block can get executed:
 - by normal execution (ie. after the code in the `try` block),
 - by raising an exception inside the `try` block (which will execute the necessary `finally` blocks and terminate the method in Finished state),
-- by calling `DisposeAsync()` (which resumes execution in dispose mode and jumps to the relevant finally),
-- following a `yield break` (which enters dispose mode and jumps to the relevant finally),
+- by calling `DisposeAsync()` (which resumes execution in dispose mode and jumps to the enclosing finally),
+- following a `yield break` (which enters dispose mode and jumps to the enclosing finally),
 - in dispose mode, following a nested `finally`.
 
 A `yield return` is lowered as:
@@ -228,16 +229,19 @@ disposeMode = true;
 ```C#
 ValueTask IAsyncDisposable.DisposeAsync()
 {
-    disposeMode = true;
-    if (state == StateMachineStates.FinishedStateMachine ||
-        state == StateMachineStates.NotStartedStateMachine)
+    if (state >= StateMachineStates.NotStartedStateMachine /* -1 */)
+    {
+        throw new NotSupportedException();
+    }
+    if (state == StateMachineStates.FinishedStateMachine /* -2 */)
     {
         return default;
     }
+    disposeMode = true;
     _valueOrEndPromise.Reset();
     var inst = this;
     _builder.Start(ref inst);
-    return new ValueTask(this, _valueOrEndPromise.Version); // note this leverages the state machine's implementation of IValueTaskSource
+    return new ValueTask(this, _valueOrEndPromise.Version);  // note this leverages the state machine's implementation of IValueTaskSource
 }
 ```
 
@@ -274,39 +278,46 @@ finallyEntryLabel:
 }
 ```
 
-In both cases, we will add a `if (disposeMode) /* jump to next finally or exit */` after the block for `finally` logic.
+In both cases, we will add a `if (disposeMode) /* jump to enclosing finally or exit */` after the block for `finally` logic.
 
 #### State values and transitions
 
 The enumerable starts with state -2.
-Calling GetAsyncEnumerator sets the state to -1, or returns a fresh enumerator (also with state -1).
+Calling GetAsyncEnumerator sets the state to -3, or returns a fresh enumerator (also with state -3).
 
 From there, MoveNext will either:
-- reach the end of the method (-2)
-- reach a `yield break` (-1, dispose mode = true)
-- reach a `yield return` or `await` (N)
+- reach the end of the method (-2, we're done and disposed)
+- reach a `yield break` (state unchanged, dispose mode = true)
+- reach a `yield return` (-N, decreasing from -4)
+- reach an `await` (N, increasing from 0)
 
-From suspended state N, MoveNext will resume execution (-1).
-But if the suspension was a `yield return`, you could also call DisposeAsync, which resumes execution (-1) in dispose mode.
+From suspended state N or -N, MoveNext will resume execution (-1).
+But if the suspension was a `yield return` (-N), you could also call DisposeAsync, which resumes execution (-1) in dispose mode.
 
 When in dispose mode, MoveNext continues to suspend (N) and resume (-1) until the end of the method is reached (-2).
 
+The result of invoking `DisposeAsync` from states -1 or N is unspecified. This compiler throws `NotSupportException` for those cases.
+
 ```
-   GetAsyncEnumerator    suspension (yield return, await)
--2 -----------------> -1 -------------------------------> N
- ^                   |  ^                                 |   Dispose mode = false
- | done and disposed |  |          resuming               |
- +-------------------+  +---------------------------------+
- |                   |                                    |
- |                   |                                    |
- |             yield |                                    |
- |             break |           DisposeAsync             |
- |                   |  +---------------------------------+
- |                   |  |
- |                   |  |
- | done and disposed v  v     suspension (await)
- +------------------- -1 -------------------------------> N
-                        ^                                 |   Dispose mode = true
-                        |          resuming               |
-                        +---------------------------------+
+        DisposeAsync                              await
+ +------------------------+             +------------------------> N
+ |                        |             |                          |
+ v   GetAsyncEnumerator   |             |        resuming          |
+-2 --------------------> -3 --------> -1 <-------------------------+    Dispose mode = false
+ ^                                   |  |                          |
+ |         done and disposed         |  |      yield return        |
+ +-----------------------------------+  +-----------------------> -N
+ |                                   |                             |
+ |                                   |                             |
+ |                             yield |                             |
+ |                             break |           DisposeAsync      |
+ |                                   |  +--------------------------+
+ |                                   |  |
+ |                                   |  |
+ |         done and disposed         v  v    suspension (await)
+ +----------------------------------- -1 ------------------------> N
+                                        ^                          |    Dispose mode = true
+                                        |         resuming         |
+                                        +--------------------------+
 ```
+

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// States for `yield return` are decreasing from -3.
         /// </summary>
-        private int _nextYieldReturnState = StateMachineStates.FinishedStateMachine - 1;  // -3
+        private int _nextYieldReturnState = StateMachineStates.InitialAsyncIteratorStateMachine;  // -3
 
         internal AsyncIteratorMethodToStateMachineRewriter(MethodSymbol method,
             int methodOrdinal,

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
@@ -11,8 +11,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     /// <summary>
     /// Produces a MoveNext() method for an async-iterator method.
-    /// Compared to an async method, this handles rewriting `yield return` and
+    /// Compared to an async method, this handles rewriting `yield return` (with states decreasing from -3) and
     /// `yield break`, and adds special handling for `try` to allow disposal.
+    /// `await` is handled like in async methods (with states 0 and up).
     /// </summary>
     internal sealed class AsyncIteratorMethodToStateMachineRewriter : AsyncMethodToStateMachineRewriter
     {
@@ -26,10 +27,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         private LabelSymbol _enclosingFinallyOrExitLabel;
 
         /// <summary>
-        /// We use _exprReturnLabel for normal end of method (ie. no more values).
+        /// We use _exprReturnLabel for normal end of method (ie. no more values) and `yield break;`.
         /// We use _exprReturnLabelTrue for `yield return;`.
         /// </summary>
         private readonly LabelSymbol _exprReturnLabelTrue;
+
+        /// <summary>
+        /// States for `yield return` are decreasing from -3.
+        /// </summary>
+        private int _nextYieldReturnState = StateMachineStates.FinishedStateMachine - 1;  // -3
 
         internal AsyncIteratorMethodToStateMachineRewriter(MethodSymbol method,
             int methodOrdinal,
@@ -114,14 +120,44 @@ namespace Microsoft.CodeAnalysis.CSharp
                 GenerateJumpToCurrentFinallyOrExit());
         }
 
+        protected override BoundBinaryOperator ShouldEnterFinallyBlock()
+        {
+            // We should skip the finally block when:
+            // - the state is 0 or greater (we're suspending on an `await`)
+            // - the state is -3, -4 or lower (we're suspending on a `yield return`)
+            // We don't care about state = -2 (method already completed)
+
+            // So we only want to enter the finally when the state is -1
+            return F.IntEqual(F.Local(cachedState), F.Literal(StateMachineStates.NotStartedStateMachine));
+        }
+
         #region Visitors
 
+        /// <summary>
+        /// Lower the body, adding an entry state (-3) at the start,
+        /// so that we can differentiate a async-iterator that was never moved forward with MoveNextAsync()
+        /// from one that is running (-1).
+        /// Then we can guard against some bad usages of DisposeAsync.
+        /// </summary>
         protected override BoundStatement VisitBody(BoundStatement body)
         {
+            // Produce:
+            //  initialStateResumeLabel:
+            //  if (disposeMode) goto _exprReturnLabel;
+            //  this.state = cachedState = -1;
+            //  ... rewritten body
+
+            var initialState = _nextYieldReturnState--;
+            Debug.Assert(initialState == -3);
+            AddState(initialState, out GeneratedLabelSymbol resumeLabel);
+
+            var rewrittenBody = (BoundStatement)Visit(body);
+
             return F.Block(
-                // disposeMode = false;
-                SetDisposeMode(false),
-                (BoundStatement)Visit(body));
+                F.Label(resumeLabel), // initialStateResumeLabel:
+                GenerateJumpToCurrentFinallyOrExit(), // if (disposeMode) goto _exprReturnLabel;
+                GenerateSetBothStates(StateMachineStates.NotStartedStateMachine), // this.state = cachedState = -1;
+                rewrittenBody);
         }
 
         public override BoundNode VisitYieldReturnStatement(BoundYieldReturnStatement node)
@@ -138,7 +174,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             //  _promiseOfValueOrEnd.SetResult(true);
             //  return;
 
-            AddState(out int stateNumber, out GeneratedLabelSymbol resumeLabel);
+            var stateNumber = _nextYieldReturnState--;
+            AddState(stateNumber, out GeneratedLabelSymbol resumeLabel);
 
             var rewrittenExpression = (BoundExpression)Visit(node.Expression);
             var blockBuilder = ArrayBuilder<BoundStatement>.GetInstance();
@@ -200,8 +237,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// to restore execution from a given state, without executing other code to get there).
         ///
         /// From there, we don't want normal code flow:
-        /// - from `yield return`, we'll jump to the relevant `finally` (or method exit)
-        /// - after finishing a `finally`, we'll jump to the next relevant `finally` (or method exit)
+        /// - from `yield return`, we'll jump to the enclosing `finally` (or method exit)
+        /// - after finishing a `finally`, we'll jump to the next enclosing `finally` (or method exit)
         ///
         /// Some `finally` clauses may have already been rewritten and extracted to a plain block (<see cref="AsyncExceptionHandlerRewriter"/>).
         /// In those cases, we saved the finally-entry label in <see cref="BoundTryStatement.FinallyLabelOpt"/>.

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Awaiters of the same type always share the same slot, regardless of what await expressions they belong to.
             // Even in case of nested await expressions only one awaiter is active.
-            // So we don't need to tie the awaiter variable to a particular await expression and only use its type 
+            // So we don't need to tie the awaiter variable to a particular await expression and only use its type
             // to find the previous awaiter field.
             if (!_awaiterFields.TryGetValue(awaiterType, out result))
             {
@@ -250,9 +250,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         #region Visitors
 
         protected virtual BoundStatement VisitBody(BoundStatement body)
-        {
-            return (BoundStatement)Visit(body);
-        }
+            => (BoundStatement)Visit(body);
 
         public sealed override BoundNode VisitExpressionStatement(BoundExpressionStatement node)
         {
@@ -440,13 +438,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundStatement GenerateAwaitOnCompletedDynamic(LocalSymbol awaiterTemp)
         {
             //  temp $criticalNotifyCompletedTemp = $awaiterTemp as ICriticalNotifyCompletion
-            //  if ($criticalNotifyCompletedTemp != null) 
+            //  if ($criticalNotifyCompletedTemp != null)
             //  {
             //    this.builder.AwaitUnsafeOnCompleted<ICriticalNotifyCompletion,TSM>(
-            //      ref $criticalNotifyCompletedTemp, 
+            //      ref $criticalNotifyCompletedTemp,
             //      ref this)
-            //  } 
-            //  else 
+            //  }
+            //  else
             //  {
             //    temp $notifyCompletionTemp = (INotifyCompletion)$awaiterTemp
             //    this.builder.AwaitOnCompleted<INotifyCompletion,TSM>(ref $notifyCompletionTemp, ref this)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -23,9 +23,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // false if it implements IAsyncEnumerator<T>
             private readonly bool _isEnumerable;
 
-            // We use state=-3 to distinguish the initial state from the running state (-1)
-            private const int InitialState = -3;
-
             internal AsyncIteratorRewriter(
                 BoundStatement body,
                 MethodSymbol method,
@@ -170,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             protected override void InitializeStateMachine(ArrayBuilder<BoundStatement> bodyBuilder, NamedTypeSymbol frameType, LocalSymbol stateMachineLocal)
             {
                 // var stateMachineLocal = new {StateMachineType}({initialState})
-                int initialState = _isEnumerable ? StateMachineStates.FinishedStateMachine : InitialState;
+                int initialState = _isEnumerable ? StateMachineStates.FinishedStateMachine : StateMachineStates.InitialAsyncIteratorStateMachine;
                 bodyBuilder.Add(
                     F.Assignment(
                         F.Local(stateMachineLocal),
@@ -534,7 +531,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     .AsMember(IAsyncEnumerableOfElementType);
 
                 BoundExpression managedThreadId = null;
-                GenerateIteratorGetEnumerator(IAsyncEnumerableOfElementType_GetEnumerator, ref managedThreadId, initialState: InitialState);
+                GenerateIteratorGetEnumerator(IAsyncEnumerableOfElementType_GetEnumerator, ref managedThreadId, initialState: StateMachineStates.InitialAsyncIteratorStateMachine);
             }
 
             protected override BoundStatement GetExtraResetForIteratorGetEnumerator()

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -201,19 +201,24 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             stateNumber = _nextState++;
 
-            if (_dispatches == null)
-            {
-                _dispatches = new Dictionary<LabelSymbol, List<int>>();
-            }
-
             if (_useFinalizerBookkeeping && !_hasFinalizerState)
             {
                 _currentFinalizerState = _nextState++;
                 _hasFinalizerState = true;
             }
 
+            AddState(stateNumber, out resumeLabel);
+        }
+
+        protected void AddState(int stateNumber, out GeneratedLabelSymbol resumeLabel)
+        {
+            if (_dispatches == null)
+            {
+                _dispatches = new Dictionary<LabelSymbol, List<int>>();
+            }
+
             resumeLabel = F.GenerateLabel("stateMachine");
-            List<int> states = new List<int>();
+            var states = new List<int>();
             states.Add(stateNumber);
             _dispatches.Add(resumeLabel, states);
         }
@@ -832,7 +837,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundBlock finallyBlockOpt = node.FinallyBlockOpt == null ? null : F.Block(
                 F.HiddenSequencePoint(),
                 F.If(
-                    condition: F.IntLessThan(F.Local(cachedState), F.Literal(StateMachineStates.FirstUnusedState)),
+                    condition: ShouldEnterFinallyBlock(),
                     thenClause: (BoundBlock)this.Visit(node.FinallyBlockOpt)
                 ),
                 F.HiddenSequencePoint());
@@ -848,6 +853,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return result;
+        }
+
+        protected virtual BoundBinaryOperator ShouldEnterFinallyBlock()
+        {
+            return F.IntLessThan(F.Local(cachedState), F.Literal(StateMachineStates.FirstUnusedState));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -393,7 +393,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 managedThreadId = MakeCurrentThreadId();
 
-                var thenBuilder = ArrayBuilder<BoundStatement>.GetInstance();
+                var thenBuilder = ArrayBuilder<BoundStatement>.GetInstance(4);
                 thenBuilder.Add(
                     // this.state = {initialState};
                     F.Assignment(F.Field(F.This(), stateField), F.Literal(initialState)));

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -365,6 +366,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //    if (this.initialThreadId == {managedThreadId} && this.state == -2)
             //    {
             //        this.state = {initialState};
+            //        extraReset
             //        result = this;
             //    }
             //    else
@@ -390,18 +392,33 @@ namespace Microsoft.CodeAnalysis.CSharp
             if ((object)initialThreadIdField != null)
             {
                 managedThreadId = MakeCurrentThreadId();
+
+                var thenBuilder = ArrayBuilder<BoundStatement>.GetInstance();
+                thenBuilder.Add(
+                    // this.state = {initialState};
+                    F.Assignment(F.Field(F.This(), stateField), F.Literal(initialState)));
+
+                thenBuilder.Add(
+                    // result = this;
+                    F.Assignment(F.Local(resultVariable), F.This()));
+
+                var extraReset = GetExtraResetForIteratorGetEnumerator();
+                if (extraReset != null)
+                {
+                    thenBuilder.Add(extraReset);
+                }
+
+                thenBuilder.Add(
+                    method.IsStatic || method.ThisParameter.Type.IsReferenceType ? // if this is a reference type, no need to copy it since it is not assignable
+                        F.Goto(thisInitialized) : // goto thisInitialized
+                        (BoundStatement)F.StatementList());
+
                 makeIterator = F.If(
                     // if (this.state == -2 && this.initialThreadId == Thread.CurrentThread.ManagedThreadId)
                     condition: F.LogicalAnd(
-                            F.IntEqual(F.Field(F.This(), stateField), F.Literal(StateMachineStates.FinishedStateMachine)),
+                        F.IntEqual(F.Field(F.This(), stateField), F.Literal(StateMachineStates.FinishedStateMachine)),
                         F.IntEqual(F.Field(F.This(), initialThreadIdField), managedThreadId)),
-                    thenClause: F.Block(
-                            F.Assignment(F.Field(F.This(), stateField), F.Literal(initialState)), // this.state = {initialState};
-                            F.Assignment(F.Local(resultVariable), F.This()), // result = this;
-                            method.IsStatic || method.ThisParameter.Type.IsReferenceType ? // if this is a reference type, no need to copy it since it is not assignable
-                                F.Goto(thisInitialized) : // goto thisInitialized
-                                (BoundStatement)F.StatementList()),
-                    // else result = new {StateMachineType}({initialState})
+                    thenClause: F.Block(thenBuilder.ToImmutableAndFree()),
                     elseClauseOpt: makeIterator);
             }
 
@@ -441,6 +458,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             F.CloseMethod(F.Block(ImmutableArray.Create(resultVariable), bodyBuilder.ToImmutableAndFree()));
             return getEnumerator;
         }
+
+        /// <summary>
+        /// Async-iterator methods use a GetAsyncEnumerator method just like the GetEnumerator of iterator methods.
+        /// But they need to do a bit more work (to reset the dispose mode).
+        /// </summary>
+        protected virtual BoundStatement GetExtraResetForIteratorGetEnumerator() => null;
 
         /// <summary>
         /// Returns true if either Thread.ManagedThreadId or Environment.CurrentManagedThreadId are available

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineStates.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineStates.cs
@@ -7,5 +7,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal const int FinishedStateMachine = -2;
         internal const int NotStartedStateMachine = -1;
         internal const int FirstUnusedState = 0;
+
+        // used for async-iterators to distinguish initial state from running state (-1) so that DisposeAsync can throw in latter case
+        internal const int InitialAsyncIteratorStateMachine = -3;
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -559,6 +559,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Binary(BinaryOperatorKind.IntLessThan, SpecialType(Microsoft.CodeAnalysis.SpecialType.System_Boolean), left, right);
         }
 
+        public BoundBinaryOperator IntGreaterThanOrEqual(BoundExpression left, BoundExpression right)
+        {
+            return Binary(BinaryOperatorKind.IntGreaterThanOrEqual, SpecialType(CodeAnalysis.SpecialType.System_Boolean), left, right);
+        }
+
         public BoundLiteral Literal(int value)
         {
             return new BoundLiteral(Syntax, ConstantValue.Create(value), SpecialType(Microsoft.CodeAnalysis.SpecialType.System_Int32)) { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -145,7 +145,7 @@ class C
         return CapturedRandom.Next(50, 100);
     }
 }");
-            CompileAndVerify(comp);
+            CompileAndVerify(comp, verify: Verification.Skipped);
         }
 
         [Fact]
@@ -172,7 +172,7 @@ class C
         }
     }
 }", TestOptions.ReleaseExe);
-            var verifier = CompileAndVerify(comp, expectedOutput: @"
+            CompileAndVerify(comp, expectedOutput: @"
 2
 8");
         }
@@ -1655,66 +1655,71 @@ class C
 }");
                 verifier.VerifyIL("C.<M>d__0.System.IAsyncDisposable.DisposeAsync()", @"
 {
-  // Code size       80 (0x50)
+  // Code size       86 (0x56)
   .maxstack  2
   .locals init (C.<M>d__0 V_0,
                 System.Threading.Tasks.ValueTask V_1)
   IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.1
-  IL_0002:  stfld      ""bool C.<M>d__0.<>w__disposeMode""
-  IL_0007:  ldarg.0
-  IL_0008:  ldfld      ""int C.<M>d__0.<>1__state""
-  IL_000d:  ldc.i4.s   -2
-  IL_000f:  beq.s      IL_001a
-  IL_0011:  ldarg.0
-  IL_0012:  ldfld      ""int C.<M>d__0.<>1__state""
-  IL_0017:  ldc.i4.m1
-  IL_0018:  bne.un.s   IL_0024
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  initobj    ""System.Threading.Tasks.ValueTask""
-  IL_0022:  ldloc.1
-  IL_0023:  ret
-  IL_0024:  ldarg.0
-  IL_0025:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-  IL_002a:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.Reset()""
-  IL_002f:  ldarg.0
-  IL_0030:  stloc.0
-  IL_0031:  ldarg.0
-  IL_0032:  ldflda     ""System.Runtime.CompilerServices.AsyncIteratorMethodBuilder C.<M>d__0.<>t__builder""
-  IL_0037:  ldloca.s   V_0
-  IL_0039:  call       ""void System.Runtime.CompilerServices.AsyncIteratorMethodBuilder.MoveNext<C.<M>d__0>(ref C.<M>d__0)""
-  IL_003e:  ldarg.0
-  IL_003f:  ldarg.0
-  IL_0040:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-  IL_0045:  call       ""short System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.Version.get""
-  IL_004a:  newobj     ""System.Threading.Tasks.ValueTask..ctor(System.Threading.Tasks.Sources.IValueTaskSource, short)""
-  IL_004f:  ret
+  IL_0001:  ldfld      ""int C.<M>d__0.<>1__state""
+  IL_0006:  ldc.i4.m1
+  IL_0007:  blt.s      IL_000f
+  IL_0009:  newobj     ""System.NotSupportedException..ctor()""
+  IL_000e:  throw
+  IL_000f:  ldarg.0
+  IL_0010:  ldfld      ""int C.<M>d__0.<>1__state""
+  IL_0015:  ldc.i4.s   -2
+  IL_0017:  bne.un.s   IL_0023
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  initobj    ""System.Threading.Tasks.ValueTask""
+  IL_0021:  ldloc.1
+  IL_0022:  ret
+  IL_0023:  ldarg.0
+  IL_0024:  ldc.i4.1
+  IL_0025:  stfld      ""bool C.<M>d__0.<>w__disposeMode""
+  IL_002a:  ldarg.0
+  IL_002b:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+  IL_0030:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.Reset()""
+  IL_0035:  ldarg.0
+  IL_0036:  stloc.0
+  IL_0037:  ldarg.0
+  IL_0038:  ldflda     ""System.Runtime.CompilerServices.AsyncIteratorMethodBuilder C.<M>d__0.<>t__builder""
+  IL_003d:  ldloca.s   V_0
+  IL_003f:  call       ""void System.Runtime.CompilerServices.AsyncIteratorMethodBuilder.MoveNext<C.<M>d__0>(ref C.<M>d__0)""
+  IL_0044:  ldarg.0
+  IL_0045:  ldarg.0
+  IL_0046:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+  IL_004b:  call       ""short System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.Version.get""
+  IL_0050:  newobj     ""System.Threading.Tasks.ValueTask..ctor(System.Threading.Tasks.Sources.IValueTaskSource, short)""
+  IL_0055:  ret
 }
 ");
                 verifier.VerifyIL("C.<M>d__0.System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator()", @"
 {
-  // Code size       43 (0x2b)
+  // Code size       52 (0x34)
   .maxstack  2
   .locals init (C.<M>d__0 V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<M>d__0.<>1__state""
   IL_0006:  ldc.i4.s   -2
-  IL_0008:  bne.un.s   IL_0022
+  IL_0008:  bne.un.s   IL_002a
   IL_000a:  ldarg.0
   IL_000b:  ldfld      ""int C.<M>d__0.<>l__initialThreadId""
   IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
-  IL_0015:  bne.un.s   IL_0022
+  IL_0015:  bne.un.s   IL_002a
   IL_0017:  ldarg.0
-  IL_0018:  ldc.i4.m1
-  IL_0019:  stfld      ""int C.<M>d__0.<>1__state""
-  IL_001e:  ldarg.0
-  IL_001f:  stloc.0
-  IL_0020:  br.s       IL_0029
-  IL_0022:  ldc.i4.m1
-  IL_0023:  newobj     ""C.<M>d__0..ctor(int)""
-  IL_0028:  stloc.0
-  IL_0029:  ldloc.0
-  IL_002a:  ret
+  IL_0018:  ldc.i4.s   -3
+  IL_001a:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_001f:  ldarg.0
+  IL_0020:  stloc.0
+  IL_0021:  ldarg.0
+  IL_0022:  ldc.i4.0
+  IL_0023:  stfld      ""bool C.<M>d__0.<>w__disposeMode""
+  IL_0028:  br.s       IL_0032
+  IL_002a:  ldc.i4.s   -3
+  IL_002c:  newobj     ""C.<M>d__0..ctor(int)""
+  IL_0031:  stloc.0
+  IL_0032:  ldloc.0
+  IL_0033:  ret
 }");
                 verifier.VerifyIL("C.<M>d__0.System.Threading.Tasks.Sources.IValueTaskSource<bool>.GetResult(short)", @"
 {
@@ -2095,7 +2100,7 @@ class C
 }}";
                 var comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe);
                 comp.VerifyDiagnostics();
-                var verifier = CompileAndVerify(comp, expectedOutput: expectation);
+                CompileAndVerify(comp, expectedOutput: expectation);
             }
 
             void verifyLocalFunction(Instruction[] spec)
@@ -2123,7 +2128,7 @@ class C
 }}";
                 var comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe);
                 comp.VerifyDiagnostics();
-                var verifier = CompileAndVerify(comp, expectedOutput: expectation);
+                CompileAndVerify(comp, expectedOutput: expectation);
             }
 
             (string code, string expectation) generateCode(Instruction[] spec)
@@ -2196,7 +2201,7 @@ class C
 }";
             var comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "0 1 2 3 4 Done");
+            CompileAndVerify(comp, expectedOutput: "0 1 2 3 4 Done");
         }
 
         [ConditionalTheory(typeof(WindowsDesktopOnly))]
@@ -2366,7 +2371,6 @@ public class C : System.IAsyncDisposable
 ";
             var comp = CreateCompilationWithAsyncIterator(new[] { Run(iterations), source }, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            var v = CompileAndVerify(comp);
             CompileAndVerify(comp, expectedOutput: expectedOutput);
         }
 
@@ -4138,6 +4142,105 @@ class C
                 //         async Unknown local()
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Unknown").WithArguments("Unknown").WithLocation(8, 15)
                 );
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        public void DisposeAsyncInBadState()
+        {
+            string source = @"
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async System.Collections.Generic.IAsyncEnumerable<int> M(CancellationToken token)
+    {
+        yield return 1;
+        while (true)
+        {
+            await Task.Delay(10);
+            token.ThrowIfCancellationRequested();
+        }
+    }
+    public static async System.Threading.Tasks.Task Main()
+    {
+        CancellationTokenSource source = new CancellationTokenSource();
+        CancellationToken token = source.Token;
+        var enumerator = M(token).GetAsyncEnumerator();
+        if (!await enumerator.MoveNextAsync()) { throw null; }
+
+        var task = enumerator.MoveNextAsync();
+        try
+        {
+            await enumerator.DisposeAsync();
+        }
+        catch (System.NotSupportedException)
+        {
+            System.Console.Write(""DisposeAsync threw"");
+        }
+
+        source.Cancel();
+        try
+        {
+            await task;
+        }
+        catch (System.OperationCanceledException) { }
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "DisposeAsync threw");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        public void DisposeAsyncBeforeRunning()
+        {
+            string source = @"
+class C
+{
+    static async System.Collections.Generic.IAsyncEnumerable<int> M()
+    {
+        yield return 1;
+        await System.Threading.Tasks.Task.CompletedTask;
+    }
+    public static async System.Threading.Tasks.Task Main()
+    {
+        var enumerator = M().GetAsyncEnumerator();
+        await enumerator.DisposeAsync();
+        System.Console.Write(""done"");
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "done");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        public void DisposeAsyncTwiceAfterRunning()
+        {
+            string source = @"
+class C
+{
+    static async System.Collections.Generic.IAsyncEnumerable<int> M()
+    {
+        yield return 1;
+        await System.Threading.Tasks.Task.CompletedTask;
+    }
+    public static async System.Threading.Tasks.Task Main()
+    {
+        var enumerator = M().GetAsyncEnumerator();
+        if (!await enumerator.MoveNextAsync()) throw null;
+
+        if (await enumerator.MoveNextAsync()) throw null;
+
+        await enumerator.DisposeAsync();
+        await enumerator.DisposeAsync();
+
+        if (await enumerator.MoveNextAsync()) throw null;
+
+        System.Console.Write(""done"");
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "done");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -145,7 +145,7 @@ class C
         return CapturedRandom.Next(50, 100);
     }
 }");
-            CompileAndVerify(comp, verify: Verification.Skipped);
+            CompileAndVerify(comp);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -1458,15 +1458,15 @@ class C
     {
         yield return 0;
         Write(""1 "");
-        await Task.Delay(10);
+        await Task.Yield();
         Write(""2 "");
         yield return 3;
-        await Task.Delay(10);
+        await Task.Yield();
         Write(""4 "");
         value++;
-        await Task.Delay(10);
+        await Task.Yield();
         Write($""{value} "");
-        await Task.Delay(10);
+        await Task.Yield();
     }
     static async Task Main()
     {
@@ -1476,7 +1476,7 @@ class C
             Write($""Stream1:{item1} "");
         }
         Write(""Await "");
-        await Task.Delay(10);
+        await Task.Yield();
         await foreach (var item2 in enumerable)
         {
             Write($""Stream2:{item2} "");
@@ -1502,7 +1502,7 @@ class C
         try
         {
             yield return 1;
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             yield return 2;
         }
         finally
@@ -1837,7 +1837,7 @@ class C
     {
         Write($""p:{parameter} "");
         parameter++;
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         Write($""p:{parameter} "");
         parameter++;
         yield return 42;
@@ -1870,7 +1870,7 @@ class C
     {
         Write($""f:{this.field} "");
         this.field++;
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         Write($""f:{this.field} "");
         this.field++;
         yield return 42;
@@ -1985,7 +1985,7 @@ class C
         Write(""1 "");
         yield return 2;
         Write(""3 "");
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
     }
     static async System.Threading.Tasks.Task Main()
     {
@@ -2155,8 +2155,8 @@ class C
                             counter++;
                             break;
                         case AwaitSlow:
-                            //await System.Threading.Tasks.Task.Delay(10);
-                            builder.AppendLine("await System.Threading.Tasks.Task.Delay(10);");
+                            //await System.Threading.Tasks.Task.Yield();
+                            builder.AppendLine("await System.Threading.Tasks.Task.Yield();");
                             break;
                         case AwaitFast:
                             //await new System.Threading.Tasks.Task.CompletedTask;
@@ -2183,11 +2183,11 @@ class C
     static async System.Collections.Generic.IAsyncEnumerable<int> M()
     {
         Write(""1 "");
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         Write(""2 "");
         yield return 3;
         Write(""4 "");
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
     }
     static async System.Threading.Tasks.Task Main()
     {
@@ -2221,7 +2221,7 @@ public class C
         int counter = 0;
         start:
         yield return counter++;
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         try
         {
             yield return counter++;
@@ -2230,7 +2230,7 @@ public class C
         finally
         {
             Write(""Finally "");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
         }
     }
 }";
@@ -2254,12 +2254,12 @@ public class C : System.Collections.Generic.IAsyncEnumerable<int>
     public async System.Collections.Generic.IAsyncEnumerator<int> GetAsyncEnumerator()
     {
         yield return 1;
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         try
         {
             try
             {
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 Write(""Break "");
                 yield break;
             }
@@ -2272,13 +2272,13 @@ public class C : System.Collections.Generic.IAsyncEnumerable<int>
         catch
         {
             Write(""Caught "");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             yield break;
         }
         finally
         {
             Write(""Finally "");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
         }
     }
 }";
@@ -2413,7 +2413,7 @@ public class C
     public static async System.Collections.Generic.IAsyncEnumerable<int> M2()
     {
         yield return 1;
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         yield return 2;
     }
 }
@@ -2446,7 +2446,7 @@ public class C : System.IAsyncDisposable
             {
                 await System.Threading.Tasks.Task.CompletedTask;
                 Write(""Caught "");
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 bool b = true;
                 Write(""Throw2 "");
                 if (b) throw null;
@@ -2482,7 +2482,7 @@ public class C
             Write(""Try "");
             await foreach (var i in M2())
             {
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 Write($""Item{i} "");
                 if (i > 1)
                 {
@@ -2496,7 +2496,7 @@ public class C
             Write(""Finally "");
             await foreach (var j in M2())
             {
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 Write($""Item{j} "");
                 if (j > 1)
                 {
@@ -2511,7 +2511,7 @@ public class C
     public static async System.Collections.Generic.IAsyncEnumerable<int> M2()
     {
         yield return 1;
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         yield return 2;
     }
 }
@@ -2537,7 +2537,7 @@ public class C
         {
             try
             {
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 Write(""Throw "");
                 bool b = true;
                 if (b) throw null;
@@ -2581,7 +2581,7 @@ public class C
         {
             try
             {
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 Write(""Throw "");
                 bool b = true;
                 if (b) throw null;
@@ -2590,7 +2590,7 @@ public class C
             catch
             {
                 Write(""Caught "");
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 yield break;
             }
             yield return 42;
@@ -2598,7 +2598,7 @@ public class C
         }
         finally
         {
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Finally "");
         }
         yield return 42;
@@ -2627,7 +2627,7 @@ public class C
             yield return 1;
             try
             {
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 Write(""Throw "");
                 bool b = true;
                 if (b) throw null;
@@ -2637,7 +2637,7 @@ public class C
                 Write(""Caught "");
                 try
                 {
-                    await System.Threading.Tasks.Task.Delay(10);
+                    await System.Threading.Tasks.Task.Yield();
                     Write(""Break "");
                     bool b = true;
                     if (b) yield break;
@@ -2652,7 +2652,7 @@ public class C
         }
         finally
         {
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Finally2 "");
         }
         Write(""SKIPPED"");
@@ -2679,7 +2679,7 @@ public class C
         try
         {
             yield return 1;
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Break "");
             bool b = true;
             if (b) yield break;
@@ -2757,7 +2757,7 @@ public class C
             finally
             {
                 Write(""Finally1 "");
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 Write(""Finally2 "");
             }
 
@@ -2772,7 +2772,7 @@ public class C
             finally
             {
                 Write(""Finally3 "");
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 Write(""Finally4 "");
             }
             yield return 6;
@@ -2780,7 +2780,7 @@ public class C
         finally
         {
             Write(""Finally5 "");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Finally6 "");
         }
 
@@ -2841,7 +2841,7 @@ public class C
 {
     public static async System.Collections.Generic.IAsyncEnumerable<int> M()
     {
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         try
         {
             yield return 1;
@@ -2870,7 +2870,7 @@ public class C
 {
     public static async System.Collections.Generic.IAsyncEnumerable<int> M()
     {
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         try
         {
             yield return 1;
@@ -2908,11 +2908,11 @@ public class C
         {
             await System.Threading.Tasks.Task.CompletedTask;
             Write(""Try "");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
         }
         finally
         {
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Finally "");
             await System.Threading.Tasks.Task.CompletedTask;
         }
@@ -2940,11 +2940,11 @@ public class C
         yield return 1;
         try
         {
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Throw "");
             bool b = true;
             if (b) throw null;
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""SKIPPED"");
         }
         finally
@@ -2974,10 +2974,10 @@ public class C
         yield return 1;
         try
         {
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             await SlowThrowAsync();
             Write(""SKIPPED"");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
         }
         finally
         {
@@ -2988,7 +2988,7 @@ public class C
     static async System.Threading.Tasks.Task SlowThrowAsync()
     {
         Write(""Throw1 "");
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         Write(""Throw2 "");
         throw null;
     }
@@ -3013,7 +3013,7 @@ public class C
         yield return 1;
         try
         {
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             await FastThrowAsync();
             Write(""SKIPPED"");
             await System.Threading.Tasks.Task.CompletedTask;
@@ -3141,14 +3141,14 @@ class C
         {
             Write(""1 "");
             ThrowIf(1);
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             ThrowIf(2);
 
             try
             {
                 Write(""2 "");
                 ThrowIf(3);
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 ThrowIf(4);
                 await System.Threading.Tasks.Task.CompletedTask;
                 ThrowIf(5);
@@ -3164,7 +3164,7 @@ class C
                 ThrowIf(6);
                 await System.Threading.Tasks.Task.CompletedTask;
                 ThrowIf(7);
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 ThrowIf(8);
             }
             finally
@@ -3233,7 +3233,7 @@ public class C
         {
             await System.Threading.Tasks.Task.CompletedTask;
             Write(""Caught1 "");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Caught2 "");
         }
         Write(""After "");
@@ -3711,12 +3711,12 @@ public class C
             try
             {
                 yield return counter++;
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
             }
             finally
             {
                 Write($""Finally{counter++} "");
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
             }
 
             Write($""Again "");
@@ -3746,12 +3746,12 @@ public class C
         try
         {
             yield return 1;
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
         }
         finally
         {
             Write($""Finally "");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             bool b = true;
             if (b) throw null;
         }
@@ -3782,12 +3782,12 @@ public class C
             try
             {
                 yield return 1;
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
             }
             finally
             {
                 Write($""Finally1 "");
-                await System.Threading.Tasks.Task.Delay(10);
+                await System.Threading.Tasks.Task.Yield();
                 bool b = true;
                 if (b) throw null;
             }
@@ -3823,7 +3823,7 @@ public class C
         try
         {
             Write(""Try1 "");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Try2 "");
             throw new System.Exception();
         }
@@ -3834,7 +3834,7 @@ public class C
         finally
         {
             Write(""Finally1 "");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Finally2 "");
         }
     }
@@ -3861,7 +3861,7 @@ public class C
         {
             Write(""Try1 "");
             yield return 1;
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Throw "");
             bool b = true;
             if (b) throw new System.Exception();
@@ -3869,7 +3869,7 @@ public class C
         finally
         {
             Write(""Finally1 "");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Finally2 "");
         }
         Write(""SKIPPED"");
@@ -3898,13 +3898,13 @@ public class C
         {
             Write(""Try1 "");
             yield return 1;
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Try2 "");
         }
         finally
         {
             Write(""Finally1 "");
-            await System.Threading.Tasks.Task.Delay(10);
+            await System.Threading.Tasks.Task.Yield();
             Write(""Finally2 "");
         }
     }
@@ -4157,11 +4157,11 @@ class C
         yield return 1;
         while (true)
         {
-            await Task.Delay(10);
+            await Task.Yield();
             token.ThrowIfCancellationRequested();
         }
     }
-    public static async System.Threading.Tasks.Task Main()
+    public static async Task Main()
     {
         CancellationTokenSource source = new CancellationTokenSource();
         CancellationToken token = source.Token;
@@ -4175,7 +4175,7 @@ class C
         }
         catch (System.NotSupportedException)
         {
-            System.Console.Write(""DisposeAsync threw"");
+            System.Console.Write(""DisposeAsync threw. "");
         }
 
         source.Cancel();
@@ -4183,12 +4183,15 @@ class C
         {
             await task;
         }
-        catch (System.OperationCanceledException) { }
+        catch (System.OperationCanceledException)
+        {
+            System.Console.Write(""Already cancelled"");
+        }
     }
 }";
             var comp = CreateCompilationWithAsyncIterator(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "DisposeAsync threw");
+            CompileAndVerify(comp, expectedOutput: "DisposeAsync threw. Already cancelled");
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly))]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -121,14 +121,14 @@ public class C : IAsyncEnumerable<uint>
         public uint Current => 0xFFFFFFFF;
         public async ValueTask<bool> MoveNextAsync()
         {
-            await Task.Delay(10);
+            await Task.Yield();
             bool result = firstValue;
             firstValue = false;
             return result;
         }
         public async ValueTask DisposeAsync()
         {
-            await Task.Delay(10);
+            await Task.Yield();
         }
     }
 }
@@ -769,7 +769,7 @@ class C
         public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await Task.Delay(10);
+            await Task.Yield();
         }
     }
 }
@@ -821,7 +821,7 @@ public class C
         }
         public async ValueTask DisposeAsync()
         {
-            await Task.Delay(10);
+            await Task.Yield();
         }
     }
 }";
@@ -878,7 +878,7 @@ class C<T> where T : IntContainer, new()
         public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await Task.Delay(10);
+            await Task.Yield();
         }
     }
 }";
@@ -962,7 +962,7 @@ public class C
         public async ValueTask DisposeAsync()
         {
             Write(""dispose "");
-            await Task.Delay(10);
+            await Task.Yield();
         }
     }
 }";
@@ -1003,13 +1003,13 @@ public class C
         public async Task<bool> MoveNextAsync()
         {
             Write(""wait "");
-            await Task.Delay(10);
+            await Task.Yield();
             return true;
         }
         public async ValueTask DisposeAsync()
         {
             Write(""dispose "");
-            await Task.Delay(10);
+            await Task.Yield();
         }
     }
 }";
@@ -1049,7 +1049,7 @@ public class C
         public async Task<bool> MoveNextAsync()
         {
             Write(""wait "");
-            await Task.Delay(10);
+            await Task.Yield();
             return false;
         }
         public ValueTask DisposeAsync()
@@ -1774,7 +1774,7 @@ public class C
         }
         public async ValueTask DisposeAsync()
         {
-            await Task.Delay(10);
+            await Task.Yield();
         }
     }
 }
@@ -1918,7 +1918,7 @@ class C
         public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await new ValueTask(Task.Delay(10));
+            await Task.Yield();
         }
     }
 }";
@@ -1970,7 +1970,7 @@ class C
         public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await new ValueTask(Task.Delay(10));
+            await Task.Yield();
         }
     }
 }";
@@ -2031,7 +2031,7 @@ public class C
         public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
-            await Task.Delay(10);
+            await Task.Yield();
             Write($""ose({i}) "");
         }
     }
@@ -2095,7 +2095,7 @@ public class C
         public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
-            await Task.Delay(10);
+            await Task.Yield();
             Write($""ose({i}) "");
         }
     }
@@ -2393,7 +2393,7 @@ class C
         public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
-            await Task.Delay(10);
+            await Task.Yield();
             Write($""ose({i}) "");
         }
     }
@@ -2427,7 +2427,7 @@ public class C
         public Task<bool> MoveNextAsync() => throw null;
         public async ValueTask DisposeAsync()
         {
-            await new ValueTask(Task.Delay(10));
+            await Task.Yield();
         }
     }
 }";
@@ -2559,7 +2559,7 @@ class C : IAsyncEnumerable<int>
         public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
-            await Task.Delay(10);
+            await Task.Yield();
             Write($""ose({i}) "");
         }
     }
@@ -2686,7 +2686,7 @@ class C : IAsyncEnumerable<int>
         public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
-            await Task.Delay(10);
+            await Task.Yield();
             Write($""ose({i}) "");
         }
     }
@@ -2743,7 +2743,7 @@ class C : IAsyncEnumerable<int>
         public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
-            await Task.Delay(10);
+            await Task.Yield();
             Write($""ose({i}) "");
         }
     }
@@ -2800,7 +2800,7 @@ class C : IAsyncEnumerable<int>
         public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await Task.Delay(10);
+            await Task.Yield();
         }
     }
 }";
@@ -2951,7 +2951,7 @@ class C : IAsyncEnumerable<int>
         public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
-            await Task.Delay(10);
+            await Task.Yield();
             Write($""ose({i}) "");
         }
     }
@@ -3033,7 +3033,7 @@ class C : IAsyncEnumerable<int>
         public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
-            await Task.Delay(10);
+            await Task.Yield();
             Write($""ose({i}) "");
         }
     }
@@ -3113,7 +3113,7 @@ struct C : IAsyncEnumerable<int>
         public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
-            await Task.Delay(10);
+            await Task.Yield();
             Write($""ose({i}) "");
         }
     }
@@ -3220,7 +3220,7 @@ class C : IAsyncEnumerable<int>
         public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await new ValueTask(Task.Delay(10));
+            await Task.Yield();
         }
     }
 }
@@ -3324,7 +3324,7 @@ class C : IAsyncEnumerable<(string, int)>
         public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await new ValueTask(Task.Delay(10));
+            await Task.Yield();
         }
     }
 }";
@@ -3398,7 +3398,7 @@ class C : IAsyncEnumerable<int>
         public async ValueTask DisposeAsync()
         {
             Write($""Disp"");
-            await Task.Delay(10);
+            await Task.Yield();
             Write($""ose({i}) "");
         }
     }
@@ -3540,7 +3540,7 @@ class Collection<T> : IAsyncEnumerable<T>
         public async ValueTask DisposeAsync()
         {
             Write($""Dispose({i}) "");
-            await new ValueTask(Task.Delay(10));
+            await Task.Yield();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
@@ -182,7 +182,7 @@ class C : System.IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         System.Console.Write(""DisposeAsync1 "");
-        await Task.Delay(10);
+        await Task.Yield();
         System.Console.Write(""DisposeAsync2 "");
     }
 }
@@ -267,7 +267,7 @@ class C : System.IAsyncDisposable
     [System.Obsolete]
     public async System.Threading.Tasks.ValueTask DisposeAsync()
     {
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
     }
 }
 ";
@@ -323,7 +323,7 @@ class C : System.IAsyncDisposable
     public async System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write($""dispose_start "");
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         System.Console.Write($""dispose_end "");
     }
 }
@@ -438,7 +438,7 @@ class C : System.IAsyncDisposable
     public async System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write($""dispose_start "");
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         System.Console.Write($""dispose_end "");
     }
 }
@@ -475,7 +475,7 @@ class C : System.IAsyncDisposable
         bool b = true;
         if (b) throw new System.Exception(""message"");
         System.Console.Write(""SKIPPED"");
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
     }
 }
 ";
@@ -499,7 +499,7 @@ class C
         finally
         {
             System.Console.Write(""before "");
-            await Task.Delay(10);
+            await Task.Yield();
             System.Console.Write(""after"");
         }
         return 1;
@@ -1480,7 +1480,7 @@ class S : System.IAsyncDisposable
     public async System.Threading.Tasks.ValueTask DisposeAsync()
     {
         System.Console.Write($""dispose{_i}_start "");
-        await System.Threading.Tasks.Task.Delay(10);
+        await System.Threading.Tasks.Task.Yield();
         System.Console.Write($""dispose{_i}_end "");
     }
 }


### PR DESCRIPTION
The behavior for `DisposeAsync` is only specified if the method is at the beginning, the end or a `yield return`. It is unspecified if the method is suspended at an `await` or running.
Per discussion with LDM, although it doesn't not guarantee that users couldn't call `DisposeAsync` at the wrong time (there are still possible race conditions that we can't guard against) we'll throw in such cases.

To that effect:
- a new state is introduced to represent the beginning of the method (-3)
- the states for `yield return` and `await` are split: `yield return` uses negative numbers (-4 and down), `await` uses positive numbers (0 and up, as in regular async methods)

The APIs could be mis-used in other ways , but we will not guard those:
- calling `MoveNextAsync()` on two separate threads is unspecified,
- calling `MoveNextAsync()` after `DisposeAsync()` is unspecified, but the implementation just returns `false` (no items left).

```C#
ValueTask IAsyncDisposable.DisposeAsync()
{
    if (state >= StateMachineStates.NotStartedStateMachine /* -1 */)
    {
        throw new NotSupportedException();
    }
    if (state == StateMachineStates.FinishedStateMachine /* -2 */)
    {
        return default;
    }
    disposeMode = true;
    _valueOrEndPromise.Reset();
    var inst = this;
    _builder.Start(ref inst);
    return new ValueTask(this, _valueOrEndPromise.Version);  // note this leverages the state machine's implementation of IValueTaskSource
}
```

```
        DisposeAsync                              await
 +------------------------+             +------------------------> N
 |                        |             |                          |
 v   GetAsyncEnumerator   |             |        resuming          |
-2 --------------------> -3 --------> -1 <-------------------------+    Dispose mode = false
 ^                                   |  |                          |
 |         done and disposed         |  |      yield return        |
 +-----------------------------------+  +-----------------------> -N
 |                                   |                             |
 |                                   |                             |
 |                             yield |                             |
 |                             break |           DisposeAsync      |
 |                                   |  +--------------------------+
 |                                   |  |
 |                                   |  |
 |         done and disposed         v  v    suspension (await)
 +----------------------------------- -1 ------------------------> N
                                        ^                          |    Dispose mode = true
                                        |         resuming         |
                                        +--------------------------+
```

Fixes https://github.com/dotnet/roslyn/issues/30109