### PR TITLE
Use speakable annotations in method type re-inference

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             var conversions = this.Conversions.WithNullability(includeNullability: true);
                             type.CheckConstraints(this.Compilation, conversions, location, diagnostics);
                         }
-                        else if (constructedType.TypeSymbol.IsUnconstrainedTypeParameter())
+                        else if (constructedType.TypeSymbol.IsTypeParameterDisallowingAnnotation())
                         {
                             diagnostics.Add(ErrorCode.ERR_NullableUnconstrainedTypeParameter, syntax.Location);
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             NullableAnnotation? result = null;
             foreach (var type in types)
             {
+                Debug.Assert(type.NullableAnnotation.IsSpeakable());
                 if (type.IsNull)
                 {
                     // https://github.com/dotnet/roslyn/issues/27961 Should ignore untyped

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -59,6 +59,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return type;
                     }
 
+                    if (conversions.IncludeNullability)
+                    {
+                        type = type.SetSpeakableNullabilityForReferenceTypes();
+                    }
                     candidateTypes.Add(type);
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -24,21 +24,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continue;
                 }
 
-                Debug.Assert(type.NullableAnnotation.IsSpeakable());
-                if (!type.IsReferenceType && !type.TypeSymbol.IsPossiblyNullableReferenceTypeTypeParameter())
+                var speakableType = type.AsSpeakable();
+                if (!speakableType.IsReferenceType && !speakableType.TypeSymbol.IsPossiblyNullableReferenceTypeTypeParameter())
                 {
                     return NullableAnnotation.Unknown;
                 }
 
                 NullableAnnotation nullableAnnotation;
 
-                if (type.IsPossiblyNullableReferenceTypeTypeParameter() && !bestTypeIsPossiblyNullableReferenceTypeTypeParameter)
+                if (speakableType.IsPossiblyNullableReferenceTypeTypeParameter() && !bestTypeIsPossiblyNullableReferenceTypeTypeParameter)
                 {
                     nullableAnnotation = NullableAnnotation.Nullable;
                 }
                 else
                 {
-                    nullableAnnotation = type.NullableAnnotation;
+                    nullableAnnotation = speakableType.NullableAnnotation;
                 }
 
                 if (nullableAnnotation == NullableAnnotation.Unknown)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -11,19 +10,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal static class BestTypeInferrer
     {
-        public static NullableAnnotation GetNullableAnnotation(TypeSymbol bestType, ArrayBuilder<TypeSymbolWithAnnotations> types)
+        public static NullableAnnotation GetNullableAnnotation(ArrayBuilder<TypeSymbolWithAnnotations> types)
         {
             NullableAnnotation result = NullableAnnotation.NotAnnotated;
             foreach (var type in types)
             {
-                if (type.IsNull)
-                {
-                    // https://github.com/dotnet/roslyn/issues/27961 Should ignore untyped
-                    // expressions such as unbound lambdas and typeless tuples.
-                    result = NullableAnnotation.Annotated;
-                    continue;
-                }
-
+                Debug.Assert(!type.IsNull);
                 // This uses the covariant merging rules.
                 result = result.JoinForFixingLowerBounds(type.AsSpeakable().NullableAnnotation);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -12,7 +13,6 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public static NullableAnnotation GetNullableAnnotation(TypeSymbol bestType, ArrayBuilder<TypeSymbolWithAnnotations> types)
         {
-            bool bestTypeIsPossiblyNullableReferenceTypeTypeParameter = bestType.IsPossiblyNullableReferenceTypeTypeParameter();
             NullableAnnotation result = NullableAnnotation.NotAnnotated;
             foreach (var type in types)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -13,63 +13,22 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static NullableAnnotation GetNullableAnnotation(TypeSymbol bestType, ArrayBuilder<TypeSymbolWithAnnotations> types)
         {
             bool bestTypeIsPossiblyNullableReferenceTypeTypeParameter = bestType.IsPossiblyNullableReferenceTypeTypeParameter();
-            NullableAnnotation? result = null;
+            NullableAnnotation result = NullableAnnotation.NotAnnotated;
             foreach (var type in types)
             {
                 if (type.IsNull)
                 {
                     // https://github.com/dotnet/roslyn/issues/27961 Should ignore untyped
                     // expressions such as unbound lambdas and typeless tuples.
-                    result = NullableAnnotation.Nullable;
+                    result = NullableAnnotation.Annotated;
                     continue;
                 }
 
-                var speakableType = type.AsSpeakable();
-                if (!speakableType.IsReferenceType && !speakableType.TypeSymbol.IsPossiblyNullableReferenceTypeTypeParameter())
-                {
-                    return NullableAnnotation.Unknown;
-                }
-
-                NullableAnnotation nullableAnnotation;
-
-                if (speakableType.IsPossiblyNullableReferenceTypeTypeParameter() && !bestTypeIsPossiblyNullableReferenceTypeTypeParameter)
-                {
-                    nullableAnnotation = NullableAnnotation.Nullable;
-                }
-                else
-                {
-                    nullableAnnotation = speakableType.NullableAnnotation;
-                }
-
-                if (nullableAnnotation == NullableAnnotation.Unknown)
-                {
-                    if (result?.IsAnyNotNullable() != false)
-                    {
-                        result = NullableAnnotation.Unknown;
-                    }
-                }
-                else if (nullableAnnotation.IsAnyNullable())
-                {
-                    if (result?.IsAnyNullable() != true)
-                    {
-                        result = nullableAnnotation;
-                    }
-                    else if (result != nullableAnnotation)
-                    {
-                        result = NullableAnnotation.Annotated;
-                    }
-                }
-                else if (result == null)
-                {
-                    result = nullableAnnotation;
-                }
-                else if (result.GetValueOrDefault() == NullableAnnotation.NotNullable && nullableAnnotation == NullableAnnotation.NotAnnotated)
-                {
-                    result = NullableAnnotation.NotAnnotated;
-                }
+                // This uses the covariant merging rules.
+                result = result.JoinForFixingLowerBounds(type.AsSpeakable().NullableAnnotation);
             }
 
-            return result ?? NullableAnnotation.NotAnnotated;
+            return result;
         }
 
         /// <remarks>

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             NullableAnnotation? result = null;
             foreach (var type in types)
             {
-                Debug.Assert(type.NullableAnnotation.IsSpeakable());
                 if (type.IsNull)
                 {
                     // https://github.com/dotnet/roslyn/issues/27961 Should ignore untyped
@@ -25,6 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continue;
                 }
 
+                Debug.Assert(type.NullableAnnotation.IsSpeakable());
                 if (!type.IsReferenceType && !type.TypeSymbol.IsPossiblyNullableReferenceTypeTypeParameter())
                 {
                     return NullableAnnotation.Unknown;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var type in types)
             {
                 Debug.Assert(!type.IsNull);
+                Debug.Assert(type.Equals(types[0], TypeCompareKind.AllIgnoreOptions));
                 // This uses the covariant merging rules.
                 result = result.JoinForFixingLowerBounds(type.AsSpeakable().NullableAnnotation);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1915,7 +1915,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 destination,
                 ref useSiteDiagnostics,
                 ConversionKind.ImplicitTupleLiteral,
-                (ConversionsBase conversions, BoundExpression s, TypeSymbolWithAnnotations d, ref HashSet<DiagnosticInfo> u, bool a) => conversions.ClassifyImplicitConversionFromExpression(s, d.TypeSymbol, ref u),
+                (ConversionsBase conversions, BoundExpression s, TypeSymbolWithAnnotations d, ref HashSet<DiagnosticInfo> u, bool a)
+                    => conversions.ClassifyImplicitConversionFromExpression(s, d.TypeSymbol, ref u),
                 arg: false);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1514,7 +1514,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
 
             // True if the type is nullable but not an unconstrained type parameter.
-            bool isNullableOnly(TypeSymbolWithAnnotations type) => type.NullableAnnotation.IsAnyNullable() && !type.TypeSymbol.IsUnconstrainedTypeParameter();
+            bool isNullableOnly(TypeSymbolWithAnnotations type) => type.NullableAnnotation.IsAnyNullable() && !type.TypeSymbol.IsTypeParameterDisallowingAnnotation();
         }
 
         private bool ExactNullableInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1510,11 +1510,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return false;
-        }
 
-        // True if the type is nullable but not an unconstrained type parameter.
-        private readonly static Func<TypeSymbolWithAnnotations, bool> s_isNullableOnly =
-            (type) => type.NullableAnnotation.IsAnyNullable() && !type.TypeSymbol.IsTypeParameterDisallowingAnnotation();
+            // True if the type is nullable but not an unconstrained type parameter.
+            bool s_isNullableOnly (TypeSymbolWithAnnotations type)
+                => type.NullableAnnotation.IsAnyNullable() && !type.TypeSymbol.IsTypeParameterDisallowingAnnotation();
+        }
 
         private bool ExactNullableInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly ImmutableArray<TypeSymbolWithAnnotations> _formalParameterTypes;
         private readonly ImmutableArray<RefKind> _formalParameterRefKinds;
         private readonly ImmutableArray<BoundExpression> _arguments;
-        private readonly Func<BoundExpression, NullableAnnotation> _getNullableAnnotationOpt;
+        private readonly Func<BoundExpression, TypeSymbolWithAnnotations> _getTypeWithAnnotationOpt;
 
         private readonly TypeSymbolWithAnnotations[] _fixedResults;
         private readonly HashSet<TypeSymbolWithAnnotations>[] _exactBounds;
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                       // no arguments per se we cons up some fake arguments.
             out bool hadNullabilityMismatch,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics,
-            Func<BoundExpression, NullableAnnotation> getNullableAnnotationOpt = null)
+            Func<BoundExpression, TypeSymbolWithAnnotations> getTypeWithAnnotationOpt = null)
         {
             Debug.Assert(!methodTypeParameters.IsDefault);
             Debug.Assert(methodTypeParameters.Length > 0);
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 formalParameterTypes,
                 formalParameterRefKinds,
                 arguments,
-                getNullableAnnotationOpt);
+                getTypeWithAnnotationOpt);
             return inferrer.InferTypeArgs(binder, out hadNullabilityMismatch, ref useSiteDiagnostics);
         }
 
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<TypeSymbolWithAnnotations> formalParameterTypes,
             ImmutableArray<RefKind> formalParameterRefKinds,
             ImmutableArray<BoundExpression> arguments,
