### PR TITLE
MakeMethodAsync: fix iterator methods

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -495,6 +495,212 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        public async Task BadAwaitInEnumerableMethod()
+        {
+            var initial =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    IEnumerable<int> Test()
+    {
+        yield return 1;
+        [|await Task.Delay(1);|]
+    }
+}";
+
+            var expected =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    async IAsyncEnumerable<int> TestAsync()
+    {
+        yield return 1;
+        await Task.Delay(1);
+    }
+}";
+            await TestInRegularAndScriptAsync(initial, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        public async Task BadAwaitInEnumeratorMethodWithReturn()
+        {
+            var initial =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    IEnumerable<int> Test()
+    {
+        [|await Task.Delay(1);|]
+        return null;
+    }
+}";
+
+            var expected =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    async IAsyncEnumerable<int> TestAsync()
+    {
+        await Task.Delay(1);
+        return null;
+    }
+}";
+            // We could detect that the method was not an iterator, to produce a `Task<IEnumerable<int>>` return type instead.
+            // But we currently don't.
+            // The compiler does not expose its IsIterator property.
+            await TestInRegularAndScriptAsync(initial, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        public async Task BadAwaitInEnumeratorMethod()
+        {
+            var initial =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    IEnumerator<int> Test()
+    {
+        yield return 1;
+        [|await Task.Delay(1);|]
+    }
+}";
+
+            var expected =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    async IAsyncEnumerator<int> TestAsync()
+    {
+        yield return 1;
+        await Task.Delay(1);
+    }
+}";
+            await TestInRegularAndScriptAsync(initial, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        public async Task BadAwaitInEnumeratorLocalFunction()
+        {
+            var initial =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    void M()
+    {
+        IEnumerator<int> Test()
+        {
+            yield return 1;
+            [|await Task.Delay(1);|]
+        }
+    }
+}";
+
+            var expected =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    void M()
+    {
+        async IAsyncEnumerator<int> TestAsync()
+        {
+            yield return 1;
+            await Task.Delay(1);
+        }
+    }
+}";
+            await TestInRegularAndScriptAsync(initial, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        public async Task BadAwaitInIAsyncEnumerableMethod()
+        {
+            var initial =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    IAsyncEnumerable<int> Test()
+    {
+        yield return 1;
+        [|await Task.Delay(1);|]
+    }
+}" + iAsyncEnumerable;
+
+            var expected =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    async IAsyncEnumerable<int> TestAsync()
+    {
+        yield return 1;
+        await Task.Delay(1);
+    }
+}" + iAsyncEnumerable;
+            await TestInRegularAndScriptAsync(initial, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        public async Task BadAwaitInIAsyncEnumeratorMethod()
+        {
+            var initial =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    IAsyncEnumerator<int> Test()
+    {
+        yield return 1;
+        [|await Task.Delay(1);|]
+    }
+}" + iAsyncEnumerable;
+
+            var expected =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    async IAsyncEnumerator<int> TestAsync()
+    {
+        yield return 1;
+        await Task.Delay(1);
+    }
+}" + iAsyncEnumerable;
+            await TestInRegularAndScriptAsync(initial, expected);
+        }
+
+        const string iAsyncEnumerable = @"
+namespace System
+{
+    public interface IAsyncDisposable
+    {
+        ValueTask DisposeAsync();
+    }
+}
+
+namespace System.Collections.Generic
+{
+    public interface IAsyncEnumerable<out T>
+    {
+        IAsyncEnumerator<T> GetAsyncEnumerator();
+    }
+
+    public interface IAsyncEnumerator<out T> : IAsyncDisposable
+    {
+        ValueTask<bool> MoveNextAsync();
+        T Current { get; }
+    }
+}";
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
         public async Task AwaitInMember()
         {
             var code =

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -507,7 +507,7 @@ class Program
         yield return 1;
         [|await Task.Delay(1);|]
     }
-}";
+}" + IAsyncEnumerable;
 
             var expected =
 @"using System.Threading.Tasks;
@@ -519,7 +519,7 @@ class Program
         yield return 1;
         await Task.Delay(1);
     }
-}";
+}" + IAsyncEnumerable;
             await TestInRegularAndScriptAsync(initial, expected);
         }
 
@@ -633,7 +633,7 @@ class Program
         yield return 1;
         [|await Task.Delay(1);|]
     }
-}";
+}" + IAsyncEnumerable;
 
             var expected =
 @"using System.Threading.Tasks;
@@ -645,7 +645,7 @@ class Program
         yield return 1;
         await Task.Delay(1);
     }
-}";
+}" + IAsyncEnumerable;
             await TestInRegularAndScriptAsync(initial, expected);
         }
 
@@ -665,7 +665,7 @@ class Program
             [|await Task.Delay(1);|]
         }
     }
-}";
+}" + IAsyncEnumerable;
 
             var expected =
 @"using System.Threading.Tasks;
@@ -680,7 +680,7 @@ class Program
             await Task.Delay(1);
         }
     }
