### PR TITLE
Use recommended msdn names for parameters when generating operators.

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -1171,7 +1171,7 @@ struct Program
 
     public static bool operator ==(Program left, Program right)
     {
-        return program1.Equals(right);
+        return left.Equals(right);
     }
 
     public static bool operator !=(Program left, Program right)

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -1056,14 +1056,14 @@ class Program
                s == program.s;
     }
 
-    public static bool operator ==(Program program1, Program program2)
+    public static bool operator ==(Program left, Program right)
     {
-        return EqualityComparer<Program>.Default.Equals(program1, program2);
+        return EqualityComparer<Program>.Default.Equals(left, right);
     }
 
-    public static bool operator !=(Program program1, Program program2)
+    public static bool operator !=(Program left, Program right)
     {
-        return !(program1 == program2);
+        return !(left == right);
     }
 }",
 chosenSymbols: null,
@@ -1096,8 +1096,8 @@ class Program
                s == program.s;
     }
 
-    public static bool operator ==(Program program1, Program program2) => EqualityComparer<Program>.Default.Equals(program1, program2);
-    public static bool operator !=(Program program1, Program program2) => !(program1 == program2);
+    public static bool operator ==(Program left, Program right) => EqualityComparer<Program>.Default.Equals(left, right);
+    public static bool operator !=(Program left, Program right) => !(left == right);
 }",
 chosenSymbols: null,
 optionsCallback: options => EnableOption(options, GenerateOperatorsId),
@@ -1117,7 +1117,7 @@ class Program
     public string s;
     [||]
 
-    public static bool operator ==(Program program1, Program program2) => true;
+    public static bool operator ==(Program left, Program right) => true;
 }",
 @"
 using System.Collections.Generic;
@@ -1133,7 +1133,7 @@ class Program
                s == program.s;
     }
 
-    public static bool operator ==(Program program1, Program program2) => true;
+    public static bool operator ==(Program left, Program right) => true;
 }",
 chosenSymbols: null,
 optionsCallback: options => Assert.Null(options.FirstOrDefault(i => i.Id == GenerateOperatorsId)));
@@ -1169,14 +1169,14 @@ struct Program
         return s == program.s;
     }
 
-    public static bool operator ==(Program program1, Program program2)
+    public static bool operator ==(Program left, Program right)
     {
-        return program1.Equals(program2);
+        return program1.Equals(right);
     }
 
-    public static bool operator !=(Program program1, Program program2)
+    public static bool operator !=(Program left, Program right)
     {
-        return !(program1 == program2);
+        return !(left == right);
     }
 }",
 chosenSymbols: null,

--- a/src/EditorFeatures/VisualBasicTest/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.vb
@@ -267,12 +267,12 @@ Class Program
                s = program.s
     End Function
 
-    Public Shared Operator =(program1 As Program, program2 As Program) As Boolean
-        Return EqualityComparer(Of Program).Default.Equals(program1, program2)
+    Public Shared Operator =(left As Program, right As Program) As Boolean
+        Return EqualityComparer(Of Program).Default.Equals(left, right)
     End Operator
 
-    Public Shared Operator <>(program1 As Program, program2 As Program) As Boolean
-        Return Not program1 = program2
+    Public Shared Operator <>(left As Program, right As Program) As Boolean
+        Return Not left = right
     End Operator
 End Class",
 chosenSymbols:=Nothing,
@@ -289,7 +289,7 @@ Class Program
     Public s As String
     [||]
 
-    Public Shared Operator =(program1 As Program, program2 As Program) As Boolean
+    Public Shared Operator =(left As Program, right As Program) As Boolean
         Return True
     End Operator
 End Class",
@@ -305,7 +305,7 @@ Class Program
                s = program.s
     End Function
 
-    Public Shared Operator =(program1 As Program, program2 As Program) As Boolean
+    Public Shared Operator =(left As Program, right As Program) As Boolean
         Return True
     End Operator
 End Class",
@@ -338,12 +338,12 @@ Structure Program
         Return s = program.s
     End Function
 
