### PR TITLE
Force cancellation if switching to UI thread completed after cancellation request

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/InlineRenameSession.cs
@@ -269,6 +269,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 async t =>
                 {
                     await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationTokenSource.Token);
+                    _cancellationTokenSource.Token.ThrowIfCancellationRequested();
+
                     RaiseSessionSpansUpdated(t.Result.Locations.ToImmutableArray());
                 },
                 _cancellationTokenSource.Token,
@@ -513,6 +515,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     async t =>
                     {
                         await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _conflictResolutionTaskCancellationSource.Token);
+                        _conflictResolutionTaskCancellationSource.Token.ThrowIfCancellationRequested();
+
                         ApplyReplacements(t.Result.replacementInfo, t.Result.mergeResult, _conflictResolutionTaskCancellationSource.Token);
                     },
                     _conflictResolutionTaskCancellationSource.Token,

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
@@ -36,6 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             // This means we have to query for "third party navigation", from
             // XAML, etc. That call has to be done on the UI thread.
             await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
 
             var definitions = GoToDefinitionHelpers.GetDefinitions(symbol, document.Project, thirdPartyNavigationAllowed: true, cancellationToken)
                 .WhereAsArray(d => d.CanNavigateTo(document.Project.Solution.Workspace));

--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -522,6 +522,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                     // Have to see if this fix is still applicable.  Jump to the foreground thread
                     // to make that check.
                     await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     var applicable = fix.Action.IsApplicable(document.Project.Solution.Workspace);
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/ModelComputation.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/ModelComputation.cs
@@ -148,6 +148,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
                 async tasks =>
                 {
                     await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _stopCancellationToken);
+                    _stopCancellationToken.ThrowIfCancellationRequested();
 
                     if (tasks.All(t => t.Status == TaskStatus.RanToCompletion))
                     {

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -145,6 +145,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
                     async t =>
                     {
                         await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
+                        cancellationToken.ThrowIfCancellationRequested();
+
                         PushSelectedItemsToPresenter(t.Result);
                     },
                     cancellationToken,

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -77,6 +77,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                         async t =>
                         {
                             await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationToken);
+                            _cancellationToken.ThrowIfCancellationRequested();
+
                             stateMachine.UpdateTrackingSessionIfRenamable();
                         },
                         _cancellationToken,
@@ -103,6 +105,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 task.SafeContinueWithFromAsync(async t =>
                    {
                        await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationToken);
+                       _cancellationToken.ThrowIfCancellationRequested();
 
                        if (_isRenamableIdentifierTask.Result != TriggerIdentifierKind.NotRenamable)
                        {

--- a/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
@@ -87,6 +87,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
                     async () =>
                     {
                         await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                        cancellationToken.ThrowIfCancellationRequested();
+
                         action();
                     },
                     cancellationToken,

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupSessionManager_EventHookupSession.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupSessionManager_EventHookupSession.cs
@@ -116,6 +116,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
                         async t =>
                         {
                             await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _cancellationTokenSource.Token);
+                            _cancellationTokenSource.Token.ThrowIfCancellationRequested();
+
                             if (t.Result != null)
                             {
                                 commandHandler.EventHookupSessionManager.EventHookupFoundInSession(this);

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -145,6 +145,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             var vsWorkspace = project.Solution.Workspace as VisualStudioWorkspaceImpl;
 
             await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
             var cps = vsWorkspace?.IsCPSProject(project) == true;
 
             // The remainder of this method does not need to execute on the UI thread, but it's pointless to force a

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -371,6 +371,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                         async _ =>
                         {
                             await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
+                            cancellationToken.ThrowIfCancellationRequested();
+
                             ProcessBatchedChangesOnForeground(cancellationToken);
                         },
                         cancellationToken,
@@ -414,6 +416,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                 async () =>
                 {
                     await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     ProcessBatchedChangesOnForeground(cancellationToken);
                 },
                 cancellationToken,


### PR DESCRIPTION
This issue was discovered by @jasonmalinowski while investigating #30661.

To ensure the issue does not affect other code, the changes in 2c85db1c were audited and updated to ensure code does not continue executing after a cancellation request.

Fixes #30661