-}";
+}" + IAsyncEnumerable;
             await TestInRegularAndScriptAsync(initial, expected);
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -524,7 +524,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
-        public async Task BadAwaitInEnumeratorMethodWithReturn()
+        public async Task BadAwaitInEnumerableMethodWithReturn()
         {
             var initial =
 @"using System.Threading.Tasks;
@@ -543,15 +543,41 @@ class Program
 using System.Collections.Generic;
 class Program
 {
-    async IAsyncEnumerable<int> TestAsync()
+    async Task<IEnumerable<int>> TestAsync()
     {
         await Task.Delay(1);
         return null;
     }
 }";
-            // We could detect that the method was not an iterator, to produce a `Task<IEnumerable<int>>` return type instead.
-            // But we currently don't.
-            // The compiler does not expose its IsIterator property.
+            await TestInRegularAndScriptAsync(initial, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        public async Task BadAwaitInEnumeratorMethodWithReturn()
+        {
+            var initial =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    IEnumerator<int> Test()
+    {
+        [|await Task.Delay(1);|]
+        return null;
+    }
+}";
+
+            var expected =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    async Task<IEnumerator<int>> TestAsync()
+    {
+        await Task.Delay(1);
+        return null;
+    }
+}";
             await TestInRegularAndScriptAsync(initial, expected);
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -697,7 +697,7 @@ class Program
         yield return 1;
         [|await Task.Delay(1);|]
     }
-}" + iAsyncEnumerable;
+}" + IAsyncEnumerable;
 
             var expected =
 @"using System.Threading.Tasks;
@@ -709,7 +709,7 @@ class Program
         yield return 1;
         await Task.Delay(1);
     }
-}" + iAsyncEnumerable;
+}" + IAsyncEnumerable;
             await TestInRegularAndScriptAsync(initial, expected);
         }
 
@@ -726,7 +726,7 @@ class Program
         yield return 1;
         [|await Task.Delay(1);|]
     }
-}" + iAsyncEnumerable;
+}" + IAsyncEnumerable;
 
             var expected =
 @"using System.Threading.Tasks;
@@ -738,11 +738,11 @@ class Program
         yield return 1;
         await Task.Delay(1);
     }
-}" + iAsyncEnumerable;
+}" + IAsyncEnumerable;
             await TestInRegularAndScriptAsync(initial, expected);
         }
 
-        const string iAsyncEnumerable = @"
+        const string IAsyncEnumerable = @"
 namespace System
 {
     public interface IAsyncDisposable

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -524,6 +524,35 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        public async Task BadAwaitInEnumerableMethodMissingIAsyncEnumerableType()
+        {
+            var initial =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    IEnumerable<int> Test()
+    {
+        yield return 1;
+        [|await Task.Delay(1);|]
+    }
+}";
+
+            var expected =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    async IAsyncEnumerable<int> TestAsync()
+    {
+        yield return 1;
+        await Task.Delay(1);
+    }
+}";
+            await TestInRegularAndScriptAsync(initial, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
         public async Task BadAwaitInEnumerableMethodWithReturn()
         {
             var initial =

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -553,6 +553,45 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
+        public async Task BadAwaitInEnumerableMethodWithYieldInsideLocalFunction()
+        {
+            var initial =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    IEnumerable<int> Test()
+    {
+        [|await Task.Delay(1);|]
+        return local();
+
+        IEnumerable<int> local()
+        {
+            yield return 1;
+        }
+    }
+}";
+
+            var expected =
+@"using System.Threading.Tasks;
+using System.Collections.Generic;
+class Program
+{
+    async Task<IEnumerable<int>> TestAsync()
+    {
+        await Task.Delay(1);
+        return local();
+
+        IEnumerable<int> local()
+        {
+            yield return 1;
+        }
+    }
+}";
+            await TestInRegularAndScriptAsync(initial, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
         public async Task BadAwaitInEnumeratorMethodWithReturn()
         {
             var initial =

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -119,11 +119,10 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
 
         private static bool IsIterator(IMethodSymbol x)
         {
-            return x.Locations
-                .Any(l => ContainsYield(l));
+            return x.Locations.Any(l => ContainsYield(l.FindNode(cancellationToken: default)));
 
-            bool ContainsYield(Location l)
-                => l.FindNode(default).DescendantNodes().Any(n => IsYield(n));
+            bool ContainsYield(SyntaxNode node)
+                => node.DescendantNodes(n => n == node || !n.IsKind(SyntaxKind.LocalFunctionStatement)).Any(n => IsYield(n));
 
             bool IsYield(SyntaxNode node)
                 => node.IsKind(SyntaxKind.YieldBreakStatement, SyntaxKind.YieldReturnStatement);

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -90,15 +90,15 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
                 var returnType = methodSymbol.ReturnType;
                 if (IsIEnumerable(returnType, knownTypes) && IsIterator(methodSymbol))
                 {
-                    newReturnType = knownTypes._iAsyncEnumerableOfTType is null
+                    newReturnType = knownTypes._iAsyncEnumerableOfTTypeOpt is null
                         ? MakeGenericType("IAsyncEnumerable", methodSymbol.ReturnType)
-                        : knownTypes._iAsyncEnumerableOfTType.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
+                        : knownTypes._iAsyncEnumerableOfTTypeOpt.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
                 }
                 else if (IsIEnumerator(returnType, knownTypes) && IsIterator(methodSymbol))
                 {
-                    newReturnType = knownTypes._iAsyncEnumeratorOfTType is null
+                    newReturnType = knownTypes._iAsyncEnumeratorOfTTypeOpt is null
                         ? MakeGenericType("IAsyncEnumerator", methodSymbol.ReturnType)
-                        : knownTypes._iAsyncEnumeratorOfTType.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
+                        : knownTypes._iAsyncEnumeratorOfTTypeOpt.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
                 }
                 else if (IsIAsyncEnumerableOrEnumerator(returnType, knownTypes))
                 {
@@ -135,8 +135,8 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
         }
 
         private static bool IsIAsyncEnumerableOrEnumerator(ITypeSymbol returnType, KnownTypes knownTypes)
-            => returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumerableOfTType) ||
-                returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumeratorOfTType);
+            => returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumerableOfTTypeOpt) ||
+                returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumeratorOfTTypeOpt);
 
         private static bool IsIEnumerable(ITypeSymbol returnType, KnownTypes knownTypes)
             => returnType.OriginalDefinition.Equals(knownTypes._iEnumerableOfTType);

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
             {
                 if (!keepVoid)
                 {
-                    newReturnType = knownTypes.TaskType.GenerateTypeSyntax();
+                    newReturnType = knownTypes._taskType.GenerateTypeSyntax();
                 }
             }
             else
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
                 {
                     // If it's not already Task-like, then wrap the existing return type
                     // in Task<>.
-                    newReturnType = knownTypes.TaskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax();
+                    newReturnType = knownTypes._taskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax();
                 }
             }
 
