### PR TITLE
Fix the action registration for unused parameters analyzer to ensure …

### DIFF
--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -50,8 +50,15 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
             {
                 var attributeSetForMethodsToIgnore = ImmutableHashSet.CreateRange(GetAttributesForMethodsToIgnore(context.Compilation).WhereNotNull());
                 var eventsArgType = context.Compilation.EventArgsType();
-                var symbolAnalyzer = new SymbolStartAnalyzer(analyzer, eventsArgType, attributeSetForMethodsToIgnore);
-                context.RegisterSymbolStartAction(symbolAnalyzer.OnSymbolStart, SymbolKind.NamedType);
+                context.RegisterSymbolStartAction(symbolStartContext =>
+                {
+                    // Create a new SymbolStartAnalyzer instance for every named type symbol
+                    // to ensure there is no shared state (such as identified unused parameters within the type),
+                    // as that would lead to duplicate diagnostics being reported from symbol end action callbacks
+                    // for unrelated named types.
+                    var symbolAnalyzer = new SymbolStartAnalyzer(analyzer, eventsArgType, attributeSetForMethodsToIgnore);
+                    symbolAnalyzer.OnSymbolStart(symbolStartContext);
+                }, SymbolKind.NamedType);
             }
 
             private void OnSymbolStart(SymbolStartAnalysisContext context)


### PR DESCRIPTION
…no duplicate diagnostics are reported

Fixes #31381 
Fixes #31743

This repros intermittently based on the ordering of symbol end action callbacks, so it is not possible to add a reliable regression test.