### PR TITLE
Add some more bail out cases for unused parameters and value assignments analyzers

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -367,6 +367,8 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
         public async Task UnusedInLambda_LambdaPassedAsArgument()
         {
+            // We bail out from unused value analysis when lambda is passed as argument.
+            // We should still report unused parameters.
             await TestDiagnosticsAsync(
 @"using System;
 

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -941,6 +941,27 @@ $@"class C
 }}");
         }
 
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        [InlineData("System.Composition", "ImportingConstructorAttribute")]
+        [InlineData("System.ComponentModel.Composition", "ImportingConstructorAttribute")]
+        public async Task Parameter_ConstructorsWithSpecialAttributes(string attributeNamespace, string attributeName)
+        {
+            await TestDiagnosticMissingAsync(
+$@"
+namespace {attributeNamespace}
+{{
+    public class {attributeName} : System.Attribute {{ }}
+}}
+
+class C
+{{
+    [{attributeNamespace}.{attributeName}()]
+    public C(int [|p|])
+    {{
+    }}
+}}");
+        }
+
         [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
         public async Task Parameter_DiagnosticMessages()
         {

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -2720,6 +2720,78 @@ class C
 }", optionName);
         }
 
+        [WorkItem(31744, "https://github.com/dotnet/roslyn/issues/31744")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task UnusedInExpressionTree_PassedAsArgument(string optionName)
+        {
+            // Currently we bail out of analysis in presence of expression trees.
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+using System.Linq.Expressions;
+
+class C
+{
+    public static void M1()
+    {
+        object [|p|] = null;
+        M2(x => x.M3());
+    }
+
+    private static C M2(Expression<Func<C, int>> a) { return null; }
+    private int M3() { return 0; }
+}", optionName);
+        }
+
+        [WorkItem(31744, "https://github.com/dotnet/roslyn/issues/31744")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task ReadInExpressionTree_PassedAsArgument(string optionName)
+        {
+            // Currently we bail out of analysis in presence of expression trees.
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+using System.Linq.Expressions;
+
+class C
+{
+    public static void M1()
+    {
+        object [|p|] = null;
+        M2(x => x.M3(p));
+    }
+
+    private static C M2(Expression<Func<C, int>> a) { return null; }
+    private int M3(object o) { return 0; }
+}", optionName);
+        }
+
+        [WorkItem(31744, "https://github.com/dotnet/roslyn/issues/31744")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task OnlyWrittenInExpressionTree_PassedAsArgument(string optionName)
+        {
+            // Currently we bail out of analysis in presence of expression trees.
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+using System.Linq.Expressions;
+
+class C
+{
+    public static void M1()
+    {
+        object [|p|] = null;
+        M2(x => x.M3(out p));
+    }
+
+    private static C M2(Expression<Func<C, int>> a) { return null; }
+    private int M3(out object o) { o = null; return 0; }
+}", optionName);
+        }
+
         [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
         [InlineData(nameof(PreferDiscard))]
         [InlineData(nameof(PreferUnusedLocal))]

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -2646,6 +2646,37 @@ class C
         [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
         [InlineData(nameof(PreferDiscard))]
         [InlineData(nameof(PreferUnusedLocal))]
+        public async Task UseInLambda_PassedAsArgument_02(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    public C(bool flag)
+    {
+        Flag = flag;
+    }
+
+    public bool Flag { get; }
+    public static bool M()
+    {
+        bool flag = true;
+        var c = Create(() => flag);
+
+        M2(c);
+        [|flag|] = false;
+        return M2(c);
+    }
+
+    private static C Create(Func<bool> isFlagTrue) { return new C(isFlagTrue()); }
+    private static bool M2(C c) => c.Flag;
+}", optionName);
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
         public async Task UseInLocalFunction_PassedAsArgument(string optionName)
         {
             await TestMissingInRegularAndScriptAsync(

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.vb
@@ -63,5 +63,17 @@ $"Class C
 End Class", parameters:=Nothing,
             Diagnostic(IDEDiagnosticIds.UnusedParameterDiagnosticId))
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)>
+        Public Async Function ParameterOfMethodThatHandlesEvent() As Task
+            Await TestDiagnosticMissingAsync(
+$"Public Class C
+    Public Event E(p As Integer)
+    Dim WithEvents field As New C
+
+    Public Sub M([|p|] As Integer) Handles field.E
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.vb
@@ -341,5 +341,21 @@ Class C
     End Sub
 End Class")
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)>
+        Public Async Function StaticLocals() As Task
+            Await TestMissingInRegularAndScriptAsync(
+$"Class C
+    Function Increment() As Boolean
+        Static count As Integer = 0
+        If count > 10 Then
+            Return True
+        End If
+
+        [|count|] = count + 1
+        Return False
+    End Function
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/RemoveUnusedParametersAndValues/CSharpRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/RemoveUnusedParametersAndValues/CSharpRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -22,6 +22,9 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedParametersAndValues
         protected override bool SupportsDiscard(SyntaxTree tree)
             => ((CSharpParseOptions)tree.Options).LanguageVersion >= LanguageVersion.CSharp7;
 
+        protected override bool MethodHasHandlesClause(IMethodSymbol method)
+            => false;
+
         // C# does not have an explicit "call" statement syntax for invocations with explicit value discard.
         protected override bool IsCallStatement(IExpressionStatementOperation expressionStatement)
             => false;

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -394,11 +394,11 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                         // Bail out in following cases:
                         //   1. End user has configured the diagnostic to be suppressed.
                         //   2. Symbol has error type, hence the diagnostic could be noised
-                        //   3. Symbol is static. For example, assignment to static locals in VB
+                        //   3. Static local symbols. Assignment to static locals
                         //      is not unnecessary as the assigned value can be used on the next invocation.
                         if (_options.UnusedValueAssignmentSeverity == ReportDiagnostic.Suppress ||
                             symbol.GetSymbolType().IsErrorType() ||
-                            symbol.IsStatic)
+                            symbol.IsStatic && symbol.Kind == SymbolKind.Local)
                         {
                             return false;
                         }

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -366,8 +366,15 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                         out ImmutableDictionary<string, string> properties)
                     {
                         properties = null;
+
+                        // Bail out in following cases:
+                        //   1. End user has configured the diagnostic to be suppressed.
+                        //   2. Symbol has error type, hence the diagnostic could be noised
+                        //   3. Symbol is static. For example, assignment to static locals in VB
+                        //      is not unnecessary as the assigned value can be used on the next invocation.
                         if (_options.UnusedValueAssignmentSeverity == ReportDiagnostic.Suppress ||
-                            symbol.GetSymbolType().IsErrorType())
+                            symbol.GetSymbolType().IsErrorType() ||
+                            symbol.IsStatic)
                         {
                             return false;
                         }

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -179,7 +179,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     method.IsOverride ||
                     !method.ExplicitOrImplicitInterfaceImplementations().IsEmpty ||
                     method.IsAccessor() ||
-                    method.IsAnonymousFunction())
+                    method.IsAnonymousFunction() ||
+                    _compilationAnalyzer.MethodHasHandlesClause(method))
                 {
                     return false;
                 }

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -159,6 +159,10 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
 
                 // Don't flag obsolete methods.
                 yield return compilation.ObsoleteAttribute();
+
+                // Don't flag MEF import constructors with ImportingConstructor attribute.
+                yield return compilation.SystemCompositionImportingConstructorAttribute();
+                yield return compilation.SystemComponentModelCompositionImportingConstructorAttribute();
             }
 
             private bool IsUnusedParameterCandidate(IParameterSymbol parameter)

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -88,6 +88,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
 
         protected abstract Location GetDefinitionLocationToFade(IOperation unusedDefinition);
         protected abstract bool SupportsDiscard(SyntaxTree tree);
+        protected abstract bool MethodHasHandlesClause(IMethodSymbol method);
         protected abstract Option<CodeStyleOption<UnusedValuePreference>> UnusedValueExpressionStatementOption { get; }
         protected abstract Option<CodeStyleOption<UnusedValuePreference>> UnusedValueAssignmentOption { get; }
 

--- a/src/Features/VisualBasic/Portable/RemoveUnusedParametersAndValues/VisualBasicRemoveUnusedParametersAndValuesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/RemoveUnusedParametersAndValues/VisualBasicRemoveUnusedParametersAndValuesDiagnosticAnalyzer.vb
@@ -29,6 +29,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedParametersAndValues
             Return False
         End Function
 
+        Protected Overrides Function MethodHasHandlesClause(method As IMethodSymbol) As Boolean
+            Return method.DeclaringSyntaxReferences().Any(Function(decl)
+                                                              Return TryCast(decl.GetSyntax(), MethodStatementSyntax)?.HandlesClause IsNot Nothing
+                                                          End Function)
+        End Function
+
         Protected Overrides Function IsCallStatement(expressionStatement As IExpressionStatementOperation) As Boolean
             Return TryCast(expressionStatement.Syntax, CallStatementSyntax) IsNot Nothing
         End Function

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ICompilationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ICompilationExtensions.cs
@@ -161,5 +161,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         public static INamedTypeSymbol ObsoleteAttribute(this Compilation compilation)
             => compilation.GetTypeByMetadataName(typeof(ObsoleteAttribute).FullName);
+
+        public static INamedTypeSymbol SystemCompositionImportingConstructorAttribute(this Compilation compilation)
+            => compilation.GetTypeByMetadataName(typeof(System.Composition.ImportingConstructorAttribute).FullName);
+
+        public static INamedTypeSymbol SystemComponentModelCompositionImportingConstructorAttribute(this Compilation compilation)
+            => compilation.GetTypeByMetadataName("System.ComponentModel.Composition.ImportingConstructorAttribute");
     }
 }


### PR DESCRIPTION
1. Presence of expression trees
2. Assignment to VB static locals
3. Parameters of VB handles method
4. Parameters of MEF importing constructors

Fixes #31744