@@ -130,18 +130,18 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
 
         private static bool IsIAsyncEnumerableOrEnumerator(ITypeSymbol returnType, KnownTypes knownTypes)
         {
-            return returnType.OriginalDefinition.Equals(knownTypes.IAsyncEnumerableOfTType) ||
-                returnType.OriginalDefinition.Equals(knownTypes.IAsyncEnumeratorOfTType);
+            return returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumerableOfTType) ||
+                returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumeratorOfTType);
         }
 
         private static bool IsIEnumerable(ITypeSymbol returnType, KnownTypes knownTypes)
         {
-            return returnType.OriginalDefinition.Equals(knownTypes.IEnumerableOfTType);
+            return returnType.OriginalDefinition.Equals(knownTypes._iEnumerableOfTType);
         }
 
         private static bool IsIEnumerator(ITypeSymbol returnType, KnownTypes knownTypes)
         {
-            return returnType.OriginalDefinition.Equals(knownTypes.IEnumeratorOfTType);
+            return returnType.OriginalDefinition.Equals(knownTypes._iEnumeratorOfTType);
         }
 
         private static SyntaxTokenList AddAsyncModifierWithCorrectedTrivia(SyntaxTokenList modifiers, ref TypeSyntax newReturnType)

--- a/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.MakeMethodSynchronous;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using static Microsoft.CodeAnalysis.MakeMethodAsynchronous.AbstractMakeMethodAsynchronousCodeFixProvider;
 
 namespace Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous
 {

--- a/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
@@ -21,12 +21,12 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous
         protected override bool IsAsyncSupportingFunctionSyntax(SyntaxNode node)
             => node.IsAsyncSupportingFunctionSyntax();
 
-        protected override SyntaxNode RemoveAsyncTokenAndFixReturnType(IMethodSymbol methodSymbolOpt, SyntaxNode node, ITypeSymbol taskType, ITypeSymbol taskOfTType)
+        protected override SyntaxNode RemoveAsyncTokenAndFixReturnType(IMethodSymbol methodSymbolOpt, SyntaxNode node, KnownTypes knownTypes)
         {
             switch (node)
             {
-                case MethodDeclarationSyntax method: return FixMethod(methodSymbolOpt, method, taskType, taskOfTType);
-                case LocalFunctionStatementSyntax localFunction: return FixLocalFunction(methodSymbolOpt, localFunction, taskType, taskOfTType);
+                case MethodDeclarationSyntax method: return FixMethod(methodSymbolOpt, method, knownTypes);
+                case LocalFunctionStatementSyntax localFunction: return FixLocalFunction(methodSymbolOpt, localFunction, knownTypes);
                 case AnonymousMethodExpressionSyntax method: return FixAnonymousMethod(method);
                 case ParenthesizedLambdaExpressionSyntax lambda: return FixParenthesizedLambda(lambda);
                 case SimpleLambdaExpressionSyntax lambda: return FixSimpleLambda(lambda);
@@ -34,33 +34,44 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous
             }
         }
 
-        private SyntaxNode FixMethod(IMethodSymbol methodSymbol, MethodDeclarationSyntax method, ITypeSymbol taskType, ITypeSymbol taskOfTType)
+        private SyntaxNode FixMethod(IMethodSymbol methodSymbol, MethodDeclarationSyntax method, KnownTypes knownTypes)
         {
-            var newReturnType = FixMethodReturnType(methodSymbol, method.ReturnType, taskType, taskOfTType);
+            var newReturnType = FixMethodReturnType(methodSymbol, method.ReturnType, knownTypes);
             var newModifiers = FixMethodModifiers(method.Modifiers, ref newReturnType);
             return method.WithReturnType(newReturnType).WithModifiers(newModifiers);
         }
 
-        private SyntaxNode FixLocalFunction(IMethodSymbol methodSymbol, LocalFunctionStatementSyntax localFunction, ITypeSymbol taskType, ITypeSymbol taskOfTType)
+        private SyntaxNode FixLocalFunction(IMethodSymbol methodSymbol, LocalFunctionStatementSyntax localFunction, KnownTypes knownTypes)
         {
-            var newReturnType = FixMethodReturnType(methodSymbol, localFunction.ReturnType, taskType, taskOfTType);
+            var newReturnType = FixMethodReturnType(methodSymbol, localFunction.ReturnType, knownTypes);
             var newModifiers = FixMethodModifiers(localFunction.Modifiers, ref newReturnType);
             return localFunction.WithReturnType(newReturnType).WithModifiers(newModifiers);
         }
 
-        private static TypeSyntax FixMethodReturnType(IMethodSymbol methodSymbol, TypeSyntax returnType, ITypeSymbol taskType, ITypeSymbol taskOfTType)
+        private static TypeSyntax FixMethodReturnType(IMethodSymbol methodSymbol, TypeSyntax returnTypeSyntax, KnownTypes knownTypes)
         {
-            var newReturnType = returnType;
+            var newReturnType = returnTypeSyntax;
 
-            // If the return type is Task<T>, then make the new return type "T".
-            // If it is Task, then make the new return type "void".
-            if (methodSymbol.ReturnType.OriginalDefinition.Equals(taskType))
+            var returnType = methodSymbol.ReturnType;
+            if (returnType.OriginalDefinition.Equals(knownTypes._taskType))
             {
-                newReturnType = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)).WithTriviaFrom(returnType);
+                // If the return type is Task, then make the new return type "void".
+                newReturnType = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)).WithTriviaFrom(returnTypeSyntax);
             }
