### PR TITLE
Avoid cascading diagnostic for unexpected override

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -745,7 +745,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             }
                             else if (!overridingMemberType.Equals(overriddenMemberType, TypeCompareKind.AllIgnoreOptions))
                             {
-                                diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.TypeSymbol);
+                                // if the type is or contains an error type, the type must be fixed before the override can be found, so suppress error
+                                if (overridingMemberType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
+                                {
+                                    diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.TypeSymbol);
+                                }
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
                             }
                             else if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureNullableReferenceTypes) == true &&
@@ -789,7 +793,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             // Ignore custom modifiers because this diagnostic is based on the C# semantics.
                             if (!overridingMemberType.Equals(overriddenMemberType, TypeCompareKind.AllIgnoreOptions))
                             {
-                                diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.TypeSymbol);
+                                // if the type is or contains an error type, the type must be fixed before the override can be found, so suppress error
+                                if (overridingMemberType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
+                                {
+                                    diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.TypeSymbol);
+                                }
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
                             }
                             else if (((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)?.IsFeatureEnabled(MessageID.IDS_FeatureNullableReferenceTypes) == true &&
@@ -819,8 +827,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             }
                             else if (!overridingMethod.ReturnType.Equals(overriddenMethod.ReturnType, TypeCompareKind.AllIgnoreOptions))
                             {
-                                // error CS0508: return type must be 'C<V>' to match overridden member 'M<T>()'
-                                diagnostics.Add(ErrorCode.ERR_CantChangeReturnTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMethod.ReturnType.TypeSymbol);
+                                // if the Return type is or contains an error type, the return type must be fixed before the override can be found, so suppress error
+                                if (overridingMethod.ReturnType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
+                                {
+                                    // error CS0508: return type must be 'C<V>' to match overridden member 'M<T>()'
+                                    diagnostics.Add(ErrorCode.ERR_CantChangeReturnTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMethod.ReturnType.TypeSymbol);
+                                }
                             }
                             else if (overriddenMethod.IsRuntimeFinalizer())
                             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -617,7 +617,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                             foreach (var parameterType in parameterTypes)
                             {
-                                if ((object)parameterType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) != null)
+                                if (isOrContainsErrorType(parameterType.TypeSymbol))
                                 {
                                     suppressError = true; // The parameter type must be fixed before the override can be found, so suppress error
                                     break;
@@ -746,7 +746,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             else if (!overridingMemberType.Equals(overriddenMemberType, TypeCompareKind.AllIgnoreOptions))
                             {
                                 // if the type is or contains an error type, the type must be fixed before the override can be found, so suppress error
-                                if ((object)overridingMemberType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
+                                if (!isOrContainsErrorType(overridingMemberType.TypeSymbol))
                                 {
                                     diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.TypeSymbol);
                                 }
@@ -794,7 +794,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             if (!overridingMemberType.Equals(overriddenMemberType, TypeCompareKind.AllIgnoreOptions))
                             {
                                 // if the type is or contains an error type, the type must be fixed before the override can be found, so suppress error
-                                if ((object)overridingMemberType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
+                                if (!isOrContainsErrorType(overridingMemberType.TypeSymbol))
                                 {
                                     diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.TypeSymbol);
                                 }
@@ -828,7 +828,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             else if (!overridingMethod.ReturnType.Equals(overriddenMethod.ReturnType, TypeCompareKind.AllIgnoreOptions))
                             {
                                 // if the Return type is or contains an error type, the return type must be fixed before the override can be found, so suppress error
-                                if ((object)overridingMethod.ReturnType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
+                                if (!isOrContainsErrorType(overridingMethod.ReturnType.TypeSymbol))
                                 {
                                     // error CS0508: return type must be 'C<V>' to match overridden member 'M<T>()'
                                     diagnostics.Add(ErrorCode.ERR_CantChangeReturnTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMethod.ReturnType.TypeSymbol);
@@ -905,6 +905,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var ambiguousMethod = runtimeOverriddenMembers[0];
                 diagnostics.Add(ErrorCode.WRN_MultipleRuntimeOverrideMatches, ambiguousMethod.Locations[0], ambiguousMethod, overridingMember);
                 suppressAccessors = true;
+            }
+
+            bool isOrContainsErrorType(TypeSymbol typeSymbol)
+            {
+                return (object)typeSymbol.VisitType((currentTypeSymbol, unused1, unused2) => currentTypeSymbol.IsErrorType(), (object)null) != null;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -608,7 +608,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     if ((object)associatedPropertyOrEvent == null)
                     {
-                        diagnostics.Add(ErrorCode.ERR_OverrideNotExpected, overridingMemberLocation, overridingMember);
+                        if (overridingMember.GetTypeOrReturnType().Kind == SymbolKind.ErrorType)
+                        {
+                            // The return type must be fixed before the override can be found, so suppress error
+                        }
+                        else if (overridingMemberIsMethod && ((MethodSymbol) overridingMember).ParameterTypes.Any(SymbolKind.ErrorType))
+                        {
+                            // The parameter type/s must be fixed before the override can be found, so suppress error
+                        }
+                        else
+                        {
+                            diagnostics.Add(ErrorCode.ERR_OverrideNotExpected, overridingMemberLocation,
+                                overridingMember);
+                        }
                     }
                     else if (associatedPropertyOrEvent.Kind == SymbolKind.Property) //no specific errors for event accessors
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -618,8 +618,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         }
                         else
                         {
-                            diagnostics.Add(ErrorCode.ERR_OverrideNotExpected, overridingMemberLocation,
-                                overridingMember);
+                            diagnostics.Add(ErrorCode.ERR_OverrideNotExpected, overridingMemberLocation, overridingMember);
                         }
                     }
                     else if (associatedPropertyOrEvent.Kind == SymbolKind.Property) //no specific errors for event accessors

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -612,12 +612,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         if (overridingMemberIsMethod || overridingMember.IsIndexer())
                         {
                             var parameterTypes = overridingMemberIsMethod
-                                ? ((MethodSymbol) overridingMember).ParameterTypes
-                                : ((PropertySymbol) overridingMember).ParameterTypes;
+                                ? ((MethodSymbol)overridingMember).ParameterTypes
+                                : ((PropertySymbol)overridingMember).ParameterTypes;
 
                             foreach (var parameterType in parameterTypes)
                             {
-                                if (parameterType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) != null)
+                                if ((object)parameterType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) != null)
                                 {
                                     suppressError = true; // The parameter type must be fixed before the override can be found, so suppress error
                                     break;
@@ -746,7 +746,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             else if (!overridingMemberType.Equals(overriddenMemberType, TypeCompareKind.AllIgnoreOptions))
                             {
                                 // if the type is or contains an error type, the type must be fixed before the override can be found, so suppress error
-                                if (overridingMemberType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
+                                if ((object)overridingMemberType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
                                 {
                                     diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.TypeSymbol);
                                 }
@@ -794,7 +794,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             if (!overridingMemberType.Equals(overriddenMemberType, TypeCompareKind.AllIgnoreOptions))
                             {
                                 // if the type is or contains an error type, the type must be fixed before the override can be found, so suppress error
-                                if (overridingMemberType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
+                                if ((object)overridingMemberType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
                                 {
                                     diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType.TypeSymbol);
                                 }
@@ -828,7 +828,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             else if (!overridingMethod.ReturnType.Equals(overriddenMethod.ReturnType, TypeCompareKind.AllIgnoreOptions))
                             {
                                 // if the Return type is or contains an error type, the return type must be fixed before the override can be found, so suppress error
-                                if (overridingMethod.ReturnType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
+                                if ((object)overridingMethod.ReturnType.TypeSymbol.VisitType((typeSymbol, unused1, unused2) => typeSymbol.IsErrorType(), (object)null) == null)
                                 {
                                     // error CS0508: return type must be 'C<V>' to match overridden member 'M<T>()'
                                     diagnostics.Add(ErrorCode.ERR_CantChangeReturnTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMethod.ReturnType.TypeSymbol);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -694,6 +694,83 @@ class Derived : Base, Interface
         }
 
         [Fact]
+        public void TestSupressOverrideNotExpectedErrorWhenMethodParameterTypeNotFound()
+        {
+            var text = @"
+class Base
+{
+}
+
+class Derived : Base
+{
+    public override void Method0(String x) { }
+    public override void Method1(string x, String y) { }
+    public override void Method2(String[] x) { }
+    public override void Method3(System.Func<String> x) { }
+    public override void Method4((string a, String b) x) { }
+    public override void Method5(System.Func<(string a, String[] b)> x) { }
+    public override void Method6(Outer<String>.Inner<string> x) { }
+    public override void Method7(Outer<string>.Inner<String> x) { }
+    public override void Method8(String? x) { }
+}
+
+class Outer<T>
+{
+    public class Inner<U>{}
+}
+";
+            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 8, Column = 34},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 9, Column = 44},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 10, Column = 34},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 11, Column = 46},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 12, Column = 45},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 13, Column = 57},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 14, Column = 40},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 15, Column = 54},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 34},
+            });
+        }
+
+        [Fact]
+        public void TestSupressOverrideNotExpectedErrorWhenIndexerParameterTypeNotFound()
+        {
+            var text = @"
+class Base
+{
+}
+
+class Derived : Base
+{
+    public override int this[String x] => 0;
+    public override int this[string x, String y] => 0;
+    public override int this[String[] x] => 0;
+    public override int this[System.Func<String> x] => 0;
+    public override int this[(string a, String b) x] => 0;
+    public override int this[System.Func<(string a, String[] b)> x] => 0;
+    public override int this[Outer<String>.Inner<string> x] => 0;
+    public override int this[Outer<string>.Inner<String> x] => 0;
+    public override int this[String? x] => 0;
+}
+
+class Outer<T>
+{
+    public class Inner<U>{}
+}
+";
+            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 8, Column = 30},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 9, Column = 40},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 10, Column = 30},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 11, Column = 42},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 12, Column = 41},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 13, Column = 53},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 14, Column = 36},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 15, Column = 50},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 30},
+            });
+        }
+        [Fact]
         public void TestOverrideSealedMethod()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -711,7 +711,7 @@ class Derived : Base
     public override void Method5(System.Func<(string a, String[] b)> x) { }
     public override void Method6(Outer<String>.Inner<string> x) { }
     public override void Method7(Outer<string>.Inner<String> x) { }
