### PR TITLE
Set the ulimit higher to avoid too many open files when running build.sh

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -214,6 +214,12 @@ function BuildSolution {
     enable_analyzers=false
   fi
 
+  # NuGet often exceeds the limit of open files on Mac and Linux
+  # https://github.com/NuGet/Home/issues/2163
+  if [[ "$UNAME" == "Darwin" || "$UNAME" == "Linux" ]]; then
+    ulimit -n 6500
+  fi
+
   local quiet_restore=""
   if [[ "$ci" != true ]]; then
     quiet_restore=true


### PR DESCRIPTION
Many builds have been failing the Linux_Test coreclr build with Too many open files.

```console
2018-12-18T21:04:36.3036095Z   Restoring packages for /data/agent/_work/7/s/src/CodeStyle/CSharp/Tests/Microsoft.CodeAnalysis.CSharp.CodeStyle.UnitTests.csproj...
2018-12-18T21:04:36.3107197Z   Restoring packages for /data/agent/_work/7/s/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj...
2018-12-18T21:04:37.9511911Z   Retrying 'FindPackagesByIdAsync' for source 'https://dotnetmyget.blob.core.windows.net/artifacts/roslyn-tools/nuget/v3/flatcontainer/system.threading.tasks.parallel/index.json'.
2018-12-18T21:04:37.9512179Z   Too many open files in system
2018-12-18T21:04:37.9512597Z   Retrying 'FindPackagesByIdAsync' for source 'https://api.nuget.org/v3-flatcontainer/system.text.regularexpressions/index.json'.
2018-12-18T21:04:37.9512669Z   Too many open files
2018-12-18T21:04:37.9513048Z   Retrying 'FindPackagesByIdAsync' for source 'https://dotnetmyget.blob.core.windows.net/artifacts/roslyn-tools/nuget/v3/flatcontainer/system.threading.tasks.parallel/index.json'.
2018-12-18T21:04:37.9513175Z   Too many open files in system
2018-12-18T21:04:37.9513557Z   Retrying 'FindPackagesByIdAsync' for source 'https://dotnetmyget.blob.core.windows.net/artifacts/symreader-native/nuget/v3/flatcontainer/system.text.regularexpressions/index.json'.
2018-12-18T21:04:37.9513628Z   Too many open files in system
```

For example attempts 1 and 2 from this build for #31648 - [Logs](https://dnceng.visualstudio.com/public/_build/results?buildId=60451)