-            else if (methodSymbol.ReturnType.OriginalDefinition.Equals(taskOfTType))
+            else if (returnType.OriginalDefinition.Equals(knownTypes._taskOfTType))
             {
-                newReturnType = methodSymbol.ReturnType.GetTypeArguments()[0].GenerateTypeSyntax().WithTriviaFrom(returnType);
+                // If the return type is Task<T>, then make the new return type "T".
+                newReturnType = returnType.GetTypeArguments()[0].GenerateTypeSyntax().WithTriviaFrom(returnTypeSyntax);
+            }
+            else if (returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumerableOfTType))
+            {
+                // If the return type is IAsyncEnumerable<T>, then make the new return type IEnumerable<T>.
+                newReturnType = knownTypes._iEnumerableOfTType.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
+            }
+            else if (returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumeratorOfTType))
+            {
+                // If the return type is IAsyncEnumerator<T>, then make the new return type IEnumerator<T>.
+                newReturnType = knownTypes._iEnumeratorOfTType.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
             }
 
             return newReturnType;

--- a/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
@@ -64,12 +64,12 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous
                 // If the return type is Task<T>, then make the new return type "T".
                 newReturnType = returnType.GetTypeArguments()[0].GenerateTypeSyntax().WithTriviaFrom(returnTypeSyntax);
             }
-            else if (returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumerableOfTType))
+            else if (returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumerableOfTTypeOpt))
             {
                 // If the return type is IAsyncEnumerable<T>, then make the new return type IEnumerable<T>.
                 newReturnType = knownTypes._iEnumerableOfTType.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
             }