-    public override void Method8(String? x) { }
+    public override void Method8(Int? x) { }
 }
 
 class Outer<T>
@@ -750,7 +750,7 @@ class Derived : Base
     public override int this[System.Func<(string a, String[] b)> x] => 0;
     public override int this[Outer<String>.Inner<string> x] => 0;
     public override int this[Outer<string>.Inner<String> x] => 0;
-    public override int this[String? x] => 0;
+    public override int this[Int? x] => 0;
 }
 
 class Outer<T>
@@ -770,6 +770,225 @@ class Outer<T>
                 new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 30},
             });
         }
+
+        [Fact]
+        public void TestSupressCantChangeReturnTypeErrorWhenMethodReturnTypeNotFound()
+        {
+            var text = @"
+abstract class Base
+{
+    public abstract void Method0();
+    public abstract void Method1();
+    public abstract void Method2();
+    public abstract void Method3();
+    public abstract void Method4();
+    public abstract void Method5();
+    public abstract void Method6();
+    public abstract void Method7();
+}
+
+class Derived : Base
+{
+    public override String Method0() => null;
+    public override String[] Method1() => null;
+    public override System.Func<String> Method2() => null;
+    public override (string a, String b) Method3() => (null, null);
+    public override System.Func<(string a, String[] b)> Method4() => null;
+    public override Outer<String>.Inner<string> Method5() => null;
+    public override Outer<string>.Inner<String> Method6() => null;
+    public override Int? Method7() => null;
+}
+
+class Outer<T>
+{
+    public class Inner<U> { }
+}
+";
+            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 21},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 17, Column = 21},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 18, Column = 33},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 19, Column = 32},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 20, Column = 44},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 21, Column = 27},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 22, Column = 41},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 23, Column = 21},
+            });
+        }
+
+        [Fact]
+        public void TestSupressCantChangeTypeErrorWhenPropertyTypeNotFound()
+        {
+            var text = @"
+abstract class Base
+{
+    public abstract int Property0 { get; }
+    public abstract int Property1 { get; }
+    public abstract int Property2 { get; }
+    public abstract int Property3 { get; }
+    public abstract int Property4 { get; }
+    public abstract int Property5 { get; }
+    public abstract int Property6 { get; }
+    public abstract int Property7 { get; }
+}
+
+class Derived : Base
+{
+    public override String Property0 => null;
+    public override String[] Property1 => null;
+    public override System.Func<String> Property2 => null;
+    public override (string a, String b) Property3 => (null, null);
+    public override System.Func<(string a, String[] b)> Property4 => null;
+    public override Outer<String>.Inner<string> Property5 => null;
+    public override Outer<string>.Inner<String> Property6 => null;
+    public override Int? Property7 => null;
+}
+
+class Outer<T>
+{
+    public class Inner<U> { }
+}
+";
+            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 21},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 17, Column = 21},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 18, Column = 33},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 19, Column = 32},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 20, Column = 44},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 21, Column = 27},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 22, Column = 41},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 23, Column = 21},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+            });
+        }
+        
+        [Fact]
+        public void TestSupressCantChangeTypeErrorWhenIndexerTypeNotFound()
+        {
+            var text = @"
+abstract class Base
+{
+    public abstract int this[int index] { get; }
+}
+
+class Derived : Base
+{
+    public override String this[int index] => null;
+    public override String[] this[int index] => null;
+    public override System.Func<String> this[int index] => null;
+    public override (string a, String b) this[int index] => (null, null);
+    public override System.Func<(string a, String[] b)> this[int index] => null;
+    public override Outer<String>.Inner<string> this[int index] => null;
+    public override Outer<string>.Inner<String> this[int index] => null;
+    public override Int? this[int index] => null;
+}
+
+class Outer<T>
+{
+    public class Inner<U> { }
+}
+";
+            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 9, Column = 21},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 10, Column = 21},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 11, Column = 33},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 12, Column = 32},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 13, Column = 44},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 14, Column = 27},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 15, Column = 41},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 21},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 7, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 10, Column = 30},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 11, Column = 41},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 12, Column = 42},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 13, Column = 57},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 14, Column = 49},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 15, Column = 49},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 16, Column = 26},
+            });
+        }
+
+        [Fact]
+        public void TestSupressCantChangeTypeErrorWhenEventTypeNotFound()
+        {
+            var text = @"
+abstract class Base
+{
+    public abstract event System.Action Event0;
+    public abstract event System.Action Event1;
+    public abstract event System.Action Event2;
+    public abstract event System.Action Event3;
+    public abstract event System.Action Event4;
+    public abstract event System.Action Event5;
+    public abstract event System.Action Event6;
+    public abstract event System.Action Event7;
+}
+
+class Derived : Base
+{
+    public override event String Event0;
+    public override event String[] Event1;
+    public override event System.Func<String> Event2;
+    public override event (string a, String b) Event3;
+    public override event System.Func<(string a, String[] b)> Event4;
+    public override event Outer<String>.Inner<string> Event5;
+    public override event Outer<string>.Inner<String> Event6;
+    public override event Int? Event7;
+}
+
+class Outer<T>
+{
+	public class Inner<U> { }
+}
+";
+            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 27},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 17, Column = 27},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 18, Column = 39},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 19, Column = 38},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 20, Column = 50},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 21, Column = 33},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 22, Column = 47},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 23, Column = 27},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_EventNotDelegate, Line = 17, Column = 36},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_EventNotDelegate, Line = 19, Column = 48},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_EventNotDelegate, Line = 21, Column = 55},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_EventNotDelegate, Line = 22, Column = 55},
+                new ErrorDescription {Code = (int) ErrorCode.ERR_EventNotDelegate, Line = 23, Column = 32},
+                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 16, Column = 34, IsWarning = true},
+                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 17, Column = 36, IsWarning = true},
+                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 18, Column = 47, IsWarning = true},
+                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 19, Column = 48, IsWarning = true},
+                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 20, Column = 63, IsWarning = true},
+                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 21, Column = 55, IsWarning = true},
+                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 22, Column = 55, IsWarning = true},
+                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 23, Column = 32, IsWarning = true},
+            });
+        }
+
         [Fact]
         public void TestOverrideSealedMethod()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -719,17 +719,34 @@ class Outer<T>
     public class Inner<U>{}
 }
 ";