-            Func<BoundExpression, NullableAnnotation> getNullableAnnotationOpt)
+            Func<BoundExpression, TypeSymbolWithAnnotations> getTypeWithAnnotationOpt)
         {
             _conversions = conversions;
             _methodTypeParameters = methodTypeParameters;
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _formalParameterTypes = formalParameterTypes;
             _formalParameterRefKinds = formalParameterRefKinds;
             _arguments = arguments;
-            _getNullableAnnotationOpt = getNullableAnnotationOpt;
+            _getTypeWithAnnotationOpt = getTypeWithAnnotationOpt;
             _fixedResults = new TypeSymbolWithAnnotations[methodTypeParameters.Length];
             _exactBounds = new HashSet<TypeSymbolWithAnnotations>[methodTypeParameters.Length];
             _upperBounds = new HashSet<TypeSymbolWithAnnotations>[methodTypeParameters.Length];
@@ -541,8 +541,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // SPEC: * Otherwise, no inference is made for this argument
 
-            var source = argument.Type;
-
             if (argument.Kind == BoundKind.UnboundLambda)
             {
                 ExplicitParameterTypeInference(argument, target, ref useSiteDiagnostics);
@@ -551,10 +549,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 !MakeExplicitParameterTypeInferences(binder, (BoundTupleLiteral)argument, target, kind, ref useSiteDiagnostics))
             {
                 // Either the argument is not a tuple literal, or we were unable to do the inference from its elements, let's try to infer from argument type
-                if (IsReallyAType(source))
+                if (IsReallyAType(argument.Type))
                 {
-                    var annotation = GetNullableAnnotation(argument);
-                    ExactOrBoundsInference(kind, TypeSymbolWithAnnotations.Create(source, annotation), target, ref useSiteDiagnostics);
+                    ExactOrBoundsInference(kind, GetTypeWithAnnotations(argument), target, ref useSiteDiagnostics);
                 }
             }
         }
@@ -1197,7 +1194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             // SPEC: * Otherwise, if E is an expression with type U then a lower-bound
             // SPEC:   inference is made from U to T.
-            var sourceType = TypeSymbolWithAnnotations.Create(expression.Type, GetNullableAnnotation(expression));
+            var sourceType = GetTypeWithAnnotations(expression);
             if (!sourceType.IsNull)
             {
                 LowerBoundInference(sourceType, target, ref useSiteDiagnostics);
@@ -2443,13 +2440,13 @@ OuterBreak:
             return best;
         }
 
-        private NullableAnnotation GetNullableAnnotation(BoundExpression expr)
+        private TypeSymbolWithAnnotations GetTypeWithAnnotations(BoundExpression expr)
         {
-            if (!_conversions.IncludeNullability)
+            if (_conversions.IncludeNullability && _getTypeWithAnnotationOpt != null)
             {
-                return NullableAnnotation.Unknown;
+                return _getTypeWithAnnotationOpt.Invoke(expr);
             }
-            return _getNullableAnnotationOpt?.Invoke(expr) ?? NullableAnnotation.Unknown;
+            return TypeSymbolWithAnnotations.Create(expr.Type);
         }
 
         internal static TypeSymbolWithAnnotations Merge(TypeSymbolWithAnnotations first, TypeSymbolWithAnnotations second, VarianceKind variance, ConversionsBase conversions, out bool hadNullabilityMismatch)
@@ -2712,7 +2709,7 @@ OuterBreak:
                 constructedFromMethod.GetParameterTypes(),
                 constructedFromMethod.ParameterRefKinds,
                 arguments,
-                getNullableAnnotationOpt: null);
+                getTypeWithAnnotationOpt: null);
 
             if (!inferrer.InferTypeArgumentsFromFirstArgument(ref useSiteDiagnostics))
             {
@@ -2738,8 +2735,7 @@ OuterBreak:
             {
                 return false;
             }
-            var annotation = GetNullableAnnotation(argument);
-            LowerBoundInference(TypeSymbolWithAnnotations.Create(source, annotation), dest, ref useSiteDiagnostics);
+            LowerBoundInference(GetTypeWithAnnotations(argument), dest, ref useSiteDiagnostics);
             // Now check to see that every type parameter used by the first
             // formal parameter type was successfully inferred.
             for (int iParam = 0; iParam < _methodTypeParameters.Length; ++iParam)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -444,6 +444,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void AddBound(TypeSymbolWithAnnotations addedBound, HashSet<TypeSymbolWithAnnotations>[] collectedBounds, TypeSymbolWithAnnotations methodTypeParameterWithAnnotations)
         {
             Debug.Assert(IsUnfixedTypeParameter(methodTypeParameterWithAnnotations));
+            Debug.Assert(addedBound.NullableAnnotation.IsSpeakable());
 
             var methodTypeParameter = (TypeParameterSymbol)methodTypeParameterWithAnnotations.TypeSymbol;
             int methodTypeParameterIndex = methodTypeParameter.Ordinal;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1502,17 +1502,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return true;
             }
 
-            if (isNullableOnly(source) && isNullableOnly(target))
+            if (s_isNullableOnly(source) && s_isNullableOnly(target))
             {
                 ExactOrBoundsInference(kind, source.AsNotNullableReferenceType(), target.AsNotNullableReferenceType(), ref useSiteDiagnostics);
                 return true;
             }
 
             return false;
-
-            // True if the type is nullable but not an unconstrained type parameter.
-            bool isNullableOnly(TypeSymbolWithAnnotations type) => type.NullableAnnotation.IsAnyNullable() && !type.TypeSymbol.IsTypeParameterDisallowingAnnotation();
         }
+
+        // True if the type is nullable but not an unconstrained type parameter.
+        private readonly static Func<TypeSymbolWithAnnotations, bool> s_isNullableOnly =
+            (type) => type.NullableAnnotation.IsAnyNullable() && !type.TypeSymbol.IsTypeParameterDisallowingAnnotation();
 
         private bool ExactNullableInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2444,7 +2444,7 @@ OuterBreak:
         {
             if (_conversions.IncludeNullability && _getTypeWithAnnotationOpt != null)
             {
-                return _getTypeWithAnnotationOpt.Invoke(expr);
+                return _getTypeWithAnnotationOpt(expr);
             }
             return TypeSymbolWithAnnotations.Create(expr.Type);
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    types.Add(type);
+                    types.Add(type.AsSpeakable());
                 }
             }
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -171,9 +171,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     bestResultType = default;
                     break;
                 case 1:
-                    bestResultType = returns[0].Item2;
+                    bestResultType = returns[0].resultType;
                     break;
                 default:
+                    // Need to handle ref returns. See https://github.com/dotnet/roslyn/issues/30432
                     bestResultType = NullableWalker.BestTypeForLambdaReturns(returns, compilation, node);
                     break;
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    types.Add(type.AsSpeakable());
+                    types.Add(type);
                 }
             }
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -172,6 +172,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
                 case 1:
                     bestResultType = returns[0].resultType;
+                    if (conversions.IncludeNullability)
+                    {
+                        bestResultType = bestResultType.SetSpeakableNullabilityForReferenceTypes();
+                    }
                     break;
                 default:
                     // Need to handle ref returns. See https://github.com/dotnet/roslyn/issues/30432
@@ -323,7 +327,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         public bool HasSignature { get { return Data.HasSignature; } }
         public bool HasExplicitlyTypedParameterList { get { return Data.HasExplicitlyTypedParameterList; } }
         public int ParameterCount { get { return Data.ParameterCount; } }
