### PR TITLE
DeclareAsNullable: handle iterator methods

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -396,6 +396,34 @@ class Program
         }
 
         [Fact]
+        public async Task FixReturnType_IteratorProperty()
+        {
+            await TestInRegularAndScript1Async(
+NonNullTypes + @"
+class Program
+{
+    System.Collections.Generic.IEnumerable<string> Property
+    {
+        get
+        {
+            yield return [|null|];
+        }
+    }
+}",
+NonNullTypes + @"
+class Program
+{
+    System.Collections.Generic.IEnumerable<string?> Property
+    {
+        get
+        {
+            yield return null;
+        }
+    }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
         public async Task FixReturnType_Iterator_LocalFunction()
         {
             await TestInRegularAndScript1Async(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -372,5 +372,55 @@ class Program
     }
 }", parameters: s_nullableFeature);
         }
+
+        [Fact]
+        public async Task FixReturnType_Iterator()
+        {
+            await TestInRegularAndScript1Async(
+NonNullTypes + @"
+class Program
+{
+    static System.Collections.Generic.IEnumerable<string> M()
+    {
+        yield return [|null|];
+    }
+}",
+NonNullTypes + @"
+class Program
+{
+    static System.Collections.Generic.IEnumerable<string?> M()
+    {
+        yield return null;
+    }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task FixReturnType_Iterator_LocalFunction()
+        {
+            await TestInRegularAndScript1Async(
+NonNullTypes + @"
+class Program
+{
+    void M()
+    {
+        System.Collections.Generic.IEnumerable<string> local()
+        {
+            yield return [|null|];
+        }
+    }
+}",
+NonNullTypes + @"
+class Program
+{
+    void M()
+    {
+        System.Collections.Generic.IEnumerable<string?> local()
+        {
+            yield return null;
+        }
+    }
+}", parameters: s_nullableFeature);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Nullable/CSharpDeclareAsNullableCodeFixTests.cs
@@ -374,7 +374,7 @@ class Program
         }
 
         [Fact]
-        public async Task FixReturnType_Iterator()
+        public async Task FixReturnType_Iterator_Enumerable()
         {
             await TestInRegularAndScript1Async(
 NonNullTypes + @"
@@ -389,6 +389,28 @@ NonNullTypes + @"
 class Program
 {
     static System.Collections.Generic.IEnumerable<string?> M()
+    {
+        yield return null;
+    }
+}", parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task FixReturnType_Iterator_Enumerator()
+        {
+            await TestInRegularAndScript1Async(
+NonNullTypes + @"
+class Program
+{
+    static System.Collections.Generic.IEnumerator<string> M()
+    {
+        yield return [|null|];
+    }
+}",
+NonNullTypes + @"
+class Program
+{
+    static System.Collections.Generic.IEnumerator<string?> M()
     {
         yield return null;
     }

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -98,17 +98,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
                         // string M() { return null; }
                         // async Task<string> M() { return null; }
                         // IEnumerable<string> M() { yield return null; }
-                        return TryGetMethodReturnType(method.ReturnType, method.Modifiers, onYield);
+                        return TryGetReturnType(method.ReturnType, method.Modifiers, onYield);
 
                     case LocalFunctionStatementSyntax localFunction:
                         // string local() { return null; }
                         // async Task<string> local() { return null; }
                         // IEnumerable<string> local() { yield return null; }
-                        return TryGetMethodReturnType(localFunction.ReturnType, localFunction.Modifiers, onYield);
+                        return TryGetReturnType(localFunction.ReturnType, localFunction.Modifiers, onYield);
 
                     case PropertyDeclarationSyntax property:
                         // string x { get { return null; } }
-                        return property.Type;
+                        // IEnumerable<string> Property { get { yield return null; } }
+                        return TryGetReturnType(property.Type, modifiers: default, onYield);
 
                     default:
                         return null;
@@ -152,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
             return null;
 
             // local functions
-            TypeSyntax TryGetMethodReturnType(TypeSyntax returnType, SyntaxTokenList modifiers, bool onYield)
+            TypeSyntax TryGetReturnType(TypeSyntax returnType, SyntaxTokenList modifiers, bool onYield)
             {
                 if (modifiers.Any(SyntaxKind.AsyncKeyword) || onYield)
                 {

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
                 return null;
             }
 
-            if (node.IsParentKind(SyntaxKind.ReturnStatement))
+            if (node.IsParentKind(SyntaxKind.ReturnStatement, SyntaxKind.YieldReturnStatement))
             {
                 var containingMember = node.GetAncestors().FirstOrDefault(a => a.IsKind(
                     SyntaxKind.MethodDeclaration, SyntaxKind.PropertyDeclaration, SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression,
@@ -90,17 +90,21 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
                     return null;
                 }
 
+                var onYield = node.IsParentKind(SyntaxKind.YieldReturnStatement);
+
                 switch (containingMember)
                 {
                     case MethodDeclarationSyntax method:
                         // string M() { return null; }
                         // async Task<string> M() { return null; }
-                        return TryGetMethodReturnType(method.ReturnType, method.Modifiers);
+                        // IEnumerable<string> M() { yield return null; }
+                        return TryGetMethodReturnType(method.ReturnType, method.Modifiers, onYield);
 
                     case LocalFunctionStatementSyntax localFunction:
                         // string local() { return null; }
                         // async Task<string> local() { return null; }
-                        return TryGetMethodReturnType(localFunction.ReturnType, localFunction.Modifiers);
+                        // IEnumerable<string> local() { yield return null; }
+                        return TryGetMethodReturnType(localFunction.ReturnType, localFunction.Modifiers, onYield);
 
                     case PropertyDeclarationSyntax property:
                         // string x { get { return null; } }
@@ -148,11 +152,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
             return null;
 
             // local functions
-            TypeSyntax TryGetMethodReturnType(TypeSyntax returnType, SyntaxTokenList modifiers)
+            TypeSyntax TryGetMethodReturnType(TypeSyntax returnType, SyntaxTokenList modifiers, bool onYield)
             {
-                if (modifiers.Any(SyntaxKind.AsyncKeyword))
+                if (modifiers.Any(SyntaxKind.AsyncKeyword) || onYield)
                 {
                     // async Task<string> M() { return null; }
+                    // async IAsyncEnumerable<string> M() { yield return null; }
+                    // IEnumerable<string> M() { yield return null; }
                     return TryGetSingleTypeArgument(returnType);
                 }
 


### PR DESCRIPTION
I just realized that my recent fix for async methods (PR https://github.com/dotnet/roslyn/pull/31708) didn't consider iterator methods.
The scenario is that you have a diagnostic on `yield return null;` and the fix should make the nested type nullable (for example, `IEnumerable<string?>`).

Tagging @sharwell @CyrusNajmabadi 