-            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 8, Column = 34},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 9, Column = 44},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 10, Column = 34},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 11, Column = 46},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 12, Column = 45},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 13, Column = 57},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 14, Column = 40},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 15, Column = 54},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 34},
-            });
+            CreateCompilation(text).VerifyDiagnostics(
+                // (8,34): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override void Method0(String x) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(8, 34),
+                // (9,44): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override void Method1(string x, String y) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(9, 44),
+                // (10,34): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override void Method2(String[] x) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(10, 34),
+                // (11,46): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override void Method3(System.Func<String> x) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(11, 46),
+                // (12,45): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override void Method4((string a, String b) x) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(12, 45),
+                // (13,57): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override void Method5(System.Func<(string a, String[] b)> x) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(13, 57),
+                // (14,40): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override void Method6(Outer<String>.Inner<string> x) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(14, 40),
+                // (15,54): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override void Method7(Outer<string>.Inner<String> x) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(15, 54),
+                // (16,34): error CS0246: The type or namespace name 'Int' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override void Method8(Int? x) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Int").WithArguments("Int").WithLocation(16, 34));
         }
 
         [Fact]
@@ -758,17 +775,34 @@ class Outer<T>
     public class Inner<U>{}
 }
 ";
-            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 8, Column = 30},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 9, Column = 40},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 10, Column = 30},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 11, Column = 42},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 12, Column = 41},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 13, Column = 53},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 14, Column = 36},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 15, Column = 50},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 30},
-            });
+            CreateCompilation(text).VerifyDiagnostics(
+                // (8,30): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override int this[String x] => 0;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(8, 30),
+                // (9,40): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override int this[string x, String y] => 0;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(9, 40),
+                // (10,30): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override int this[String[] x] => 0;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(10, 30),
+                // (11,42): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override int this[System.Func<String> x] => 0;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(11, 42),
+                // (12,41): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override int this[(string a, String b) x] => 0;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(12, 41),
+                // (13,53): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override int this[System.Func<(string a, String[] b)> x] => 0;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(13, 53),
+                // (14,36): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override int this[Outer<String>.Inner<string> x] => 0;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(14, 36),
+                // (15,50): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override int this[Outer<string>.Inner<String> x] => 0;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(15, 50),
+                // (16,30): error CS0246: The type or namespace name 'Int' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override int this[Int? x] => 0;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Int").WithArguments("Int").WithLocation(16, 30));
         }
 
         [Fact]