-            else if (returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumeratorOfTType))
+            else if (returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumeratorOfTTypeOpt))
             {
                 // If the return type is IAsyncEnumerator<T>, then make the new return type IEnumerator<T>.
                 newReturnType = knownTypes._iEnumeratorOfTType.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.KnownTypes.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.KnownTypes.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
+{
+    internal abstract partial class AbstractMakeMethodAsynchronousCodeFixProvider
+    {
+        internal readonly struct KnownTypes
+        {
+            public readonly INamedTypeSymbol _taskType;
+            public readonly INamedTypeSymbol _taskOfTType;
+            public readonly INamedTypeSymbol _valueTaskOfTTypeOpt;
+
+            public readonly INamedTypeSymbol _iEnumerableOfTType;
+            public readonly INamedTypeSymbol _iEnumeratorOfTType;
+
+            public readonly INamedTypeSymbol _iAsyncEnumerableOfTType;
+            public readonly INamedTypeSymbol _iAsyncEnumeratorOfTType;
+
+            internal KnownTypes(Compilation compilation)
+            {
+                _taskType = compilation.TaskType();
+                _taskOfTType = compilation.TaskOfTType();
+                _valueTaskOfTTypeOpt = compilation.ValueTaskOfTType();
+
+                _iEnumerableOfTType = compilation.IEnumerableOfTType();
+                _iEnumeratorOfTType = compilation.IEnumeratorOfTType();
+
+                _iAsyncEnumerableOfTType = compilation.IAsyncEnumerableOfTType();
+                _iAsyncEnumeratorOfTType = compilation.IAsyncEnumeratorOfTType();
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.KnownTypes.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.KnownTypes.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             public readonly INamedTypeSymbol _iEnumerableOfTType;
             public readonly INamedTypeSymbol _iEnumeratorOfTType;
 
-            public readonly INamedTypeSymbol _iAsyncEnumerableOfTType;
-            public readonly INamedTypeSymbol _iAsyncEnumeratorOfTType;
+            public readonly INamedTypeSymbol _iAsyncEnumerableOfTTypeOpt;
+            public readonly INamedTypeSymbol _iAsyncEnumeratorOfTTypeOpt;
 
             internal KnownTypes(Compilation compilation)
             {
@@ -27,8 +27,8 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
                 _iEnumerableOfTType = compilation.IEnumerableOfTType();
                 _iEnumeratorOfTType = compilation.IEnumeratorOfTType();
 
-                _iAsyncEnumerableOfTType = compilation.IAsyncEnumerableOfTType();
-                _iAsyncEnumeratorOfTType = compilation.IAsyncEnumeratorOfTType();
+                _iAsyncEnumerableOfTTypeOpt = compilation.IAsyncEnumerableOfTType();
+                _iAsyncEnumeratorOfTTypeOpt = compilation.IAsyncEnumeratorOfTType();
             }
         }
     }

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
@@ -13,7 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
 {
-    internal abstract class AbstractMakeMethodAsynchronousCodeFixProvider : CodeFixProvider
+    internal abstract partial class AbstractMakeMethodAsynchronousCodeFixProvider : CodeFixProvider
     {
         protected abstract bool IsAsyncSupportingFunctionSyntax(SyntaxNode node);
 
@@ -186,32 +186,6 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             public MyCodeAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution)
                 : base(title, createChangedSolution, equivalenceKey: title)
             {
-            }
-        }
-
-        protected struct KnownTypes
-        {
-            public INamedTypeSymbol _taskType;
-            public INamedTypeSymbol _taskOfTType;
-            public INamedTypeSymbol _valueTaskOfTTypeOpt;
-
-            public INamedTypeSymbol _iEnumerableOfTType;
-            public INamedTypeSymbol _iEnumeratorOfTType;
-
-            public INamedTypeSymbol _iAsyncEnumerableOfTType;
-            public INamedTypeSymbol _iAsyncEnumeratorOfTType;
-
-            internal KnownTypes(Compilation compilation)
-            {
-                _taskType = compilation.TaskType();
-                _taskOfTType = compilation.TaskOfTType();
-                _valueTaskOfTTypeOpt = compilation.ValueTaskOfTType();
-
-                _iEnumerableOfTType = compilation.IEnumerableOfTType();
-                _iEnumeratorOfTType = compilation.IEnumeratorOfTType();
-
-                _iAsyncEnumerableOfTType = compilation.IAsyncEnumerableOfTType();
-                _iAsyncEnumeratorOfTType = compilation.IAsyncEnumeratorOfTType();
             }
         }
     }

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
 
         protected abstract SyntaxNode AddAsyncTokenAndFixReturnType(
             bool keepVoid, IMethodSymbol methodSymbolOpt, SyntaxNode node,
-            INamedTypeSymbol taskType, INamedTypeSymbol taskOfTType, INamedTypeSymbol valueTaskOfTType);
+            KnownTypes knownTypes);
 
         public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -42,8 +42,8 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             // method if we convert it.  The last is optional.  It is only needed to know
             // if our member is already Task-Like, and that functionality recognizes
             // ValueTask if it is available, but does not care if it is not.
-            var (taskType, taskOfTType, valueTaskOfTTypeOpt) = GetTaskTypes(compilation);
-            if (taskType == null || taskOfTType == null)
+            var knownTypes = new KnownTypes(compilation);
+            if (knownTypes.TaskType == null || knownTypes.TaskOfTType == null)
             {
                 return;
             }
@@ -74,15 +74,6 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
         {
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
             return syntaxFacts.StringComparer.Equals(name, "Main");
-        }
-
-        private (INamedTypeSymbol taskType, INamedTypeSymbol taskOfTType, INamedTypeSymbol valueTaskOfTTypeOpt) GetTaskTypes(Compilation compilation)
-        {
-            var taskType = compilation.TaskType();
-            var taskOfTType = compilation.TaskOfTType();
-            var valueTaskOfTType = compilation.ValueTaskOfTType();
-
-            return (taskType, taskOfTType, valueTaskOfTType);
         }
 
         protected abstract string GetMakeAsyncTaskFunctionResource();
@@ -154,9 +145,8 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             SyntaxNode node, CancellationToken cancellationToken)
         {
             var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var (taskType, taskOfTType, valueTaskOfTType) = GetTaskTypes(compilation);
-
-            var newNode = AddAsyncTokenAndFixReturnType(keepVoid, methodSymbolOpt, node, taskType, taskOfTType, valueTaskOfTType);
+            var knownTypes = new KnownTypes(compilation);
+            var newNode = AddAsyncTokenAndFixReturnType(keepVoid, methodSymbolOpt, node, knownTypes);
 
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var newRoot = root.ReplaceNode(node, newNode);
@@ -165,21 +155,19 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             return newDocument.Project.Solution;
         }
 