-        public TypeSymbolWithAnnotations InferReturnType(ConversionsBase conversions, NamedTypeSymbol delegateType, ref HashSet<DiagnosticInfo> useSiteDiagnostics) { return BindForReturnTypeInference(delegateType).GetInferredReturnType(conversions, _nullableState, ref useSiteDiagnostics); }
+        public TypeSymbolWithAnnotations InferReturnType(ConversionsBase conversions, NamedTypeSymbol delegateType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+            => BindForReturnTypeInference(delegateType).GetInferredReturnType(conversions, _nullableState, ref useSiteDiagnostics);
+
         public RefKind RefKind(int index) { return Data.RefKind(index); }
         public void GenerateAnonymousFunctionConversionError(DiagnosticBag diagnostics, TypeSymbol targetType) { Data.GenerateAnonymousFunctionConversionError(diagnostics, targetType); }
         public bool GenerateSummaryErrors(DiagnosticBag diagnostics) { return Data.GenerateSummaryErrors(diagnostics); }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -176,6 +176,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     bool hadNullabilityMismatch;
                     var bestType = BestTypeInferrer.GetBestType(typesOnly, conversions, out hadNullabilityMismatch, ref useSiteDiagnostics);
+
+
+                    // WIP: TODO: convert types to bestType to determine top-level nullabilities
+                    // WIP: TODO: merge the top-level nullabilities
+
                     // https://github.com/dotnet/roslyn/issues/30480: Should return `bestType` even if
                     // there was a nullability mismatch, and `hadNullabilityMismatch` should be available
                     // to the caller, and up through MethodTypeInferrer.Infer.

--- a/src/Compilers/CSharp/Portable/Errors/LazyUseSiteDiagnosticsInfoForNullableType.cs
+++ b/src/Compilers/CSharp/Portable/Errors/LazyUseSiteDiagnosticsInfoForNullableType.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return _possiblyNullableTypeSymbol.TypeSymbol.OriginalDefinition.GetUseSiteDiagnostic();
             }
-            else if (_possiblyNullableTypeSymbol.TypeSymbol.IsUnconstrainedTypeParameter())
+            else if (_possiblyNullableTypeSymbol.TypeSymbol.IsTypeParameterDisallowingAnnotation())
             {
                 return new CSDiagnosticInfo(ErrorCode.ERR_NullableUnconstrainedTypeParameter);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -614,7 +614,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 isDefaultOfUnconstrainedTypeParameter(conversion.Operand);
                         }
                     case BoundKind.DefaultExpression:
-                        return IsUnconstrainedTypeParameter(expr.Type);
+                        return IsTypeParameterDisallowingAnnotation(expr.Type);
                     default:
                         return false;
                 }
@@ -1080,7 +1080,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return returnType;
         }
 
-        private static bool IsUnconstrainedTypeParameter(TypeSymbol typeOpt)
+        private static bool IsTypeParameterDisallowingAnnotation(TypeSymbol typeOpt)
         {
             return typeOpt?.IsTypeParameterDisallowingAnnotation() == true;
         }
@@ -3536,7 +3536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             resultAnnotation = (operandType.IsNullableTypeOrTypeParameter() && operandType.GetValueNullableAnnotation().IsAnyNullable()) ? NullableAnnotation.Nullable : NullableAnnotation.NotNullable;
                             break;
                         }
-                        else if (IsUnconstrainedTypeParameter(operandType.TypeSymbol))
+                        else if (IsTypeParameterDisallowingAnnotation(operandType.TypeSymbol))
                         {
                             if (operandType.IsPossiblyNullableReferenceTypeTypeParameter() && !targetTypeWithNullability.IsPossiblyNullableReferenceTypeTypeParameter())
                             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2947,8 +2947,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 if (argument is BoundLocal local && local.DeclarationKind == BoundLocalDeclarationKind.WithInferredType)
                 {
-                    // TODO: the condition seems too lose. This might be a regular local, not an out var... Need to test
-
                     // 'out var' doesn't contribute to inference
                     return new BoundExpressionWithNullability(argument.Syntax, argument, NullableAnnotation.Unknown, type: null);
                 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2984,7 +2984,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 arguments,
                 out hadNullabilityMismatch,
                 ref useSiteDiagnostics,
-                getTypeWithAnnotationOpt: getTypeWithSpeakableAnnotations);
+                getTypeWithAnnotationOpt: s_getTypeWithSpeakableAnnotations);
 
             if (!result.Success)
             {
@@ -2995,11 +2995,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ReportSafetyDiagnostic(ErrorCode.WRN_CantInferNullabilityOfMethodTypeArgs, node.Syntax, definition);
             }
             return definition.Construct(result.InferredTypeArguments);
-
-            // Note: although only tuple types can have nested types that are unspeakable, we make all nested types speakable to be sure
-            TypeSymbolWithAnnotations getTypeWithSpeakableAnnotations(BoundExpression expr)
-                => TypeSymbolWithAnnotations.Create(expr.Type, GetNullableAnnotation(expr)).SetSpeakableNullabilityForReferenceTypes();
         }
+
+        // Note: although only tuple types can have nested types that are unspeakable, we make all nested types speakable to be sure
+        private readonly static Func<BoundExpression, TypeSymbolWithAnnotations> s_getTypeWithSpeakableAnnotations =
+            (expr) => TypeSymbolWithAnnotations.Create(expr.Type, GetNullableAnnotation(expr)).SetSpeakableNullabilityForReferenceTypes();
 
         private ImmutableArray<BoundExpression> GetArgumentsForMethodTypeInference(ImmutableArray<BoundExpression> arguments, ImmutableArray<TypeSymbolWithAnnotations> argumentResults)
         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1384,9 +1384,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (BoundExpression element, Conversion conversion) = RemoveConversion(elementBuilder[i], includeExplicitConversions: false);
                 elementBuilder[i] = element;
                 conversionBuilder.Add(conversion);
-                var value = VisitRvalueWithResult(element);
-                resultBuilder.Add(value);
-                speakableResultBuilder.Add(value.AsSpeakable());
+                var resultType = VisitRvalueWithResult(element);
+                resultBuilder.Add(resultType);
+                speakableResultBuilder.Add(resultType.AsSpeakable());
             }
 
             bool checkConversions = true;
@@ -1895,11 +1895,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             if (constant.IsNull)
                             {
-                                return NullableAnnotation.Nullable;
+                                return NullableAnnotation.Annotated;
                             }
                             if (expr.Type?.IsReferenceType == true)
                             {
-                                return NullableAnnotation.NotNullable;
+                                return NullableAnnotation.NotAnnotated;
                             }
                         }
                         return NullableAnnotation.Unknown;
@@ -2863,7 +2863,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private MethodSymbol InferMethodTypeArguments(BoundCall node, MethodSymbol method, ImmutableArray<BoundExpression> arguments)
         {
             Debug.Assert(method.IsGenericMethod);
-            Debug.Assert(arguments.All(a => a.GetTypeAndNullability().NullableAnnotation.IsSpeakable()));
+            Debug.Assert(arguments.All(a => GetNullableAnnotation(a).IsSpeakable()));
 
             // https://github.com/dotnet/roslyn/issues/27961 OverloadResolution.IsMemberApplicableInNormalForm and
             // IsMemberApplicableInExpandedForm use the least overridden method. We need to do the same here.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     continue;
                 }
-                if (!fieldType.NullableAnnotation.IsAnyNotNullable() && !fieldType.TypeSymbol.IsUnconstrainedTypeParameter())
+                if (!fieldType.NullableAnnotation.IsAnyNotNullable() && !fieldType.TypeSymbol.IsTypeParameterDisallowingAnnotation())
                 {
                     continue;
                 }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -100,13 +100,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier) &&
                 !typeOpt.IsNullableType() && !typeOpt.IsValueType &&
                 (typeOpt.NullableAnnotation == NullableAnnotation.Annotated ||
-                 (typeOpt.NullableAnnotation == NullableAnnotation.Nullable && !typeOpt.TypeSymbol.IsUnconstrainedTypeParameter())))
+                 (typeOpt.NullableAnnotation == NullableAnnotation.Nullable && !typeOpt.TypeSymbol.IsTypeParameterDisallowingAnnotation())))
             {
                 AddPunctuation(SyntaxKind.QuestionToken);
             }
             else if (format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeNonNullableTypeModifier) &&
                 !typeOpt.IsValueType &&
