### PR TITLE
Clean the per-project assembly attributes files

### DIFF
--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -227,6 +227,11 @@
   <!--
     Ensure TargetFrameworkMonikerAssemblyAttributeText is treated as auto-generated
   -->
+  <PropertyGroup>
+    <!-- We generate per-project assembly attributes files, so we can safely delete them when cleaning the project -->
+    <TargetFrameworkMonikerAssemblyAttributesFileClean>true</TargetFrameworkMonikerAssemblyAttributesFileClean>
+  </PropertyGroup>
+
   <Target Name="TreatTargetFrameworkMonikerAssemblyAttributeTextAsGenerated"
           AfterTargets="_SetTargetFrameworkMonikerAttribute"
           Condition="'$(Language)' == 'VB'">


### PR DESCRIPTION
@tmat This was an oversight on my part that caused the warnings. Your Arcade PR did not introduce the build warnings.

This should probably be migrated to Arcade (https://github.com/dotnet/arcade/issues/1588).