### PR TITLE
SetupAuthoring for Roslyn localization

### DIFF
--- a/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
+++ b/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
@@ -23,48 +23,49 @@
     <ProjectReference Include="..\..\VisualStudio\Setup\Roslyn.VisualStudio.Setup.csproj">
       <Name>VisualStudioSetup</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <IncludeOutputGroupsInVSIX>SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Core\Source\ExpressionCompiler\Microsoft.CodeAnalysis.ExpressionCompiler.csproj">
       <Name>ExpressionCompiler</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\Core\Source\FunctionResolver\Microsoft.CodeAnalysis.FunctionResolver.csproj">
       <Name>FunctionResolver</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <AdditionalProperties>TargetFramework=netstandard1.3</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\Core\Source\ResultProvider\Portable\Microsoft.CodeAnalysis.ResultProvider.csproj">
       <Name>ResultProvider.Portable</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\CSharp\Source\ExpressionCompiler\Microsoft.CodeAnalysis.CSharp.ExpressionCompiler.csproj">
       <Name>CSharpExpressionCompiler</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\CSharp\Source\ResultProvider\Portable\Microsoft.CodeAnalysis.CSharp.ResultProvider.csproj">
       <Name>CSharpResultProvider.Portable</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\VisualBasic\Source\ExpressionCompiler\Microsoft.CodeAnalysis.VisualBasic.ExpressionCompiler.vbproj">
       <Name>BasicExpressionCompiler</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\VisualBasic\Source\ResultProvider\Portable\Microsoft.CodeAnalysis.VisualBasic.ResultProvider.vbproj">
       <Name>BasicResultProvider.Portable</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>

--- a/src/NuGet/Microsoft.Net.Compilers/CompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers/CompilerArtifacts.targets
@@ -60,14 +60,6 @@
       
       <CompilerArtifact Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.*.dll" Exclude="@(_NoOptimizationData)" NgenArchitecture="all" NgenApplication="VBCSCompiler.exe" OverwriteNgenOptimizationData="true"/>
       <CompilerArtifact Include="@(_NoOptimizationData)" NgenArchitecture="all" NgenApplication="VBCSCompiler.exe" OverwriteNgenOptimizationData="false"/>
-
-      <!-- Satellite assemblies for insertion into VS -->
-      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.resources.dll"/>
-      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.CSharp.resources.dll"/>
-      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Scripting\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.Scripting.resources.dll"/>
-      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.Scripting\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.CSharp.Scripting.resources.dll"/>
-      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.VisualBasic.resources.dll"/>
-      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll"/>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/NuGet/Microsoft.Net.Compilers/CompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers/CompilerArtifacts.targets
@@ -60,6 +60,14 @@
       
       <CompilerArtifact Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.*.dll" Exclude="@(_NoOptimizationData)" NgenArchitecture="all" NgenApplication="VBCSCompiler.exe" OverwriteNgenOptimizationData="true"/>
       <CompilerArtifact Include="@(_NoOptimizationData)" NgenArchitecture="all" NgenApplication="VBCSCompiler.exe" OverwriteNgenOptimizationData="false"/>
+
+      <!-- Satellite assemblies for insertion into VS -->
+      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.resources.dll"/>
+      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.CSharp.resources.dll"/>
+      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Scripting\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.Scripting.resources.dll"/>
+      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.Scripting\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.CSharp.Scripting.resources.dll"/>
+      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.VisualBasic.resources.dll"/>
+      <SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll"/>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
@@ -74,12 +74,12 @@
       <_FileEntries Include='file source="%(_File.Path)"%(_File.NGenArchitectureString)%(_File.NGenPriorityString)%(_File.NGenApplicationString)'/>
 
       <!-- Satellite assemblies -->
