### PR TITLE
Fix additional newlines being added when adding all missing imports

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeRefactorings/AddMissingImports/CSharpAddMissingImportsRefactoringProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeRefactorings/AddMissingImports/CSharpAddMissingImportsRefactoringProviderTests.cs
@@ -336,5 +336,51 @@ namespace B
 
             await TestMissingInRegularAndScriptAsync(code);
         }
+
+        [WorkItem(31768, "https://github.com/dotnet/roslyn/issues/31768")]
+        [WpfFact]
+        public async Task AddMissingImports_AddMultipleImports_NoPreviousImports()
+        {
+            var code = @"
+class C
+{
+    [|public D Foo { get; }
+    public E Bar { get; }|]
+}
+
+namespace A
+{
+    public class D { }
+}
+
+namespace B
+{
+    public class E { }
+}
+";
+
+            var expected = @"
+using A;
+using B;
+
+class C
+{
+    public D Foo { get; }
+    public E Bar { get; }
+}
+
+namespace A
+{
+    public class D { }
+}
+
+namespace B
+{
+    public class E { }
+}
+";
+
+            await TestInRegularAndScriptAsync(code, expected, placeSystemNamespaceFirst: false, separateImportDirectiveGroups: false);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeRefactorings/AddMissingImports/VisualBasicAddMissingImportsRefactoringProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeRefactorings/AddMissingImports/VisualBasicAddMissingImportsRefactoringProviderTests.vb
@@ -315,5 +315,48 @@ End Namespace
 
             Await TestInRegularAndScriptAsync(code, expected)
         End Function
+
+        <WorkItem(31768, "https://github.com/dotnet/roslyn/issues/31768")>
+        <WpfFact>
+        Public Async Function AddMissingImports_AddMultipleImports_NoPreviousImports() As Task
+            Dim code = "
+Class C
+    [|Dim foo As D
+    Dim bar As E|]
+End Class
+
+Namespace A
+    Public Class D
+    End Class
+End Namespace
+
+Namespace B
+    Public Class E
+    End Class
+End Namespace
+"
+
+            Dim expected = "
+Imports A
+Imports B
+
+Class C
+    Dim foo As D
+    Dim bar As E
+End Class
+
+Namespace A
+    Public Class D
+    End Class
+End Namespace
+
+Namespace B
+    Public Class E
+    End Class
+End Namespace
+"
+
+            Await TestInRegularAndScriptAsync(code, expected, placeSystemNamespaceFirst:=False, separateImportDirectiveGroups:=False)
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             var newText = text.WithChanges(orderedTextInserts);
             var newDocument = newProject.GetDocument(document.Id).WithText(newText);
 
-            // When imports are added to a code file that has no previous imports extra
+            // When imports are added to a code file that has no previous imports, extra
             // newlines are generated between each import because the fix is expecting to
             // separate the imports from the rest of the code file. We need to format the
             // imports to remove these extra newlines.
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
 
             // Since imports can be added at both the CompilationUnit and the Namespace level,
             // format each span individually so that we can retain each newline that was intended
-            // separate the import section from the other content.
+            // to separate the import section from the other content.
             foreach (var insertSpan in insertSpans)
             {
                 newDocument = await CleanUpNewLinesAsync(newDocument, insertSpan, languageFormatter, options, cancellationToken).ConfigureAwait(false);
@@ -230,9 +230,9 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             return (projectChanges, textChanges);
         }
 
-        class CleanUpNewLinesFormatter : AbstractFormattingRule
+        private sealed class CleanUpNewLinesFormatter : AbstractFormattingRule
         {
-            private SourceText _text;
+            private readonly SourceText _text;
 
             public CleanUpNewLinesFormatter(SourceText text)
             {

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -200,6 +201,9 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             {
                 return document;
             }
+
+            // The last text change should end where the insert span ends
+            Debug.Assert(textChanges.Last().Span.End == insertSpan.End);
 
             // If there are changes then, this was a case where there were no
             // previous imports statements. We need to retain the final extra

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -202,8 +202,8 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
                 return document;
             }
 
-            // The last text change should end where the insert span ends
-            Debug.Assert(textChanges.Last().Span.End == insertSpan.End);
+            // The last text change should include where the insert span ends
+            Debug.Assert(textChanges.Last().Span.IntersectsWith(insertSpan.End));
 
             // If there are changes then, this was a case where there were no
             // previous imports statements. We need to retain the final extra


### PR DESCRIPTION
Before applying the missing imports remove any additional newlines that are introduced by add import wanting to separate the import from the rest of the code. This only occurs when there are no pre-existing imports.

Fixes #31768
