### PR TITLE
Keybinding reset gold bar is displayed when not applicable

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
@@ -157,10 +157,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
 
             // make sure all state machine change work is serialized so that cancellation
             // doesn't mess the state up.   
-            _lastTask = _lastTask.ContinueWith(_ =>
+            _lastTask = _lastTask.SafeContinueWithFromAsync(_ =>
             {
-                UpdateStateMachineWorkerAsync(cancellationToken).ConfigureAwait(false);
-            }, cancellationToken, TaskContinuationOptions.LazyCancellation, TaskScheduler.Default);
+                return UpdateStateMachineWorkerAsync(cancellationToken);
+            }, cancellationToken, TaskScheduler.Default);
         }
 
         private async Task UpdateStateMachineWorkerAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
@@ -75,7 +75,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
         /// </summary>
         private bool _resharperExtensionInstalledAndEnabled = false;
         private bool _infoBarOpen = false;
-        private bool _isFirstRun = true;
 
         /// <summary>
         /// Chain all update tasks so that task runs serially
@@ -152,7 +151,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
             // cancel previous state machine update request
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource = new CancellationTokenSource();
-
             var cancellationToken = _cancellationTokenSource.Token;
 
             // make sure all state machine change work is serialized so that cancellation
@@ -179,7 +177,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
                 return;
             }
 
-            if (!_isFirstRun && currentStatus == lastStatus)
+            if (currentStatus == lastStatus)
             {
                 return;
             }
@@ -194,11 +192,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
                     {
                         // N->E or S->E. If ReSharper was just installed and is enabled, reset NeedsReset.
                         options = options.WithChangedOption(KeybindingResetOptions.NeedsReset, false);
-                    }
-                    else if (currentStatus == ReSharperStatus.Suspended && _isFirstRun)
-                    {
-                        // S->VS closed and restarted. If ReSharper was suspended and the user closed and reopened VS, we want to reset the gold bar.
-                        options = options.WithChangedOption(KeybindingResetOptions.NeedsReset, true);
                     }
 
                     // Else is N->N, N->S, S->N, S->S. N->S can occur if the user suspends ReSharper, then disables
@@ -222,8 +215,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
             {
                 ShowGoldBar();
             }
-
-            _isFirstRun = false;
         }
 
         private void ShowGoldBar()

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
@@ -285,13 +285,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
                 }
 
                 // When ReSharper is running, the ReSharper_Suspend command is Enabled and not Invisible
-                if ((suspendFlag).HasFlag(OLECMDF.OLECMDF_ENABLED) && !(suspendFlag).HasFlag(OLECMDF.OLECMDF_INVISIBLE))
+                if (suspendFlag.HasFlag(OLECMDF.OLECMDF_ENABLED) && !suspendFlag.HasFlag(OLECMDF.OLECMDF_INVISIBLE))
                 {
                     return ReSharperStatus.Enabled;
                 }
 
                 // When ReSharper is suspended, the ReSharper_Resume command is Enabled and not Invisible
-                if ((resumeFlag).HasFlag(OLECMDF.OLECMDF_ENABLED) && !(resumeFlag).HasFlag(OLECMDF.OLECMDF_INVISIBLE))
+                if (resumeFlag.HasFlag(OLECMDF.OLECMDF_ENABLED) && !resumeFlag.HasFlag(OLECMDF.OLECMDF_INVISIBLE))
                 {
                     return ReSharperStatus.Suspended;
                 }

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
@@ -200,7 +200,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
                     // if there is still a pending show.
 
                     // If ReSharper was suspended and the user closed and reopened VS, we want to reset the gold bar
-                    else if (_isFirstRun)
+                    else if (currentStatus == ReSharperStatus.Suspended && _isFirstRun)
                     {
                         options = options.WithChangedOption(KeybindingResetOptions.NeedsReset, true);
                     }

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
@@ -281,7 +281,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
             cmds_resume[0].cmdID = ResumeId;
             cmds_resume[0].cmdf = 0;
 
-            // poll until either suspend or resume botton is available, or until operation is canceled
+            // poll until either suspend or resume button is available, or until operation is canceled
             while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
@@ -326,6 +326,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
             async Task<int> QueryStatusAsync(OLECMD[] cmds)
             {
                 await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
 
                 return _oleCommandTarget.QueryStatus(ReSharperCommandGroup, (uint)cmds.Length, cmds, IntPtr.Zero);
             }

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/ReSharperStatus.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/ReSharperStatus.cs
@@ -13,13 +13,8 @@ namespace Microsoft.CodeAnalysis.Experimentation
         /// </summary>
         Suspended,
         /// <summary>
-        /// ReSharper is running.
+        /// ReSharper is installed and enabled.
         /// </summary>
-        Enabled,
-        /// <summary>
-        /// Need to wait longer for ReSharper to report status
-        /// </summary>
-        Undetermined
-
+        Enabled
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/ReSharperStatus.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/ReSharperStatus.cs
@@ -15,6 +15,11 @@ namespace Microsoft.CodeAnalysis.Experimentation
         /// <summary>
         /// ReSharper is running.
         /// </summary>
-        Enabled
+        Enabled,
+        /// <summary>
+        /// Need to wait longer for ReSharper to report status
+        /// </summary>
+        Undetermined
+
     }
 }


### PR DESCRIPTION
Fix for reverted PR: #31132

Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/659765

In some scenarios we display the gold bar with "We notice you suspended 'ReSharper Ultimate'. Reset Keymappings to continue to navigate and refactor" when ReSharper is in fact running. This occurs when launching VS by opening a project that takes a while to load, for example a project that last had a XAML page open.

We originally did a single check for ReSharper's Suspend button; if it was active ReSharper was assumed to be running, if not it was assumed to be suspended.

This fix will instead periodically check for ReSharper's Resume button to be active, and if that doesn't occur after a reasonable amount of time will assume ReSharper is running.