-                typeOpt.NullableAnnotation.IsAnyNotNullable() && !typeOpt.TypeSymbol.IsUnconstrainedTypeParameter())
+                typeOpt.NullableAnnotation.IsAnyNotNullable() && !typeOpt.TypeSymbol.IsTypeParameterDisallowingAnnotation())
             {
                 AddPunctuation(SyntaxKind.ExclamationToken);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -399,9 +399,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> transform)
         {
-            return WithElementType(predicate(ElementType));
+            return WithElementType(transform(ElementType));
         }
 
         internal override TypeSymbol MergeNullability(TypeSymbol other, VarianceKind variance, out bool hadNullabilityMismatch)

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -399,9 +399,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetUnknownNullabilityForReferenceTypes()
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
         {
-            return WithElementType(ElementType.SetUnknownNullabilityForReferenceTypes());
+            return WithElementType(predicate(ElementType));
         }
 
         internal override TypeSymbol MergeNullability(TypeSymbol other, VarianceKind variance, out bool hadNullabilityMismatch)

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> transform)
         {
             return this;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetUnknownNullabilityForReferenceTypes()
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
         {
             return this;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -813,7 +813,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> transform)
         {
             if (!IsGenericType)
             {
@@ -827,7 +827,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             for (int i = 0; i < allTypeArguments.Count; i++)
             {
                 TypeSymbolWithAnnotations oldTypeArgument = allTypeArguments[i];
-                TypeSymbolWithAnnotations newTypeArgument = predicate(oldTypeArgument);
+                TypeSymbolWithAnnotations newTypeArgument = transform(oldTypeArgument);
                 if (!oldTypeArgument.IsSameAs(newTypeArgument))
                 {
                     allTypeArguments[i] = newTypeArgument;

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -813,7 +813,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetUnknownNullabilityForReferenceTypes()
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
         {
             if (!IsGenericType)
             {
@@ -827,7 +827,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             for (int i = 0; i < allTypeArguments.Count; i++)
             {
                 TypeSymbolWithAnnotations oldTypeArgument = allTypeArguments[i];
-                TypeSymbolWithAnnotations newTypeArgument = oldTypeArgument.SetUnknownNullabilityForReferenceTypes();
+                TypeSymbolWithAnnotations newTypeArgument = predicate(oldTypeArgument);
                 if (!oldTypeArgument.IsSameAs(newTypeArgument))
                 {
                     allTypeArguments[i] = newTypeArgument;

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -269,9 +269,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> transform)
         {
-            return WithPointedAtType(predicate(PointedAtType));
+            return WithPointedAtType(transform(PointedAtType));
         }
 
         internal override TypeSymbol MergeNullability(TypeSymbol other, VarianceKind variance, out bool hadNullabilityMismatch)

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -269,9 +269,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetUnknownNullabilityForReferenceTypes()
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
         {
-            return WithPointedAtType(PointedAtType.SetUnknownNullabilityForReferenceTypes());
+            return WithPointedAtType(predicate(PointedAtType));
         }
 
         internal override TypeSymbol MergeNullability(TypeSymbol other, VarianceKind variance, out bool hadNullabilityMismatch)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -623,7 +623,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     break;
                                 }
                             }
-                            
                         }
 
                         if (!suppressError)

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1446,9 +1446,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        internal override TypeSymbol SetUnknownNullabilityForReferenceTypes()
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
         {
-            var underlyingType = (NamedTypeSymbol)_underlyingType.SetUnknownNullabilityForReferenceTypes();
+            var underlyingType = (NamedTypeSymbol)_underlyingType.SetNullabilityForReferenceTypes(predicate);
             if ((object)underlyingType == _underlyingType)
             {
                 return this;

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1497,7 +1497,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 TypeSymbolWithAnnotations typeArgumentA = typeArgumentsA[i];
                 TypeSymbolWithAnnotations typeArgumentB = typeArgumentsB[i];
-                TypeSymbolWithAnnotations merged = typeArgumentA.MergeNullability(typeArgumentB, variance, out bool hadMismatch);
+                TypeSymbolWithAnnotations merged = mergeNullability(typeArgumentA, typeArgumentB, out bool hadMismatch);
                 hadNullabilityMismatch |= hadMismatch;
                 allTypeArguments.Add(merged);
                 if (!typeArgumentA.IsSameAs(merged))
@@ -1514,7 +1514,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             allTypeArguments.Free();
             return haveChanges;
+
+            // We use special rules for merging tuples, allowing nested types to remain unspeakable
+            TypeSymbolWithAnnotations mergeNullability(TypeSymbolWithAnnotations one, TypeSymbolWithAnnotations other, out bool nullabilityMismatch)
+            {
+                TypeSymbol typeSymbol = other.TypeSymbol;
+                NullableAnnotation nullableAnnotation = mergeNullableAnnotation(typeSymbol, one.NullableAnnotation, other.NullableAnnotation, out bool hadTopLevelMismatch);
+                TypeSymbol type = one.TypeSymbol.MergeNullability(typeSymbol, variance, out bool hadNestedMismatch);
+                Debug.Assert((object)type != null);
+                nullabilityMismatch = hadTopLevelMismatch | hadNestedMismatch;
+                return TypeSymbolWithAnnotations.Create(type, nullableAnnotation, one.CustomModifiers);
+            }
+
+            NullableAnnotation mergeNullableAnnotation(TypeSymbol type, NullableAnnotation a, NullableAnnotation b, out bool nullabilityMismatch)
+            {
+                nullabilityMismatch = false;
+                switch (variance)
+                {
+                    case VarianceKind.In:
+                        return a.MeetForFlowAnalysisFinally(b);
+                    case VarianceKind.Out:
+                        return a.JoinForFlowAnalysisBranches(b, type, _IsPossiblyNullableReferenceTypeTypeParameterDelegate);
+                    case VarianceKind.None:
+                        return a.EnsureCompatibleForTuples(b, type, _IsPossiblyNullableReferenceTypeTypeParameterDelegate, out nullabilityMismatch);
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(variance);
+                }
+            }
         }
+
+        private readonly static Func<TypeSymbol, bool> _IsPossiblyNullableReferenceTypeTypeParameterDelegate = type => type.IsPossiblyNullableReferenceTypeTypeParameter();
 
         #region Use-Site Diagnostics
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1446,9 +1446,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> transform)
         {
-            var underlyingType = (NamedTypeSymbol)_underlyingType.SetNullabilityForReferenceTypes(predicate);
+            var underlyingType = (NamedTypeSymbol)_underlyingType.SetNullabilityForReferenceTypes(transform);
             if ((object)underlyingType == _underlyingType)
             {
                 return this;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -677,7 +677,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetUnknownNullabilityForReferenceTypes()
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
         {
             return this;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -677,7 +677,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate)
+        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> transform)
         {
             return this;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -633,23 +633,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract bool ApplyNullableTransforms(byte defaultTransformFlag, ImmutableArray<byte> transforms, ref int position, out TypeSymbol result);
 
-        internal abstract TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate);
+        internal abstract TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> transform);
 
         internal TypeSymbol SetUnknownNullabilityForReferenceTypes()
         {
-            return SetNullabilityForReferenceTypes(setUnknownNullability);
-
-            TypeSymbolWithAnnotations setUnknownNullability(TypeSymbolWithAnnotations type)
-                => type.SetUnknownNullabilityForReferenceTypes();
+            return SetNullabilityForReferenceTypes(s_setUnknownNullability);
         }
+
+        private readonly static Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> s_setUnknownNullability =
+            (type) => type.SetUnknownNullabilityForReferenceTypes();
 
         internal TypeSymbol SetSpeakableNullabilityForReferenceTypes()
         {
-            return SetNullabilityForReferenceTypes(setSpeakableNullability);
-
-            TypeSymbolWithAnnotations setSpeakableNullability(TypeSymbolWithAnnotations type)
-                => type.SetSpeakableNullabilityForReferenceTypes();
+            return SetNullabilityForReferenceTypes(s_setSpeakableNullability);
         }
+
+        private readonly static Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> s_setSpeakableNullability =
+           (type) => type.SetSpeakableNullabilityForReferenceTypes();
 
         /// <summary>
         /// Merges nested nullability from an otherwise identical type.

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -633,7 +633,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract bool ApplyNullableTransforms(byte defaultTransformFlag, ImmutableArray<byte> transforms, ref int position, out TypeSymbol result);
 
-        internal abstract TypeSymbol SetUnknownNullabilityForReferenceTypes();
+        internal abstract TypeSymbol SetNullabilityForReferenceTypes(Func<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> predicate);
+
+        internal TypeSymbol SetUnknownNullabilityForReferenceTypes()
+        {
+            return SetNullabilityForReferenceTypes(setUnknownNullability);
+
+            TypeSymbolWithAnnotations setUnknownNullability(TypeSymbolWithAnnotations type)
+                => type.SetUnknownNullabilityForReferenceTypes();
+        }
+
+        internal TypeSymbol SetSpeakableNullabilityForReferenceTypes()
+        {
+            return SetNullabilityForReferenceTypes(setSpeakableNullability);
+
+            TypeSymbolWithAnnotations setSpeakableNullability(TypeSymbolWithAnnotations type)
+                => type.SetSpeakableNullabilityForReferenceTypes();
+        }
 
         /// <summary>
         /// Merges nested nullability from an otherwise identical type.

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         //    T where T : class? => true
         //    T where T : IComparable => true
         //    T where T : IComparable? => true
-        public static bool IsUnconstrainedTypeParameter(this TypeSymbol type)
+        public static bool IsTypeParameterDisallowingAnnotation(this TypeSymbol type)
         {
             if (type.TypeKind != TypeKind.TypeParameter)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -41,15 +41,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return typeSymbol.IsReferenceType || typeSymbol.IsEnumType() || typeSymbol.SpecialType.CanBeConst();
         }
 
-        // https://github.com/dotnet/roslyn/issues/30056: Should probably rename this method to have more specific name.
-        //                                    At the moment it is used only for Nullable Reference Types feature and
-        //                                    its implementation is specialized for this feature.
-        //    T => true
-        //    T where T : struct => false
-        //    T where T : class => false
-        //    T where T : class? => true
-        //    T where T : IComparable => true
-        //    T where T : IComparable? => true
+        /// <summary>
+        /// T => true
+        /// T where T : struct => false
+        /// T where T : class => false
+        /// T where T : class? => true
+        /// T where T : IComparable => true
+        /// T where T : IComparable? => true
+        /// </summary>
         public static bool IsTypeParameterDisallowingAnnotation(this TypeSymbol type)
         {
             if (type.TypeKind != TypeKind.TypeParameter)
@@ -62,12 +61,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return !typeParameter.IsValueType && !(typeParameter.IsReferenceType && typeParameter.IsNotNullableIfReferenceType == true);
         }
 
-        //    T => true
-        //    T where T : struct => false
-        //    T where T : class => false
-        //    T where T : class? => true
-        //    T where T : IComparable => false
-        //    T where T : IComparable? => true
+        /// <summary>
+        /// T => true
+        /// T where T : struct => false
+        /// T where T : class => false
+        /// T where T : class? => true
+        /// T where T : IComparable => false
+        /// T where T : IComparable? => true
+        /// </summary>
         public static bool IsPossiblyNullableReferenceTypeTypeParameter(this TypeSymbol type)
         {
             if (type.TypeKind != TypeKind.TypeParameter)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -343,6 +343,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _extensions = extensions;
         }
 
+        public TypeSymbolWithAnnotations AsSpeakable()
+        {
+            return Create(this.TypeSymbol, this.GetSpeakableNullableAnnotation(), this.CustomModifiers);
+        }
+
         /// <summary>
         /// This method projects nullable annotations onto a smaller set that can be expressed in source.
         /// </summary>
@@ -563,7 +568,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// The list of custom modifiers, if any, associated with the <see cref="TypeSymbol"/>.
         /// </summary>
-        public ImmutableArray<CustomModifier> CustomModifiers => _extensions.CustomModifiers;
+        public ImmutableArray<CustomModifier> CustomModifiers => _extensions is null ? default : _extensions.CustomModifiers;
 
         public bool IsReferenceType => TypeSymbol.IsReferenceType;
         public bool IsValueType => TypeSymbol.IsValueType;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -476,8 +476,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal TypeSymbolWithAnnotations MergeNullability(TypeSymbolWithAnnotations other, VarianceKind variance, out bool hadNullabilityMismatch)
         {
-            TypeSymbol typeSymbol = other.TypeSymbol;
-            NullableAnnotation nullableAnnotation = MergeNullableAnnotation(typeSymbol, NullableAnnotation, other.NullableAnnotation, variance, out bool hadTopLevelMismatch);
+            // There is no loss of information from applying AsSpeakable, because we've called AsSpeakable to adjust top-level nullability in relevant callers,
+            // and other callers don't produce this combination (you can't get a nested unspeakable type during nullability analysis).
+            Debug.Assert(this.NullableAnnotation != NullableAnnotation.NotNullable || !this.TypeSymbol.IsTypeParameterDisallowingAnnotation());
+            Debug.Assert(other.NullableAnnotation != NullableAnnotation.NotNullable || !other.TypeSymbol.IsTypeParameterDisallowingAnnotation());
+
+            TypeSymbolWithAnnotations speakableThis = this.AsSpeakable();
+            TypeSymbolWithAnnotations speakableOther = other.AsSpeakable();
+
+            TypeSymbol typeSymbol = speakableOther.TypeSymbol;
+            NullableAnnotation nullableAnnotation = MergeNullableAnnotation(speakableThis.NullableAnnotation, speakableOther.NullableAnnotation, variance, out bool hadTopLevelMismatch);
             TypeSymbol type = TypeSymbol.MergeNullability(typeSymbol, variance, out bool hadNestedMismatch);
             Debug.Assert((object)type != null);
             hadNullabilityMismatch = hadTopLevelMismatch | hadNestedMismatch;
@@ -488,8 +496,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Merges nullability.
         /// <paramref name="hadNullabilityMismatch"/> is true if there was conflict.
         /// </summary>
-        private static NullableAnnotation MergeNullableAnnotation(TypeSymbol type, NullableAnnotation a, NullableAnnotation b, VarianceKind variance, out bool hadNullabilityMismatch)
+        private static NullableAnnotation MergeNullableAnnotation(NullableAnnotation a, NullableAnnotation b, VarianceKind variance, out bool hadNullabilityMismatch)
         {
+            Debug.Assert(a.IsSpeakable());
+            Debug.Assert(b.IsSpeakable());
+
             hadNullabilityMismatch = false;
             switch (variance)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public TypeSymbolWithAnnotations AsSpeakable()
         {
-            return Create(this.TypeSymbol, this.GetSpeakableNullableAnnotation(), this.CustomModifiers);
+            return Create(this.TypeSymbol, this.GetSpeakableNullableAnnotation(), this.IsNull ? default : this.CustomModifiers);
         }
 
         /// <summary>
@@ -566,7 +566,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// The list of custom modifiers, if any, associated with the <see cref="TypeSymbol"/>.
         /// </summary>
-        public ImmutableArray<CustomModifier> CustomModifiers => _extensions is null ? default : _extensions.CustomModifiers;
+        public ImmutableArray<CustomModifier> CustomModifiers => _extensions.CustomModifiers;
 
         public bool IsReferenceType => TypeSymbol.IsReferenceType;
         public bool IsValueType => TypeSymbol.IsValueType;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -1002,6 +1002,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public TypeSymbolWithAnnotations SetSpeakableNullabilityForReferenceTypes()
         {
+            if (IsNull)
+            {
+                return default;
+            }
+
             var newTypeSymbol = TypeSymbol.SetSpeakableNullabilityForReferenceTypes();
 
             if (!NullableAnnotation.IsSpeakable())

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // If nullability on both sides matches - result is that nullability (trivial cases like these are handled above)
             // If either candidate is nullable - result is nullable
-            // Otherwise - result is "oblivious". 
+            // Otherwise - result is "oblivious".
 
             if (a.IsAnyNullable())
             {
@@ -77,8 +77,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert((a == NullableAnnotation.NotAnnotated && b == NullableAnnotation.NotNullable) ||
                 (b == NullableAnnotation.NotAnnotated && a == NullableAnnotation.NotNullable));
             return NullableAnnotation.NotAnnotated; // It is reasonable to settle on this value because the difference in annotations is either
-                                                    // not significant for the type, or candidate corresponding to this value is possibly a 
-                                                    // nullable reference type type parameter and nullable should win. 
+                                                    // not significant for the type, or candidate corresponding to this value is possibly a
+                                                    // nullable reference type type parameter and nullable should win.
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // If nullability on both sides matches - result is that nullability (trivial cases like these are handled above)
             // If either candidate is not nullable - result is not nullable
-            // Otherwise - result is "oblivious". 
+            // Otherwise - result is "oblivious".
 
             if (a == NullableAnnotation.NotNullable || b == NullableAnnotation.NotNullable)
             {
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // If nullability on both sides matches - result is that nullability (trivial cases like these are handled above)
             // If either candidate is "oblivious" - result is the nullability of the other candidate
-            // Otherwise - we declare a mismatch and result is not nullable. 
+            // Otherwise - we declare a mismatch and result is not nullable.
 
             if (a == NullableAnnotation.Unknown)
             {
@@ -368,8 +368,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 case NullableAnnotation.NotNullable:
                     // Example of unspeakable types:
-                    // - a "tight T", which is an unconstrained T which was null-tested already
-                    // - a "tight int?"
+                    // - an unconstrained T which was null-tested already
+                    // - a nullable value type which was null-tested already
                     return NullableAnnotation.NotAnnotated;
 
                 default:

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -44,6 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public static NullableAnnotation AsSpeakable(this NullableAnnotation annotation, TypeSymbol type)
         {
+            Debug.Assert((object)type != null);
             switch (annotation)
             {
                 case NullableAnnotation.Unknown:
@@ -479,8 +480,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // There is no loss of information from applying AsSpeakable, because we've called AsSpeakable to adjust top-level nullability in relevant callers,
             // and other callers don't produce this combination (you can't get a nested unspeakable type during nullability analysis).
-            Debug.Assert(this.NullableAnnotation != NullableAnnotation.NotNullable || !this.TypeSymbol.IsTypeParameterDisallowingAnnotation());
-            Debug.Assert(other.NullableAnnotation != NullableAnnotation.NotNullable || !other.TypeSymbol.IsTypeParameterDisallowingAnnotation());
+            Debug.Assert(this.NullableAnnotation != NullableAnnotation.NotNullable && this.NullableAnnotation != NullableAnnotation.Nullable);
+            Debug.Assert(other.NullableAnnotation != NullableAnnotation.NotNullable && other.NullableAnnotation != NullableAnnotation.Nullable);
 
             TypeSymbolWithAnnotations speakableThis = this.AsSpeakable();
             TypeSymbolWithAnnotations speakableOther = other.AsSpeakable();

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -32,14 +32,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return annotation == NullableAnnotation.NotAnnotated || annotation == NullableAnnotation.NotNullable;
         }
 
-#if DEBUG
         public static bool IsSpeakable(this NullableAnnotation annotation)
         {
             return annotation == NullableAnnotation.Unknown ||
                 annotation == NullableAnnotation.NotAnnotated ||
                 annotation == NullableAnnotation.Annotated;
         }
-#endif
 
         /// <summary>
         /// Join nullable annotations from the set of lower bounds for fixing a type parameter.

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -62,6 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // Example of unspeakable types:
                     // - an unconstrained T which was null-tested already
                     // - a nullable value type which was null-tested already
+                    // Note this projection is lossy for such types (we forget about the non-nullable state)
                     return NullableAnnotation.NotAnnotated;
 
                 default:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -8556,9 +8556,12 @@ class C
         }
 
         [WorkItem(21028, "https://github.com/dotnet/roslyn/issues/21028")]
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/32006")]
         public void InferredName_Lambda()
         {
+            // See https://github.com/dotnet/roslyn/issues/32006
+            // need to relax assertion in GetImplicitTupleLiteralConversion
+
             var source =
 @"class C
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -18087,9 +18087,12 @@ public class C
             Assert.Equal("(System.Int32 a, System.Int32) x1", x1.ToTestDisplayString());
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/32006")]
         public void LambdaTypeInferenceWithDynamic()
         {
+            // See https://github.com/dotnet/roslyn/issues/32006
+            // need to relax assertion in GetImplicitTupleLiteralConversion
+
             var source = @"
 public class C
 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -74,28 +74,36 @@ class C
                 );
         }
 
-        [Theory]
-        [InlineData("void M(int? t)")]
-        [InlineData("void M<T>(T? t) where T : struct")]
-        public void SpeakableInference_MethodTypeInference_NullableValueType(string signature)
+        [Fact]
+        public void SpeakableInference_MethodTypeInference_NullableValueType()
         {
             var source =
 @"class Program
 {
-    SIGNATURE
+    void M(int? t)
     {
         if (t == null) throw null;
         t.Value.ToString();
         var t2 = Copy(t);
         t2.Value.ToString(); // warn
     }
-    static T Copy<T>(T t) => throw null;
+    void M2<T>(T? t) where T : struct
+    {
+        if (t == null) throw null;
+        t.Value.ToString();
+        var t2 = Copy(t);
+        t2.Value.ToString(); // warn
+    }
+     static T Copy<T>(T t) => throw null;
 }";
-            var comp = CreateCompilationWithIndexAndRange(source.Replace("SIGNATURE", signature), options: WithNonNullTypesTrue());
+            var comp = CreateCompilationWithIndexAndRange(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (8,9): warning CS8629: Nullable value type may be null.
                 //         t2.Value.ToString(); // warn
-                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "t2.Value").WithLocation(8, 9)
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "t2.Value").WithLocation(8, 9),
+                // (15,9): warning CS8629: Nullable value type may be null.
+                //         t2.Value.ToString(); // warn
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "t2.Value").WithLocation(15, 9)
                 );
         }
 
@@ -121,15 +129,20 @@ class C
                 );
         }
 
-        [Theory]
-        [InlineData("void M(int? t)")]
-        [InlineData("void M<T>(T? t) where T : struct")]
-        public void SpeakableInference_ArrayTypeInference_NullableValueType(string signature)
+        [Fact]
+        public void SpeakableInference_ArrayTypeInference_NullableValueType()
         {
             var source =
 @"class Program
 {
-    SIGNATURE
+    void M(int? t)
+    {
+        if (t == null) throw null;
+        t.Value.ToString();
+        var t2 = new[] { t };
+        t2[0].Value.ToString(); // warn
+    }
+    void M2<T>(T? t) where T : struct
     {
         if (t == null) throw null;
         t.Value.ToString();
@@ -137,11 +150,14 @@ class C
         t2[0].Value.ToString(); // warn
     }
 }";
-            var comp = CreateCompilationWithIndexAndRange(source.Replace("SIGNATURE", signature), options: WithNonNullTypesTrue());
+            var comp = CreateCompilationWithIndexAndRange(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (8,9): warning CS8629: Nullable value type may be null.
                 //         t2[0].Value.ToString(); // warn
-                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "t2[0].Value").WithLocation(8, 9)
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "t2[0].Value").WithLocation(8, 9),
+                // (15,9): warning CS8629: Nullable value type may be null.
+                //         t2[0].Value.ToString(); // warn
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "t2[0].Value").WithLocation(15, 9)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -64270,10 +64270,10 @@ partial class Program
         }
 
         [Fact]
-        public void TestEnsureCompatible_IsPossiblyNullableReferenceTypeTypeParameterTrue()
+        public void TestEnsureCompatible()
         {
             var inputs = new[] { NullableAnnotation.Annotated, NullableAnnotation.Unknown, NullableAnnotation.NotAnnotated };
-            Func<int, int, NullableAnnotation> getResult = (i, j) => NullableAnnotationExtensions.EnsureCompatible<string>(inputs[i], inputs[j], null, _ => true, out _);
+            Func<int, int, NullableAnnotation> getResult = (i, j) => NullableAnnotationExtensions.EnsureCompatible(inputs[i], inputs[j], out _);
 
             var expected = new NullableAnnotation[3, 3]
             {
@@ -64289,7 +64289,7 @@ partial class Program
         public void TestEnsureCompatible_IsPossiblyNullableReferenceTypeTypeParameterTrue_HadNullabilityMismatch()
         {
             var inputs = new[] { NullableAnnotation.Annotated, NullableAnnotation.Unknown, NullableAnnotation.NotAnnotated };
-            Func<int, int, bool> getResult = (i, j) => { NullableAnnotationExtensions.EnsureCompatible<string>(inputs[i], inputs[j], null, _ => true, out var hadNullabilityMismatch); return hadNullabilityMismatch; };
+            Func<int, int, bool> getResult = (i, j) => { NullableAnnotationExtensions.EnsureCompatible(inputs[i], inputs[j], out var hadNullabilityMismatch); return hadNullabilityMismatch; };
 
             var expected = new bool[3, 3]
             {
@@ -64298,78 +64298,7 @@ partial class Program
                 { true,  false, false },
             };
 
-            AssertEqual(expected, getResult, inputs.Length);
-        }
-
-        [Fact]
-        public void TestEnsureCompatible_IsPossiblyNullableReferenceTypeTypeParameterFalse()
-        {
-            var inputs = new[] { NullableAnnotation.Annotated, NullableAnnotation.Unknown, NullableAnnotation.NotAnnotated };
-            Func<int, int, NullableAnnotation> getResult = (i, j) => NullableAnnotationExtensions.EnsureCompatible<string>(inputs[i], inputs[j], null, _ => false, out _);
-
-            var expected = new NullableAnnotation[3, 3]
-            {
-                { NullableAnnotation.Annotated,    NullableAnnotation.Annotated,    NullableAnnotation.NotAnnotated  },
-                { NullableAnnotation.Annotated,    NullableAnnotation.Unknown,      NullableAnnotation.NotAnnotated  },
-                { NullableAnnotation.NotAnnotated, NullableAnnotation.NotAnnotated, NullableAnnotation.NotAnnotated  },
-            };
-
-            AssertEqual(expected, getResult, inputs.Length);
-        }
-
-        [Fact]
-        public void TestEnsureCompatible_IsPossiblyNullableReferenceTypeTypeParameterFalse_HadNullabilityMismatch()
-        {
-            var inputs = new[] { NullableAnnotation.Annotated, NullableAnnotation.Unknown, NullableAnnotation.NotAnnotated };
-            Func<int, int, bool> getResult = (i, j) => { NullableAnnotationExtensions.EnsureCompatible<string>(inputs[i], inputs[j], null, _ => false, out var hadNullabilityMismatch); return hadNullabilityMismatch; };
-
-            var expected = new bool[3, 3]
-            {
-                { false, false, true   },
-                { false, false, false  },
-                { true,  false, false  },
-            };
-
-            AssertEqual(expected, getResult, inputs.Length);
-        }
-
-        private static void AssertEqual(bool[,] expected, Func<int, int, bool> getResult, int size)
-        {
-            bool mismatch = false;
-            for (int i = 0; i < size; i++)
-            {
-                for (int j = 0; j < size; j++)
-                {
-                    if (expected[i, j] != getResult(i, j))
-                    {
-                        mismatch = true;
-                    }
-                }
-            }
-
-            if (mismatch)
-            {
-                var builder = new StringBuilder();
-                builder.AppendLine("Actual result: ");
-                for (int i = 0; i < size; i++)
-                {
-                    builder.Append("{ ");
-                    for (int j = 0; j < size; j++)
-                    {
-                        string resultWithComma = getResult(i, j) ? "true" : "false";
-                        if (j < size - 1)
-                        {
-                            resultWithComma += ",";
-                        }
-
-                        builder.Append($"{resultWithComma,-7:G}");
-
-                    }
-                    builder.AppendLine("},");
-                }
-
-                Assert.True(false, builder.ToString());
-            }
+            AssertEx.Equal(expected, getResult, inputs.Length);
         }
 
         private static void AssertEqual(NullableAnnotation[,] expected, Func<int, int, NullableAnnotation> getResult, int size)
@@ -64495,8 +64424,8 @@ partial class Program
                     {
                         foreach (bool isPossiblyNullableReferenceTypeTypeParameter in new[] { true, false })
                         {
-                            var leftFirst = a.EnsureCompatible(b, isPossiblyNullableReferenceTypeTypeParameter, identity, out var w1a).EnsureCompatible(c, isPossiblyNullableReferenceTypeTypeParameter, identity, out var w1b);
-                            var rightFirst = a.EnsureCompatible(b.EnsureCompatible(c, isPossiblyNullableReferenceTypeTypeParameter, identity, out var w2a), isPossiblyNullableReferenceTypeTypeParameter, identity, out var w2b);
+                            var leftFirst = a.EnsureCompatible(b, out var w1a).EnsureCompatible(c, out var w1b);
+                            var rightFirst = a.EnsureCompatible(b.EnsureCompatible(c, out var w2a), out var w2b);
                             Assert.Equal(leftFirst, rightFirst);
                             Assert.Equal(w1a | w1b, w2a | w2b);
                         }
@@ -64578,8 +64507,8 @@ partial class Program
                 {
                     foreach (bool isPossiblyNullableReferenceTypeTypeParameter in new[] { true, false })
                     {
-                        var leftFirst = a.EnsureCompatible(b, isPossiblyNullableReferenceTypeTypeParameter, identity, out var w1);
-                        var rightFirst = b.EnsureCompatible(a, isPossiblyNullableReferenceTypeTypeParameter, identity, out var w2);
+                        var leftFirst = a.EnsureCompatible(b, out var w1);
+                        var rightFirst = b.EnsureCompatible(a, out var w2);
                         Assert.Equal(leftFirst, rightFirst);
                         Assert.Equal(w1, w2);
                     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -64001,8 +64001,8 @@ partial class Program
 
             var expected = new NullableAnnotation[5, 5]
             {
+                { NullableAnnotation.Annotated,     NullableAnnotation.Annotated,     NullableAnnotation.Unknown,       NullableAnnotation.NotNullable,   NullableAnnotation.NotAnnotated },
                 { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Unknown,       NullableAnnotation.NotNullable,   NullableAnnotation.NotAnnotated },
-                { NullableAnnotation.Nullable,      NullableAnnotation.Nullable,      NullableAnnotation.Unknown,       NullableAnnotation.NotNullable,   NullableAnnotation.NotAnnotated },
                 { NullableAnnotation.Unknown,       NullableAnnotation.Unknown,       NullableAnnotation.Unknown,       NullableAnnotation.NotNullable,   NullableAnnotation.NotAnnotated },
                 { NullableAnnotation.NotNullable,   NullableAnnotation.NotNullable,   NullableAnnotation.NotNullable,   NullableAnnotation.NotNullable,   NullableAnnotation.NotNullable  },
                 { NullableAnnotation.NotAnnotated,  NullableAnnotation.NotAnnotated,  NullableAnnotation.NotAnnotated,  NullableAnnotation.NotNullable,   NullableAnnotation.NotAnnotated },

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -431,6 +431,33 @@ class C<T>
         }
 
         [Fact]
+        public void SpeakableInference_LambdaReturnTypeInference_WithSingleReturn()
+        {
+            var source =
+@"class Program
+{
+    void M<T>()
+    {
+        var x1 = Copy(() => """");
+        x1.ToString();
+    }
+    void M2<T>(T t)
+    {
+        if (t == null) throw null;
+        var x1 = Copy(() => t);
+        x1.ToString(); // 1
+    }
+    T Copy<T>(System.Func<T> f) => throw null;
+}";
+            var comp = CreateCompilationWithIndexAndRange(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (12,9): warning CS8602: Possible dereference of a null reference.
+                //         x1.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(12, 9)
+                );
+        }
+
+        [Fact]
         public void SpeakableInference_LambdaReturnTypeInference_WithTuple()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -64269,6 +64269,109 @@ partial class Program
             AssertEqual(expected, getResult, inputs.Length);
         }
 
+        [Fact]
+        public void TestEnsureCompatible_IsPossiblyNullableReferenceTypeTypeParameterTrue()
+        {
+            var inputs = new[] { NullableAnnotation.Annotated, NullableAnnotation.Unknown, NullableAnnotation.NotAnnotated };
+            Func<int, int, NullableAnnotation> getResult = (i, j) => NullableAnnotationExtensions.EnsureCompatible<string>(inputs[i], inputs[j], null, _ => true, out _);
+
+            var expected = new NullableAnnotation[3, 3]
+            {
+                { NullableAnnotation.Annotated,    NullableAnnotation.Annotated,    NullableAnnotation.NotAnnotated  },
+                { NullableAnnotation.Annotated,    NullableAnnotation.Unknown,      NullableAnnotation.NotAnnotated  },
+                { NullableAnnotation.NotAnnotated, NullableAnnotation.NotAnnotated, NullableAnnotation.NotAnnotated  },
+            };
+
+            AssertEqual(expected, getResult, inputs.Length);
+        }
+
+        [Fact]
+        public void TestEnsureCompatible_IsPossiblyNullableReferenceTypeTypeParameterTrue_HadNullabilityMismatch()
+        {
+            var inputs = new[] { NullableAnnotation.Annotated, NullableAnnotation.Unknown, NullableAnnotation.NotAnnotated };
+            Func<int, int, bool> getResult = (i, j) => { NullableAnnotationExtensions.EnsureCompatible<string>(inputs[i], inputs[j], null, _ => true, out var hadNullabilityMismatch); return hadNullabilityMismatch; };
+
+            var expected = new bool[3, 3]
+            {
+                { false, false, true  },
+                { false, false, false },
+                { true,  false, false },
+            };
+
+            AssertEqual(expected, getResult, inputs.Length);
+        }
+
+        [Fact]
+        public void TestEnsureCompatible_IsPossiblyNullableReferenceTypeTypeParameterFalse()
+        {
+            var inputs = new[] { NullableAnnotation.Annotated, NullableAnnotation.Unknown, NullableAnnotation.NotAnnotated };
+            Func<int, int, NullableAnnotation> getResult = (i, j) => NullableAnnotationExtensions.EnsureCompatible<string>(inputs[i], inputs[j], null, _ => false, out _);
+
+            var expected = new NullableAnnotation[3, 3]
+            {
+                { NullableAnnotation.Annotated,    NullableAnnotation.Annotated,    NullableAnnotation.NotAnnotated  },
+                { NullableAnnotation.Annotated,    NullableAnnotation.Unknown,      NullableAnnotation.NotAnnotated  },
+                { NullableAnnotation.NotAnnotated, NullableAnnotation.NotAnnotated, NullableAnnotation.NotAnnotated  },
+            };
+
+            AssertEqual(expected, getResult, inputs.Length);
+        }
+
+        [Fact]
+        public void TestEnsureCompatible_IsPossiblyNullableReferenceTypeTypeParameterFalse_HadNullabilityMismatch()
+        {
+            var inputs = new[] { NullableAnnotation.Annotated, NullableAnnotation.Unknown, NullableAnnotation.NotAnnotated };
+            Func<int, int, bool> getResult = (i, j) => { NullableAnnotationExtensions.EnsureCompatible<string>(inputs[i], inputs[j], null, _ => false, out var hadNullabilityMismatch); return hadNullabilityMismatch; };
+
+            var expected = new bool[3, 3]
+            {
+                { false, false, true   },
+                { false, false, false  },
+                { true,  false, false  },
+            };
+
+            AssertEqual(expected, getResult, inputs.Length);
+        }
+
+        private static void AssertEqual(bool[,] expected, Func<int, int, bool> getResult, int size)
+        {
+            bool mismatch = false;
+            for (int i = 0; i < size; i++)
+            {
+                for (int j = 0; j < size; j++)
+                {
+                    if (expected[i, j] != getResult(i, j))
+                    {
+                        mismatch = true;
+                    }
+                }
+            }
+
+            if (mismatch)
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine("Actual result: ");
+                for (int i = 0; i < size; i++)
+                {
+                    builder.Append("{ ");
+                    for (int j = 0; j < size; j++)
+                    {
+                        string resultWithComma = getResult(i, j) ? "true" : "false";
+                        if (j < size - 1)
+                        {
+                            resultWithComma += ",";
+                        }
+
+                        builder.Append($"{resultWithComma,-7:G}");
+
+                    }
+                    builder.AppendLine("},");
+                }
+
+                Assert.True(false, builder.ToString());
+            }
+        }
+
         private static void AssertEqual(NullableAnnotation[,] expected, Func<int, int, NullableAnnotation> getResult, int size)
         {
             bool mismatch = false;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -63952,30 +63952,42 @@ partial class Program
         }
 
         [Fact]
-        public void TestJoinForFlowAnalysisBranches()
+        public void TestJoinForFlowAnalysisBranches_IsPossiblyNullableReferenceTypeTypeParameterFalse()
         {
-            (NullableAnnotation annotation, bool isPNTP)[] inputs = new[]
-            {
-                (NullableAnnotation.Annotated, false),
-                (NullableAnnotation.Nullable, false),
-                (NullableAnnotation.Unknown, false),
-                (NullableAnnotation.NotNullable, false),
-                (NullableAnnotation.NotAnnotated, false),
-                (NullableAnnotation.NotAnnotated, true)
-            };
+            var inputs = new[] { NullableAnnotation.Annotated, NullableAnnotation.Nullable, NullableAnnotation.Unknown, NullableAnnotation.NotNullable, NullableAnnotation.NotAnnotated };
 
             Func<int, int, NullableAnnotation> getResult =
                 (i, j) => NullableAnnotationExtensions.JoinForFlowAnalysisBranches<string>(
-                    inputs[i].annotation, inputs[j].annotation, type: null, isPossiblyNullableReferenceTypeTypeParameter: _ => inputs[i].isPNTP);
+                    inputs[i], inputs[j], type: null, isPossiblyNullableReferenceTypeTypeParameter: _ => false);
 
-            var expected = new NullableAnnotation[6, 6]
+            var expected = new NullableAnnotation[5, 5]
             {
-                { NullableAnnotation.Annotated,     NullableAnnotation.Annotated,     NullableAnnotation.Annotated,     NullableAnnotation.Annotated,     NullableAnnotation.Annotated,     NullableAnnotation.Annotated    },
-                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Nullable,      NullableAnnotation.Nullable,      NullableAnnotation.Nullable,      NullableAnnotation.Nullable     },
-                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Unknown,       NullableAnnotation.Unknown,       NullableAnnotation.Unknown,       NullableAnnotation.Unknown      },
-                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Unknown,       NullableAnnotation.NotNullable,   NullableAnnotation.NotAnnotated,  NullableAnnotation.NotAnnotated },
-                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Unknown,       NullableAnnotation.NotAnnotated,  NullableAnnotation.NotAnnotated,  NullableAnnotation.NotAnnotated },
-                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.NotAnnotated,  NullableAnnotation.NotAnnotated,  NullableAnnotation.NotAnnotated,  NullableAnnotation.NotAnnotated },
+                { NullableAnnotation.Annotated,     NullableAnnotation.Annotated,     NullableAnnotation.Annotated,     NullableAnnotation.Annotated,     NullableAnnotation.Annotated    },
+                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Nullable,      NullableAnnotation.Nullable,      NullableAnnotation.Nullable     },
+                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Unknown,       NullableAnnotation.Unknown,       NullableAnnotation.Unknown      },
+                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Unknown,       NullableAnnotation.NotNullable,   NullableAnnotation.NotAnnotated },
+                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Unknown,       NullableAnnotation.NotAnnotated,  NullableAnnotation.NotAnnotated },
+            };
+
+            AssertEqual(expected, getResult, inputs.Length);
+        }
+
+        [Fact]
+        public void TestJoinForFlowAnalysisBranches_IsPossiblyNullableReferenceTypeTypeParameterTrue()
+        {
+            var inputs = new[] { NullableAnnotation.Annotated, NullableAnnotation.Nullable, NullableAnnotation.Unknown, NullableAnnotation.NotNullable, NullableAnnotation.NotAnnotated };
+
+            Func<int, int, NullableAnnotation> getResult =
+                (i, j) => NullableAnnotationExtensions.JoinForFlowAnalysisBranches<string>(
+                    inputs[i], inputs[j], type: null, isPossiblyNullableReferenceTypeTypeParameter: _ => true);
+
+            var expected = new NullableAnnotation[5, 5]
+            {
+                { NullableAnnotation.Annotated,     NullableAnnotation.Annotated,     NullableAnnotation.Annotated,     NullableAnnotation.Annotated,     NullableAnnotation.Annotated    },
+                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Nullable,      NullableAnnotation.Nullable,      NullableAnnotation.Nullable     },
+                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Unknown,       NullableAnnotation.Unknown,       NullableAnnotation.NotAnnotated },
+                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.Unknown,       NullableAnnotation.NotNullable,   NullableAnnotation.NotAnnotated },
+                { NullableAnnotation.Annotated,     NullableAnnotation.Nullable,      NullableAnnotation.NotAnnotated,  NullableAnnotation.NotAnnotated,  NullableAnnotation.NotAnnotated },
             };
 
             AssertEqual(expected, getResult, inputs.Length);

--- a/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
@@ -325,14 +325,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 {
                     // Result types cannot have nested types that are lossy unspeakables
                     Assert.Null(entry.VisitType(typeOpt: null,
-                        typeWithAnnotationsPredicateOpt: (tswa, a, b) => !tswa.Equals(entry, TypeCompareKind.ConsiderEverything) && isLossyUnspeakable(tswa),
+                        typeWithAnnotationsPredicateOpt: (tswa, a, b) => !tswa.Equals(entry, TypeCompareKind.ConsiderEverything) && isUnspeakable(tswa),
                         typePredicateOpt: (ts, _, b) => false, arg: (object)null, canDigThroughNullable: true));
                 }
 
                 // Returns true if the application of TypeSymbolWithAnnotations.AsSpeakable would lose information
-                bool isLossyUnspeakable(TypeSymbolWithAnnotations tswa)
+                bool isUnspeakable(TypeSymbolWithAnnotations tswa)
                 {
-                    return tswa.NullableAnnotation == NullableAnnotation.NotNullable && tswa.TypeSymbol.IsTypeParameterDisallowingAnnotation();
+                    return tswa.NullableAnnotation == NullableAnnotation.NotNullable || tswa.NullableAnnotation == NullableAnnotation.Nullable;
                 }
 
                 string toDisplayString(SyntaxNode syntaxOpt)

--- a/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
                 foreach (var entry in dictionary.Values.Where(v => !v.IsNull))
                 {
-                    // Result types cannot have nested types that are lossy unspeakables
+                    // Result types cannot have nested types that are unspeakables
                     Assert.Null(entry.VisitType(typeOpt: null,
                         typeWithAnnotationsPredicateOpt: (tswa, a, b) => !tswa.Equals(entry, TypeCompareKind.ConsiderEverything) && !tswa.NullableAnnotation.IsSpeakable(),
                         typePredicateOpt: (ts, _, b) => false, arg: (object)null, canDigThroughNullable: true));

--- a/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
@@ -325,14 +325,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 {
                     // Result types cannot have nested types that are lossy unspeakables
                     Assert.Null(entry.VisitType(typeOpt: null,
-                        typeWithAnnotationsPredicateOpt: (tswa, a, b) => !tswa.Equals(entry, TypeCompareKind.ConsiderEverything) && isUnspeakable(tswa),
+                        typeWithAnnotationsPredicateOpt: (tswa, a, b) => !tswa.Equals(entry, TypeCompareKind.ConsiderEverything) && !tswa.NullableAnnotation.IsSpeakable(),
                         typePredicateOpt: (ts, _, b) => false, arg: (object)null, canDigThroughNullable: true));
-                }
-
-                // Returns true if the application of TypeSymbolWithAnnotations.AsSpeakable would lose information
-                bool isUnspeakable(TypeSymbolWithAnnotations tswa)
-                {
-                    return tswa.NullableAnnotation == NullableAnnotation.NotNullable || tswa.NullableAnnotation == NullableAnnotation.Nullable;
                 }
 
                 string toDisplayString(SyntaxNode syntaxOpt)

--- a/src/Test/Utilities/Portable/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Portable/Assert/AssertEx.cs
@@ -677,12 +677,17 @@ namespace Roslyn.Test.Utilities
 
         public static void Equal(bool[,] expected, Func<int, int, bool> getResult, int size)
         {
+            Equal<bool>(expected, getResult, (b1, b2) => b1 == b2, b => b ? "true" : "false", "{0,-6:G}", size);
+        }
+
+        public static void Equal<T>(T[,] expected, Func<int, int, T> getResult, Func<T, T, bool> valuesEqual, Func<T, string> printValue, string format, int size)
+        {
             bool mismatch = false;
             for (int i = 0; i < size; i++)
             {
                 for (int j = 0; j < size; j++)
                 {
-                    if (expected[i, j] != getResult(i, j))
+                    if (!valuesEqual(expected[i, j], getResult(i, j)))
                     {
                         mismatch = true;
                     }
@@ -698,13 +703,13 @@ namespace Roslyn.Test.Utilities
                     builder.Append("{ ");
                     for (int j = 0; j < size; j++)
                     {
-                        string resultWithComma = getResult(i, j) ? "true" : "false";
+                        string resultWithComma = printValue(getResult(i, j));
                         if (j < size - 1)
                         {
                             resultWithComma += ",";
                         }
 
-                        builder.Append($"{resultWithComma,-6:G}");
+                        builder.Append(string.Format(format, resultWithComma));
                         if (j < size - 1)
                         {
                             builder.Append(' ');

--- a/src/Test/Utilities/Portable/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Portable/Assert/AssertEx.cs
@@ -674,5 +674,47 @@ namespace Roslyn.Test.Utilities
                 checker?.Invoke((TException)e);
             }
         }
+
+        public static void Equal(bool[,] expected, Func<int, int, bool> getResult, int size)
+        {
+            bool mismatch = false;
+            for (int i = 0; i < size; i++)
+            {
+                for (int j = 0; j < size; j++)
+                {
+                    if (expected[i, j] != getResult(i, j))
+                    {
+                        mismatch = true;
+                    }
+                }
+            }
+
+            if (mismatch)
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine("Actual result: ");
+                for (int i = 0; i < size; i++)
+                {
+                    builder.Append("{ ");
+                    for (int j = 0; j < size; j++)
+                    {
+                        string resultWithComma = getResult(i, j) ? "true" : "false";
+                        if (j < size - 1)
+                        {
+                            resultWithComma += ",";
+                        }
+
+                        builder.Append($"{resultWithComma,-6:G}");
+                        if (j < size - 1)
+                        {
+                            builder.Append(' ');
+                        }
+                    }
+                    builder.AppendLine("},");
+                }
+
+                Assert.True(false, builder.ToString());
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/31557 (method, array and lambda inference should produce speakable types)

Fixes https://github.com/dotnet/roslyn/issues/30056 (renaming IsUnconstrainedTypeParameter)

Fixes https://github.com/dotnet/roslyn/issues/31718 (array inference with user-defined conversion)

Relates to https://github.com/dotnet/roslyn/issues/30480 (missing warning in lambda inference)

Relates to  https://github.com/dotnet/roslyn/issues/32006 (lambda returning some typeless tuples). I will fix that in follow-up PR.

Relates to https://github.com/dotnet/roslyn/issues/30964 (ref-returning lambdas)