-        protected static bool IsTaskLike(
-            ITypeSymbol returnType, INamedTypeSymbol taskType,
-            INamedTypeSymbol taskOfTType, INamedTypeSymbol valueTaskOfTType)
+        protected static bool IsTaskLike(ITypeSymbol returnType, KnownTypes knownTypes)
         {
-            if (returnType.Equals(taskType))
+            if (returnType.Equals(knownTypes.TaskType))
             {
                 return true;
             }
 
-            if (returnType.OriginalDefinition.Equals(taskOfTType))
+            if (returnType.OriginalDefinition.Equals(knownTypes.TaskOfTType))
             {
                 return true;
             }
 
-            if (returnType.OriginalDefinition.Equals(valueTaskOfTType))
+            if (returnType.OriginalDefinition.Equals(knownTypes.ValueTaskOfTTypeOpt))
             {
                 return true;
             }
@@ -199,6 +187,32 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
                 : base(title, createChangedSolution, equivalenceKey: title)
             {
             }
+        }
+
+        protected struct KnownTypes
+        {
+            internal KnownTypes(Compilation compilation)
+            {
+                TaskType = compilation.TaskType();
+                TaskOfTType = compilation.TaskOfTType();
+                ValueTaskOfTTypeOpt = compilation.ValueTaskOfTType();
+
+                IEnumerableOfTType = compilation.IEnumerableOfTType();
+                IEnumeratorOfTType = compilation.IEnumeratorOfTType();
+
+                IAsyncEnumerableOfTType = compilation.IAsyncEnumerableOfTType();
+                IAsyncEnumeratorOfTType = compilation.IAsyncEnumeratorOfTType();
+            }
+
+            public INamedTypeSymbol TaskType;
+            public INamedTypeSymbol TaskOfTType;
+            public INamedTypeSymbol ValueTaskOfTTypeOpt;
+
+            public INamedTypeSymbol IEnumerableOfTType;
+            public INamedTypeSymbol IEnumeratorOfTType;
+
+            public INamedTypeSymbol IAsyncEnumerableOfTType;
+            public INamedTypeSymbol IAsyncEnumeratorOfTType;
         }
     }
 }

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             // if our member is already Task-Like, and that functionality recognizes
             // ValueTask if it is available, but does not care if it is not.
             var knownTypes = new KnownTypes(compilation);
-            if (knownTypes.TaskType == null || knownTypes.TaskOfTType == null)
+            if (knownTypes._taskType == null || knownTypes._taskOfTType == null)
             {
                 return;
             }
@@ -157,17 +157,17 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
 
         protected static bool IsTaskLike(ITypeSymbol returnType, KnownTypes knownTypes)
         {
-            if (returnType.Equals(knownTypes.TaskType))
+            if (returnType.Equals(knownTypes._taskType))
             {
                 return true;
             }
 
-            if (returnType.OriginalDefinition.Equals(knownTypes.TaskOfTType))
+            if (returnType.OriginalDefinition.Equals(knownTypes._taskOfTType))
             {
                 return true;
             }
 
-            if (returnType.OriginalDefinition.Equals(knownTypes.ValueTaskOfTTypeOpt))
+            if (returnType.OriginalDefinition.Equals(knownTypes._valueTaskOfTTypeOpt))
             {
                 return true;
             }
@@ -191,28 +191,28 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
 
         protected struct KnownTypes
         {
+            public INamedTypeSymbol _taskType;
+            public INamedTypeSymbol _taskOfTType;
+            public INamedTypeSymbol _valueTaskOfTTypeOpt;
+
+            public INamedTypeSymbol _iEnumerableOfTType;
+            public INamedTypeSymbol _iEnumeratorOfTType;
+
+            public INamedTypeSymbol _iAsyncEnumerableOfTType;
+            public INamedTypeSymbol _iAsyncEnumeratorOfTType;
+
             internal KnownTypes(Compilation compilation)
             {
-                TaskType = compilation.TaskType();
-                TaskOfTType = compilation.TaskOfTType();
-                ValueTaskOfTTypeOpt = compilation.ValueTaskOfTType();
+                _taskType = compilation.TaskType();
+                _taskOfTType = compilation.TaskOfTType();
+                _valueTaskOfTTypeOpt = compilation.ValueTaskOfTType();
 
-                IEnumerableOfTType = compilation.IEnumerableOfTType();
-                IEnumeratorOfTType = compilation.IEnumeratorOfTType();
+                _iEnumerableOfTType = compilation.IEnumerableOfTType();
+                _iEnumeratorOfTType = compilation.IEnumeratorOfTType();
 
-                IAsyncEnumerableOfTType = compilation.IAsyncEnumerableOfTType();
-                IAsyncEnumeratorOfTType = compilation.IAsyncEnumeratorOfTType();
+                _iAsyncEnumerableOfTType = compilation.IAsyncEnumerableOfTType();
+                _iAsyncEnumeratorOfTType = compilation.IAsyncEnumeratorOfTType();
             }
-
-            public INamedTypeSymbol TaskType;
-            public INamedTypeSymbol TaskOfTType;
-            public INamedTypeSymbol ValueTaskOfTTypeOpt;
-
-            public INamedTypeSymbol IEnumerableOfTType;
-            public INamedTypeSymbol IEnumeratorOfTType;
-
-            public INamedTypeSymbol IAsyncEnumerableOfTType;
-            public INamedTypeSymbol IAsyncEnumeratorOfTType;
         }
     }
 }