@@ -804,16 +838,31 @@ class Outer<T>
     public class Inner<U> { }
 }
 ";
-            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 21},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 17, Column = 21},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 18, Column = 33},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 19, Column = 32},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 20, Column = 44},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 21, Column = 27},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 22, Column = 41},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 23, Column = 21},
-            });
+            CreateCompilation(text).VerifyDiagnostics(
+                // (16,21): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override String Method0() => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(16, 21),
+                // (17,21): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override String[] Method1() => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(17, 21),
+                // (18,33): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override System.Func<String> Method2() => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(18, 33),
+                // (19,32): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override (string a, String b) Method3() => (null, null);
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(19, 32),
+                // (20,44): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override System.Func<(string a, String[] b)> Method4() => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(20, 44),
+                // (21,27): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override Outer<String>.Inner<string> Method5() => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(21, 27),
+                // (22,41): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override Outer<string>.Inner<String> Method6() => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(22, 41),
+                // (23,21): error CS0246: The type or namespace name 'Int' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override Int? Method7() => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Int").WithArguments("Int").WithLocation(23, 21));
         }
 
         [Fact]
@@ -849,24 +898,55 @@ class Outer<T>
     public class Inner<U> { }
 }
 ";
-            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 21},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 17, Column = 21},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 18, Column = 33},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 19, Column = 32},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 20, Column = 44},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 21, Column = 27},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 22, Column = 41},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 23, Column = 21},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-            });
+            CreateCompilation(text).VerifyDiagnostics(
+                // (16,21): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override String Property0 => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(16, 21),
+                // (17,21): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override String[] Property1 => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(17, 21),
+                // (18,33): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override System.Func<String> Property2 => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(18, 33),
+                // (19,32): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override (string a, String b) Property3 => (null, null);
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(19, 32),
+                // (20,44): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override System.Func<(string a, String[] b)> Property4 => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(20, 44),
+                // (21,27): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override Outer<String>.Inner<string> Property5 => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(21, 27),
+                // (22,41): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override Outer<string>.Inner<String> Property6 => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(22, 41),
+                // (23,21): error CS0246: The type or namespace name 'Int' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override Int? Property7 => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Int").WithArguments("Int").WithLocation(23, 21),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Property4.get'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Property4.get").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Property2.get'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Property2.get").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Property7.get'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Property7.get").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Property3.get'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Property3.get").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Property1.get'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Property1.get").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Property5.get'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Property5.get").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Property6.get'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Property6.get").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Property0.get'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Property0.get").WithLocation(14, 7));
         }
         
         [Fact]