-    Public Shared Operator =(program1 As Program, program2 As Program) As Boolean
-        Return program1.Equals(program2)
+    Public Shared Operator =(left As Program, right As Program) As Boolean
+        Return left.Equals(right)
     End Operator
 
-    Public Shared Operator <>(program1 As Program, program2 As Program) As Boolean
-        Return Not program1 = program2
+    Public Shared Operator <>(left As Program, right As Program) As Boolean
+        Return Not left = right
     End Operator
 End Structure",
 chosenSymbols:=Nothing,

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeAction.cs
@@ -19,6 +19,11 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
     {
         private partial class GenerateEqualsAndGetHashCodeAction : CodeAction
         {
+            // https://docs.microsoft.com/dotnet/standard/design-guidelines/naming-parameters#naming-operator-overload-parameters
+            //  DO use left and right for binary operator overload parameter names if there is no meaning to the parameters.
+            private const string LeftName = "left";
+            private const string RightName = "right";
+
             private readonly bool _generateEquals;
             private readonly bool _generateGetHashCode;
             private readonly bool _implementIEquatable;
@@ -139,31 +144,29 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 var generator = _document.GetLanguageService<SyntaxGenerator>();
 
                 var localName = _containingType.GetLocalName();
-                var left = localName + "1";
-                var right = localName + "2";
 
                 var parameters = ImmutableArray.Create(
-                    CodeGenerationSymbolFactory.CreateParameterSymbol(_containingType, left),
-                    CodeGenerationSymbolFactory.CreateParameterSymbol(_containingType, right));
+                    CodeGenerationSymbolFactory.CreateParameterSymbol(_containingType, LeftName),
+                    CodeGenerationSymbolFactory.CreateParameterSymbol(_containingType, RightName));
 
-                members.Add(CreateEqualityOperator(compilation, generator, left, right, parameters));
-                members.Add(CreateInequalityOperator(compilation, generator, left, right, parameters));
+                members.Add(CreateEqualityOperator(compilation, generator, parameters));
+                members.Add(CreateInequalityOperator(compilation, generator, parameters));
             }
 
-            private IMethodSymbol CreateEqualityOperator(Compilation compilation, SyntaxGenerator generator, string left, string right, ImmutableArray<IParameterSymbol> parameters)
+            private IMethodSymbol CreateEqualityOperator(Compilation compilation, SyntaxGenerator generator, ImmutableArray<IParameterSymbol> parameters)
             {
                 var expression = _containingType.IsValueType
                     ? generator.InvocationExpression(
                         generator.MemberAccessExpression(
-                            generator.IdentifierName(left),
+                            generator.IdentifierName(LeftName),
                             generator.IdentifierName(EqualsName)),
-                        generator.IdentifierName(right))
+                        generator.IdentifierName(RightName))
                     : generator.InvocationExpression(
                         generator.MemberAccessExpression(
                             generator.GetDefaultEqualityComparer(compilation, _containingType),
                             generator.IdentifierName(EqualsName)),
-                        generator.IdentifierName(left),
-                        generator.IdentifierName(right));
+                        generator.IdentifierName(LeftName),
+                        generator.IdentifierName(RightName));
 
                 return CodeGenerationSymbolFactory.CreateOperatorSymbol(
                     default,
@@ -175,12 +178,12 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                     ImmutableArray.Create(generator.ReturnStatement(expression)));
             }
 
-            private IMethodSymbol CreateInequalityOperator(Compilation compilation, SyntaxGenerator generator, string left, string right, ImmutableArray<IParameterSymbol> parameters)
+            private IMethodSymbol CreateInequalityOperator(Compilation compilation, SyntaxGenerator generator, ImmutableArray<IParameterSymbol> parameters)
             {
                 var expression = generator.LogicalNotExpression(
                     generator.ValueEqualsExpression(
-                        generator.IdentifierName(left),
-                        generator.IdentifierName(right)));
+                        generator.IdentifierName(LeftName),
+                        generator.IdentifierName(RightName)));
 
                 return CodeGenerationSymbolFactory.CreateOperatorSymbol(
                     default,


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/31750
