### PR TITLE
Fix up benchmarks after arcade refactoring

### DIFF
--- a/src/Tools/CompilerBenchmarks/run-perf.ps1
+++ b/src/Tools/CompilerBenchmarks/run-perf.ps1
@@ -12,7 +12,6 @@ $ErrorActionPreference = "Stop"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 try {
-    . (Join-Path $roslynDir "eng/common/tools.ps1")
     . (Join-Path $roslynDir "eng/build-utils.ps1")
 
     # Download dotnet if it isn't already available
@@ -23,8 +22,7 @@ try {
     if (-not (Test-Path $reproPath)) {
         $tmpFile = [System.IO.Path]::GetTempFileName()
         Invoke-WebRequest -Uri "https://roslyninfra.blob.core.windows.net/perf-artifacts/CodeAnalysisRepro.zip" -UseBasicParsing -OutFile $tmpFile
-        [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem') | Out-Null
-        [IO.Compression.ZipFile]::ExtractToDirectory($tmpFile, $ArtifactsDir)
+        Unzip $tmpFile $ArtifactsDir
     }
 
     Exec-Command "dotnet" "run -c Release $reproPath"

--- a/src/Tools/CompilerBenchmarks/run-perf.ps1
+++ b/src/Tools/CompilerBenchmarks/run-perf.ps1
@@ -12,18 +12,19 @@ $ErrorActionPreference = "Stop"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 try {
-    . (Join-Path $roslynDir "build/scripts/build-utils.ps1")
+    . (Join-Path $roslynDir "eng/common/tools.ps1")
+    . (Join-Path $roslynDir "eng/build-utils.ps1")
 
     # Download dotnet if it isn't already available
     Ensure-DotnetSdk
 
-    $reproPath = Join-Path $binariesDir "CodeAnalysisRepro"
+    $reproPath = Join-Path $ArtifactsDir "CodeAnalysisRepro"
 
     if (-not (Test-Path $reproPath)) {
         $tmpFile = [System.IO.Path]::GetTempFileName()
         Invoke-WebRequest -Uri "https://roslyninfra.blob.core.windows.net/perf-artifacts/CodeAnalysisRepro.zip" -UseBasicParsing -OutFile $tmpFile
         [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem') | Out-Null
-        [IO.Compression.ZipFile]::ExtractToDirectory($tmpFile, $binariesDir)
+        [IO.Compression.ZipFile]::ExtractToDirectory($tmpFile, $ArtifactsDir)
     }
 
     Exec-Command "dotnet" "run -c Release $reproPath"


### PR DESCRIPTION
Moving the utility scripts around broke the compiler benchmarks,
since they referenced by file path.