--- a/src/Features/Core/Portable/MakeMethodSynchronous/AbstractMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodSynchronous/AbstractMakeMethodSynchronousCodeFixProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.MakeMethodAsynchronous.AbstractMakeMethodAsynchronousCodeFixProvider;
 
 namespace Microsoft.CodeAnalysis.MakeMethodSynchronous
 {
@@ -251,28 +252,6 @@ namespace Microsoft.CodeAnalysis.MakeMethodSynchronous
             public MyCodeAction(Func<CancellationToken, Task<Solution>> createChangedSolution)
                 : base(FeaturesResources.Make_method_synchronous, createChangedSolution, AbstractMakeMethodSynchronousCodeFixProvider.EquivalenceKey)
             {
-            }
-        }
-
-        protected struct KnownTypes
-        {
-            public ITypeSymbol _taskType;
-            public ITypeSymbol _taskOfTType;
-
-            public INamedTypeSymbol _iEnumerableOfTType;
-            public INamedTypeSymbol _iEnumeratorOfTType;
-
-            public ITypeSymbol _iAsyncEnumerableOfTType;
-            public ITypeSymbol _iAsyncEnumeratorOfTType;
-
-            internal KnownTypes(Compilation compilation)
-            {
-                _taskType = compilation.TaskType();
-                _taskOfTType = compilation.TaskOfTType();
-                _iEnumerableOfTType = compilation.IEnumerableOfTType();
-                _iEnumeratorOfTType = compilation.IEnumeratorOfTType();
-                _iAsyncEnumerableOfTType = compilation.IAsyncEnumerableOfTType();
-                _iAsyncEnumeratorOfTType = compilation.IAsyncEnumeratorOfTType();
             }
         }
     }

--- a/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodAsynchronous
 
         Protected Overrides Function AddAsyncTokenAndFixReturnType(
                 keepVoid As Boolean, methodSymbolOpt As IMethodSymbol, node As SyntaxNode,
-                taskType As INamedTypeSymbol, taskOfTType As INamedTypeSymbol, valueTaskOfTType As INamedTypeSymbol) As SyntaxNode
+                knownTypes As KnownTypes) As SyntaxNode
 
             If node.IsKind(SyntaxKind.SingleLineSubLambdaExpression) OrElse
                node.IsKind(SyntaxKind.SingleLineFunctionLambdaExpression) Then
@@ -52,22 +52,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodAsynchronous
 
                 Return FixMultiLineLambdaExpression(DirectCast(node, MultiLineLambdaExpressionSyntax))
             ElseIf node.IsKind(SyntaxKind.SubBlock) Then
-                Return FixSubBlock(keepVoid, DirectCast(node, MethodBlockSyntax), taskType)
+                Return FixSubBlock(keepVoid, DirectCast(node, MethodBlockSyntax), knownTypes.TaskType)
             Else
                 Return FixFunctionBlock(
-                    methodSymbolOpt, DirectCast(node, MethodBlockSyntax), taskType, taskOfTType, valueTaskOfTType)
+                    methodSymbolOpt, DirectCast(node, MethodBlockSyntax), knownTypes)
             End If
         End Function
 
-        Private Function FixFunctionBlock(methodSymbol As IMethodSymbol, node As MethodBlockSyntax,
-                                          taskType As INamedTypeSymbol, taskOfTType As INamedTypeSymbol, valueTaskOfTType As INamedTypeSymbol) As SyntaxNode
+        Private Function FixFunctionBlock(methodSymbol As IMethodSymbol, node As MethodBlockSyntax, knownTypes As KnownTypes) As SyntaxNode
 
             Dim functionStatement = node.SubOrFunctionStatement
             Dim newFunctionStatement = AddAsyncKeyword(functionStatement)
 
-            If Not IsTaskLike(methodSymbol.ReturnType, taskType, taskOfTType, valueTaskOfTType) Then
+            If Not IsTaskLike(methodSymbol.ReturnType, knownTypes) Then
                 ' if the current return type is not already task-list, then wrap it in Task(of ...)
-                Dim returnType = taskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax()
+                Dim returnType = knownTypes.TaskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax()
                 newFunctionStatement = newFunctionStatement.WithAsClause(
                 newFunctionStatement.AsClause.WithType(returnType))
             End If

--- a/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
@@ -52,7 +52,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodAsynchronous
 
                 Return FixMultiLineLambdaExpression(DirectCast(node, MultiLineLambdaExpressionSyntax))
             ElseIf node.IsKind(SyntaxKind.SubBlock) Then
-                Return FixSubBlock(keepVoid, DirectCast(node, MethodBlockSyntax), knownTypes.TaskType)
+                Return FixSubBlock(keepVoid, DirectCast(node, MethodBlockSyntax), knownTypes._taskType)
             Else
                 Return FixFunctionBlock(
                     methodSymbolOpt, DirectCast(node, MethodBlockSyntax), knownTypes)