-      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.resources.dll"/>
-      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.CSharp.resources.dll"/>
-      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Scripting\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.Scripting.resources.dll"/>
-      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.Scripting\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.CSharp.Scripting.resources.dll"/>
-      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.VisualBasic.resources.dll"/>
-      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll"/>
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis\$(Configuration)\netstandard2.0\**\*.resources.dll"/>
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp\$(Configuration)\netstandard2.0\**\*.resources.dll"/>
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Scripting\$(Configuration)\netstandard2.0\**\*.resources.dll"/>
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.Scripting\$(Configuration)\netstandard2.0\**\*.resources.dll"/>
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic\$(Configuration)\netstandard2.0\**\*.resources.dll"/>
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\**\*.resources.dll"/>
 
       <_CsSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'cs\'">
         <_FileEntries>file source=%(Identity)</_FileEntries>

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
@@ -73,71 +73,65 @@
 
       <_FileEntries Include='file source="%(_File.Path)"%(_File.NGenArchitectureString)%(_File.NGenPriorityString)%(_File.NGenApplicationString)'/>
 
-      <_CsSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'cs\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <!-- Satellite assemblies -->
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.resources.dll"/>
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.CSharp.resources.dll"/>
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Scripting\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.Scripting.resources.dll"/>
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.CSharp.Scripting\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.CSharp.Scripting.resources.dll"/>
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.VisualBasic.resources.dll"/>
+      <_SatelliteAssembly Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll"/>
+
+      <_CsSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'cs\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_CsSatellite>
-      <_CsSatelliteEntries Include='file source="%(_CsSatellite.Path)"'/>
 
-      <_DeSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'de\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_DeSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'de\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_DeSatellite>
-      <_DeSatelliteEntries Include='file source="%(_DeSatellite.Path)"'/>
 
-      <_EsSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'es\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_EsSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'es\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_EsSatellite>
-      <_EsSatelliteEntries Include='file source="%(_EsSatellite.Path)"'/>
 
-      <_FrSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'fr\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_FrSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'fr\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_FrSatellite>
-      <_FrSatelliteEntries Include='file source="%(_FrSatellite.Path)"'/>
 
-      <_ItSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'it\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_ItSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'it\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_ItSatellite>
-      <_ItSatelliteEntries Include='file source="%(_ItSatellite.Path)"'/>
 
-      <_JaSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'ja\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_JaSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'ja\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_JaSatellite>
-      <_JaSatelliteEntries Include='file source="%(_JaSatellite.Path)"'/>
 
-      <_KoSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'ko\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_KoSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'ko\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_KoSatellite>
-      <_KoSatelliteEntries Include='file source="%(_KoSatellite.Path)"'/>
 
-      <_PlSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'pl\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_PlSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'pl\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_PlSatellite>
-      <_PlSatelliteEntries Include='file source="%(_PlSatellite.Path)"'/>
 
-      <_PtBrSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'pt-BR\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_PtBrSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'pt-BR\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_PtBrSatellite>
-      <_PtBrSatelliteEntries Include='file source="%(_PtBrSatellite.Path)"'/>
 
-      <_RuSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'ru\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_RuSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'ru\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_RuSatellite>
-      <_RuSatelliteEntries Include='file source="%(_RuSatellite.Path)"'/>
 
-      <_TrSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'tr\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_TrSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'tr\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_TrSatellite>
-      <_TrSatelliteEntries Include='file source="%(_TrSatellite.Path)"'/>
 
-      <_Zh-HansSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'zh-Hans\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_Zh-HansSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'zh-Hans\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_Zh-HansSatellite>
-      <_Zh-HansSatelliteEntries Include='file source="%(_Zh-HansSatellite.Path)"'/>
 
-      <_Zh-HantSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'zh-Hant\'">
-        <Path>%(SatelliteAssembly.Identity)</Path>
+      <_Zh-HantSatellite Include="@(_SatelliteAssembly)" Condition="'%(_SatelliteAssembly.RecursiveDir)' == 'zh-Hant\'">
+        <_FileEntries>file source=%(Identity)</_FileEntries>
       </_Zh-HantSatellite>