@@ -895,24 +975,55 @@ class Outer<T>
     public class Inner<U> { }
 }
 ";
-            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 9, Column = 21},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 10, Column = 21},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 11, Column = 33},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 12, Column = 32},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 13, Column = 44},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 14, Column = 27},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 15, Column = 41},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 21},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 7, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 10, Column = 30},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 11, Column = 41},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 12, Column = 42},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 13, Column = 57},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 14, Column = 49},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 15, Column = 49},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_MemberAlreadyExists, Line = 16, Column = 26},
-            });
+            CreateCompilation(text).VerifyDiagnostics(
+                // (9,21): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override String this[int index] => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(9, 21),
+                // (10,21): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override String[] this[int index] => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(10, 21),
+                // (11,33): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override System.Func<String> this[int index] => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(11, 33),
+                // (12,32): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override (string a, String b) this[int index] => (null, null);
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(12, 32),
+                // (13,44): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override System.Func<(string a, String[] b)> this[int index] => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(13, 44),
+                // (14,27): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override Outer<String>.Inner<string> this[int index] => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(14, 27),
+                // (15,41): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override Outer<string>.Inner<String> this[int index] => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(15, 41),
+                // (16,21): error CS0246: The type or namespace name 'Int' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override Int? this[int index] => null;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Int").WithArguments("Int").WithLocation(16, 21),
+                // (7,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.this[int].get'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.this[int].get").WithLocation(7, 7),
+                // (10,30): error CS0111: Type 'Derived' already defines a member called 'this' with the same parameter types
+                //     public override String[] this[int index] => null;
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "this").WithArguments("this", "Derived").WithLocation(10, 30),
+                // (11,41): error CS0111: Type 'Derived' already defines a member called 'this' with the same parameter types
+                //     public override System.Func<String> this[int index] => null;
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "this").WithArguments("this", "Derived").WithLocation(11, 41),
+                // (12,42): error CS0111: Type 'Derived' already defines a member called 'this' with the same parameter types
+                //     public override (string a, String b) this[int index] => (null, null);
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "this").WithArguments("this", "Derived").WithLocation(12, 42),
+                // (13,57): error CS0111: Type 'Derived' already defines a member called 'this' with the same parameter types
+                //     public override System.Func<(string a, String[] b)> this[int index] => null;
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "this").WithArguments("this", "Derived").WithLocation(13, 57),
+                // (14,49): error CS0111: Type 'Derived' already defines a member called 'this' with the same parameter types
+                //     public override Outer<String>.Inner<string> this[int index] => null;
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "this").WithArguments("this", "Derived").WithLocation(14, 49),
+                // (15,49): error CS0111: Type 'Derived' already defines a member called 'this' with the same parameter types
+                //     public override Outer<string>.Inner<String> this[int index] => null;
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "this").WithArguments("this", "Derived").WithLocation(15, 49),
+                // (16,26): error CS0111: Type 'Derived' already defines a member called 'this' with the same parameter types
+                //     public override Int? this[int index] => null;
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "this").WithArguments("this", "Derived").WithLocation(16, 26));
         }
 
         [Fact]
@@ -948,45 +1059,118 @@ class Outer<T>
 	public class Inner<U> { }
 }
 ";