@@ -66,7 +66,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodAsynchronous
 
             If Not IsTaskLike(methodSymbol.ReturnType, knownTypes) Then
                 ' if the current return type is not already task-list, then wrap it in Task(of ...)
-                Dim returnType = knownTypes.TaskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax()
+                Dim returnType = knownTypes._taskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax()
                 newFunctionStatement = newFunctionStatement.WithAsClause(
                 newFunctionStatement.AsClause.WithType(returnType))
             End If

--- a/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
@@ -3,6 +3,7 @@
 Imports System.Collections.Immutable
 Imports System.Composition
 Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.MakeMethodAsynchronous.AbstractMakeMethodAsynchronousCodeFixProvider
 Imports Microsoft.CodeAnalysis.MakeMethodSynchronous
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 

--- a/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodSynchronous
             Return node.IsAsyncSupportedFunctionSyntax()
         End Function
 
-        Protected Overrides Function RemoveAsyncTokenAndFixReturnType(methodSymbolOpt As IMethodSymbol, node As SyntaxNode, taskType As ITypeSymbol, taskOfTType As ITypeSymbol) As SyntaxNode
+        Protected Overrides Function RemoveAsyncTokenAndFixReturnType(methodSymbolOpt As IMethodSymbol, node As SyntaxNode, knownTypes As KnownTypes) As SyntaxNode
             If node.IsKind(SyntaxKind.SingleLineSubLambdaExpression) OrElse
                 node.IsKind(SyntaxKind.SingleLineFunctionLambdaExpression) Then
 
@@ -38,21 +38,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodSynchronous
             ElseIf node.IsKind(SyntaxKind.SubBlock) Then
                 Return FixSubBlock(DirectCast(node, MethodBlockSyntax))
             Else
-                Return FixFunctionBlock(methodSymbolOpt, DirectCast(node, MethodBlockSyntax), taskType, taskOfTType)
+                Return FixFunctionBlock(methodSymbolOpt, DirectCast(node, MethodBlockSyntax), knownTypes)
             End If
         End Function
 
-        Private Function FixFunctionBlock(methodSymbol As IMethodSymbol, node As MethodBlockSyntax, taskType As ITypeSymbol, taskOfTType As ITypeSymbol) As SyntaxNode
+        Private Function FixFunctionBlock(methodSymbol As IMethodSymbol, node As MethodBlockSyntax, knownTypes As KnownTypes) As SyntaxNode
             Dim functionStatement = node.SubOrFunctionStatement
 
             ' if this returns Task(of T), then we want to convert this to a T returning function.
             ' if this returns Task, then we want to convert it to a Sub method.
-            If methodSymbol.ReturnType.OriginalDefinition.Equals(taskOfTType) Then
+            If methodSymbol.ReturnType.OriginalDefinition.Equals(knownTypes._taskOfTType) Then
                 Dim newAsClause = functionStatement.AsClause.WithType(methodSymbol.ReturnType.GetTypeArguments()(0).GenerateTypeSyntax())
                 Dim newFunctionStatement = functionStatement.WithAsClause(newAsClause)
                 newFunctionStatement = RemoveAsyncKeyword(newFunctionStatement)
                 Return node.WithSubOrFunctionStatement(newFunctionStatement)
-            ElseIf methodSymbol.ReturnType.OriginalDefinition Is taskType Then
+            ElseIf methodSymbol.ReturnType.OriginalDefinition Is knownTypes._taskType Then
                 ' Convert this to a 'Sub' method.
                 Dim subStatement = SyntaxFactory.SubStatement(
                     functionStatement.AttributeLists,

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ICompilationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ICompilationExtensions.cs
@@ -104,9 +104,17 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         public static INamedTypeSymbol ValueTaskOfTType(this Compilation compilation)
             => compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
-
         public static INamedTypeSymbol IEnumerableOfTType(this Compilation compilation)
             => compilation.GetTypeByMetadataName(typeof(IEnumerable<>).FullName);
+
+        public static INamedTypeSymbol IEnumeratorOfTType(this Compilation compilation)
+            => compilation.GetTypeByMetadataName(typeof(IEnumerator<>).FullName);
+
+        public static INamedTypeSymbol IAsyncEnumerableOfTType(this Compilation compilation)
+            => compilation.GetTypeByMetadataName("System.Collections.Generic.IAsyncEnumerable`1");
+
+        public static INamedTypeSymbol IAsyncEnumeratorOfTType(this Compilation compilation)
+            => compilation.GetTypeByMetadataName("System.Collections.Generic.IAsyncEnumerator`1");
 
         public static INamedTypeSymbol SerializableAttributeType(this Compilation compilation)
             => compilation.GetTypeByMetadataName(typeof(SerializableAttribute).FullName);


### PR DESCRIPTION
If you have a method returning `IEnumerable<>`, then add an `await`, the fixer helps you fix the declaration to make an async-iterator.
If you have an async-iterator method, the remove all `await`s, the fixer helps you fix the declaration to make an iterator.

Fixes https://github.com/dotnet/roslyn/issues/31841

FYI @Neme12 @CyrusNajmabadi 