-      <_Zh-HantSatelliteEntries Include='file source="%(_Zh-HantSatellite.Path)"'/>
-
     </ItemGroup>
 
     <PropertyGroup>
@@ -156,47 +150,47 @@ vs.nonCriticalProcesses
 folder InstallDir:\MSBuild\15.0\Bin\Roslyn
   @(_FileEntries, '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\cs
-  @(_CsSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\de
-  @(_DeSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\es
-  @(_EsSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\fr
-  @(_FrSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\it
-  @(_ItSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ja
-  @(_JaSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ko
-  @(_KoSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\pl
-  @(_PlSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\pt-BR
-  @(_PlSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ru
-  @(_RuSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\tr
-  @(_TrSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\zh-Hans
-  @(_zh-HansSatelliteEntries, '%0d%0a  ')
-
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\zh-Hant
-  @(_zh-HantSatelliteEntries, '%0d%0a  ')
-
 folder InstallDir:\Common7\Tools\vsdevcmd\ext
   file source="$(MSBuildProjectDirectory)\roslyn.bat"
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\cs
+  @(_CsSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\de
+  @(_DeSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\es
+  @(_EsSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\fr
+  @(_FrSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\it
+  @(_ItSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ja
+  @(_JaSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ko
+  @(_KoSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\pl
+  @(_PlSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\pt-BR
+  @(_PlSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ru
+  @(_RuSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\tr
+  @(_TrSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\zh-Hans
+  @(_zh-HansSatellite->'%(_FileEntries)', '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\zh-Hant
+  @(_zh-HantSatellite->'%(_FileEntries)', '%0d%0a  ')
 ]]>
       </_Lines>
     </PropertyGroup>

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
@@ -70,8 +70,74 @@
         <NGenPriorityString Condition="'%(CompilerArtifact.NGenPriority)' != ''"> vs.file.ngenPriority=%(CompilerArtifact.NGenPriority)</NGenPriorityString>
         <NGenApplicationString Condition="'%(CompilerArtifact.NGenApplication)' != ''"> vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\Roslyn\%(CompilerArtifact.NGenApplication)"</NGenApplicationString>
       </_File>
-      
+
       <_FileEntries Include='file source="%(_File.Path)"%(_File.NGenArchitectureString)%(_File.NGenPriorityString)%(_File.NGenApplicationString)'/>
+
+      <_CsSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'cs\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_CsSatellite>
+      <_CsSatelliteEntries Include='file source="%(_CsSatellite.Path)"'/>
+
+      <_DeSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'de\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_DeSatellite>
+      <_DeSatelliteEntries Include='file source="%(_DeSatellite.Path)"'/>
+
+      <_EsSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'es\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_EsSatellite>
+      <_EsSatelliteEntries Include='file source="%(_EsSatellite.Path)"'/>
+
+      <_FrSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'fr\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_FrSatellite>
+      <_FrSatelliteEntries Include='file source="%(_FrSatellite.Path)"'/>
+
+      <_ItSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'it\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_ItSatellite>
+      <_ItSatelliteEntries Include='file source="%(_ItSatellite.Path)"'/>
+
+      <_JaSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'ja\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_JaSatellite>
+      <_JaSatelliteEntries Include='file source="%(_JaSatellite.Path)"'/>
+
+      <_KoSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'ko\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_KoSatellite>
+      <_KoSatelliteEntries Include='file source="%(_KoSatellite.Path)"'/>
+
+      <_PlSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'pl\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_PlSatellite>
+      <_PlSatelliteEntries Include='file source="%(_PlSatellite.Path)"'/>
+
+      <_PtBrSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'pt-BR\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_PtBrSatellite>
+      <_PtBrSatelliteEntries Include='file source="%(_PtBrSatellite.Path)"'/>
+
+      <_RuSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'ru\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_RuSatellite>
+      <_RuSatelliteEntries Include='file source="%(_RuSatellite.Path)"'/>
+
+      <_TrSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'tr\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_TrSatellite>
+      <_TrSatelliteEntries Include='file source="%(_TrSatellite.Path)"'/>
+
+      <_Zh-HansSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'zh-Hans\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_Zh-HansSatellite>
+      <_Zh-HansSatelliteEntries Include='file source="%(_Zh-HansSatellite.Path)"'/>
+
+      <_Zh-HantSatellite Include="@(SatelliteAssembly)" Condition="'%(SatelliteAssembly.RecursiveDir)' == 'zh-Hant\'">
+        <Path>%(SatelliteAssembly.Identity)</Path>
+      </_Zh-HantSatellite>
+      <_Zh-HantSatelliteEntries Include='file source="%(_Zh-HantSatellite.Path)"'/>
+
     </ItemGroup>
 
     <PropertyGroup>
@@ -89,6 +155,45 @@ vs.nonCriticalProcesses
 
 folder InstallDir:\MSBuild\15.0\Bin\Roslyn
   @(_FileEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\cs
+  @(_CsSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\de
+  @(_DeSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\es
+  @(_EsSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\fr
+  @(_FrSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\it
+  @(_ItSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ja
+  @(_JaSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ko
+  @(_KoSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\pl
+  @(_PlSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\pt-BR
+  @(_PlSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ru
+  @(_RuSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\tr
+  @(_TrSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\zh-Hans
+  @(_zh-HansSatelliteEntries, '%0d%0a  ')
+
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn\zh-Hant
+  @(_zh-HantSatelliteEntries, '%0d%0a  ')
 
 folder InstallDir:\Common7\Tools\vsdevcmd\ext
   file source="$(MSBuildProjectDirectory)\roslyn.bat"

--- a/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
+++ b/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
@@ -23,139 +23,139 @@
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj">
       <Name>CodeAnalysis</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj">
       <Name>CSharpCodeAnalysis</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Compilers\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.vbproj">
       <Name>BasicCodeAnalysis</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Workspaces\Core\Desktop\Microsoft.CodeAnalysis.Workspaces.Desktop.csproj">
       <Name>Workspaces.Desktop</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Features\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Features.vbproj">
       <Name>BasicFeatures</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Features\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj">
       <Name>CSharpFeatures</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\EditorFeatures\CSharp\Microsoft.CodeAnalysis.CSharp.EditorFeatures.csproj">
       <Name>CSharpEditorFeatures</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\EditorFeatures\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj">
       <Name>EditorFeatures</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\EditorFeatures\Core.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj">
       <Name>EditorFeatures.Wpf</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj">
       <Name>Features</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\EditorFeatures\Text\Microsoft.CodeAnalysis.EditorFeatures.Text.csproj">
       <Name>TextEditorFeatures</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\EditorFeatures\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.vbproj">
       <Name>BasicEditorFeatures</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj">
       <Name>Workspaces</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Workspaces\Core\MSBuild\Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj">
       <Name>Workspaces.MSBuild</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <AdditionalProperties>TargetFramework=net472</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\..\Workspaces\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Workspaces.csproj">
       <Name>CSharpWorkspace</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Workspaces\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Workspaces.vbproj">
       <Name>BasicWorkspace</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\Core\Def\Microsoft.VisualStudio.LanguageServices.csproj">
       <Name>ServicesVisualStudio</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;PkgDefProjectOutputGroup;VsdConfigOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;PkgDefProjectOutputGroup;VsdConfigOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\Core\Impl\Microsoft.VisualStudio.LanguageServices.Implementation.csproj">
       <Name>ServicesVisualStudioImpl</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\Core\SolutionExplorerShim\Microsoft.VisualStudio.LanguageServices.SolutionExplorer.csproj">
       <Name>SolutionExplorerShim</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\CSharp\Impl\Microsoft.VisualStudio.LanguageServices.CSharp.csproj">
       <Name>CSharpVisualStudio</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bPkgDefProjectOutputGroup%3bContentFilesProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bPkgDefProjectOutputGroup%3bContentFilesProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\VisualBasic\Impl\Microsoft.VisualStudio.LanguageServices.VisualBasic.vbproj">
       <Name>BasicVisualStudio</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bPkgDefProjectOutputGroup%3bContentFilesProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bPkgDefProjectOutputGroup%3bContentFilesProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\Setup.Dependencies\Roslyn.VisualStudio.Setup.Dependencies.csproj">
       <Name>VisualStudioSetup.Dependencies</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <IncludeOutputGroupsInVSIX></IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
       <Private>false</Private>
     </ProjectReference>
     <ProjectReference Include="..\Xaml\Impl\Microsoft.VisualStudio.LanguageServices.Xaml.csproj">
       <Name>XamlVisualStudio</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Workspaces\Remote\Core\Microsoft.CodeAnalysis.Remote.Workspaces.csproj">
       <Name>RemoteWorkspaces</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Workspaces\Remote\Razor\Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.csproj">
       <Name>RazorServiceHub</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Workspaces\Remote\ServiceHub\Microsoft.CodeAnalysis.Remote.ServiceHub.csproj">
       <Name>ServiceHub</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\Razor\Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.csproj">
       <Name>RazorVisualStudio</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
   </ItemGroup>

--- a/src/VisualStudio/VisualStudioInteractiveComponents/Roslyn.VisualStudio.InteractiveComponents.csproj
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/Roslyn.VisualStudio.InteractiveComponents.csproj
@@ -23,74 +23,76 @@
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Interactive\Host\InteractiveHost32.csproj">
+      <IncludeOutputGroupsInVSIX>SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <Ngen>false</Ngen>
     </ProjectReference>
     <ProjectReference Include="..\..\Interactive\Host\InteractiveHost64.csproj">
+      <IncludeOutputGroupsInVSIX>SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <Ngen>false</Ngen>
     </ProjectReference>
     <ProjectReference Include="..\CSharp\Repl\Microsoft.VisualStudio.CSharp.Repl.csproj">
       <Name>CSharpVisualStudioRepl</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;PkgDefProjectOutputGroup;ContentFilesProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;PkgDefProjectOutputGroup;ContentFilesProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj">
       <Name>CodeAnalysis</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj">
       <Name>CSharpCodeAnalysis</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Interactive\EditorFeatures\Core\Microsoft.CodeAnalysis.InteractiveEditorFeatures.csproj">
       <Name>InteractiveEditorFeatures</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Interactive\EditorFeatures\CSharp\Microsoft.CodeAnalysis.CSharp.InteractiveEditorFeatures.csproj">
       <Name>CSharpInteractiveEditorFeatures</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Scripting\Core\Microsoft.CodeAnalysis.Scripting.csproj">
       <Name>Scripting</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Scripting\CSharp\Microsoft.CodeAnalysis.CSharp.Scripting.csproj">
       <Name>CSharpScripting</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Interactive\Features\Microsoft.CodeAnalysis.InteractiveFeatures.csproj">
       <Name>InteractiveFeatures</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\InteractiveServices\Microsoft.VisualStudio.InteractiveServices.csproj">
       <Name>VisualStudioInteractiveServices</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj">
       <Name>Features</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj">
       <Name>Workspaces</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
@@ -98,7 +100,7 @@
       <Name>VisualStudioSetup</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Private>False</Private>
-      <IncludeOutputGroupsInVSIX></IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
[Issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/723558)
So this PR will enable 
ExpressionEvaluatorPackage.vsix, Roslyn.VisualStudio.InteractiveComponents.vsix and Roslyn.VisualStudio.Setup.vsix contains the Satellite Dlls.

As for Microsoft.CodeAnalysis.Compilers.vsix, I checked my current VS2017 directory under C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\Roslyn and there is no Resources file in there, so I guess it won't need it. @tmeschter for double check.
 