-            CompileAndVerifyDiagnostics(text, new ErrorDescription[] {
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 16, Column = 27},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 17, Column = 27},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 18, Column = 39},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 19, Column = 38},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 20, Column = 50},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 21, Column = 33},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 22, Column = 47},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_SingleTypeNameNotFound, Line = 23, Column = 27},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_UnimplementedAbstractMethod, Line = 14, Column = 7},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_EventNotDelegate, Line = 17, Column = 36},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_EventNotDelegate, Line = 19, Column = 48},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_EventNotDelegate, Line = 21, Column = 55},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_EventNotDelegate, Line = 22, Column = 55},
-                new ErrorDescription {Code = (int) ErrorCode.ERR_EventNotDelegate, Line = 23, Column = 32},
-                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 16, Column = 34, IsWarning = true},
-                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 17, Column = 36, IsWarning = true},
-                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 18, Column = 47, IsWarning = true},
-                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 19, Column = 48, IsWarning = true},
-                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 20, Column = 63, IsWarning = true},
-                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 21, Column = 55, IsWarning = true},
-                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 22, Column = 55, IsWarning = true},
-                new ErrorDescription {Code = (int) ErrorCode.WRN_UnreferencedEvent, Line = 23, Column = 32, IsWarning = true},
-            });
+            CreateCompilation(text).VerifyDiagnostics(
+                // (16,27): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override event String Event0;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(16, 27),
+                // (17,27): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override event String[] Event1;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(17, 27),
+                // (18,39): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override event System.Func<String> Event2;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(18, 39),
+                // (19,38): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override event (string a, String b) Event3;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(19, 38),
+                // (20,50): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override event System.Func<(string a, String[] b)> Event4;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(20, 50),
+                // (21,33): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override event Outer<String>.Inner<string> Event5;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(21, 33),
+                // (22,47): error CS0246: The type or namespace name 'String' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override event Outer<string>.Inner<String> Event6;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "String").WithArguments("String").WithLocation(22, 47),
+                // (23,27): error CS0246: The type or namespace name 'Int' could not be found (are you missing a using directive or an assembly reference?)
+                //     public override event Int? Event7;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Int").WithArguments("Int").WithLocation(23, 27),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event6.add'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event6.add").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event1.add'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event1.add").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event1.remove'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event1.remove").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event5.add'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event5.add").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event3.add'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event3.add").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event2.add'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event2.add").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event4.remove'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event4.remove").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event4.add'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event4.add").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event3.remove'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event3.remove").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event7.add'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event7.add").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event0.add'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event0.add").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event6.remove'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event6.remove").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event2.remove'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event2.remove").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event7.remove'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event7.remove").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event0.remove'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event0.remove").WithLocation(14, 7),
+                // (14,7): error CS0534: 'Derived' does not implement inherited abstract member 'Base.Event5.remove'
+                // class Derived : Base
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Derived").WithArguments("Derived", "Base.Event5.remove").WithLocation(14, 7),
+                // (17,36): error CS0066: 'Derived.Event1': event must be of a delegate type
+                //     public override event String[] Event1;
+                Diagnostic(ErrorCode.ERR_EventNotDelegate, "Event1").WithArguments("Derived.Event1").WithLocation(17, 36),
+                // (19,48): error CS0066: 'Derived.Event3': event must be of a delegate type
+                //     public override event (string a, String b) Event3;
+                Diagnostic(ErrorCode.ERR_EventNotDelegate, "Event3").WithArguments("Derived.Event3").WithLocation(19, 48),
+                // (21,55): error CS0066: 'Derived.Event5': event must be of a delegate type
+                //     public override event Outer<String>.Inner<string> Event5;
+                Diagnostic(ErrorCode.ERR_EventNotDelegate, "Event5").WithArguments("Derived.Event5").WithLocation(21, 55),
+                // (22,55): error CS0066: 'Derived.Event6': event must be of a delegate type
+                //     public override event Outer<string>.Inner<String> Event6;
+                Diagnostic(ErrorCode.ERR_EventNotDelegate, "Event6").WithArguments("Derived.Event6").WithLocation(22, 55),
+                // (23,32): error CS0066: 'Derived.Event7': event must be of a delegate type
+                //     public override event Int? Event7;
+                Diagnostic(ErrorCode.ERR_EventNotDelegate, "Event7").WithArguments("Derived.Event7").WithLocation(23, 32),
+                // (19,48): warning CS0067: The event 'Derived.Event3' is never used
+                //     public override event (string a, String b) Event3;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Event3").WithArguments("Derived.Event3").WithLocation(19, 48),
+                // (23,32): warning CS0067: The event 'Derived.Event7' is never used
+                //     public override event Int? Event7;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Event7").WithArguments("Derived.Event7").WithLocation(23, 32),
+                // (17,36): warning CS0067: The event 'Derived.Event1' is never used
+                //     public override event String[] Event1;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Event1").WithArguments("Derived.Event1").WithLocation(17, 36),
+                // (22,55): warning CS0067: The event 'Derived.Event6' is never used
+                //     public override event Outer<string>.Inner<String> Event6;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Event6").WithArguments("Derived.Event6").WithLocation(22, 55),
+                // (18,47): warning CS0067: The event 'Derived.Event2' is never used
+                //     public override event System.Func<String> Event2;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Event2").WithArguments("Derived.Event2").WithLocation(18, 47),
+                // (21,55): warning CS0067: The event 'Derived.Event5' is never used
+                //     public override event Outer<String>.Inner<string> Event5;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Event5").WithArguments("Derived.Event5").WithLocation(21, 55),
+                // (20,63): warning CS0067: The event 'Derived.Event4' is never used
+                //     public override event System.Func<(string a, String[] b)> Event4;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Event4").WithArguments("Derived.Event4").WithLocation(20, 63),
+                // (16,34): warning CS0067: The event 'Derived.Event0' is never used
+                //     public override event String Event0;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Event0").WithArguments("Derived.Event0").WithLocation(16, 34));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UseSiteErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UseSiteErrorTests.cs
@@ -96,17 +96,7 @@ class C : CSharpErrors.ClassMethods
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnavailableClass").WithArguments("UnavailableClass"),
                 // (5,41): error CS0246: The type or namespace name 'UnavailableClass' could not be found (are you missing a using directive or an assembly reference?)
                 //     public override void ParameterType2(UnavailableClass[] x) { }
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnavailableClass").WithArguments("UnavailableClass"),
-
-                // CONSIDER: Dev10 doesn't report these cascading errors (CS0115)
-                // NOTE: Cascaded error messages would be the same for non-existent class - not specific to use site errors.
-
-                // (4,26): error CS0115: 'C.ParameterType1(UnavailableClass)': no suitable method found to override
-                //     public override void ParameterType1(UnavailableClass x) { }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "ParameterType1").WithArguments("C.ParameterType1(UnavailableClass)"),
-                // (5,26): error CS0115: 'C.ParameterType2(UnavailableClass[])': no suitable method found to override
-                //     public override void ParameterType2(UnavailableClass[] x) { }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "ParameterType2").WithArguments("C.ParameterType2(UnavailableClass[])"));
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnavailableClass").WithArguments("UnavailableClass"));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UseSiteErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UseSiteErrorTests.cs
@@ -44,15 +44,6 @@ class C : CSharpErrors.ClassMethods
                 //     public override UnavailableClass[] ReturnType2() { return null; }
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnavailableClass").WithArguments("UnavailableClass"),
 
-                // CONSIDER: Dev10 doesn't report these cascading errors (CS0115)
-
-                // (4,38): error CS0508: 'C.ReturnType1()': return type must be 'UnavailableClass' to match overridden member 'CSharpErrors.ClassMethods.ReturnType1()'
-                //     public override UnavailableClass ReturnType1() { return null; }
-                Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "ReturnType1").WithArguments("C.ReturnType1()", "CSharpErrors.ClassMethods.ReturnType1()", "UnavailableClass"),
-                // (5,40): error CS0508: 'C.ReturnType2()': return type must be 'UnavailableClass[]' to match overridden member 'CSharpErrors.ClassMethods.ReturnType2()'
-                //     public override UnavailableClass[] ReturnType2() { return null; }
-                Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "ReturnType2").WithArguments("C.ReturnType2()", "CSharpErrors.ClassMethods.ReturnType2()", "UnavailableClass[]"),
-
                 // (4,38): error CS0012: The type 'UnavailableClass' is defined in an assembly that is not referenced. You must add a reference to assembly 'Unavailable, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //     public override UnavailableClass ReturnType1() { return null; }
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "ReturnType1").WithArguments("UnavailableClass", "Unavailable, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"),
@@ -299,27 +290,6 @@ class C : CSharpErrors.ClassProperties
                 // (11,21): error CS0246: The type or namespace name 'UnavailableClass' could not be found (are you missing a using directive or an assembly reference?)
                 //     public override UnavailableClass[] GetSet2 { get { return null; } set { } }
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnavailableClass").WithArguments("UnavailableClass"),
-
-                // CONSIDER: Dev10 doesn't report these cascading errors (CS0115)
-
-                // (4,38): error CS1715: 'C.Get1': type must be 'UnavailableClass' to match overridden member 'CSharpErrors.ClassProperties.Get1'
-                //     public override UnavailableClass Get1 { get { return null; } }
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "Get1").WithArguments("C.Get1", "CSharpErrors.ClassProperties.Get1", "UnavailableClass"),
-                // (5,40): error CS1715: 'C.Get2': type must be 'UnavailableClass[]' to match overridden member 'CSharpErrors.ClassProperties.Get2'
-                //     public override UnavailableClass[] Get2 { get { return null; } }
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "Get2").WithArguments("C.Get2", "CSharpErrors.ClassProperties.Get2", "UnavailableClass[]"),
-                // (7,38): error CS1715: 'C.Set1': type must be 'UnavailableClass' to match overridden member 'CSharpErrors.ClassProperties.Set1'
-                //     public override UnavailableClass Set1 { set { } }
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "Set1").WithArguments("C.Set1", "CSharpErrors.ClassProperties.Set1", "UnavailableClass"),
-                // (8,40): error CS1715: 'C.Set2': type must be 'UnavailableClass[]' to match overridden member 'CSharpErrors.ClassProperties.Set2'
-                //     public override UnavailableClass[] Set2 { set { } }
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "Set2").WithArguments("C.Set2", "CSharpErrors.ClassProperties.Set2", "UnavailableClass[]"),
-                // (10,38): error CS1715: 'C.GetSet1': type must be 'UnavailableClass' to match overridden member 'CSharpErrors.ClassProperties.GetSet1'
-                //     public override UnavailableClass GetSet1 { get { return null; } set { } }
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "GetSet1").WithArguments("C.GetSet1", "CSharpErrors.ClassProperties.GetSet1", "UnavailableClass"),
-                // (11,40): error CS1715: 'C.GetSet2': type must be 'UnavailableClass[]' to match overridden member 'CSharpErrors.ClassProperties.GetSet2'
-                //     public override UnavailableClass[] GetSet2 { get { return null; } set { } }
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "GetSet2").WithArguments("C.GetSet2", "CSharpErrors.ClassProperties.GetSet2", "UnavailableClass[]"),
 
                 // (4,38): error CS0012: The type 'UnavailableClass' is defined in an assembly that is not referenced. You must add a reference to assembly 'Unavailable, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //     public override UnavailableClass Get1 { get { return null; } }
