### PR TITLE
Disable warn as error in build correctness

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -41,6 +41,7 @@ param (
     [switch]$deployExtensions,
     [switch]$prepareMachine,
     [switch]$useGlobalNuGetCache = $true,
+    [switch]$warnAsError = $true,
 
     # Test actions
     [switch]$test32,

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -34,7 +34,7 @@ try {
     Push-Location $RepoRoot
 
     Write-Host "Building Roslyn"
-    Exec-Block { & (Join-Path $PSScriptRoot "build.ps1") -restore -build -ci:$ci -configuration:$configuration -pack -binaryLog -useGlobalNuGetCache:$false -properties "/p:RoslynEnforceCodeStyle=true"}
+    Exec-Block { & (Join-Path $PSScriptRoot "build.ps1") -restore -build -ci:$ci -configuration:$configuration -pack -binaryLog -useGlobalNuGetCache:$false -warnAsError:$false -properties "/p:RoslynEnforceCodeStyle=true"}
 
 
     # Verify the state of our various build artifacts


### PR DESCRIPTION
This re-establishes our warning only behavior for the build correctness
leg. Fixes a regression introduced in #31913