@@ -662,18 +632,6 @@ class C : CSharpErrors.ClassEvents
                 //     public override event CSharpErrors.EventDelegate<UnavailableClass[]> Event3;
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnavailableClass").WithArguments("UnavailableClass"),
 
-                // CONSIDER: Dev10 doesn't report these cascading errors (CS1715, CS0012)
-
-                // (4,47): error CS1715: 'C.Event1': type must be 'UnavailableDelegate' to match overridden member 'CSharpErrors.ClassEvents.Event1'
-                //     public override event UnavailableDelegate Event1;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "Event1").WithArguments("C.Event1", "CSharpErrors.ClassEvents.Event1", "UnavailableDelegate"),
-                // (5,72): error CS1715: 'C.Event2': type must be 'CSharpErrors.EventDelegate<UnavailableClass>' to match overridden member 'CSharpErrors.ClassEvents.Event2'
-                //     public override event CSharpErrors.EventDelegate<UnavailableClass> Event2;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "Event2").WithArguments("C.Event2", "CSharpErrors.ClassEvents.Event2", "CSharpErrors.EventDelegate<UnavailableClass>"),
-                // (6,74): error CS1715: 'C.Event3': type must be 'CSharpErrors.EventDelegate<UnavailableClass[]>' to match overridden member 'CSharpErrors.ClassEvents.Event3'
-                //     public override event CSharpErrors.EventDelegate<UnavailableClass[]> Event3;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "Event3").WithArguments("C.Event3", "CSharpErrors.ClassEvents.Event3", "CSharpErrors.EventDelegate<UnavailableClass[]>"),
-
                 // (4,47): error CS0012: The type 'UnavailableDelegate' is defined in an assembly that is not referenced. You must add a reference to assembly 'Unavailable, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //     public override event UnavailableDelegate Event1;
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "Event1").WithArguments("UnavailableDelegate", "Unavailable, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"),
@@ -706,18 +664,6 @@ class C : CSharpErrors.ClassEvents
                 // (6,54): error CS0246: The type or namespace name 'UnavailableClass' could not be found (are you missing a using directive or an assembly reference?)
                 //     public override event CSharpErrors.EventDelegate<UnavailableClass[]> Event3;
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnavailableClass").WithArguments("UnavailableClass"),
-
-                // CONSIDER: Dev10 doesn't report these cascading errors (CS0066, CS1715, CS0012)
-
-                // (4,47): error CS1715: 'C.Event1': type must be 'UnavailableDelegate' to match overridden member 'CSharpErrors.ClassEvents.Event1'
-                //     public override event UnavailableDelegate Event1;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "Event1").WithArguments("C.Event1", "CSharpErrors.ClassEvents.Event1", "UnavailableDelegate"),
-                // (5,72): error CS1715: 'C.Event2': type must be 'CSharpErrors.EventDelegate<UnavailableClass>' to match overridden member 'CSharpErrors.ClassEvents.Event2'
-                //     public override event CSharpErrors.EventDelegate<UnavailableClass> Event2;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "Event2").WithArguments("C.Event2", "CSharpErrors.ClassEvents.Event2", "CSharpErrors.EventDelegate<UnavailableClass>"),
-                // (6,74): error CS1715: 'C.Event3': type must be 'CSharpErrors.EventDelegate<UnavailableClass[]>' to match overridden member 'CSharpErrors.ClassEvents.Event3'
-                //     public override event CSharpErrors.EventDelegate<UnavailableClass[]> Event3;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "Event3").WithArguments("C.Event3", "CSharpErrors.ClassEvents.Event3", "CSharpErrors.EventDelegate<UnavailableClass[]>"),
 
                 // (4,47): error CS0012: The type 'UnavailableDelegate' is defined in an assembly that is not referenced. You must add a reference to assembly 'Unavailable, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //     public override event UnavailableDelegate Event1;


### PR DESCRIPTION
Check if there are any errors in a parameter type of an overriding method before reporting ERR_OverrideNotExpected.

Fixes #31437