### PR TITLE
 VB: Replace usages of TypeSymbol comparison operators with explicit method

### DIFF
--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -124,7 +124,7 @@ Friend Module Extensions
 
     <Extension>
     Friend Function GetAttribute(this As Symbol, c As NamedTypeSymbol) As VisualBasicAttributeData
-        Return this.GetAttributes().Where(Function(a) a.AttributeClass = c).First()
+        Return this.GetAttributes().Where(Function(a) TypeSymbol.Equals(a.AttributeClass, c, TypeCompareKind.ConsiderEverything2)).First()
     End Function
 
     <Extension>
@@ -134,7 +134,7 @@ Friend Module Extensions
 
     <Extension>
     Friend Function GetAttributes(this As Symbol, c As NamedTypeSymbol) As IEnumerable(Of VisualBasicAttributeData)
-        Return this.GetAttributes().Where(Function(a) a.AttributeClass = c)
+        Return this.GetAttributes().Where(Function(a) TypeSymbol.Equals(a.AttributeClass, c, TypeCompareKind.ConsiderEverything2))
     End Function
 
     <Extension>

--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -124,7 +124,7 @@ Friend Module Extensions
 
     <Extension>
     Friend Function GetAttribute(this As Symbol, c As NamedTypeSymbol) As VisualBasicAttributeData
-        Return this.GetAttributes().Where(Function(a) TypeSymbol.Equals(a.AttributeClass, c, TypeCompareKind.ConsiderEverything2)).First()
+        Return this.GetAttributes().Where(Function(a) TypeSymbol.Equals(a.AttributeClass, c, TypeCompareKind.ConsiderEverything)).First()
     End Function
 
     <Extension>
@@ -134,7 +134,7 @@ Friend Module Extensions
 
     <Extension>
     Friend Function GetAttributes(this As Symbol, c As NamedTypeSymbol) As IEnumerable(Of VisualBasicAttributeData)
-        Return this.GetAttributes().Where(Function(a) TypeSymbol.Equals(a.AttributeClass, c, TypeCompareKind.ConsiderEverything2))
+        Return this.GetAttributes().Where(Function(a) TypeSymbol.Equals(a.AttributeClass, c, TypeCompareKind.ConsiderEverything))
     End Function
 
     <Extension>

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.vb
@@ -536,7 +536,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' descend through Rest fields
                 ' force corresponding slots if do not exist
-                While containingType <> symbol.ContainingType
+                While Not TypeSymbol.Equals(containingType, symbol.ContainingType, TypeCompareKind.ConsiderEverything2)
                     Dim restField = TryCast(containingType.GetMembers(TupleTypeSymbol.RestFieldName).FirstOrDefault(), FieldSymbol)
                     If restField Is Nothing Then
                         Return -1

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.vb
@@ -536,7 +536,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' descend through Rest fields
                 ' force corresponding slots if do not exist
-                While Not TypeSymbol.Equals(containingType, symbol.ContainingType, TypeCompareKind.ConsiderEverything2)
+                While Not TypeSymbol.Equals(containingType, symbol.ContainingType, TypeCompareKind.ConsiderEverything)
                     Dim restField = TryCast(containingType.GetMembers(TupleTypeSymbol.RestFieldName).FirstOrDefault(), FieldSymbol)
                     If restField Is Nothing Then
                         Return -1

--- a/src/Compilers/VisualBasic/Portable/Analysis/InitializerRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/InitializerRewriter.vb
@@ -116,7 +116,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Dim receiver As BoundExpression = Nothing
                             If Not addHandlerMethod.IsShared Then
                                 Dim meParam = constructorMethod.MeParameter
-                                If addHandlerMethod.ContainingType = containingType Then
+                                If TypeSymbol.Equals(addHandlerMethod.ContainingType, containingType, TypeCompareKind.ConsiderEverything2) Then
                                     receiver = New BoundMeReference(syntax, meParam.Type).MakeCompilerGenerated()
                                 Else
                                     'Dev10 always performs base call if event is in the base class. 
@@ -270,7 +270,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Dim methodSymbol = callExpression.Method
                             If methodSymbol.MethodKind = MethodKind.Constructor Then
                                 isMyBaseConstructorCall = receiver.IsMyBaseReference
-                                Return methodSymbol.ContainingType = container
+                                Return TypeSymbol.Equals(methodSymbol.ContainingType, container, TypeCompareKind.ConsiderEverything2)
                             End If
                         End If
                     End If

--- a/src/Compilers/VisualBasic/Portable/Analysis/InitializerRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/InitializerRewriter.vb
@@ -116,7 +116,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Dim receiver As BoundExpression = Nothing
                             If Not addHandlerMethod.IsShared Then
                                 Dim meParam = constructorMethod.MeParameter
-                                If TypeSymbol.Equals(addHandlerMethod.ContainingType, containingType, TypeCompareKind.ConsiderEverything2) Then
+                                If TypeSymbol.Equals(addHandlerMethod.ContainingType, containingType, TypeCompareKind.ConsiderEverything) Then
                                     receiver = New BoundMeReference(syntax, meParam.Type).MakeCompilerGenerated()
                                 Else
                                     'Dev10 always performs base call if event is in the base class. 
@@ -270,7 +270,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Dim methodSymbol = callExpression.Method
                             If methodSymbol.MethodKind = MethodKind.Constructor Then
                                 isMyBaseConstructorCall = receiver.IsMyBaseReference
-                                Return TypeSymbol.Equals(methodSymbol.ContainingType, container, TypeCompareKind.ConsiderEverything2)
+                                Return TypeSymbol.Equals(methodSymbol.ContainingType, container, TypeCompareKind.ConsiderEverything)
                             End If
                         End If
                     End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -534,7 +534,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim parameterType = parameter.Type
                 If parameterType.OriginalDefinition.SpecialType <> SpecialType.System_Collections_Generic_IEnumerable_T OrElse
-                        DirectCast(parameterType, NamedTypeSymbol).TypeArgumentsNoUseSiteDiagnostics(0) <> Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XElement) Then
+                        Not TypeSymbol.Equals(DirectCast(parameterType, NamedTypeSymbol).TypeArgumentsNoUseSiteDiagnostics(0), Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XElement), TypeCompareKind.ConsiderEverything2) Then
                     Continue For
                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -534,7 +534,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim parameterType = parameter.Type
                 If parameterType.OriginalDefinition.SpecialType <> SpecialType.System_Collections_Generic_IEnumerable_T OrElse
-                        Not TypeSymbol.Equals(DirectCast(parameterType, NamedTypeSymbol).TypeArgumentsNoUseSiteDiagnostics(0), Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XElement), TypeCompareKind.ConsiderEverything2) Then
+                        Not TypeSymbol.Equals(DirectCast(parameterType, NamedTypeSymbol).TypeArgumentsNoUseSiteDiagnostics(0), Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XElement), TypeCompareKind.ConsiderEverything) Then
                     Continue For
                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -520,7 +520,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If propertySym IsNot Nothing Then
                     lValue = New BoundPropertyAccess(identifierName, propertySym, Nothing, PropertyAccessKind.Set, Not isReadOnly, Nothing, ImmutableArray(Of BoundExpression).Empty, defaultArguments:=BitVector.Null, hasErrors)
-                    Debug.Assert(lValue.Type = fieldOrPropType)
+                    Debug.Assert(TypeSymbol.Equals(lValue.Type, fieldOrPropType, TypeCompareKind.ConsiderEverything2))
                 ElseIf fieldSym IsNot Nothing Then
                     lValue = New BoundFieldAccess(identifierName, Nothing, fieldSym, True, fieldOrPropType, hasErrors)
                 Else

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -520,7 +520,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If propertySym IsNot Nothing Then
                     lValue = New BoundPropertyAccess(identifierName, propertySym, Nothing, PropertyAccessKind.Set, Not isReadOnly, Nothing, ImmutableArray(Of BoundExpression).Empty, defaultArguments:=BitVector.Null, hasErrors)
-                    Debug.Assert(TypeSymbol.Equals(lValue.Type, fieldOrPropType, TypeCompareKind.ConsiderEverything2))
+                    Debug.Assert(TypeSymbol.Equals(lValue.Type, fieldOrPropType, TypeCompareKind.ConsiderEverything))
                 ElseIf fieldSym IsNot Nothing Then
                     lValue = New BoundFieldAccess(identifierName, Nothing, fieldSym, True, fieldOrPropType, hasErrors)
                 Else

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -1651,7 +1651,7 @@ DoneWithDiagnostics:
                 convertedArguments.ToImmutableAndFree(),
                 targetType)
 
-            If sourceTuple.Type <> destination AndAlso convKind <> Nothing Then
+            If Not TypeSymbol.Equals(sourceTuple.Type, destination, TypeCompareKind.ConsiderEverything2) AndAlso convKind <> Nothing Then
                 ' literal cast is applied to the literal 
                 result = New BoundConversion(sourceTuple.Syntax, result, convKind, checked:=False, explicitCastInCode:=isExplicit, type:=destination)
             End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -1651,7 +1651,7 @@ DoneWithDiagnostics:
                 convertedArguments.ToImmutableAndFree(),
                 targetType)
 
-            If Not TypeSymbol.Equals(sourceTuple.Type, destination, TypeCompareKind.ConsiderEverything2) AndAlso convKind <> Nothing Then
+            If Not TypeSymbol.Equals(sourceTuple.Type, destination, TypeCompareKind.ConsiderEverything) AndAlso convKind <> Nothing Then
                 ' literal cast is applied to the literal 
                 result = New BoundConversion(sourceTuple.Syntax, result, convKind, checked:=False, explicitCastInCode:=isExplicit, type:=destination)
             End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -2723,7 +2723,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If CaseInsensitiveComparison.Equals(leftType.Name, leftName) AndAlso leftType.TypeKind <> TypeKind.TypeParameter Then
                             Dim typeDiagnostics = New DiagnosticBag()
                             Dim boundType = Me.BindNamespaceOrTypeExpression(node, typeDiagnostics)
-                            If boundType.Type = leftType Then
+                            If TypeSymbol.Equals(boundType.Type, leftType, TypeCompareKind.ConsiderEverything2) Then
                                 Dim err As ERRID = Nothing
                                 If isInstanceMember AndAlso (Not CanAccessMe(implicitReference:=True, errorId:=err) OrElse Not BindSimpleNameIsMemberOfType(leftSymbol, ContainingType)) Then
                                     diagnostics.AddRange(typeDiagnostics)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -2723,7 +2723,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If CaseInsensitiveComparison.Equals(leftType.Name, leftName) AndAlso leftType.TypeKind <> TypeKind.TypeParameter Then
                             Dim typeDiagnostics = New DiagnosticBag()
                             Dim boundType = Me.BindNamespaceOrTypeExpression(node, typeDiagnostics)
-                            If TypeSymbol.Equals(boundType.Type, leftType, TypeCompareKind.ConsiderEverything2) Then
+                            If TypeSymbol.Equals(boundType.Type, leftType, TypeCompareKind.ConsiderEverything) Then
                                 Dim err As ERRID = Nothing
                                 If isInstanceMember AndAlso (Not CanAccessMe(implicitReference:=True, errorId:=err) OrElse Not BindSimpleNameIsMemberOfType(leftSymbol, ContainingType)) Then
                                     diagnostics.AddRange(typeDiagnostics)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Initializers.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Initializers.vb
@@ -340,7 +340,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If propertySymbol.IsReadOnly AndAlso propertySymbol.AssociatedField IsNot Nothing Then
                 ' For ReadOnly auto-implemented properties we have to write directly to the backing field.
-                Debug.Assert(propertySymbol.Type = propertySymbol.AssociatedField.Type)
+                Debug.Assert(TypeSymbol.Equals(propertySymbol.Type, propertySymbol.AssociatedField.Type, TypeCompareKind.ConsiderEverything2))
                 Debug.Assert(propertySymbols.Length = 1)
                 boundPropertyOrFieldAccess = New BoundFieldAccess(syntaxNode,
                                                                   boundReceiver,

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Initializers.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Initializers.vb
@@ -340,7 +340,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If propertySymbol.IsReadOnly AndAlso propertySymbol.AssociatedField IsNot Nothing Then
                 ' For ReadOnly auto-implemented properties we have to write directly to the backing field.
-                Debug.Assert(TypeSymbol.Equals(propertySymbol.Type, propertySymbol.AssociatedField.Type, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(propertySymbol.Type, propertySymbol.AssociatedField.Type, TypeCompareKind.ConsiderEverything))
                 Debug.Assert(propertySymbols.Length = 1)
                 boundPropertyOrFieldAccess = New BoundFieldAccess(syntaxNode,
                                                                   boundReceiver,

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -1776,7 +1776,7 @@ ProduceBoundNode:
                 Dim container As NamedTypeSymbol = bestSymbols(0).ContainingType
 
                 For i As Integer = 1 To bestSymbols.Length - 1 Step 1
-                    If bestSymbols(i).ContainingType <> container Then
+                    If Not TypeSymbol.Equals(bestSymbols(i).ContainingType, container, TypeCompareKind.ConsiderEverything2) Then
                         withContainingTypeInDiagnostics = True
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -1776,7 +1776,7 @@ ProduceBoundNode:
                 Dim container As NamedTypeSymbol = bestSymbols(0).ContainingType
 
                 For i As Integer = 1 To bestSymbols.Length - 1 Step 1
-                    If Not TypeSymbol.Equals(bestSymbols(i).ContainingType, container, TypeCompareKind.ConsiderEverything2) Then
+                    If Not TypeSymbol.Equals(bestSymbols(i).ContainingType, container, TypeCompareKind.ConsiderEverything) Then
                         withContainingTypeInDiagnostics = True
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lambda.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lambda.vb
@@ -178,7 +178,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     If Not targetReturnType.IsErrorType() Then
                         If source.Flags = SourceMemberFlags.Async Then
-                            If Not targetReturnType.OriginalDefinition = Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T) Then
+                            If Not TypeSymbol.Equals(targetReturnType.OriginalDefinition, Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T), TypeCompareKind.ConsiderEverything2) Then
                                 ReportDiagnostic(diagnostics, LambdaHeaderErrorNode(source), ERRID.ERR_BadAsyncReturn)
                             End If
                         End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lambda.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lambda.vb
@@ -178,7 +178,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     If Not targetReturnType.IsErrorType() Then
                         If source.Flags = SourceMemberFlags.Async Then
-                            If Not TypeSymbol.Equals(targetReturnType.OriginalDefinition, Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T), TypeCompareKind.ConsiderEverything2) Then
+                            If Not TypeSymbol.Equals(targetReturnType.OriginalDefinition, Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T), TypeCompareKind.ConsiderEverything) Then
                                 ReportDiagnostic(diagnostics, LambdaHeaderErrorNode(source), ERRID.ERR_BadAsyncReturn)
                             End If
                         End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -829,15 +829,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return iFaceSpecial = SpecialType.System_Collections_Generic_IEnumerable_T OrElse
                        iFaceSpecial = SpecialType.System_Collections_Generic_IList_T OrElse
                        iFaceSpecial = SpecialType.System_Collections_Generic_ICollection_T OrElse
-                       iFaceOriginal = idictSymbol OrElse
+                       TypeSymbol.Equals(iFaceOriginal, idictSymbol, TypeCompareKind.ConsiderEverything2) OrElse
                        iFaceSpecial = SpecialType.System_Collections_Generic_IReadOnlyList_T OrElse
                        iFaceSpecial = SpecialType.System_Collections_Generic_IReadOnlyCollection_T OrElse
-                       iFaceOriginal = iroDictSymbol OrElse
+                       TypeSymbol.Equals(iFaceOriginal, iroDictSymbol, TypeCompareKind.ConsiderEverything2) OrElse
                        iFaceSpecial = SpecialType.System_Collections_IEnumerable OrElse
-                       iFaceOriginal = iListSymbol OrElse
-                       iFaceOriginal = iCollectionSymbol OrElse
-                       iFaceOriginal = inccSymbol OrElse
-                       iFaceOriginal = inpcSymbol
+                       TypeSymbol.Equals(iFaceOriginal, iListSymbol, TypeCompareKind.ConsiderEverything2) OrElse
+                       TypeSymbol.Equals(iFaceOriginal, iCollectionSymbol, TypeCompareKind.ConsiderEverything2) OrElse
+                       TypeSymbol.Equals(iFaceOriginal, inccSymbol, TypeCompareKind.ConsiderEverything2) OrElse
+                       TypeSymbol.Equals(iFaceOriginal, inpcSymbol, TypeCompareKind.ConsiderEverything2)
             End Function
 
 
@@ -1335,14 +1335,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Debug.Assert(base.IsInterface)
                 Debug.Assert(derived.IsInterface)
 
-                If derived.OriginalDefinition = base.OriginalDefinition Then
+                If TypeSymbol.Equals(derived.OriginalDefinition, base.OriginalDefinition, TypeCompareKind.ConsiderEverything2) Then
                     Return False
                 End If
 
                 ' if we are not resolving bases we can just go through AllInterfaces list
                 If basesBeingResolved Is Nothing Then
                     For Each i In derived.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
-                        If i = base Then
+                        If TypeSymbol.Equals(i, base, TypeCompareKind.ConsiderEverything2) Then
                             Return True
                         End If
                     Next
@@ -1362,7 +1362,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
             ) As Boolean
 
-                Debug.Assert(base <> derived, "should already be verified for equality")
+                Debug.Assert(Not TypeSymbol.Equals(base, derived, TypeCompareKind.ConsiderEverything2), "should already be verified for equality")
                 Debug.Assert(base.IsInterface)
                 Debug.Assert(derived.IsInterface)
 
@@ -1373,7 +1373,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If Not interfaces.IsDefaultOrEmpty Then
                     For Each i In interfaces
-                        If i = base Then
+                        If TypeSymbol.Equals(i, base, TypeCompareKind.ConsiderEverything2) Then
                             Return True
                         End If
 
@@ -1746,7 +1746,7 @@ ExitForFor:
                         End If
 
                         ' container of the first new symbol should be container of all others
-                        Debug.Assert(newSymbolContainer = newSymbol.ContainingType)
+                        Debug.Assert(TypeSymbol.Equals(newSymbolContainer, newSymbol.ContainingType, TypeCompareKind.ConsiderEverything2))
 
                         ' Are the known and new symbols of the right kinds to overload?
                         Dim cantOverloadEachOther = Not LookupResult.CanOverload(knownSymbol, newSymbol)
@@ -1781,7 +1781,7 @@ ExitForFor:
                                 ' we can do a quick check and remove them here
                                 For k = i + 1 To knownSymbols.Count - 1
                                     Dim otherKnown As Symbol = knownSymbols(k)
-                                    If otherKnown IsNot Nothing AndAlso otherKnown.ContainingType = knownSymbolContainer Then
+                                    If otherKnown IsNot Nothing AndAlso TypeSymbol.Equals(otherKnown.ContainingType, knownSymbolContainer, TypeCompareKind.ConsiderEverything2) Then
                                         knownSymbols(k) = Nothing
                                     End If
                                 Next
@@ -1943,7 +1943,7 @@ ExitForFor:
                 If containingMethod IsNot Nothing AndAlso
                    containingMethod.MethodKind = MethodKind.Constructor AndAlso
                    (container.TypeKind = TypeKind.Class OrElse container.TypeKind = TypeKind.Structure) AndAlso
-                   (containingMethod.ContainingType = container OrElse containingMethod.ContainingType.BaseTypeNoUseSiteDiagnostics = container) Then
+                   (TypeSymbol.Equals(containingMethod.ContainingType, container, TypeCompareKind.ConsiderEverything2) OrElse TypeSymbol.Equals(containingMethod.ContainingType.BaseTypeNoUseSiteDiagnostics, container, TypeCompareKind.ConsiderEverything2)) Then
                     nameSet.AddSymbol(Nothing, WellKnownMemberNames.InstanceConstructorName, 0)
                 End If
             End Sub

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -829,15 +829,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return iFaceSpecial = SpecialType.System_Collections_Generic_IEnumerable_T OrElse
                        iFaceSpecial = SpecialType.System_Collections_Generic_IList_T OrElse
                        iFaceSpecial = SpecialType.System_Collections_Generic_ICollection_T OrElse
-                       TypeSymbol.Equals(iFaceOriginal, idictSymbol, TypeCompareKind.ConsiderEverything2) OrElse
+                       TypeSymbol.Equals(iFaceOriginal, idictSymbol, TypeCompareKind.ConsiderEverything) OrElse
                        iFaceSpecial = SpecialType.System_Collections_Generic_IReadOnlyList_T OrElse
                        iFaceSpecial = SpecialType.System_Collections_Generic_IReadOnlyCollection_T OrElse
-                       TypeSymbol.Equals(iFaceOriginal, iroDictSymbol, TypeCompareKind.ConsiderEverything2) OrElse
+                       TypeSymbol.Equals(iFaceOriginal, iroDictSymbol, TypeCompareKind.ConsiderEverything) OrElse
                        iFaceSpecial = SpecialType.System_Collections_IEnumerable OrElse
-                       TypeSymbol.Equals(iFaceOriginal, iListSymbol, TypeCompareKind.ConsiderEverything2) OrElse
-                       TypeSymbol.Equals(iFaceOriginal, iCollectionSymbol, TypeCompareKind.ConsiderEverything2) OrElse
-                       TypeSymbol.Equals(iFaceOriginal, inccSymbol, TypeCompareKind.ConsiderEverything2) OrElse
-                       TypeSymbol.Equals(iFaceOriginal, inpcSymbol, TypeCompareKind.ConsiderEverything2)
+                       TypeSymbol.Equals(iFaceOriginal, iListSymbol, TypeCompareKind.ConsiderEverything) OrElse
+                       TypeSymbol.Equals(iFaceOriginal, iCollectionSymbol, TypeCompareKind.ConsiderEverything) OrElse
+                       TypeSymbol.Equals(iFaceOriginal, inccSymbol, TypeCompareKind.ConsiderEverything) OrElse
+                       TypeSymbol.Equals(iFaceOriginal, inpcSymbol, TypeCompareKind.ConsiderEverything)
             End Function
 
 
@@ -1254,7 +1254,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If symbol Is Nothing Then
                     ' Match the native compiler which reports ERR_XmlFeaturesNotAvailable in this case.
                     Dim useSiteError = ErrorFactory.ErrorInfo(ERRID.ERR_XmlFeaturesNotAvailable)
-                    singleResult = New SingleLookupResult(LookupResultKind.NotReferencable, binder.GetErrorSymbol(name, useSiteError), useSiteError)
+                    singleResult = New SingleLookupResult(LookupResultKind.NotReferencable, Binder.GetErrorSymbol(name, useSiteError), useSiteError)
                 Else
                     Dim reduced = New ReducedExtensionPropertySymbol(DirectCast(symbol, PropertySymbol))
                     singleResult = binder.CheckViability(reduced, arity, options, reduced.ContainingType, useSiteDiagnostics)
@@ -1335,14 +1335,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Debug.Assert(base.IsInterface)
                 Debug.Assert(derived.IsInterface)
 
-                If TypeSymbol.Equals(derived.OriginalDefinition, base.OriginalDefinition, TypeCompareKind.ConsiderEverything2) Then
+                If TypeSymbol.Equals(derived.OriginalDefinition, base.OriginalDefinition, TypeCompareKind.ConsiderEverything) Then
                     Return False
                 End If
 
                 ' if we are not resolving bases we can just go through AllInterfaces list
                 If basesBeingResolved Is Nothing Then
                     For Each i In derived.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
-                        If TypeSymbol.Equals(i, base, TypeCompareKind.ConsiderEverything2) Then
+                        If TypeSymbol.Equals(i, base, TypeCompareKind.ConsiderEverything) Then
                             Return True
                         End If
                     Next
@@ -1362,7 +1362,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
             ) As Boolean
 
-                Debug.Assert(Not TypeSymbol.Equals(base, derived, TypeCompareKind.ConsiderEverything2), "should already be verified for equality")
+                Debug.Assert(Not TypeSymbol.Equals(base, derived, TypeCompareKind.ConsiderEverything), "should already be verified for equality")
                 Debug.Assert(base.IsInterface)
                 Debug.Assert(derived.IsInterface)
 
@@ -1373,7 +1373,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If Not interfaces.IsDefaultOrEmpty Then
                     For Each i In interfaces
-                        If TypeSymbol.Equals(i, base, TypeCompareKind.ConsiderEverything2) Then
+                        If TypeSymbol.Equals(i, base, TypeCompareKind.ConsiderEverything) Then
                             Return True
                         End If
 
@@ -1746,7 +1746,7 @@ ExitForFor:
                         End If
 
                         ' container of the first new symbol should be container of all others
-                        Debug.Assert(TypeSymbol.Equals(newSymbolContainer, newSymbol.ContainingType, TypeCompareKind.ConsiderEverything2))
+                        Debug.Assert(TypeSymbol.Equals(newSymbolContainer, newSymbol.ContainingType, TypeCompareKind.ConsiderEverything))
 
                         ' Are the known and new symbols of the right kinds to overload?
                         Dim cantOverloadEachOther = Not LookupResult.CanOverload(knownSymbol, newSymbol)
@@ -1781,7 +1781,7 @@ ExitForFor:
                                 ' we can do a quick check and remove them here
                                 For k = i + 1 To knownSymbols.Count - 1
                                     Dim otherKnown As Symbol = knownSymbols(k)
-                                    If otherKnown IsNot Nothing AndAlso TypeSymbol.Equals(otherKnown.ContainingType, knownSymbolContainer, TypeCompareKind.ConsiderEverything2) Then
+                                    If otherKnown IsNot Nothing AndAlso TypeSymbol.Equals(otherKnown.ContainingType, knownSymbolContainer, TypeCompareKind.ConsiderEverything) Then
                                         knownSymbols(k) = Nothing
                                     End If
                                 Next
@@ -1943,7 +1943,7 @@ ExitForFor:
                 If containingMethod IsNot Nothing AndAlso
                    containingMethod.MethodKind = MethodKind.Constructor AndAlso
                    (container.TypeKind = TypeKind.Class OrElse container.TypeKind = TypeKind.Structure) AndAlso
-                   (TypeSymbol.Equals(containingMethod.ContainingType, container, TypeCompareKind.ConsiderEverything2) OrElse TypeSymbol.Equals(containingMethod.ContainingType.BaseTypeNoUseSiteDiagnostics, container, TypeCompareKind.ConsiderEverything2)) Then
+                   (TypeSymbol.Equals(containingMethod.ContainingType, container, TypeCompareKind.ConsiderEverything) OrElse TypeSymbol.Equals(containingMethod.ContainingType.BaseTypeNoUseSiteDiagnostics, container, TypeCompareKind.ConsiderEverything)) Then
                     nameSet.AddSymbol(Nothing, WellKnownMemberNames.InstanceConstructorName, 0)
                 End If
             End Sub

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
@@ -198,7 +198,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim errorReported As Boolean = False        ' was an error already reported?
             Dim type As NamedTypeSymbol = Nothing
 
-            Debug.Assert(objectInitializerExpressionOpt Is Nothing OrElse objectInitializerExpressionOpt.Type = type0)
+            Debug.Assert(objectInitializerExpressionOpt Is Nothing OrElse TypeSymbol.Equals(objectInitializerExpressionOpt.Type, type0, TypeCompareKind.ConsiderEverything2))
 
             Select Case type0.TypeKind
                 Case TypeKind.Class
@@ -470,7 +470,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Debug.Assert(type.Equals(DirectCast(type0, NamedTypeSymbol).CoClassType))
                         ApplyImplicitConversion(node, type0, New BoundRValuePlaceholder(node, type), diagnostics)
                     Else
-                        Debug.Assert(type = type0)
+                        Debug.Assert(TypeSymbol.Equals(type, type0, TypeCompareKind.ConsiderEverything2))
                     End If
 
                     ' If the type was not creatable, create a bad expression so that semantic model results can reflect that.
@@ -717,7 +717,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 memberAssignments.Add(assignmentOperator)
 
                 ' assert that the conversion really happened.
-                Debug.Assert(DirectCast(memberAssignments.Last, BoundAssignmentOperator).Right.Type = DirectCast(memberAssignments.Last, BoundAssignmentOperator).Left.Type)
+                Debug.Assert(TypeSymbol.Equals(DirectCast(memberAssignments.Last, BoundAssignmentOperator).Right.Type, DirectCast(memberAssignments.Last, BoundAssignmentOperator).Left.Type, TypeCompareKind.ConsiderEverything2))
 
                 memberBindingDiagnostics.Clear()
             Next

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
@@ -198,7 +198,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim errorReported As Boolean = False        ' was an error already reported?
             Dim type As NamedTypeSymbol = Nothing
 
-            Debug.Assert(objectInitializerExpressionOpt Is Nothing OrElse TypeSymbol.Equals(objectInitializerExpressionOpt.Type, type0, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(objectInitializerExpressionOpt Is Nothing OrElse TypeSymbol.Equals(objectInitializerExpressionOpt.Type, type0, TypeCompareKind.ConsiderEverything))
 
             Select Case type0.TypeKind
                 Case TypeKind.Class
@@ -470,7 +470,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Debug.Assert(type.Equals(DirectCast(type0, NamedTypeSymbol).CoClassType))
                         ApplyImplicitConversion(node, type0, New BoundRValuePlaceholder(node, type), diagnostics)
                     Else
-                        Debug.Assert(TypeSymbol.Equals(type, type0, TypeCompareKind.ConsiderEverything2))
+                        Debug.Assert(TypeSymbol.Equals(type, type0, TypeCompareKind.ConsiderEverything))
                     End If
 
                     ' If the type was not creatable, create a bad expression so that semantic model results can reflect that.
@@ -717,7 +717,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 memberAssignments.Add(assignmentOperator)
 
                 ' assert that the conversion really happened.
-                Debug.Assert(TypeSymbol.Equals(DirectCast(memberAssignments.Last, BoundAssignmentOperator).Right.Type, DirectCast(memberAssignments.Last, BoundAssignmentOperator).Left.Type, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(DirectCast(memberAssignments.Last, BoundAssignmentOperator).Right.Type, DirectCast(memberAssignments.Last, BoundAssignmentOperator).Left.Type, TypeCompareKind.ConsiderEverything))
 
                 memberBindingDiagnostics.Clear()
             Next

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
@@ -2457,7 +2457,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 diagnostics.Add(node.Name, useSiteDiagnostics)
 
-                Debug.Assert(targetAsEvent.Type = eventField.Type OrElse eventSym.IsWindowsRuntimeEvent, "non-WinRT event should have the same type as its backing field")
+                Debug.Assert(TypeSymbol.Equals(targetAsEvent.Type, eventField.Type, TypeCompareKind.ConsiderEverything2) OrElse eventSym.IsWindowsRuntimeEvent, "non-WinRT event should have the same type as its backing field")
 
                 receiver = New BoundFieldAccess(node.Name,
                                                 targetAsEvent.ReceiverOpt,
@@ -2514,7 +2514,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return New BoundBadStatement(node, StaticCast(Of BoundNode).From(boundArguments).Add(target), True)
                 End If
 
-                If fireMethod.ContainingType <> Me.ContainingType Then
+                If Not TypeSymbol.Equals(fireMethod.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything2) Then
                     ' Re: Dev10
                     ' // UNDONE: harishk - note that this is different from the check for an
                     ' // accessible event field for non-block events. This is because there
@@ -3772,7 +3772,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If ((collection.IsNothingLiteral OrElse collectionType.IsObjectType) AndAlso Me.OptionStrict <> OptionStrict.On) OrElse
                        (Not collection.IsNothingLiteral AndAlso Not collectionType.IsArrayType AndAlso IsOrInheritsFromOrImplementsInterface(collectionType, ienumerable, useSiteDiagnostics, matchingInterfaces)) Then
 
-                        Debug.Assert(collection.IsNothingLiteral OrElse collectionType.IsObjectType OrElse (matchingInterfaces.First = ienumerable AndAlso matchingInterfaces.Count = 1))
+                        Debug.Assert(collection.IsNothingLiteral OrElse collectionType.IsObjectType OrElse (TypeSymbol.Equals(matchingInterfaces.First, ienumerable, TypeCompareKind.ConsiderEverything2) AndAlso matchingInterfaces.Count = 1))
 
                         diagnostics.Add(collectionSyntax, useSiteDiagnostics)
 
@@ -4317,7 +4317,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Next
             Else
                 ' derivedType could be an interface
-                If derivedType.OriginalDefinition = interfaceType Then
+                If TypeSymbol.Equals(derivedType.OriginalDefinition, interfaceType, TypeCompareKind.ConsiderEverything2) Then
                     If matchingInterfaces Is Nothing Then
                         Return True
                     End If
@@ -4327,7 +4327,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' implements or inherits interface
                 For Each interfaceOfDerived In derivedType.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
-                    If interfaceOfDerived.OriginalDefinition = interfaceType Then
+                    If TypeSymbol.Equals(interfaceOfDerived.OriginalDefinition, interfaceType, TypeCompareKind.ConsiderEverything2) Then
                         If matchingInterfaces Is Nothing Then
                             Return True
                         End If
@@ -4821,7 +4821,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     If Not previousType.IsErrorType() Then
-                        If previousType = exceptionType Then
+                        If TypeSymbol.Equals(previousType, exceptionType, TypeCompareKind.ConsiderEverything2) Then
                             ReportDiagnostic(diagnostics, declaration, ERRID.WRN_DuplicateCatch, exceptionType)
                             Exit For
                         End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
@@ -2457,7 +2457,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 diagnostics.Add(node.Name, useSiteDiagnostics)
 
-                Debug.Assert(TypeSymbol.Equals(targetAsEvent.Type, eventField.Type, TypeCompareKind.ConsiderEverything2) OrElse eventSym.IsWindowsRuntimeEvent, "non-WinRT event should have the same type as its backing field")
+                Debug.Assert(TypeSymbol.Equals(targetAsEvent.Type, eventField.Type, TypeCompareKind.ConsiderEverything) OrElse eventSym.IsWindowsRuntimeEvent, "non-WinRT event should have the same type as its backing field")
 
                 receiver = New BoundFieldAccess(node.Name,
                                                 targetAsEvent.ReceiverOpt,
@@ -2514,7 +2514,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return New BoundBadStatement(node, StaticCast(Of BoundNode).From(boundArguments).Add(target), True)
                 End If
 
-                If Not TypeSymbol.Equals(fireMethod.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything2) Then
+                If Not TypeSymbol.Equals(fireMethod.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything) Then
                     ' Re: Dev10
                     ' // UNDONE: harishk - note that this is different from the check for an
                     ' // accessible event field for non-block events. This is because there
@@ -2572,7 +2572,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim expression = statement.Expression
 
-            Dim boundExpression As boundExpression
+            Dim boundExpression As BoundExpression
 
             Select Case expression.Kind
                 Case SyntaxKind.InvocationExpression,
@@ -2662,7 +2662,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function BindPrintStatement(printStmt As PrintStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
-            Dim boundExpression As boundExpression = BindRValue(printStmt.Expression, diagnostics)
+            Dim boundExpression As BoundExpression = BindRValue(printStmt.Expression, diagnostics)
             Return New BoundExpressionStatement(printStmt, boundExpression)
         End Function
 
@@ -2956,7 +2956,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If result.IsGood AndAlso
                         result.Symbols(0).Kind = SymbolKind.Local Then
 
-                        Dim localSymbol = DirectCast(result.Symbols(0), localSymbol)
+                        Dim localSymbol = DirectCast(result.Symbols(0), LocalSymbol)
                         If localSymbol.IdentifierToken = identifier Then
                             ' This is an inferred local, we will need to compute its type.
                             isInferredLocal = True
@@ -3468,7 +3468,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     ' create TryCast
                     Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Dim conversionKind As conversionKind = Conversions.ClassifyTryCastConversion(enumeratorType, idisposableType, useSiteDiagnostics)
+                    Dim conversionKind As ConversionKind = Conversions.ClassifyTryCastConversion(enumeratorType, idisposableType, useSiteDiagnostics)
 
                     If diagnostics.Add(collectionSyntax, useSiteDiagnostics) Then
                         ' Suppress additional diagnostics
@@ -3772,7 +3772,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If ((collection.IsNothingLiteral OrElse collectionType.IsObjectType) AndAlso Me.OptionStrict <> OptionStrict.On) OrElse
                        (Not collection.IsNothingLiteral AndAlso Not collectionType.IsArrayType AndAlso IsOrInheritsFromOrImplementsInterface(collectionType, ienumerable, useSiteDiagnostics, matchingInterfaces)) Then
 
-                        Debug.Assert(collection.IsNothingLiteral OrElse collectionType.IsObjectType OrElse (TypeSymbol.Equals(matchingInterfaces.First, ienumerable, TypeCompareKind.ConsiderEverything2) AndAlso matchingInterfaces.Count = 1))
+                        Debug.Assert(collection.IsNothingLiteral OrElse collectionType.IsObjectType OrElse (TypeSymbol.Equals(matchingInterfaces.First, ienumerable, TypeCompareKind.ConsiderEverything) AndAlso matchingInterfaces.Count = 1))
 
                         diagnostics.Add(collectionSyntax, useSiteDiagnostics)
 
@@ -4051,7 +4051,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' GetEnumerator
             '
             ' first, get GetEnumerator function that takes no arguments, also search in extension methods
-            Dim lookupResult As New lookupResult()
+            Dim lookupResult As New LookupResult()
             If Not GetMemberIfMatchesRequirements(WellKnownMemberNames.GetEnumeratorMethodName,
                                                    collectionType,
                                                    s_isFunctionWithoutArguments,
@@ -4317,7 +4317,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Next
             Else
                 ' derivedType could be an interface
-                If TypeSymbol.Equals(derivedType.OriginalDefinition, interfaceType, TypeCompareKind.ConsiderEverything2) Then
+                If TypeSymbol.Equals(derivedType.OriginalDefinition, interfaceType, TypeCompareKind.ConsiderEverything) Then
                     If matchingInterfaces Is Nothing Then
                         Return True
                     End If
@@ -4327,7 +4327,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' implements or inherits interface
                 For Each interfaceOfDerived In derivedType.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
-                    If TypeSymbol.Equals(interfaceOfDerived.OriginalDefinition, interfaceType, TypeCompareKind.ConsiderEverything2) Then
+                    If TypeSymbol.Equals(interfaceOfDerived.OriginalDefinition, interfaceType, TypeCompareKind.ConsiderEverything) Then
                         If matchingInterfaces Is Nothing Then
                             Return True
                         End If
@@ -4432,7 +4432,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     ' check if all declared variables are initialized                    
                     If localDeclarations.Kind = BoundKind.LocalDeclaration Then
-                        Dim boundLocalDeclaration = DirectCast(localDeclarations, boundLocalDeclaration)
+                        Dim boundLocalDeclaration = DirectCast(localDeclarations, BoundLocalDeclaration)
 
                         Dim initializerExpression = boundLocalDeclaration.InitializerOpt
                         If initializerExpression Is Nothing Then
@@ -4481,7 +4481,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' Bind the body of the using statement.
             Dim usingBody As BoundBlock = BindBlock(node, node.Statements, diagnostics).MakeCompilerGenerated()
-            Dim usingInfo As New usingInfo(node, placeholderInfo)
+            Dim usingInfo As New UsingInfo(node, placeholderInfo)
             Dim locals As ImmutableArray(Of LocalSymbol) = GetUsingBlockLocals(usingBinder)
 
             Return New BoundUsingStatement(node, resourceList, resourceExpression, usingBody, usingInfo, locals)
@@ -4821,7 +4821,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     If Not previousType.IsErrorType() Then
-                        If TypeSymbol.Equals(previousType, exceptionType, TypeCompareKind.ConsiderEverything2) Then
+                        If TypeSymbol.Equals(previousType, exceptionType, TypeCompareKind.ConsiderEverything) Then
                             ReportDiagnostic(diagnostics, declaration, ERRID.WRN_DuplicateCatch, exceptionType)
                             Exit For
                         End If

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentBinder.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If commentedNamedType IsNot Nothing AndAlso commentedNamedType.TypeKind <> TypeKind.Delegate Then
                 Debug.Assert(binderContainingMember = commentedSymbol)
             ElseIf commentedSymbol.ContainingType IsNot Nothing Then
-                Debug.Assert(TypeSymbol.Equals(DirectCast(binderContainingMember, TypeSymbol), commentedSymbol.ContainingType, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(DirectCast(binderContainingMember, TypeSymbol), commentedSymbol.ContainingType, TypeCompareKind.ConsiderEverything))
             Else
                 ' It's not worth writing a complicated check that handles merged namespaces.
                 Debug.Assert(binderContainingMember <> commentedSymbol)

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentBinder.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If commentedNamedType IsNot Nothing AndAlso commentedNamedType.TypeKind <> TypeKind.Delegate Then
                 Debug.Assert(binderContainingMember = commentedSymbol)
             ElseIf commentedSymbol.ContainingType IsNot Nothing Then
-                Debug.Assert(binderContainingMember = commentedSymbol.ContainingType)
+                Debug.Assert(TypeSymbol.Equals(DirectCast(binderContainingMember, TypeSymbol), commentedSymbol.ContainingType, TypeCompareKind.ConsiderEverything2))
             Else
                 ' It's not worth writing a complicated check that handles merged namespaces.
                 Debug.Assert(binderContainingMember <> commentedSymbol)

--- a/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
@@ -623,7 +623,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' multiple viable results, either produce an result with both symbols if they can overload each other,
         ' or produce an ambiguity error otherwise.
         Public Sub MergeMembersOfTheSameType(other As SingleLookupResult, imported As Boolean)
-            Debug.Assert(Not Me.HasSymbol OrElse other.Symbol Is Nothing OrElse Me.Symbols(0).ContainingType = other.Symbol.ContainingType)
+            Debug.Assert(Not Me.HasSymbol OrElse other.Symbol Is Nothing OrElse TypeSymbol.Equals(Me.Symbols(0).ContainingType, other.Symbol.ContainingType, TypeCompareKind.ConsiderEverything2))
             Debug.Assert(Not other.IsAmbiguous)
 
             If Me.IsGoodOrAmbiguous AndAlso other.IsGood Then
@@ -730,7 +730,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Private Shared Function AreEquivalentEnumConstants(symbol1 As Symbol, symbol2 As Symbol) As Boolean
-            Debug.Assert(symbol1.ContainingType = symbol2.ContainingType)
+            Debug.Assert(TypeSymbol.Equals(symbol1.ContainingType, symbol2.ContainingType, TypeCompareKind.ConsiderEverything2))
             If symbol1.Kind <> SymbolKind.Field OrElse symbol2.Kind <> SymbolKind.Field OrElse symbol1.ContainingType.TypeKind <> TypeKind.Enum Then
                 Return False
             End If

--- a/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
@@ -623,7 +623,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' multiple viable results, either produce an result with both symbols if they can overload each other,
         ' or produce an ambiguity error otherwise.
         Public Sub MergeMembersOfTheSameType(other As SingleLookupResult, imported As Boolean)
-            Debug.Assert(Not Me.HasSymbol OrElse other.Symbol Is Nothing OrElse TypeSymbol.Equals(Me.Symbols(0).ContainingType, other.Symbol.ContainingType, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(Not Me.HasSymbol OrElse other.Symbol Is Nothing OrElse TypeSymbol.Equals(Me.Symbols(0).ContainingType, other.Symbol.ContainingType, TypeCompareKind.ConsiderEverything))
             Debug.Assert(Not other.IsAmbiguous)
 
             If Me.IsGoodOrAmbiguous AndAlso other.IsGood Then
@@ -730,7 +730,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Private Shared Function AreEquivalentEnumConstants(symbol1 As Symbol, symbol2 As Symbol) As Boolean
-            Debug.Assert(TypeSymbol.Equals(symbol1.ContainingType, symbol2.ContainingType, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(symbol1.ContainingType, symbol2.ContainingType, TypeCompareKind.ConsiderEverything))
             If symbol1.Kind <> SymbolKind.Field OrElse symbol2.Kind <> SymbolKind.Field OrElse symbol1.ContainingType.TypeKind <> TypeKind.Enum Then
                 Return False
             End If

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundObjectCreationExpressionBase.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundObjectCreationExpressionBase.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #If DEBUG Then
         Private Sub Validate()
-            Debug.Assert(InitializerOpt Is Nothing OrElse InitializerOpt.Type = Type)
+            Debug.Assert(InitializerOpt Is Nothing OrElse TypeSymbol.Equals(InitializerOpt.Type, Type, TypeCompareKind.ConsiderEverything2))
         End Sub
 #End If
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundObjectCreationExpressionBase.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundObjectCreationExpressionBase.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #If DEBUG Then
         Private Sub Validate()
-            Debug.Assert(InitializerOpt Is Nothing OrElse TypeSymbol.Equals(InitializerOpt.Type, Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(InitializerOpt Is Nothing OrElse TypeSymbol.Equals(InitializerOpt.Type, Type, TypeCompareKind.ConsiderEverything))
         End Sub
 #End If
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundPropertyAccess.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundPropertyAccess.vb
@@ -65,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(Me.ReceiverOpt Is Nothing OrElse Me.PropertyGroupOpt Is Nothing OrElse Me.PropertyGroupOpt.ReceiverOpt Is Nothing)
 
             Dim expectedType = GetTypeFromAccessKind(Me.PropertySymbol, Me.AccessKind)
-            Debug.Assert(Me.Type = expectedType)
+            Debug.Assert(TypeSymbol.Equals(Me.Type, expectedType, TypeCompareKind.ConsiderEverything2))
             Debug.Assert(DefaultArguments.IsNull OrElse Not Arguments.IsEmpty)
         End Sub
 #End If

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundPropertyAccess.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundPropertyAccess.vb
@@ -65,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(Me.ReceiverOpt Is Nothing OrElse Me.PropertyGroupOpt Is Nothing OrElse Me.PropertyGroupOpt.ReceiverOpt Is Nothing)
 
             Dim expectedType = GetTypeFromAccessKind(Me.PropertySymbol, Me.AccessKind)
-            Debug.Assert(TypeSymbol.Equals(Me.Type, expectedType, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(Me.Type, expectedType, TypeCompareKind.ConsiderEverything))
             Debug.Assert(DefaultArguments.IsNull OrElse Not Arguments.IsEmpty)
         End Sub
 #End If

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundReferenceAssignment.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundReferenceAssignment.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend Partial Class BoundReferenceAssignment
 #If DEBUG Then
         Private Sub Validate()
-            Debug.Assert(ByRefLocal.LocalSymbol.IsByRef AndAlso LValue.IsLValue AndAlso Type = LValue.Type)
+            Debug.Assert(ByRefLocal.LocalSymbol.IsByRef AndAlso LValue.IsLValue AndAlso TypeSymbol.Equals(Type, LValue.Type, TypeCompareKind.ConsiderEverything2))
         End Sub
 #End If
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundReferenceAssignment.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundReferenceAssignment.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend Partial Class BoundReferenceAssignment
 #If DEBUG Then
         Private Sub Validate()
-            Debug.Assert(ByRefLocal.LocalSymbol.IsByRef AndAlso LValue.IsLValue AndAlso TypeSymbol.Equals(Type, LValue.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(ByRefLocal.LocalSymbol.IsByRef AndAlso LValue.IsLValue AndAlso TypeSymbol.Equals(Type, LValue.Type, TypeCompareKind.ConsiderEverything))
         End Sub
 #End If
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundXmlAttribute.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundXmlAttribute.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #If DEBUG Then
         Private Sub Validate()
-            Debug.Assert(Type = ObjectCreation.Type)
+            Debug.Assert(TypeSymbol.Equals(Type, ObjectCreation.Type, TypeCompareKind.ConsiderEverything2))
         End Sub
 #End If
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundXmlAttribute.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundXmlAttribute.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #If DEBUG Then
         Private Sub Validate()
-            Debug.Assert(TypeSymbol.Equals(Type, ObjectCreation.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(Type, ObjectCreation.Type, TypeCompareKind.ConsiderEverything))
         End Sub
 #End If
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
@@ -201,13 +201,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 For i As Integer = 0 To ParameterTypes.Length - 1
-                    If Me.ParameterTypes(i) <> other.ParameterTypes(i) OrElse
+                    If Not TypeSymbol.Equals(Me.ParameterTypes(i), other.ParameterTypes(i), TypeCompareKind.ConsiderEverything2) OrElse
                        Me.ParameterIsByRef(i) <> other.ParameterIsByRef(i) Then
                         Return False
                     End If
                 Next
 
-                Return Me.ReturnsByRef = other.ReturnsByRef AndAlso Me.ReturnType = other.ReturnType
+                Return Me.ReturnsByRef = other.ReturnsByRef AndAlso TypeSymbol.Equals(Me.ReturnType, other.ReturnType, TypeCompareKind.ConsiderEverything2)
             End Function
         End Class
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
@@ -201,13 +201,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 For i As Integer = 0 To ParameterTypes.Length - 1
-                    If Not TypeSymbol.Equals(Me.ParameterTypes(i), other.ParameterTypes(i), TypeCompareKind.ConsiderEverything2) OrElse
+                    If Not TypeSymbol.Equals(Me.ParameterTypes(i), other.ParameterTypes(i), TypeCompareKind.ConsiderEverything) OrElse
                        Me.ParameterIsByRef(i) <> other.ParameterIsByRef(i) Then
                         Return False
                     End If
                 Next
 
-                Return Me.ReturnsByRef = other.ReturnsByRef AndAlso TypeSymbol.Equals(Me.ReturnType, other.ReturnType, TypeCompareKind.ConsiderEverything2)
+                Return Me.ReturnsByRef = other.ReturnsByRef AndAlso TypeSymbol.Equals(Me.ReturnType, other.ReturnType, TypeCompareKind.ConsiderEverything)
             End Function
         End Class
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitAddress.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitAddress.vb
@@ -269,7 +269,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             End If
 
             ' while readonly fields have home it is not valid to refer to it when not constructing.
-            If field.ContainingType <> Me._method.ContainingType Then
+            If Not TypeSymbol.Equals(field.ContainingType, Me._method.ContainingType, TypeCompareKind.ConsiderEverything2) Then
                 Return False
             End If
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitAddress.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitAddress.vb
@@ -269,7 +269,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             End If
 
             ' while readonly fields have home it is not valid to refer to it when not constructing.
-            If Not TypeSymbol.Equals(field.ContainingType, Me._method.ContainingType, TypeCompareKind.ConsiderEverything2) Then
+            If Not TypeSymbol.Equals(field.ContainingType, Me._method.ContainingType, TypeCompareKind.ConsiderEverything) Then
                 Return False
             End If
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -994,7 +994,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                         '       otherwise we should not use direct 'call' and must use constrained call;
 
                         ' calling a method defined in a value type considered a "write" to the target unless the target is "Me"
-                        Debug.Assert(receiverType = method.ContainingType)
+                        Debug.Assert(TypeSymbol.Equals(receiverType, method.ContainingType, TypeCompareKind.ConsiderEverything2))
                         tempOpt = EmitReceiverRef(
                             receiver,
                             isAccessConstrained:=False, addressKind:=If(IsMeReceiver(receiver),
@@ -1281,7 +1281,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     EmitStaticCast(expr.Type, expr.Syntax)
                     mergeTypeOfConsequence = expr.Type
 
-                ElseIf (expr.Type.IsInterfaceType() AndAlso expr.Type <> mergeTypeOfAlternative AndAlso expr.Type <> mergeTypeOfConsequence) Then
+                ElseIf (expr.Type.IsInterfaceType() AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfAlternative, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfConsequence, TypeCompareKind.ConsiderEverything2)) Then
                     EmitStaticCast(expr.Type, expr.Syntax)
                 End If
             End If
@@ -1303,7 +1303,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         ''' </remarks>
         Private Sub EmitBinaryConditionalExpression(expr As BoundBinaryConditionalExpression, used As Boolean)
             Debug.Assert(expr.ConvertedTestExpression Is Nothing, "coalesce with nontrivial test conversions are lowered into ternary.")
-            Debug.Assert(expr.Type = expr.ElseExpression.Type)
+            Debug.Assert(TypeSymbol.Equals(expr.Type, expr.ElseExpression.Type, TypeCompareKind.ConsiderEverything2))
             Debug.Assert(Not expr.Type.IsValueType)
 
             EmitExpression(expr.TestExpression, used:=True)
@@ -1336,7 +1336,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 If (IsVarianceCast(expr.Type, mergeTypeOfRightValue)) Then
                     EmitStaticCast(expr.Type, expr.Syntax)
                     mergeTypeOfRightValue = expr.Type
-                ElseIf (expr.Type.IsInterfaceType() AndAlso expr.Type <> mergeTypeOfLeftValue AndAlso expr.Type <> mergeTypeOfRightValue) Then
+                ElseIf (expr.Type.IsInterfaceType() AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfLeftValue, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfRightValue, TypeCompareKind.ConsiderEverything2)) Then
                     EmitStaticCast(expr.Type, expr.Syntax)
                 End If
             End If
@@ -1420,7 +1420,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         ' "complicated" casts and make them static casts to ensure we are all on 
         ' the same page with what type should be tracked.
         Private Shared Function IsVarianceCast(toType As TypeSymbol, fromType As TypeSymbol) As Boolean
-            If (toType = fromType) Then
+            If (TypeSymbol.Equals(toType, fromType, TypeCompareKind.ConsiderEverything2)) Then
                 Return False
             End If
 
@@ -1435,7 +1435,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 Return IsVarianceCast(DirectCast(toType, ArrayTypeSymbol).ElementType, DirectCast(fromType, ArrayTypeSymbol).ElementType)
             End If
 
-            Return (toType.IsDelegateType() AndAlso toType <> fromType) OrElse
+            Return (toType.IsDelegateType() AndAlso Not TypeSymbol.Equals(toType, fromType, TypeCompareKind.ConsiderEverything2)) OrElse
                    (toType.IsInterfaceType() AndAlso fromType.IsInterfaceType() AndAlso
                     Not fromType.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.ContainsKey(DirectCast(toType, NamedTypeSymbol)))
 
@@ -2156,7 +2156,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
             Debug.Assert(getField IsNot Nothing)
             EmitSymbolToken(getField, node.Syntax)
-            If node.Type <> getField.ReturnType Then
+            If Not TypeSymbol.Equals(node.Type, getField.ReturnType, TypeCompareKind.ConsiderEverything2) Then
                 _builder.EmitOpCode(ILOpCode.Castclass)
                 EmitSymbolToken(node.Type, node.Syntax)
             End If
@@ -2180,7 +2180,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
             Debug.Assert(getMethod IsNot Nothing)
             EmitSymbolToken(getMethod, node.Syntax)
-            If node.Type <> getMethod.ReturnType Then
+            If Not TypeSymbol.Equals(node.Type, getMethod.ReturnType, TypeCompareKind.ConsiderEverything2) Then
                 _builder.EmitOpCode(ILOpCode.Castclass)
                 EmitSymbolToken(node.Type, node.Syntax)
             End If

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -994,7 +994,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                         '       otherwise we should not use direct 'call' and must use constrained call;
 
                         ' calling a method defined in a value type considered a "write" to the target unless the target is "Me"
-                        Debug.Assert(TypeSymbol.Equals(receiverType, method.ContainingType, TypeCompareKind.ConsiderEverything2))
+                        Debug.Assert(TypeSymbol.Equals(receiverType, method.ContainingType, TypeCompareKind.ConsiderEverything))
                         tempOpt = EmitReceiverRef(
                             receiver,
                             isAccessConstrained:=False, addressKind:=If(IsMeReceiver(receiver),
@@ -1281,7 +1281,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                     EmitStaticCast(expr.Type, expr.Syntax)
                     mergeTypeOfConsequence = expr.Type
 
-                ElseIf (expr.Type.IsInterfaceType() AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfAlternative, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfConsequence, TypeCompareKind.ConsiderEverything2)) Then
+                ElseIf (expr.Type.IsInterfaceType() AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfAlternative, TypeCompareKind.ConsiderEverything) AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfConsequence, TypeCompareKind.ConsiderEverything)) Then
                     EmitStaticCast(expr.Type, expr.Syntax)
                 End If
             End If
@@ -1303,7 +1303,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         ''' </remarks>
         Private Sub EmitBinaryConditionalExpression(expr As BoundBinaryConditionalExpression, used As Boolean)
             Debug.Assert(expr.ConvertedTestExpression Is Nothing, "coalesce with nontrivial test conversions are lowered into ternary.")
-            Debug.Assert(TypeSymbol.Equals(expr.Type, expr.ElseExpression.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(expr.Type, expr.ElseExpression.Type, TypeCompareKind.ConsiderEverything))
             Debug.Assert(Not expr.Type.IsValueType)
 
             EmitExpression(expr.TestExpression, used:=True)
@@ -1336,7 +1336,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 If (IsVarianceCast(expr.Type, mergeTypeOfRightValue)) Then
                     EmitStaticCast(expr.Type, expr.Syntax)
                     mergeTypeOfRightValue = expr.Type
-                ElseIf (expr.Type.IsInterfaceType() AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfLeftValue, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfRightValue, TypeCompareKind.ConsiderEverything2)) Then
+                ElseIf (expr.Type.IsInterfaceType() AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfLeftValue, TypeCompareKind.ConsiderEverything) AndAlso Not TypeSymbol.Equals(expr.Type, mergeTypeOfRightValue, TypeCompareKind.ConsiderEverything)) Then
                     EmitStaticCast(expr.Type, expr.Syntax)
                 End If
             End If
@@ -1420,7 +1420,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
         ' "complicated" casts and make them static casts to ensure we are all on 
         ' the same page with what type should be tracked.
         Private Shared Function IsVarianceCast(toType As TypeSymbol, fromType As TypeSymbol) As Boolean
-            If (TypeSymbol.Equals(toType, fromType, TypeCompareKind.ConsiderEverything2)) Then
+            If (TypeSymbol.Equals(toType, fromType, TypeCompareKind.ConsiderEverything)) Then
                 Return False
             End If
 
@@ -1435,7 +1435,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 Return IsVarianceCast(DirectCast(toType, ArrayTypeSymbol).ElementType, DirectCast(fromType, ArrayTypeSymbol).ElementType)
             End If
 
-            Return (toType.IsDelegateType() AndAlso Not TypeSymbol.Equals(toType, fromType, TypeCompareKind.ConsiderEverything2)) OrElse
+            Return (toType.IsDelegateType() AndAlso Not TypeSymbol.Equals(toType, fromType, TypeCompareKind.ConsiderEverything)) OrElse
                    (toType.IsInterfaceType() AndAlso fromType.IsInterfaceType() AndAlso
                     Not fromType.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.ContainsKey(DirectCast(toType, NamedTypeSymbol)))
 
@@ -2156,7 +2156,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
             Debug.Assert(getField IsNot Nothing)
             EmitSymbolToken(getField, node.Syntax)
-            If Not TypeSymbol.Equals(node.Type, getField.ReturnType, TypeCompareKind.ConsiderEverything2) Then
+            If Not TypeSymbol.Equals(node.Type, getField.ReturnType, TypeCompareKind.ConsiderEverything) Then
                 _builder.EmitOpCode(ILOpCode.Castclass)
                 EmitSymbolToken(node.Type, node.Syntax)
             End If
@@ -2180,7 +2180,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
             Debug.Assert(getMethod IsNot Nothing)
             EmitSymbolToken(getMethod, node.Syntax)
-            If Not TypeSymbol.Equals(node.Type, getMethod.ReturnType, TypeCompareKind.ConsiderEverything2) Then
+            If Not TypeSymbol.Equals(node.Type, getMethod.ReturnType, TypeCompareKind.ConsiderEverything) Then
                 _builder.EmitOpCode(ILOpCode.Castclass)
                 EmitSymbolToken(node.Type, node.Syntax)
             End If

--- a/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
@@ -933,13 +933,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim xArrayType As ArrayTypeSymbol = DirectCast(xType, ArrayTypeSymbol)
                     Dim yArrayType As ArrayTypeSymbol = DirectCast(yType, ArrayTypeSymbol)
                     sawArrayRankDifference = sawArrayRankDifference OrElse xArrayType.Rank <> yArrayType.Rank
-                    Dim elementTypesDiffer As Boolean = xArrayType.ElementType <> yArrayType.ElementType
+                    Dim elementTypesDiffer As Boolean = Not TypeSymbol.Equals(xArrayType.ElementType, yArrayType.ElementType, TypeCompareKind.ConsiderEverything2)
                     If IsArrayOfArrays(xArrayType) AndAlso IsArrayOfArrays(yArrayType) Then ' NOTE: C# uses OrElse
                         sawArrayOfArraysDifference = sawArrayOfArraysDifference OrElse elementTypesDiffer
                     ElseIf elementTypesDiffer Then
                         Return False
                     End If
-                ElseIf xType <> yType Then
+                ElseIf Not TypeSymbol.Equals(xType, yType, TypeCompareKind.ConsiderEverything2) Then
                     Return False
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
@@ -933,13 +933,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim xArrayType As ArrayTypeSymbol = DirectCast(xType, ArrayTypeSymbol)
                     Dim yArrayType As ArrayTypeSymbol = DirectCast(yType, ArrayTypeSymbol)
                     sawArrayRankDifference = sawArrayRankDifference OrElse xArrayType.Rank <> yArrayType.Rank
-                    Dim elementTypesDiffer As Boolean = Not TypeSymbol.Equals(xArrayType.ElementType, yArrayType.ElementType, TypeCompareKind.ConsiderEverything2)
+                    Dim elementTypesDiffer As Boolean = Not TypeSymbol.Equals(xArrayType.ElementType, yArrayType.ElementType, TypeCompareKind.ConsiderEverything)
                     If IsArrayOfArrays(xArrayType) AndAlso IsArrayOfArrays(yArrayType) Then ' NOTE: C# uses OrElse
                         sawArrayOfArraysDifference = sawArrayOfArraysDifference OrElse elementTypesDiffer
                     ElseIf elementTypesDiffer Then
                         Return False
                     End If
-                ElseIf Not TypeSymbol.Equals(xType, yType, TypeCompareKind.ConsiderEverything2) Then
+                ElseIf Not TypeSymbol.Equals(xType, yType, TypeCompareKind.ConsiderEverything) Then
                     Return False
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -1216,7 +1216,7 @@ _Default:
                         meParam = New MeParameterSymbol(containingMember, containingType)
 
                     Else
-                        If referenceType = ErrorTypeSymbol.UnknownResultType Then
+                        If TypeSymbol.Equals(referenceType, ErrorTypeSymbol.UnknownResultType, TypeCompareKind.ConsiderEverything2) Then
                             ' in an instance member, but binder considered Me/MyBase/MyClass unreferenceable
                             meParam = New MeParameterSymbol(containingMember, containingType)
                             resultKind = LookupResultKind.NotReferencable
@@ -1447,7 +1447,7 @@ _Default:
                         Case BoundKind.Attribute
                             Dim boundAttribute As BoundAttribute = DirectCast(boundNodeOfSyntacticParent, BoundAttribute)
 
-                            Debug.Assert(resultKind <> LookupResultKind.Good OrElse namedTypeSymbol = boundAttribute.Type)
+                            Debug.Assert(resultKind <> LookupResultKind.Good OrElse TypeSymbol.Equals(namedTypeSymbol, boundAttribute.Type, TypeCompareKind.ConsiderEverything2))
                             constructor = boundAttribute.Constructor
                             resultKind = LookupResult.WorseResultKind(resultKind, boundAttribute.ResultKind)
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -1216,7 +1216,7 @@ _Default:
                         meParam = New MeParameterSymbol(containingMember, containingType)
 
                     Else
-                        If TypeSymbol.Equals(referenceType, ErrorTypeSymbol.UnknownResultType, TypeCompareKind.ConsiderEverything2) Then
+                        If TypeSymbol.Equals(referenceType, ErrorTypeSymbol.UnknownResultType, TypeCompareKind.ConsiderEverything) Then
                             ' in an instance member, but binder considered Me/MyBase/MyClass unreferenceable
                             meParam = New MeParameterSymbol(containingMember, containingType)
                             resultKind = LookupResultKind.NotReferencable
@@ -1447,7 +1447,7 @@ _Default:
                         Case BoundKind.Attribute
                             Dim boundAttribute As BoundAttribute = DirectCast(boundNodeOfSyntacticParent, BoundAttribute)
 
-                            Debug.Assert(resultKind <> LookupResultKind.Good OrElse TypeSymbol.Equals(namedTypeSymbol, boundAttribute.Type, TypeCompareKind.ConsiderEverything2))
+                            Debug.Assert(resultKind <> LookupResultKind.Good OrElse TypeSymbol.Equals(namedTypeSymbol, boundAttribute.Type, TypeCompareKind.ConsiderEverything))
                             constructor = boundAttribute.Constructor
                             resultKind = LookupResult.WorseResultKind(resultKind, boundAttribute.ResultKind)
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/TypeInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/TypeInfo.vb
@@ -58,8 +58,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overloads Function Equals(other As VisualBasicTypeInfo) As Boolean Implements IEquatable(Of VisualBasicTypeInfo).Equals
             Return _implicitConversion.Equals(other._implicitConversion) AndAlso
-                _type = other._type AndAlso
-                _convertedType = other._convertedType
+                TypeSymbol.Equals(_type, other._type, TypeCompareKind.ConsiderEverything2) AndAlso
+                TypeSymbol.Equals(_convertedType, other._convertedType, TypeCompareKind.ConsiderEverything2)
         End Function
 
         Public Overrides Function Equals(obj As Object) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Compilation/TypeInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/TypeInfo.vb
@@ -58,8 +58,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overloads Function Equals(other As VisualBasicTypeInfo) As Boolean Implements IEquatable(Of VisualBasicTypeInfo).Equals
             Return _implicitConversion.Equals(other._implicitConversion) AndAlso
-                TypeSymbol.Equals(_type, other._type, TypeCompareKind.ConsiderEverything2) AndAlso
-                TypeSymbol.Equals(_convertedType, other._convertedType, TypeCompareKind.ConsiderEverything2)
+                TypeSymbol.Equals(_type, other._type, TypeCompareKind.ConsiderEverything) AndAlso
+                TypeSymbol.Equals(_convertedType, other._convertedType, TypeCompareKind.ConsiderEverything)
         End Function
 
         Public Overrides Function Equals(obj As Object) As Boolean

--- a/src/Compilers/VisualBasic/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.vb
@@ -141,7 +141,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If symbol.Arity <> 0 Then
                     ' Special case: dev11 treats types instances of the declaring type in the parameter list
                     ' (And return type, for conversions) as constructed with its own type parameters.
-                    If Not _inParameterOrReturnType AndAlso symbol = symbol.ConstructedFrom Then
+                    If Not _inParameterOrReturnType AndAlso TypeSymbol.Equals(symbol, symbol.ConstructedFrom, TypeCompareKind.ConsiderEverything2) Then
                         builder.Append(MetadataHelpers.GenericTypeNameManglingChar)
                         builder.Append(symbol.Arity)
                     Else

--- a/src/Compilers/VisualBasic/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.vb
@@ -141,7 +141,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If symbol.Arity <> 0 Then
                     ' Special case: dev11 treats types instances of the declaring type in the parameter list
                     ' (And return type, for conversions) as constructed with its own type parameters.
-                    If Not _inParameterOrReturnType AndAlso TypeSymbol.Equals(symbol, symbol.ConstructedFrom, TypeCompareKind.ConsiderEverything2) Then
+                    If Not _inParameterOrReturnType AndAlso TypeSymbol.Equals(symbol, symbol.ConstructedFrom, TypeCompareKind.ConsiderEverything) Then
                         builder.Append(MetadataHelpers.GenericTypeNameManglingChar)
                         builder.Append(symbol.Arity)
                     Else

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
@@ -160,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 Dim propertyType = [property].Type
                 If propertyType.TypeKind = TypeKind.TypeParameter Then
                     Dim typeParameter = DirectCast(propertyType, TypeParameterSymbol)
-                    Debug.Assert(TypeSymbol.Equals(DirectCast(typeParameter.ContainingSymbol, TypeSymbol), type, TypeCompareKind.ConsiderEverything2))
+                    Debug.Assert(TypeSymbol.Equals(DirectCast(typeParameter.ContainingSymbol, TypeSymbol), type, TypeCompareKind.ConsiderEverything))
                     Dim index = typeParameter.Ordinal
                     Debug.Assert(properties(index).Name Is Nothing)
                     ' ReadOnly anonymous type properties were 'Key' properties.

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
@@ -160,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 Dim propertyType = [property].Type
                 If propertyType.TypeKind = TypeKind.TypeParameter Then
                     Dim typeParameter = DirectCast(propertyType, TypeParameterSymbol)
-                    Debug.Assert(typeParameter.ContainingSymbol = type)
+                    Debug.Assert(TypeSymbol.Equals(DirectCast(typeParameter.ContainingSymbol, TypeSymbol), type, TypeCompareKind.ConsiderEverything2))
                     Dim index = typeParameter.Ordinal
                     Debug.Assert(properties(index).Name Is Nothing)
                     ' ReadOnly anonymous type properties were 'Key' properties.

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                     type = Nothing
                 End If
 
-                If Interlocked.CompareExchange(Of NamedTypeSymbol)(_lazySystemStringType, type, ErrorTypeSymbol.UnknownResultType) = ErrorTypeSymbol.UnknownResultType Then
+                If TypeSymbol.Equals(Interlocked.CompareExchange(Of NamedTypeSymbol)(_lazySystemStringType, type, ErrorTypeSymbol.UnknownResultType), ErrorTypeSymbol.UnknownResultType, TypeCompareKind.ConsiderEverything2) Then
                     If info IsNot Nothing Then
                         ReportDiagnostic(diagnostics, syntaxNodeOpt, info)
                     End If

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                     type = Nothing
                 End If
 
-                If TypeSymbol.Equals(Interlocked.CompareExchange(Of NamedTypeSymbol)(_lazySystemStringType, type, ErrorTypeSymbol.UnknownResultType), ErrorTypeSymbol.UnknownResultType, TypeCompareKind.ConsiderEverything2) Then
+                If TypeSymbol.Equals(Interlocked.CompareExchange(Of NamedTypeSymbol)(_lazySystemStringType, type, ErrorTypeSymbol.UnknownResultType), ErrorTypeSymbol.UnknownResultType, TypeCompareKind.ConsiderEverything) Then
                     If info IsNot Nothing Then
                         ReportDiagnostic(diagnostics, syntaxNodeOpt, info)
                     End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
@@ -132,7 +132,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 blockBuilder.Add(
                     Me.F.Assignment(
                         Me.F.Field(Me.F.Me(), awaiterField, True),
-                        If(awaiterField.Type = awaiterTemp.Type,
+                        If(TypeSymbol.Equals(awaiterField.Type, awaiterTemp.Type, TypeCompareKind.ConsiderEverything2),
                            DirectCast(Me.F.Local(awaiterTemp, False), BoundExpression),
                            Me.F.Convert(awaiterFieldType, Me.F.Local(awaiterTemp, False)))))
 
@@ -254,7 +254,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 blockBuilder.Add(
                     Me.F.Assignment(
                         Me.F.Local(awaiterTemp, True),
-                        If(awaiterTemp.Type = awaiterField.Type,
+                        If(TypeSymbol.Equals(awaiterTemp.Type, awaiterField.Type, TypeCompareKind.ConsiderEverything2),
                            DirectCast(Me.F.Field(Me.F.Me(), awaiterField, False), BoundExpression),
                            Me.F.Convert(awaiterTemp.Type, Me.F.Field(Me.F.Me(), awaiterField, False)))))
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
@@ -132,7 +132,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 blockBuilder.Add(
                     Me.F.Assignment(
                         Me.F.Field(Me.F.Me(), awaiterField, True),
-                        If(TypeSymbol.Equals(awaiterField.Type, awaiterTemp.Type, TypeCompareKind.ConsiderEverything2),
+                        If(TypeSymbol.Equals(awaiterField.Type, awaiterTemp.Type, TypeCompareKind.ConsiderEverything),
                            DirectCast(Me.F.Local(awaiterTemp, False), BoundExpression),
                            Me.F.Convert(awaiterFieldType, Me.F.Local(awaiterTemp, False)))))
 
@@ -254,7 +254,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 blockBuilder.Add(
                     Me.F.Assignment(
                         Me.F.Local(awaiterTemp, True),
-                        If(TypeSymbol.Equals(awaiterTemp.Type, awaiterField.Type, TypeCompareKind.ConsiderEverything2),
+                        If(TypeSymbol.Equals(awaiterTemp.Type, awaiterField.Type, TypeCompareKind.ConsiderEverything),
                            DirectCast(Me.F.Field(Me.F.Me(), awaiterField, False), BoundExpression),
                            Me.F.Convert(awaiterTemp.Type, Me.F.Field(Me.F.Me(), awaiterField, False)))))
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Expressions.vb
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 Dim spillSeq = DirectCast(valueOpt, BoundSpillSequence)
-                Debug.Assert(rewrittenType = spillSeq.Type)
+                Debug.Assert(TypeSymbol.Equals(rewrittenType, spillSeq.Type, TypeCompareKind.ConsiderEverything2))
 
                 Return node.Update(
                     node.Locals.Concat(spillSeq.Locals),

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Expressions.vb
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 Dim spillSeq = DirectCast(valueOpt, BoundSpillSequence)
-                Debug.Assert(TypeSymbol.Equals(rewrittenType, spillSeq.Type, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(rewrittenType, spillSeq.Type, TypeCompareKind.ConsiderEverything))
 
                 Return node.Update(
                     node.Locals.Concat(spillSeq.Locals),

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
@@ -371,12 +371,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(compilation IsNot Nothing)
 
             Dim returnType As TypeSymbol = method.ReturnType
-            If returnType = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task) Then
+            If TypeSymbol.Equals(returnType, compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task), TypeCompareKind.ConsiderEverything2) Then
                 Return AsyncMethodKind.TaskFunction
             End If
 
             If returnType.Kind = SymbolKind.NamedType AndAlso
-                    returnType.OriginalDefinition = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T) Then
+                    TypeSymbol.Equals(returnType.OriginalDefinition, compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T), TypeCompareKind.ConsiderEverything2) Then
                 Return AsyncMethodKind.GenericTaskFunction
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
@@ -371,12 +371,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(compilation IsNot Nothing)
 
             Dim returnType As TypeSymbol = method.ReturnType
-            If TypeSymbol.Equals(returnType, compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task), TypeCompareKind.ConsiderEverything2) Then
+            If TypeSymbol.Equals(returnType, compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task), TypeCompareKind.ConsiderEverything) Then
                 Return AsyncMethodKind.TaskFunction
             End If
 
             If returnType.Kind = SymbolKind.NamedType AndAlso
-                    TypeSymbol.Equals(returnType.OriginalDefinition, compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T), TypeCompareKind.ConsiderEverything2) Then
+                    TypeSymbol.Equals(returnType.OriginalDefinition, compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T), TypeCompareKind.ConsiderEverything) Then
                 Return AsyncMethodKind.GenericTaskFunction
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_BinaryOperator.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_BinaryOperator.vb
@@ -177,12 +177,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If left Is Nothing Then
                 left = Visit(originalLeft)
-                Debug.Assert(operandType = originalLeft.Type)
+                Debug.Assert(TypeSymbol.Equals(operandType, originalLeft.Type, TypeCompareKind.ConsiderEverything2))
             End If
 
             If right Is Nothing Then
                 right = Visit(originalRight)
-                Debug.Assert(operandType = originalRight.Type)
+                Debug.Assert(TypeSymbol.Equals(operandType, originalRight.Type, TypeCompareKind.ConsiderEverything2))
             End If
 
             ' Do we need to handle special cases?
@@ -276,11 +276,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim originalLeft As BoundExpression = node.Left
             Dim left As BoundExpression = Visit(originalLeft)
-            Debug.Assert(resultType = originalLeft.Type)
+            Debug.Assert(TypeSymbol.Equals(resultType, originalLeft.Type, TypeCompareKind.ConsiderEverything2))
 
             Dim originalRight As BoundExpression = node.Right
             Dim right As BoundExpression = Visit(originalRight)
-            Debug.Assert(resultType = originalRight.Type)
+            Debug.Assert(TypeSymbol.Equals(resultType, originalRight.Type, TypeCompareKind.ConsiderEverything2))
 
             If resultUnderlyingType.IsObjectType Then
                 Dim systemBool As TypeSymbol = _factory.SpecialType(SpecialType.System_Boolean)
@@ -434,7 +434,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     ' visit and convert operand
                     result = Visit(operand)
-                    If operandType <> Me.Int32Type Then
+                    If Not TypeSymbol.Equals(operandType, Me.Int32Type, TypeCompareKind.ConsiderEverything2) Then
                         result = CreateBuiltInConversion(operandType, Me.Int32Type, result, isChecked, False, ConversionSemantics.[Default])
                     End If
 
@@ -641,7 +641,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Shared Function AdjustCallArgumentForLiftedOperator(oldArg As BoundExpression, parameterType As TypeSymbol) As BoundExpression
             Debug.Assert(oldArg.Type.IsNullableType)
             Debug.Assert(Not parameterType.IsNullableType)
-            Debug.Assert(oldArg.Type.GetNullableUnderlyingTypeOrSelf() = parameterType)
+            Debug.Assert(TypeSymbol.Equals(oldArg.Type.GetNullableUnderlyingTypeOrSelf(), parameterType, TypeCompareKind.ConsiderEverything2))
 
             If oldArg.Kind = BoundKind.ObjectCreationExpression Then
                 Dim objCreation = DirectCast(oldArg, BoundObjectCreationExpression)

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_BinaryOperator.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_BinaryOperator.vb
@@ -177,12 +177,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If left Is Nothing Then
                 left = Visit(originalLeft)
-                Debug.Assert(TypeSymbol.Equals(operandType, originalLeft.Type, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(operandType, originalLeft.Type, TypeCompareKind.ConsiderEverything))
             End If
 
             If right Is Nothing Then
                 right = Visit(originalRight)
-                Debug.Assert(TypeSymbol.Equals(operandType, originalRight.Type, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(operandType, originalRight.Type, TypeCompareKind.ConsiderEverything))
             End If
 
             ' Do we need to handle special cases?
@@ -276,11 +276,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim originalLeft As BoundExpression = node.Left
             Dim left As BoundExpression = Visit(originalLeft)
-            Debug.Assert(TypeSymbol.Equals(resultType, originalLeft.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(resultType, originalLeft.Type, TypeCompareKind.ConsiderEverything))
 
             Dim originalRight As BoundExpression = node.Right
             Dim right As BoundExpression = Visit(originalRight)
-            Debug.Assert(TypeSymbol.Equals(resultType, originalRight.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(resultType, originalRight.Type, TypeCompareKind.ConsiderEverything))
 
             If resultUnderlyingType.IsObjectType Then
                 Dim systemBool As TypeSymbol = _factory.SpecialType(SpecialType.System_Boolean)
@@ -434,7 +434,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     ' visit and convert operand
                     result = Visit(operand)
-                    If Not TypeSymbol.Equals(operandType, Me.Int32Type, TypeCompareKind.ConsiderEverything2) Then
+                    If Not TypeSymbol.Equals(operandType, Me.Int32Type, TypeCompareKind.ConsiderEverything) Then
                         result = CreateBuiltInConversion(operandType, Me.Int32Type, result, isChecked, False, ConversionSemantics.[Default])
                     End If
 
@@ -641,7 +641,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Shared Function AdjustCallArgumentForLiftedOperator(oldArg As BoundExpression, parameterType As TypeSymbol) As BoundExpression
             Debug.Assert(oldArg.Type.IsNullableType)
             Debug.Assert(Not parameterType.IsNullableType)
-            Debug.Assert(TypeSymbol.Equals(oldArg.Type.GetNullableUnderlyingTypeOrSelf(), parameterType, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(oldArg.Type.GetNullableUnderlyingTypeOrSelf(), parameterType, TypeCompareKind.ConsiderEverything))
 
             If oldArg.Kind = BoundKind.ObjectCreationExpression Then
                 Dim objCreation = DirectCast(oldArg, BoundObjectCreationExpression)

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
@@ -187,12 +187,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(outConv IsNot Nothing AndAlso
                          toType.IsSameTypeIgnoringAll(outConv.Type) OrElse
                          toType.IsSameTypeIgnoringAll([call].Type))
-            Debug.Assert(method.ReturnType = callType)
-            Debug.Assert(toType = conversion.Type)
+            Debug.Assert(TypeSymbol.Equals(method.ReturnType, callType, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(toType, conversion.Type, TypeCompareKind.ConsiderEverything2))
 
             Dim expectedParameterType As TypeSymbol = method.Parameters(0).Type
             Dim realParameterType As TypeSymbol = parameter.Type
-            Debug.Assert(expectedParameterType.GetNullableUnderlyingTypeOrSelf = realParameterType.GetNullableUnderlyingTypeOrSelf)
+            Debug.Assert(TypeSymbol.Equals(expectedParameterType.GetNullableUnderlyingTypeOrSelf, realParameterType.GetNullableUnderlyingTypeOrSelf, TypeCompareKind.ConsiderEverything2))
 
             Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
             Dim innerConversion As ConversionKind = Conversions.ClassifyConversion(realParameterType, expectedParameterType, useSiteDiagnostics).Key

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
@@ -187,12 +187,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(outConv IsNot Nothing AndAlso
                          toType.IsSameTypeIgnoringAll(outConv.Type) OrElse
                          toType.IsSameTypeIgnoringAll([call].Type))
-            Debug.Assert(TypeSymbol.Equals(method.ReturnType, callType, TypeCompareKind.ConsiderEverything2))
-            Debug.Assert(TypeSymbol.Equals(toType, conversion.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(method.ReturnType, callType, TypeCompareKind.ConsiderEverything))
+            Debug.Assert(TypeSymbol.Equals(toType, conversion.Type, TypeCompareKind.ConsiderEverything))
 
             Dim expectedParameterType As TypeSymbol = method.Parameters(0).Type
             Dim realParameterType As TypeSymbol = parameter.Type
-            Debug.Assert(TypeSymbol.Equals(expectedParameterType.GetNullableUnderlyingTypeOrSelf, realParameterType.GetNullableUnderlyingTypeOrSelf, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(expectedParameterType.GetNullableUnderlyingTypeOrSelf, realParameterType.GetNullableUnderlyingTypeOrSelf, TypeCompareKind.ConsiderEverything))
 
             Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
             Dim innerConversion As ConversionKind = Conversions.ClassifyConversion(realParameterType, expectedParameterType, useSiteDiagnostics).Key

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_Conversion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_Conversion.vb
@@ -143,7 +143,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If typeTo.IsObjectType Then
                             ' Fall through
 
-                        ElseIf notNullableFrom = notNullableTo Then
+                        ElseIf TypeSymbol.Equals(notNullableFrom, notNullableTo, TypeCompareKind.ConsiderEverything2) Then
                             Debug.Assert(semantics <> ConversionSemantics.TryCast)
 
                             ' X? -> X
@@ -157,7 +157,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Debug.Assert(semantics <> ConversionSemantics.TryCast)
 
                             Dim interimType As TypeSymbol = notNullableFrom
-                            Debug.Assert(interimType <> typeTo)
+                            Debug.Assert(Not TypeSymbol.Equals(interimType, typeTo, TypeCompareKind.ConsiderEverything2))
                             rewrittenOperand = CreateBuiltInConversion(typeFrom, interimType, rewrittenOperand, isChecked, isExplicit,
                                                                        ConversionSemantics.[Default], specialConversionForNullable:=True)
                             Return CreateBuiltInConversion(interimType, typeTo, rewrittenOperand, isChecked, isExplicit,
@@ -171,7 +171,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If typeFrom.IsObjectType Then
                             ' Fall through
 
-                        ElseIf notNullableFrom = notNullableTo Then
+                        ElseIf TypeSymbol.Equals(notNullableFrom, notNullableTo, TypeCompareKind.ConsiderEverything2) Then
                             Debug.Assert(semantics <> ConversionSemantics.TryCast)
 
                             ' X -> X?
@@ -185,7 +185,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Debug.Assert(semantics <> ConversionSemantics.TryCast)
 
                             Dim interimType As TypeSymbol = notNullableTo
-                            Debug.Assert(interimType <> typeTo)
+                            Debug.Assert(Not TypeSymbol.Equals(interimType, typeTo, TypeCompareKind.ConsiderEverything2))
                             rewrittenOperand = CreateBuiltInConversion(typeFrom, interimType, rewrittenOperand, isChecked, isExplicit,
                                                                        ConversionSemantics.[Default], specialConversionForNullable:=True)
                             Return CreateBuiltInConversion(interimType, typeTo, rewrittenOperand, isChecked, isExplicit,
@@ -401,7 +401,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function CreateTypeAsIfNeeded(operand As BoundExpression, oldType As TypeSymbol, newType As TypeSymbol) As BoundExpression
-            Return If((oldType = newType), operand, CreateTypeAs(operand, newType))
+            Return If((TypeSymbol.Equals(oldType, newType, TypeCompareKind.ConsiderEverything2)), operand, CreateTypeAs(operand, newType))
         End Function
 
         ' Emit a Convert node to a specific type with no helper method.
@@ -416,7 +416,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ' Emit a convert node if types are different.
         Private Function ConvertIfNeeded(operand As BoundExpression, oldType As TypeSymbol, newType As TypeSymbol, isChecked As Boolean) As BoundExpression
-            Return If((oldType = newType), operand, Convert(operand, newType, isChecked))
+            Return If((TypeSymbol.Equals(oldType, newType, TypeCompareKind.ConsiderEverything2)), operand, Convert(operand, newType, isChecked))
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_Conversion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_Conversion.vb
@@ -143,7 +143,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If typeTo.IsObjectType Then
                             ' Fall through
 
-                        ElseIf TypeSymbol.Equals(notNullableFrom, notNullableTo, TypeCompareKind.ConsiderEverything2) Then
+                        ElseIf TypeSymbol.Equals(notNullableFrom, notNullableTo, TypeCompareKind.ConsiderEverything) Then
                             Debug.Assert(semantics <> ConversionSemantics.TryCast)
 
                             ' X? -> X
@@ -157,7 +157,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Debug.Assert(semantics <> ConversionSemantics.TryCast)
 
                             Dim interimType As TypeSymbol = notNullableFrom
-                            Debug.Assert(Not TypeSymbol.Equals(interimType, typeTo, TypeCompareKind.ConsiderEverything2))
+                            Debug.Assert(Not TypeSymbol.Equals(interimType, typeTo, TypeCompareKind.ConsiderEverything))
                             rewrittenOperand = CreateBuiltInConversion(typeFrom, interimType, rewrittenOperand, isChecked, isExplicit,
                                                                        ConversionSemantics.[Default], specialConversionForNullable:=True)
                             Return CreateBuiltInConversion(interimType, typeTo, rewrittenOperand, isChecked, isExplicit,
@@ -171,7 +171,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If typeFrom.IsObjectType Then
                             ' Fall through
 
-                        ElseIf TypeSymbol.Equals(notNullableFrom, notNullableTo, TypeCompareKind.ConsiderEverything2) Then
+                        ElseIf TypeSymbol.Equals(notNullableFrom, notNullableTo, TypeCompareKind.ConsiderEverything) Then
                             Debug.Assert(semantics <> ConversionSemantics.TryCast)
 
                             ' X -> X?
@@ -185,7 +185,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Debug.Assert(semantics <> ConversionSemantics.TryCast)
 
                             Dim interimType As TypeSymbol = notNullableTo
-                            Debug.Assert(Not TypeSymbol.Equals(interimType, typeTo, TypeCompareKind.ConsiderEverything2))
+                            Debug.Assert(Not TypeSymbol.Equals(interimType, typeTo, TypeCompareKind.ConsiderEverything))
                             rewrittenOperand = CreateBuiltInConversion(typeFrom, interimType, rewrittenOperand, isChecked, isExplicit,
                                                                        ConversionSemantics.[Default], specialConversionForNullable:=True)
                             Return CreateBuiltInConversion(interimType, typeTo, rewrittenOperand, isChecked, isExplicit,
@@ -401,7 +401,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function CreateTypeAsIfNeeded(operand As BoundExpression, oldType As TypeSymbol, newType As TypeSymbol) As BoundExpression
-            Return If((TypeSymbol.Equals(oldType, newType, TypeCompareKind.ConsiderEverything2)), operand, CreateTypeAs(operand, newType))
+            Return If((TypeSymbol.Equals(oldType, newType, TypeCompareKind.ConsiderEverything)), operand, CreateTypeAs(operand, newType))
         End Function
 
         ' Emit a Convert node to a specific type with no helper method.
@@ -416,7 +416,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ' Emit a convert node if types are different.
         Private Function ConvertIfNeeded(operand As BoundExpression, oldType As TypeSymbol, newType As TypeSymbol, isChecked As Boolean) As BoundExpression
-            Return If((TypeSymbol.Equals(oldType, newType, TypeCompareKind.ConsiderEverything2)), operand, Convert(operand, newType, isChecked))
+            Return If((TypeSymbol.Equals(oldType, newType, TypeCompareKind.ConsiderEverything)), operand, Convert(operand, newType, isChecked))
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_UnaryOperator.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_UnaryOperator.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim origArgNotNullableType As TypeSymbol = origArgType.GetNullableUnderlyingTypeOrSelf
             Dim origArgUnderlyingType As TypeSymbol = origArgNotNullableType.GetEnumUnderlyingTypeOrSelf
             Dim origArgUnderlyingSpecialType As SpecialType = origArgUnderlyingType.SpecialType
-            Debug.Assert(origArgType = node.Type)
+            Debug.Assert(TypeSymbol.Equals(origArgType, node.Type, TypeCompareKind.ConsiderEverything2))
 
             Dim argument As BoundExpression = Visit(origArg)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_UnaryOperator.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_UnaryOperator.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim origArgNotNullableType As TypeSymbol = origArgType.GetNullableUnderlyingTypeOrSelf
             Dim origArgUnderlyingType As TypeSymbol = origArgNotNullableType.GetEnumUnderlyingTypeOrSelf
             Dim origArgUnderlyingSpecialType As SpecialType = origArgUnderlyingType.SpecialType
-            Debug.Assert(TypeSymbol.Equals(origArgType, node.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(origArgType, node.Type, TypeCompareKind.ConsiderEverything))
 
             Dim argument As BoundExpression = Visit(origArg)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DebugInfoInjector_SequencePoints.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DebugInfoInjector_SequencePoints.vb
@@ -74,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Shared Function MakeAssignmentExpression(syntax As SyntaxNode, left As BoundExpression, right As BoundExpression) As BoundExpression
-            Debug.Assert(left.Type = right.Type)
+            Debug.Assert(TypeSymbol.Equals(left.Type, right.Type, TypeCompareKind.ConsiderEverything2))
             Dim boundNode = New BoundAssignmentOperator(syntax, left, right, suppressObjectClone:=True)
             boundNode.SetWasCompilerGenerated()
             Return boundNode

--- a/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DebugInfoInjector_SequencePoints.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DebugInfoInjector_SequencePoints.vb
@@ -74,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Shared Function MakeAssignmentExpression(syntax As SyntaxNode, left As BoundExpression, right As BoundExpression) As BoundExpression
-            Debug.Assert(TypeSymbol.Equals(left.Type, right.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(left.Type, right.Type, TypeCompareKind.ConsiderEverything))
             Dim boundNode = New BoundAssignmentOperator(syntax, left, right, suppressObjectClone:=True)
             boundNode.SetWasCompilerGenerated()
             Return boundNode

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
@@ -355,7 +355,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>A bound node that computes the pointer to the required frame</returns>
         Private Function FrameOfType(syntax As SyntaxNode, frameType As NamedTypeSymbol) As BoundExpression
             Dim result As BoundExpression = FramePointer(syntax, frameType.OriginalDefinition)
-            Debug.Assert(result.Type = frameType)
+            Debug.Assert(TypeSymbol.Equals(result.Type, frameType, TypeCompareKind.ConsiderEverything2))
             Return result
         End Function
 
@@ -369,7 +369,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>A bound node that computes the pointer to the required frame</returns>
         Friend Overrides Function FramePointer(syntax As SyntaxNode, frameClass As NamedTypeSymbol) As BoundExpression
             Debug.Assert(frameClass.IsDefinition)
-            If _currentFrameThis IsNot Nothing AndAlso _currentFrameThis.Type = frameClass Then
+            If _currentFrameThis IsNot Nothing AndAlso TypeSymbol.Equals(_currentFrameThis.Type, frameClass, TypeCompareKind.ConsiderEverything2) Then
                 Return New BoundMeReference(syntax, frameClass)
             End If
 
@@ -503,7 +503,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim framePointer = New SynthesizedLocal(Me._topLevelMethod, frameType, SynthesizedLocalKind.LambdaDisplayClass, frame.ScopeSyntax)
             Dim prologue = ArrayBuilder(Of BoundExpression).GetInstance()
             Dim constructor As MethodSymbol = frame.Constructor.AsMember(frameType)
-            Debug.Assert(frameType = constructor.ContainingType)
+            Debug.Assert(TypeSymbol.Equals(frameType, constructor.ContainingType, TypeCompareKind.ConsiderEverything2))
 
             Dim syntaxNode As SyntaxNode = node.Syntax
 
@@ -806,7 +806,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Debug.Assert(Not Me.Proxies.ContainsKey(origLocal), "captured local should not need rewriting")
 
                 Dim newType = VisitType(origLocal.Type)
-                If newType = origLocal.Type Then
+                If TypeSymbol.Equals(newType, origLocal.Type, TypeCompareKind.ConsiderEverything2) Then
                     ' keeping same local
                     rewrittenCatchLocal = origLocal
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
@@ -355,7 +355,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>A bound node that computes the pointer to the required frame</returns>
         Private Function FrameOfType(syntax As SyntaxNode, frameType As NamedTypeSymbol) As BoundExpression
             Dim result As BoundExpression = FramePointer(syntax, frameType.OriginalDefinition)
-            Debug.Assert(TypeSymbol.Equals(result.Type, frameType, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(result.Type, frameType, TypeCompareKind.ConsiderEverything))
             Return result
         End Function
 
@@ -369,7 +369,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns>A bound node that computes the pointer to the required frame</returns>
         Friend Overrides Function FramePointer(syntax As SyntaxNode, frameClass As NamedTypeSymbol) As BoundExpression
             Debug.Assert(frameClass.IsDefinition)
-            If _currentFrameThis IsNot Nothing AndAlso TypeSymbol.Equals(_currentFrameThis.Type, frameClass, TypeCompareKind.ConsiderEverything2) Then
+            If _currentFrameThis IsNot Nothing AndAlso TypeSymbol.Equals(_currentFrameThis.Type, frameClass, TypeCompareKind.ConsiderEverything) Then
                 Return New BoundMeReference(syntax, frameClass)
             End If
 
@@ -503,7 +503,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim framePointer = New SynthesizedLocal(Me._topLevelMethod, frameType, SynthesizedLocalKind.LambdaDisplayClass, frame.ScopeSyntax)
             Dim prologue = ArrayBuilder(Of BoundExpression).GetInstance()
             Dim constructor As MethodSymbol = frame.Constructor.AsMember(frameType)
-            Debug.Assert(TypeSymbol.Equals(frameType, constructor.ContainingType, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(frameType, constructor.ContainingType, TypeCompareKind.ConsiderEverything))
 
             Dim syntaxNode As SyntaxNode = node.Syntax
 
@@ -806,7 +806,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Debug.Assert(Not Me.Proxies.ContainsKey(origLocal), "captured local should not need rewriting")
 
                 Dim newType = VisitType(origLocal.Type)
-                If TypeSymbol.Equals(newType, origLocal.Type, TypeCompareKind.ConsiderEverything2) Then
+                If TypeSymbol.Equals(newType, origLocal.Type, TypeCompareKind.ConsiderEverything) Then
                     ' keeping same local
                     rewrittenCatchLocal = origLocal
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.vb
@@ -193,7 +193,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(
                 sourceProperty IsNot Nothing AndAlso
                 sourceProperty.IsAutoProperty AndAlso
-                sourceProperty.ContainingType = fromMember.ContainingType AndAlso
+                TypeSymbol.Equals(sourceProperty.ContainingType, fromMember.ContainingType, TypeCompareKind.ConsiderEverything2) AndAlso
                 propertyIsStatic = fromMember.IsShared AndAlso
                 (propertyIsStatic OrElse receiver.Kind = BoundKind.MeReference) AndAlso
                 (fromMember.Kind = SymbolKind.Field OrElse (fromMember.Kind = SymbolKind.Method AndAlso

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.vb
@@ -193,7 +193,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(
                 sourceProperty IsNot Nothing AndAlso
                 sourceProperty.IsAutoProperty AndAlso
-                TypeSymbol.Equals(sourceProperty.ContainingType, fromMember.ContainingType, TypeCompareKind.ConsiderEverything2) AndAlso
+                TypeSymbol.Equals(sourceProperty.ContainingType, fromMember.ContainingType, TypeCompareKind.ConsiderEverything) AndAlso
                 propertyIsStatic = fromMember.IsShared AndAlso
                 (propertyIsStatic OrElse receiver.Kind = BoundKind.MeReference) AndAlso
                 (fromMember.Kind = SymbolKind.Field OrElse (fromMember.Kind = SymbolKind.Method AndAlso

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalExpressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalExpressions.vb
@@ -129,7 +129,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim testExpression As BoundExpression = node.TestExpression
             Dim testExpressionType As TypeSymbol = testExpression.Type
             Dim rewrittenTestExpression As BoundExpression = VisitExpression(testExpression)
-            Debug.Assert(testExpressionType = rewrittenTestExpression.Type)
+            Debug.Assert(TypeSymbol.Equals(testExpressionType, rewrittenTestExpression.Type, TypeCompareKind.ConsiderEverything2))
 
             Dim rewrittenWhenTrue As BoundExpression = Nothing
 
@@ -144,7 +144,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                             testExpressionType.GetNullableUnderlyingTypeOrSelf)
                 End If
             Else
-                Debug.Assert(node.TestExpressionPlaceholder Is Nothing OrElse node.TestExpressionPlaceholder.Type = testExpressionType.GetNullableUnderlyingTypeOrSelf)
+                Debug.Assert(node.TestExpressionPlaceholder Is Nothing OrElse TypeSymbol.Equals(node.TestExpressionPlaceholder.Type, testExpressionType.GetNullableUnderlyingTypeOrSelf, TypeCompareKind.ConsiderEverything2))
                 rewrittenWhenTrue = VisitExpressionNode(convertedTestExpression,
                                                         node.TestExpressionPlaceholder,
                                                         If(testExpressionType.IsNullableType,
@@ -187,7 +187,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' TODO: Checking type equality of test and else is not strictly needed.
             '       Consider removing this requirement.
-            If testExpr.IsConstant AndAlso (testExpr.Type = elseExpr.Type) Then
+            If testExpr.IsConstant AndAlso (TypeSymbol.Equals(testExpr.Type, elseExpr.Type, TypeCompareKind.ConsiderEverything2)) Then
                 '  the only valid IF(...) with the first constant are: IF("abc", <expr>) or IF(Nothing, <expr>)
                 If testExpr.ConstantValueOpt.IsNothing Then
                     ' CASE: IF(Nothing, <expr>) 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalExpressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalExpressions.vb
@@ -129,7 +129,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim testExpression As BoundExpression = node.TestExpression
             Dim testExpressionType As TypeSymbol = testExpression.Type
             Dim rewrittenTestExpression As BoundExpression = VisitExpression(testExpression)
-            Debug.Assert(TypeSymbol.Equals(testExpressionType, rewrittenTestExpression.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(testExpressionType, rewrittenTestExpression.Type, TypeCompareKind.ConsiderEverything))
 
             Dim rewrittenWhenTrue As BoundExpression = Nothing
 
@@ -144,7 +144,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                             testExpressionType.GetNullableUnderlyingTypeOrSelf)
                 End If
             Else
-                Debug.Assert(node.TestExpressionPlaceholder Is Nothing OrElse TypeSymbol.Equals(node.TestExpressionPlaceholder.Type, testExpressionType.GetNullableUnderlyingTypeOrSelf, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(node.TestExpressionPlaceholder Is Nothing OrElse TypeSymbol.Equals(node.TestExpressionPlaceholder.Type, testExpressionType.GetNullableUnderlyingTypeOrSelf, TypeCompareKind.ConsiderEverything))
                 rewrittenWhenTrue = VisitExpressionNode(convertedTestExpression,
                                                         node.TestExpressionPlaceholder,
                                                         If(testExpressionType.IsNullableType,
@@ -187,7 +187,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' TODO: Checking type equality of test and else is not strictly needed.
             '       Consider removing this requirement.
-            If testExpr.IsConstant AndAlso (TypeSymbol.Equals(testExpr.Type, elseExpr.Type, TypeCompareKind.ConsiderEverything2)) Then
+            If testExpr.IsConstant AndAlso (TypeSymbol.Equals(testExpr.Type, elseExpr.Type, TypeCompareKind.ConsiderEverything)) Then
                 '  the only valid IF(...) with the first constant are: IF("abc", <expr>) or IF(Nothing, <expr>)
                 If testExpr.ConstantValueOpt.IsNothing Then
                     ' CASE: IF(Nothing, <expr>) 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_FieldAccess.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_FieldAccess.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return MakeBadFieldAccess(syntax, tupleField, rewrittenReceiver)
             End If
 
-            If underlyingField.ContainingType <> currentLinkType Then
+            If Not TypeSymbol.Equals(underlyingField.ContainingType, currentLinkType, TypeCompareKind.ConsiderEverything2) Then
                 Dim wellKnownTupleRest As WellKnownMember = TupleTypeSymbol.GetTupleTypeMember(TupleTypeSymbol.RestPosition, TupleTypeSymbol.RestPosition)
                 Dim tupleRestField = DirectCast(TupleTypeSymbol.GetWellKnownMemberInType(currentLinkType.OriginalDefinition, wellKnownTupleRest, _diagnostics, syntax), FieldSymbol)
 
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     rewrittenReceiver = New BoundFieldAccess(syntax, rewrittenReceiver, nestedFieldSymbol, isLValue, nestedFieldSymbol.Type)
 
                     currentLinkType = currentLinkType.TypeArgumentsNoUseSiteDiagnostics(TupleTypeSymbol.RestPosition - 1).TupleUnderlyingType
-                Loop While underlyingField.ContainingType <> currentLinkType
+                Loop While Not TypeSymbol.Equals(underlyingField.ContainingType, currentLinkType, TypeCompareKind.ConsiderEverything2)
 
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_FieldAccess.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_FieldAccess.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return MakeBadFieldAccess(syntax, tupleField, rewrittenReceiver)
             End If
 
-            If Not TypeSymbol.Equals(underlyingField.ContainingType, currentLinkType, TypeCompareKind.ConsiderEverything2) Then
+            If Not TypeSymbol.Equals(underlyingField.ContainingType, currentLinkType, TypeCompareKind.ConsiderEverything) Then
                 Dim wellKnownTupleRest As WellKnownMember = TupleTypeSymbol.GetTupleTypeMember(TupleTypeSymbol.RestPosition, TupleTypeSymbol.RestPosition)
                 Dim tupleRestField = DirectCast(TupleTypeSymbol.GetWellKnownMemberInType(currentLinkType.OriginalDefinition, wellKnownTupleRest, _diagnostics, syntax), FieldSymbol)
 
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     rewrittenReceiver = New BoundFieldAccess(syntax, rewrittenReceiver, nestedFieldSymbol, isLValue, nestedFieldSymbol.Type)
 
                     currentLinkType = currentLinkType.TypeArgumentsNoUseSiteDiagnostics(TupleTypeSymbol.RestPosition - 1).TupleUnderlyingType
-                Loop While Not TypeSymbol.Equals(underlyingField.ContainingType, currentLinkType, TypeCompareKind.ConsiderEverything2)
+                Loop While Not TypeSymbol.Equals(underlyingField.ContainingType, currentLinkType, TypeCompareKind.ConsiderEverything)
 
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
@@ -443,7 +443,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     left As BoundExpression,
                                     right As BoundExpression) As BoundExpression
 
-            Debug.Assert(left.Type = right.Type)
+            Debug.Assert(TypeSymbol.Equals(left.Type, right.Type, TypeCompareKind.ConsiderEverything2))
             Debug.Assert(left.Type.IsBooleanType)
 
             Return MakeBinaryExpression(syntax, binaryOpKind, left, right, False, left.Type)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
@@ -443,7 +443,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     left As BoundExpression,
                                     right As BoundExpression) As BoundExpression
 
-            Debug.Assert(TypeSymbol.Equals(left.Type, right.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(left.Type, right.Type, TypeCompareKind.ConsiderEverything))
             Debug.Assert(left.Type.IsBooleanType)
 
             Return MakeBinaryExpression(syntax, binaryOpKind, left, right, False, left.Type)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_RaiseEvent.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_RaiseEvent.vb
@@ -118,7 +118,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     WellKnownMember.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationTokenTable_T__GetOrCreateEventRegistrationTokenTable), MethodSymbol)
 
             Debug.Assert(getOrCreateMethod IsNot Nothing, "Checked during initial binding")
-            Debug.Assert(getOrCreateMethod.ReturnType = fieldType.OriginalDefinition, "Shape of well-known member")
+            Debug.Assert(TypeSymbol.Equals(getOrCreateMethod.ReturnType, fieldType.OriginalDefinition, TypeCompareKind.ConsiderEverything2), "Shape of well-known member")
 
             getOrCreateMethod = getOrCreateMethod.AsMember(fieldType)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_RaiseEvent.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_RaiseEvent.vb
@@ -118,7 +118,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     WellKnownMember.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationTokenTable_T__GetOrCreateEventRegistrationTokenTable), MethodSymbol)
 
             Debug.Assert(getOrCreateMethod IsNot Nothing, "Checked during initial binding")
-            Debug.Assert(TypeSymbol.Equals(getOrCreateMethod.ReturnType, fieldType.OriginalDefinition, TypeCompareKind.ConsiderEverything2), "Shape of well-known member")
+            Debug.Assert(TypeSymbol.Equals(getOrCreateMethod.ReturnType, fieldType.OriginalDefinition, TypeCompareKind.ConsiderEverything), "Shape of well-known member")
 
             getOrCreateMethod = getOrCreateMethod.AsMember(fieldType)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_XmlLiterals.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_XmlLiterals.vb
@@ -182,7 +182,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim constructor As MethodSymbol = Nothing
             If objCreation.Arguments.Length = 1 Then
                 ' This is a branch where XElement::.ctor(XName) lands, we need to get XElement::.ctor(XName, Object()) 
-                Debug.Assert(objCreation.ConstructorOpt.ContainingType = Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XElement))
+                Debug.Assert(TypeSymbol.Equals(objCreation.ConstructorOpt.ContainingType, Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XElement), TypeCompareKind.ConsiderEverything2))
 
                 constructor = DirectCast(Me.Compilation.GetWellKnownTypeMember(If(origSideEffects.Length = 1,
                                                                                   WellKnownMember.System_Xml_Linq_XElement__ctor,
@@ -196,7 +196,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' This is a branch where XDocument::.ctor(XDeclaration, Object()) lands
                 Debug.Assert(objCreation.Arguments.Length = 2)
                 constructor = objCreation.ConstructorOpt
-                Debug.Assert(constructor.ContainingType = Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XDocument))
+                Debug.Assert(TypeSymbol.Equals(constructor.ContainingType, Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XDocument), TypeCompareKind.ConsiderEverything2))
             End If
 
             Dim syntax = objCreation.Syntax

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_XmlLiterals.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_XmlLiterals.vb
@@ -182,7 +182,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim constructor As MethodSymbol = Nothing
             If objCreation.Arguments.Length = 1 Then
                 ' This is a branch where XElement::.ctor(XName) lands, we need to get XElement::.ctor(XName, Object()) 
-                Debug.Assert(TypeSymbol.Equals(objCreation.ConstructorOpt.ContainingType, Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XElement), TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(objCreation.ConstructorOpt.ContainingType, Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XElement), TypeCompareKind.ConsiderEverything))
 
                 constructor = DirectCast(Me.Compilation.GetWellKnownTypeMember(If(origSideEffects.Length = 1,
                                                                                   WellKnownMember.System_Xml_Linq_XElement__ctor,
@@ -196,7 +196,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' This is a branch where XDocument::.ctor(XDeclaration, Object()) lands
                 Debug.Assert(objCreation.Arguments.Length = 2)
                 constructor = objCreation.ConstructorOpt
-                Debug.Assert(TypeSymbol.Equals(constructor.ContainingType, Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XDocument), TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(constructor.ContainingType, Me.Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XDocument), TypeCompareKind.ConsiderEverything))
             End If
 
             Dim syntax = objCreation.Syntax

--- a/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.vb
@@ -347,7 +347,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             For Each v In node.Locals
                 If Me.PreserveOriginalLocals OrElse Not Me.Proxies.ContainsKey(v) Then
                     Dim vType = VisitType(v.Type)
-                    If vType = v.Type Then
+                    If TypeSymbol.Equals(vType, v.Type, TypeCompareKind.ConsiderEverything2) Then
 
                         Dim replacement As LocalSymbol = Nothing
                         Dim wasReplaced As Boolean = False
@@ -460,7 +460,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             For Each v In origLocals
                 If Not Me.Proxies.ContainsKey(v) Then
                     Dim vType = VisitType(v.Type)
-                    If vType = v.Type Then
+                    If TypeSymbol.Equals(vType, v.Type, TypeCompareKind.ConsiderEverything2) Then
                         newLocals.Add(v)
                     Else
                         Dim replacement = CreateReplacementLocalOrReturnSelf(v, vType)

--- a/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.vb
@@ -347,7 +347,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             For Each v In node.Locals
                 If Me.PreserveOriginalLocals OrElse Not Me.Proxies.ContainsKey(v) Then
                     Dim vType = VisitType(v.Type)
-                    If TypeSymbol.Equals(vType, v.Type, TypeCompareKind.ConsiderEverything2) Then
+                    If TypeSymbol.Equals(vType, v.Type, TypeCompareKind.ConsiderEverything) Then
 
                         Dim replacement As LocalSymbol = Nothing
                         Dim wasReplaced As Boolean = False
@@ -460,7 +460,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             For Each v In origLocals
                 If Not Me.Proxies.ContainsKey(v) Then
                     Dim vType = VisitType(v.Type)
-                    If TypeSymbol.Equals(vType, v.Type, TypeCompareKind.ConsiderEverything2) Then
+                    If TypeSymbol.Equals(vType, v.Type, TypeCompareKind.ConsiderEverything) Then
                         newLocals.Add(v)
                     Else
                         Dim replacement = CreateReplacementLocalOrReturnSelf(v, vType)

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
@@ -127,7 +127,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim oldSyntax As SyntaxNode = Me.F.Syntax
                 Me.F.Syntax = syntax
                 Dim result = Me.F.Me()
-                Debug.Assert(frameClass = result.Type)
+                Debug.Assert(TypeSymbol.Equals(frameClass, result.Type, TypeCompareKind.ConsiderEverything2))
                 Me.F.Syntax = oldSyntax
                 Return result
             End Function
@@ -364,7 +364,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim newLocal As LocalSymbol = Nothing
                 If Not LocalMap.TryGetValue(local, newLocal) Then
                     Dim newType = VisitType(local.Type)
-                    If newType = local.Type Then
+                    If TypeSymbol.Equals(newType, local.Type, TypeCompareKind.ConsiderEverything2) Then
                         ' keeping same local
                         newLocal = local
                     Else

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
@@ -127,7 +127,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim oldSyntax As SyntaxNode = Me.F.Syntax
                 Me.F.Syntax = syntax
                 Dim result = Me.F.Me()
-                Debug.Assert(TypeSymbol.Equals(frameClass, result.Type, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(frameClass, result.Type, TypeCompareKind.ConsiderEverything))
                 Me.F.Syntax = oldSyntax
                 Return result
             End Function
@@ -364,7 +364,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim newLocal As LocalSymbol = Nothing
                 If Not LocalMap.TryGetValue(local, newLocal) Then
                     Dim newType = VisitType(local.Type)
-                    If TypeSymbol.Equals(newType, local.Type, TypeCompareKind.ConsiderEverything2) Then
+                    If TypeSymbol.Equals(newType, local.Type, TypeCompareKind.ConsiderEverything) Then
                         ' keeping same local
                         newLocal = local
                     Else

--- a/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
@@ -328,7 +328,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Function ReferenceAssignment(byRefLocal As LocalSymbol, lValue As BoundExpression) As BoundReferenceAssignment
-            Debug.Assert(byRefLocal.Type = lValue.Type)
+            Debug.Assert(TypeSymbol.Equals(byRefLocal.Type, lValue.Type, TypeCompareKind.ConsiderEverything2))
             Debug.Assert(byRefLocal.IsByRef)
 
             Dim boundNode = New BoundReferenceAssignment(_syntax, Local(byRefLocal, isLValue:=True), lValue, isLValue:=True, type:=lValue.Type)

--- a/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
@@ -328,7 +328,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Function ReferenceAssignment(byRefLocal As LocalSymbol, lValue As BoundExpression) As BoundReferenceAssignment
-            Debug.Assert(TypeSymbol.Equals(byRefLocal.Type, lValue.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(byRefLocal.Type, lValue.Type, TypeCompareKind.ConsiderEverything))
             Debug.Assert(byRefLocal.IsByRef)
 
             Dim boundNode = New BoundReferenceAssignment(_syntax, Local(byRefLocal, isLValue:=True), lValue, isLValue:=True, type:=lValue.Type)

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -590,7 +590,7 @@ Namespace Microsoft.CodeAnalysis.Operations
 
             Dim valueConversion = New Conversion(Conversions.Identity)
 
-            If boundBinaryConditionalExpression.Type <> boundBinaryConditionalExpression.TestExpression.Type Then
+            If Not TypeSymbol.Equals(boundBinaryConditionalExpression.Type, boundBinaryConditionalExpression.TestExpression.Type, TypeCompareKind.ConsiderEverything2) Then
                 Dim convertedTestExpression As BoundExpression = boundBinaryConditionalExpression.ConvertedTestExpression
                 If convertedTestExpression IsNot Nothing Then
                     If convertedTestExpression.Kind = BoundKind.Conversion Then
@@ -676,7 +676,7 @@ Namespace Microsoft.CodeAnalysis.Operations
 
             Dim boundOperand = GetConversionOperand(boundConversionOrCast)
             If boundOperand.Syntax Is boundConversionOrCast.Syntax Then
-                If boundOperand.Kind = BoundKind.ConvertedTupleLiteral AndAlso boundOperand.Type = boundConversionOrCast.Type Then
+                If boundOperand.Kind = BoundKind.ConvertedTupleLiteral AndAlso TypeSymbol.Equals(boundOperand.Type, boundConversionOrCast.Type, TypeCompareKind.ConsiderEverything2) Then
                     ' Erase this conversion, this is an artificial conversion added on top of BoundConvertedTupleLiteral
                     ' in Binder.ReclassifyTupleLiteral
                     Return Create(boundOperand)
@@ -926,7 +926,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             ' does not match the type of the containing type.
             If (boundLateMemberAccess.ContainerTypeOpt IsNot Nothing AndAlso
                 (boundLateMemberAccess.ReceiverOpt Is Nothing OrElse
-                 boundLateMemberAccess.ContainerTypeOpt <> boundLateMemberAccess.ReceiverOpt.Type)) Then
+                 Not TypeSymbol.Equals(boundLateMemberAccess.ContainerTypeOpt, boundLateMemberAccess.ReceiverOpt.Type, TypeCompareKind.ConsiderEverything2))) Then
                 containingType = boundLateMemberAccess.ContainerTypeOpt
             End If
             Dim syntax As SyntaxNode = boundLateMemberAccess.Syntax

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -590,7 +590,7 @@ Namespace Microsoft.CodeAnalysis.Operations
 
             Dim valueConversion = New Conversion(Conversions.Identity)
 
-            If Not TypeSymbol.Equals(boundBinaryConditionalExpression.Type, boundBinaryConditionalExpression.TestExpression.Type, TypeCompareKind.ConsiderEverything2) Then
+            If Not TypeSymbol.Equals(boundBinaryConditionalExpression.Type, boundBinaryConditionalExpression.TestExpression.Type, TypeCompareKind.ConsiderEverything) Then
                 Dim convertedTestExpression As BoundExpression = boundBinaryConditionalExpression.ConvertedTestExpression
                 If convertedTestExpression IsNot Nothing Then
                     If convertedTestExpression.Kind = BoundKind.Conversion Then
@@ -676,7 +676,7 @@ Namespace Microsoft.CodeAnalysis.Operations
 
             Dim boundOperand = GetConversionOperand(boundConversionOrCast)
             If boundOperand.Syntax Is boundConversionOrCast.Syntax Then
-                If boundOperand.Kind = BoundKind.ConvertedTupleLiteral AndAlso TypeSymbol.Equals(boundOperand.Type, boundConversionOrCast.Type, TypeCompareKind.ConsiderEverything2) Then
+                If boundOperand.Kind = BoundKind.ConvertedTupleLiteral AndAlso TypeSymbol.Equals(boundOperand.Type, boundConversionOrCast.Type, TypeCompareKind.ConsiderEverything) Then
                     ' Erase this conversion, this is an artificial conversion added on top of BoundConvertedTupleLiteral
                     ' in Binder.ReclassifyTupleLiteral
                     Return Create(boundOperand)
@@ -926,7 +926,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             ' does not match the type of the containing type.
             If (boundLateMemberAccess.ContainerTypeOpt IsNot Nothing AndAlso
                 (boundLateMemberAccess.ReceiverOpt Is Nothing OrElse
-                 Not TypeSymbol.Equals(boundLateMemberAccess.ContainerTypeOpt, boundLateMemberAccess.ReceiverOpt.Type, TypeCompareKind.ConsiderEverything2))) Then
+                 Not TypeSymbol.Equals(boundLateMemberAccess.ContainerTypeOpt, boundLateMemberAccess.ReceiverOpt.Type, TypeCompareKind.ConsiderEverything))) Then
                 containingType = boundLateMemberAccess.ContainerTypeOpt
             End If
             Dim syntax As SyntaxNode = boundLateMemberAccess.Syntax

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
@@ -549,14 +549,14 @@ Namespace Microsoft.CodeAnalysis.Operations
                 Dim nestedOperand As BoundExpression = GetConversionOperand(nestedConversion)
 
                 If nestedConversion.Syntax Is nestedOperand.Syntax AndAlso
-                   nestedConversion.Type <> nestedOperand.Type AndAlso
+                   Not TypeSymbol.Equals(nestedConversion.Type, nestedOperand.Type, TypeCompareKind.ConsiderEverything2) AndAlso
                    nestedConversion.ExplicitCastInCode AndAlso
-                   topLevelConversion.Type = nestedConversion.Type Then
+                   TypeSymbol.Equals(topLevelConversion.Type, nestedConversion.Type, TypeCompareKind.ConsiderEverything2) Then
 
                     Return GetConversionInfo(nestedConversion)
                 End If
             ElseIf boundOperand.Syntax.IsKind(SyntaxKind.AddressOfExpression) AndAlso
-                   topLevelConversion.Type = boundOperand.Type AndAlso
+                   TypeSymbol.Equals(topLevelConversion.Type, boundOperand.Type, TypeCompareKind.ConsiderEverything2) AndAlso
                    IsDelegateCreation(topLevelConversion.Syntax, boundOperand, boundOperand.Type) Then
 
                 Return (CreateDelegateCreationConversionOperand(boundOperand), Conversion:=Nothing, IsDelegateCreation:=True)

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
@@ -549,14 +549,14 @@ Namespace Microsoft.CodeAnalysis.Operations
                 Dim nestedOperand As BoundExpression = GetConversionOperand(nestedConversion)
 
                 If nestedConversion.Syntax Is nestedOperand.Syntax AndAlso
-                   Not TypeSymbol.Equals(nestedConversion.Type, nestedOperand.Type, TypeCompareKind.ConsiderEverything2) AndAlso
+                   Not TypeSymbol.Equals(nestedConversion.Type, nestedOperand.Type, TypeCompareKind.ConsiderEverything) AndAlso
                    nestedConversion.ExplicitCastInCode AndAlso
-                   TypeSymbol.Equals(topLevelConversion.Type, nestedConversion.Type, TypeCompareKind.ConsiderEverything2) Then
+                   TypeSymbol.Equals(topLevelConversion.Type, nestedConversion.Type, TypeCompareKind.ConsiderEverything) Then
 
                     Return GetConversionInfo(nestedConversion)
                 End If
             ElseIf boundOperand.Syntax.IsKind(SyntaxKind.AddressOfExpression) AndAlso
-                   TypeSymbol.Equals(topLevelConversion.Type, boundOperand.Type, TypeCompareKind.ConsiderEverything2) AndAlso
+                   TypeSymbol.Equals(topLevelConversion.Type, boundOperand.Type, TypeCompareKind.ConsiderEverything) AndAlso
                    IsDelegateCreation(topLevelConversion.Syntax, boundOperand, boundOperand.Type) Then
 
                 Return (CreateDelegateCreationConversionOperand(boundOperand), Conversion:=Nothing, IsDelegateCreation:=True)

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -1231,7 +1231,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Shared Function ClassifyTupleConversion(source As BoundTupleLiteral, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
-            If source.Type = destination Then
+            If TypeSymbol.Equals(source.Type, destination, TypeCompareKind.ConsiderEverything2) Then
                 Return ConversionKind.Identity
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -1231,7 +1231,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Shared Function ClassifyTupleConversion(source As BoundTupleLiteral, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
-            If TypeSymbol.Equals(source.Type, destination, TypeCompareKind.ConsiderEverything2) Then
+            If TypeSymbol.Equals(source.Type, destination, TypeCompareKind.ConsiderEverything) Then
                 Return ConversionKind.Identity
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/Operators.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Operators.vb
@@ -454,7 +454,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If containingType.SpecialType = SpecialType.System_Nullable_T Then
                 Return typeFromSignature Is containingType
             Else
-                Return typeFromSignature.GetNullableUnderlyingTypeOrSelf().GetTupleUnderlyingTypeOrSelf() = containingType.GetTupleUnderlyingTypeOrSelf()
+                Return TypeSymbol.Equals(typeFromSignature.GetNullableUnderlyingTypeOrSelf().GetTupleUnderlyingTypeOrSelf(), containingType.GetTupleUnderlyingTypeOrSelf(), TypeCompareKind.ConsiderEverything2)
             End If
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/Operators.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Operators.vb
@@ -454,7 +454,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If containingType.SpecialType = SpecialType.System_Nullable_T Then
                 Return typeFromSignature Is containingType
             Else
-                Return TypeSymbol.Equals(typeFromSignature.GetNullableUnderlyingTypeOrSelf().GetTupleUnderlyingTypeOrSelf(), containingType.GetTupleUnderlyingTypeOrSelf(), TypeCompareKind.ConsiderEverything2)
+                Return TypeSymbol.Equals(typeFromSignature.GetNullableUnderlyingTypeOrSelf().GetTupleUnderlyingTypeOrSelf(), containingType.GetTupleUnderlyingTypeOrSelf(), TypeCompareKind.ConsiderEverything)
             End If
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
@@ -1177,7 +1177,7 @@ HandleAsAGeneralExpression:
                             AddTypeToGraph(delegateParameter.Type, argNode, isOutgoingEdge:=False, haveSeenTypeParameters:=haveSeenTypeParameters) ' incoming (type->name) edge
                         Next
                     End If
-                ElseIf parameterType.OriginalDefinition = binder.Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T) Then
+                ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, binder.Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything2) Then
                     ' If we've got an Expression(Of T), skip through to T
                     AddAddressOfToGraph(DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics), argNode, binder)
                 End If
@@ -1241,7 +1241,7 @@ HandleAsAGeneralExpression:
                         AddTypeToGraph(invoke.ReturnType, argNode, isOutgoingEdge:=True, haveSeenTypeParameters:=haveSeenTypeParameters)
                     End If
 
-                ElseIf parameterType.OriginalDefinition = binder.Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T) Then
+                ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, binder.Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything2) Then
                     ' If we've got an Expression(Of T), skip through to T
                     AddLambdaToGraph(DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics), argNode, binder)
                 End If
@@ -2221,12 +2221,9 @@ HandleAsAGeneralExpression:
 
                                         ' We can assume that the lambda will have return type Task(Of T) or IEnumerable(Of T)
                                         ' or IEnumerator(Of T) as appropriate. That's already been ensured by the lambda-interpretation.
-                                        Debug.Assert(lambdaReturnNamedType.OriginalDefinition =
-                                                         argument.GetBinderFromLambda().Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T) OrElse
-                                                     lambdaReturnNamedType.OriginalDefinition =
-                                                         argument.GetBinderFromLambda().Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T) OrElse
-                                                     lambdaReturnNamedType.OriginalDefinition =
-                                                         argument.GetBinderFromLambda().Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerator_T))
+                                        Debug.Assert(TypeSymbol.Equals(lambdaReturnNamedType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T), TypeCompareKind.ConsiderEverything2) OrElse
+                                                     TypeSymbol.Equals(lambdaReturnNamedType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T), TypeCompareKind.ConsiderEverything2) OrElse
+                                                     TypeSymbol.Equals(lambdaReturnNamedType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerator_T), TypeCompareKind.ConsiderEverything2))
 
                                         lambdaReturnType = lambdaReturnNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics)
                                         returnType = returnNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics)
@@ -2274,7 +2271,7 @@ HandleAsAGeneralExpression:
                             param:=param, digThroughToBasesAndImplements:=MatchGenericArgumentToParameter.MatchBaseOfGenericArgumentToParameter,
                             inferenceRestrictions:=RequiredConversion.Any)
 
-                ElseIf parameterType.OriginalDefinition = argument.GetBinderFromLambda().Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T) Then
+                ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything2) Then
                     ' If we've got an Expression(Of T), skip through to T
                     Return InferTypeArgumentsFromLambdaArgument(argument, DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics), param)
                 End If

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
@@ -1177,7 +1177,7 @@ HandleAsAGeneralExpression:
                             AddTypeToGraph(delegateParameter.Type, argNode, isOutgoingEdge:=False, haveSeenTypeParameters:=haveSeenTypeParameters) ' incoming (type->name) edge
                         Next
                     End If
-                ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, binder.Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything2) Then
+                ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, binder.Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything) Then
                     ' If we've got an Expression(Of T), skip through to T
                     AddAddressOfToGraph(DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics), argNode, binder)
                 End If
@@ -1241,7 +1241,7 @@ HandleAsAGeneralExpression:
                         AddTypeToGraph(invoke.ReturnType, argNode, isOutgoingEdge:=True, haveSeenTypeParameters:=haveSeenTypeParameters)
                     End If
 
-                ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, binder.Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything2) Then
+                ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, binder.Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything) Then
                     ' If we've got an Expression(Of T), skip through to T
                     AddLambdaToGraph(DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics), argNode, binder)
                 End If
@@ -2221,9 +2221,9 @@ HandleAsAGeneralExpression:
 
                                         ' We can assume that the lambda will have return type Task(Of T) or IEnumerable(Of T)
                                         ' or IEnumerator(Of T) as appropriate. That's already been ensured by the lambda-interpretation.
-                                        Debug.Assert(TypeSymbol.Equals(lambdaReturnNamedType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T), TypeCompareKind.ConsiderEverything2) OrElse
-                                                     TypeSymbol.Equals(lambdaReturnNamedType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T), TypeCompareKind.ConsiderEverything2) OrElse
-                                                     TypeSymbol.Equals(lambdaReturnNamedType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerator_T), TypeCompareKind.ConsiderEverything2))
+                                        Debug.Assert(TypeSymbol.Equals(lambdaReturnNamedType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T), TypeCompareKind.ConsiderEverything) OrElse
+                                                     TypeSymbol.Equals(lambdaReturnNamedType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T), TypeCompareKind.ConsiderEverything) OrElse
+                                                     TypeSymbol.Equals(lambdaReturnNamedType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerator_T), TypeCompareKind.ConsiderEverything))
 
                                         lambdaReturnType = lambdaReturnNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics)
                                         returnType = returnNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics)
@@ -2271,7 +2271,7 @@ HandleAsAGeneralExpression:
                             param:=param, digThroughToBasesAndImplements:=MatchGenericArgumentToParameter.MatchBaseOfGenericArgumentToParameter,
                             inferenceRestrictions:=RequiredConversion.Any)
 
-                ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything2) Then
+                ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything) Then
                     ' If we've got an Expression(Of T), skip through to T
                     Return InferTypeArgumentsFromLambdaArgument(argument, DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics), param)
                 End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -527,7 +527,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     If IsAcceptableMatchForGetTypeByNameAndArity(candidate) AndAlso
                         Not candidate.IsHiddenByVisualBasicEmbeddedAttribute() AndAlso
                         Not candidate.IsHiddenByCodeAnalysisEmbeddedAttribute() AndAlso
-                        candidate <> result Then
+                        Not TypeSymbol.Equals(candidate, result, TypeCompareKind.ConsiderEverything2) Then
 
                         If (result IsNot Nothing) Then
                             ' Ambiguity

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -527,7 +527,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     If IsAcceptableMatchForGetTypeByNameAndArity(candidate) AndAlso
                         Not candidate.IsHiddenByVisualBasicEmbeddedAttribute() AndAlso
                         Not candidate.IsHiddenByCodeAnalysisEmbeddedAttribute() AndAlso
-                        Not TypeSymbol.Equals(candidate, result, TypeCompareKind.ConsiderEverything2) Then
+                        Not TypeSymbol.Equals(candidate, result, TypeCompareKind.ConsiderEverything) Then
 
                         If (result IsNot Nothing) Then
                             ' Ambiguity

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/SourceAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/SourceAttributeData.vb
@@ -234,7 +234,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 lazySystemType = GetSystemType(targetSymbol)
                             End If
 
-                            foundMatch = parameterType = lazySystemType
+                            foundMatch = TypeSymbol.Equals(parameterType, lazySystemType, TypeCompareKind.ConsiderEverything2)
                             k += 1
 
                         Case CByte(SignatureTypeCode.SZArray)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/SourceAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/SourceAttributeData.vb
@@ -234,7 +234,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 lazySystemType = GetSystemType(targetSymbol)
                             End If
 
-                            foundMatch = TypeSymbol.Equals(parameterType, lazySystemType, TypeCompareKind.ConsiderEverything2)
+                            foundMatch = TypeSymbol.Equals(parameterType, lazySystemType, TypeCompareKind.ConsiderEverything)
                             k += 1
 
                         Case CByte(SignatureTypeCode.SZArray)

--- a/src/Compilers/VisualBasic/Portable/Symbols/BaseTypeAnalysis.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/BaseTypeAnalysis.vb
@@ -188,7 +188,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Function GetDependenceChain(visited As HashSet(Of Symbol),
                                                root As SourceNamedTypeSymbol,
                                                current As TypeSymbol) As ConsList(Of DependencyDesc)
-            Debug.Assert(root.OriginalDefinition = root, "root must not be a substitution")
+            Debug.Assert(TypeSymbol.Equals(root.OriginalDefinition, root, TypeCompareKind.ConsiderEverything2), "root must not be a substitution")
 
             If current Is Nothing OrElse current.Kind = SymbolKind.ErrorType Then
                 Return Nothing

--- a/src/Compilers/VisualBasic/Portable/Symbols/BaseTypeAnalysis.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/BaseTypeAnalysis.vb
@@ -188,7 +188,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Function GetDependenceChain(visited As HashSet(Of Symbol),
                                                root As SourceNamedTypeSymbol,
                                                current As TypeSymbol) As ConsList(Of DependencyDesc)
-            Debug.Assert(TypeSymbol.Equals(root.OriginalDefinition, root, TypeCompareKind.ConsiderEverything2), "root must not be a substitution")
+            Debug.Assert(TypeSymbol.Equals(root.OriginalDefinition, root, TypeCompareKind.ConsiderEverything), "root must not be a substitution")
 
             If current Is Nothing OrElse current.Kind = SymbolKind.ErrorType Then
                 Return Nothing

--- a/src/Compilers/VisualBasic/Portable/Symbols/ConstraintsHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ConstraintsHelper.vb
@@ -1105,7 +1105,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return False
             End If
 
-            Debug.Assert(type.ConstructedFrom <> type)
+            Debug.Assert(Not TypeSymbol.Equals(type.ConstructedFrom, type, TypeCompareKind.ConsiderEverything2))
             Return True
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ConstraintsHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ConstraintsHelper.vb
@@ -1105,7 +1105,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return False
             End If
 
-            Debug.Assert(Not TypeSymbol.Equals(type.ConstructedFrom, type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(Not TypeSymbol.Equals(type.ConstructedFrom, type, TypeCompareKind.ConsiderEverything))
             Return True
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
@@ -338,7 +338,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return True
             End If
 
-            Return Me.ContainingType = other.ContainingType AndAlso Me.OriginalDefinition Is other.OriginalDefinition
+            Return TypeSymbol.Equals(Me.ContainingType, other.ContainingType, TypeCompareKind.ConsiderEverything2) AndAlso Me.OriginalDefinition Is other.OriginalDefinition
         End Function
 
         Public Overrides Function GetHashCode() As Integer

--- a/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
@@ -338,7 +338,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return True
             End If
 
-            Return TypeSymbol.Equals(Me.ContainingType, other.ContainingType, TypeCompareKind.ConsiderEverything2) AndAlso Me.OriginalDefinition Is other.OriginalDefinition
+            Return TypeSymbol.Equals(Me.ContainingType, other.ContainingType, TypeCompareKind.ConsiderEverything) AndAlso Me.OriginalDefinition Is other.OriginalDefinition
         End Function
 
         Public Overrides Function GetHashCode() As Integer

--- a/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
@@ -389,7 +389,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Function AsMember(newOwner As NamedTypeSymbol) As FieldSymbol
             Debug.Assert(Me Is Me.OriginalDefinition)
             Debug.Assert(newOwner.OriginalDefinition Is Me.ContainingSymbol.OriginalDefinition)
-            Return If(TypeSymbol.Equals(newOwner, DirectCast(Me.ContainingSymbol, TypeSymbol), TypeCompareKind.ConsiderEverything),
+            Return If(TypeSymbol.Equals(newOwner, Me.ContainingType, TypeCompareKind.ConsiderEverything),
                 Me,
                 DirectCast(DirectCast(newOwner, SubstitutedNamedType).GetMemberForDefinition(Me), FieldSymbol))
         End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
@@ -389,7 +389,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Function AsMember(newOwner As NamedTypeSymbol) As FieldSymbol
             Debug.Assert(Me Is Me.OriginalDefinition)
             Debug.Assert(newOwner.OriginalDefinition Is Me.ContainingSymbol.OriginalDefinition)
-            Return If(newOwner = Me.ContainingSymbol, Me, DirectCast(DirectCast(newOwner, SubstitutedNamedType).GetMemberForDefinition(Me), FieldSymbol))
+            Return If(TypeSymbol.Equals(newOwner, DirectCast(Me.ContainingSymbol, TypeSymbol), TypeCompareKind.ConsiderEverything2),
+                Me,
+                DirectCast(DirectCast(newOwner, SubstitutedNamedType).GetMemberForDefinition(Me), FieldSymbol))
         End Function
 
 #Region "IFieldSymbol"

--- a/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
@@ -389,7 +389,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Function AsMember(newOwner As NamedTypeSymbol) As FieldSymbol
             Debug.Assert(Me Is Me.OriginalDefinition)
             Debug.Assert(newOwner.OriginalDefinition Is Me.ContainingSymbol.OriginalDefinition)
-            Return If(TypeSymbol.Equals(newOwner, DirectCast(Me.ContainingSymbol, TypeSymbol), TypeCompareKind.ConsiderEverything2),
+            Return If(TypeSymbol.Equals(newOwner, DirectCast(Me.ContainingSymbol, TypeSymbol), TypeCompareKind.ConsiderEverything),
                 Me,
                 DirectCast(DirectCast(newOwner, SubstitutedNamedType).GetMemberForDefinition(Me), FieldSymbol))
         End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MemberRefMetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MemberRefMetadataDecoder.vb
@@ -148,7 +148,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             For Each member In targetTypeSymbol.GetMembers(targetMemberName)
                 Dim field = TryCast(member, FieldSymbol)
                 If field IsNot Nothing AndAlso
-                   field.Type = type AndAlso
+                   TypeSymbol.Equals(field.Type, type, TypeCompareKind.ConsiderEverything2) AndAlso
                    CustomModifiersMatch(field.CustomModifiers, customModifiers) Then
 
                     ' Behavior in the face of multiple matching signatures is
@@ -214,7 +214,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End If
 
             'CONSIDER: Do we want to add special handling for error types?  Right now, we expect they'll just fail to match.
-            If candidateParam.Type <> targetParam.Type Then
+            If Not TypeSymbol.Equals(candidateParam.Type, targetParam.Type, TypeCompareKind.ConsiderEverything2) Then
                 Return False
             End If
 
@@ -231,7 +231,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Dim targetReturnType As TypeSymbol = targetReturnParam.Type
 
             ' No special handling for error types.  Right now, we expect they'll just fail to match.
-            If candidateReturnType <> targetReturnType OrElse candidateMethod.ReturnsByRef <> targetReturnParam.IsByRef Then
+            If Not TypeSymbol.Equals(candidateReturnType, targetReturnType, TypeCompareKind.ConsiderEverything2) OrElse candidateMethod.ReturnsByRef <> targetReturnParam.IsByRef Then
                 Return False
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MemberRefMetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MemberRefMetadataDecoder.vb
@@ -148,7 +148,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             For Each member In targetTypeSymbol.GetMembers(targetMemberName)
                 Dim field = TryCast(member, FieldSymbol)
                 If field IsNot Nothing AndAlso
-                   TypeSymbol.Equals(field.Type, type, TypeCompareKind.ConsiderEverything2) AndAlso
+                   TypeSymbol.Equals(field.Type, type, TypeCompareKind.ConsiderEverything) AndAlso
                    CustomModifiersMatch(field.CustomModifiers, customModifiers) Then
 
                     ' Behavior in the face of multiple matching signatures is
@@ -214,7 +214,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End If
 
             'CONSIDER: Do we want to add special handling for error types?  Right now, we expect they'll just fail to match.
-            If Not TypeSymbol.Equals(candidateParam.Type, targetParam.Type, TypeCompareKind.ConsiderEverything2) Then
+            If Not TypeSymbol.Equals(candidateParam.Type, targetParam.Type, TypeCompareKind.ConsiderEverything) Then
                 Return False
             End If
 
@@ -231,7 +231,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Dim targetReturnType As TypeSymbol = targetReturnParam.Type
 
             ' No special handling for error types.  Right now, we expect they'll just fail to match.
-            If Not TypeSymbol.Equals(candidateReturnType, targetReturnType, TypeCompareKind.ConsiderEverything2) OrElse candidateMethod.ReturnsByRef <> targetReturnParam.IsByRef Then
+            If Not TypeSymbol.Equals(candidateReturnType, targetReturnType, TypeCompareKind.ConsiderEverything) OrElse candidateMethod.ReturnsByRef <> targetReturnParam.IsByRef Then
                 Return False
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -446,7 +446,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
             Debug.Assert(Not targetTypeSymbol.IsTupleType)
 
-            If scope IsNot Nothing AndAlso Not TypeSymbol.Equals(targetTypeSymbol, scope, TypeCompareKind.ConsiderEverything2) AndAlso Not targetTypeSymbol.IsBaseTypeOrInterfaceOf(scope, Nothing) Then
+            If scope IsNot Nothing AndAlso Not TypeSymbol.Equals(targetTypeSymbol, scope, TypeCompareKind.ConsiderEverything) AndAlso Not targetTypeSymbol.IsBaseTypeOrInterfaceOf(scope, Nothing) Then
                 Return Nothing
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -446,7 +446,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
             Debug.Assert(Not targetTypeSymbol.IsTupleType)
 
-            If scope IsNot Nothing AndAlso targetTypeSymbol <> scope AndAlso Not targetTypeSymbol.IsBaseTypeOrInterfaceOf(scope, Nothing) Then
+            If scope IsNot Nothing AndAlso Not TypeSymbol.Equals(targetTypeSymbol, scope, TypeCompareKind.ConsiderEverything2) AndAlso Not targetTypeSymbol.IsBaseTypeOrInterfaceOf(scope, Nothing) Then
                 Return Nothing
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEEventSymbol.vb
@@ -103,10 +103,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 ' and the remove method takes an EventRegistrationToken
                 ' as a parameter.
                 Return _
-                    _addMethod.ReturnType = evt AndAlso
+                    TypeSymbol.Equals(_addMethod.ReturnType, evt, TypeCompareKind.ConsiderEverything2) AndAlso
                     _addMethod.ParameterCount = 1 AndAlso
                     _removeMethod.ParameterCount = 1 AndAlso
-                    _removeMethod.Parameters(0).Type = evt
+                    TypeSymbol.Equals(_removeMethod.Parameters(0).Type, evt, TypeCompareKind.ConsiderEverything2)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEEventSymbol.vb
@@ -103,10 +103,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 ' and the remove method takes an EventRegistrationToken
                 ' as a parameter.
                 Return _
-                    TypeSymbol.Equals(_addMethod.ReturnType, evt, TypeCompareKind.ConsiderEverything2) AndAlso
+                    TypeSymbol.Equals(_addMethod.ReturnType, evt, TypeCompareKind.ConsiderEverything) AndAlso
                     _addMethod.ParameterCount = 1 AndAlso
                     _removeMethod.ParameterCount = 1 AndAlso
-                    TypeSymbol.Equals(_removeMethod.Parameters(0).Type, evt, TypeCompareKind.ConsiderEverything2)
+                    TypeSymbol.Equals(_removeMethod.Parameters(0).Type, evt, TypeCompareKind.ConsiderEverything)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
@@ -914,7 +914,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Private Function SetAssociatedPropertyOrEvent(propertyOrEventSymbol As Symbol, methodKind As MethodKind) As Boolean
             If Me._associatedPropertyOrEventOpt Is Nothing Then
-                Debug.Assert(propertyOrEventSymbol.ContainingType = Me.ContainingType)
+                Debug.Assert(TypeSymbol.Equals(propertyOrEventSymbol.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything2))
                 Me._associatedPropertyOrEventOpt = propertyOrEventSymbol
                 _packedFlags.MethodKind = methodKind
                 Return True

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
@@ -914,7 +914,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Private Function SetAssociatedPropertyOrEvent(propertyOrEventSymbol As Symbol, methodKind As MethodKind) As Boolean
             If Me._associatedPropertyOrEventOpt Is Nothing Then
-                Debug.Assert(TypeSymbol.Equals(propertyOrEventSymbol.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(propertyOrEventSymbol.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything))
                 Me._associatedPropertyOrEventOpt = propertyOrEventSymbol
                 _packedFlags.MethodKind = methodKind
                 Return True

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -1283,11 +1283,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Do
                         levelsOfNesting += 1
                         typeToCheck = DirectCast(typeToCheck, NamedTypeSymbol).TypeArgumentsNoUseSiteDiagnostics(TupleTypeSymbol.RestPosition - 1)
-                    Loop While typeToCheck.OriginalDefinition = Me.OriginalDefinition AndAlso Not typeToCheck.IsDefinition
+                    Loop While TypeSymbol.Equals(typeToCheck.OriginalDefinition, Me.OriginalDefinition, TypeCompareKind.ConsiderEverything2) AndAlso Not typeToCheck.IsDefinition
 
                     If typeToCheck.IsTupleType Then
                         Dim underlying = typeToCheck.TupleUnderlyingType
-                        If underlying.Arity = TupleTypeSymbol.RestPosition AndAlso underlying.OriginalDefinition <> Me.OriginalDefinition Then
+                        If underlying.Arity = TupleTypeSymbol.RestPosition AndAlso Not TypeSymbol.Equals(underlying.OriginalDefinition, Me.OriginalDefinition, TypeCompareKind.ConsiderEverything2) Then
                             tupleCardinality = 0
                             Return False
                         End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -1283,11 +1283,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Do
                         levelsOfNesting += 1
                         typeToCheck = DirectCast(typeToCheck, NamedTypeSymbol).TypeArgumentsNoUseSiteDiagnostics(TupleTypeSymbol.RestPosition - 1)
-                    Loop While TypeSymbol.Equals(typeToCheck.OriginalDefinition, Me.OriginalDefinition, TypeCompareKind.ConsiderEverything2) AndAlso Not typeToCheck.IsDefinition
+                    Loop While TypeSymbol.Equals(typeToCheck.OriginalDefinition, Me.OriginalDefinition, TypeCompareKind.ConsiderEverything) AndAlso Not typeToCheck.IsDefinition
 
                     If typeToCheck.IsTupleType Then
                         Dim underlying = typeToCheck.TupleUnderlyingType
-                        If underlying.Arity = TupleTypeSymbol.RestPosition AndAlso Not TypeSymbol.Equals(underlying.OriginalDefinition, Me.OriginalDefinition, TypeCompareKind.ConsiderEverything2) Then
+                        If underlying.Arity = TupleTypeSymbol.RestPosition AndAlso Not TypeSymbol.Equals(underlying.OriginalDefinition, Me.OriginalDefinition, TypeCompareKind.ConsiderEverything) Then
                             tupleCardinality = 0
                             Return False
                         End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/OverriddenMembersResult.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/OverriddenMembersResult.vb
@@ -89,8 +89,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim overriddenByDefinitionContainingTypeDefinition As NamedTypeSymbol = overriddenByDefinitionContaining.OriginalDefinition
                 Dim baseType As NamedTypeSymbol = substitutedOverridingMember.ContainingType.BaseTypeNoUseSiteDiagnostics
                 While baseType IsNot Nothing
-                    If baseType.OriginalDefinition = overriddenByDefinitionContainingTypeDefinition Then
-                        If baseType = overriddenByDefinitionContaining Then
+                    If TypeSymbol.Equals(baseType.OriginalDefinition, overriddenByDefinitionContainingTypeDefinition, TypeCompareKind.ConsiderEverything2) Then
+                        If TypeSymbol.Equals(baseType, overriddenByDefinitionContaining, TypeCompareKind.ConsiderEverything2) Then
                             Return overriddenByDefinitionMember
                         End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/OverriddenMembersResult.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/OverriddenMembersResult.vb
@@ -89,8 +89,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim overriddenByDefinitionContainingTypeDefinition As NamedTypeSymbol = overriddenByDefinitionContaining.OriginalDefinition
                 Dim baseType As NamedTypeSymbol = substitutedOverridingMember.ContainingType.BaseTypeNoUseSiteDiagnostics
                 While baseType IsNot Nothing
-                    If TypeSymbol.Equals(baseType.OriginalDefinition, overriddenByDefinitionContainingTypeDefinition, TypeCompareKind.ConsiderEverything2) Then
-                        If TypeSymbol.Equals(baseType, overriddenByDefinitionContaining, TypeCompareKind.ConsiderEverything2) Then
+                    If TypeSymbol.Equals(baseType.OriginalDefinition, overriddenByDefinitionContainingTypeDefinition, TypeCompareKind.ConsiderEverything) Then
+                        If TypeSymbol.Equals(baseType, overriddenByDefinitionContaining, TypeCompareKind.ConsiderEverything) Then
                             Return overriddenByDefinitionMember
                         End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
@@ -155,7 +155,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Return sourceProperty IsNot Nothing AndAlso
                 sourceProperty.IsAutoProperty AndAlso
-                sourceProperty.ContainingType = fromMember.ContainingType AndAlso
+                TypeSymbol.Equals(sourceProperty.ContainingType, fromMember.ContainingType, TypeCompareKind.ConsiderEverything2) AndAlso
                 propertyIsStatic = fromMember.IsShared AndAlso
                 (propertyIsStatic OrElse receiver.Kind = BoundKind.MeReference) AndAlso
                 ((fromMember.Kind = SymbolKind.Method AndAlso DirectCast(fromMember, MethodSymbol).IsAnyConstructor) OrElse

--- a/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
@@ -155,7 +155,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Return sourceProperty IsNot Nothing AndAlso
                 sourceProperty.IsAutoProperty AndAlso
-                TypeSymbol.Equals(sourceProperty.ContainingType, fromMember.ContainingType, TypeCompareKind.ConsiderEverything2) AndAlso
+                TypeSymbol.Equals(sourceProperty.ContainingType, fromMember.ContainingType, TypeCompareKind.ConsiderEverything) AndAlso
                 propertyIsStatic = fromMember.IsShared AndAlso
                 (propertyIsStatic OrElse receiver.Kind = BoundKind.MeReference) AndAlso
                 ((fromMember.Kind = SymbolKind.Method AndAlso DirectCast(fromMember, MethodSymbol).IsAnyConstructor) OrElse

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReducedExtensionMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReducedExtensionMethodSymbol.vb
@@ -253,7 +253,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             For Each pair As KeyValuePair(Of TypeParameterSymbol, TypeSymbol) In _fixedTypeParameters
-                If pair.Key = reducedFromTypeParameter Then
+                If TypeSymbol.Equals(pair.Key, reducedFromTypeParameter, TypeCompareKind.ConsiderEverything2) Then
                     Return pair.Value
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReducedExtensionMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReducedExtensionMethodSymbol.vb
@@ -253,7 +253,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             For Each pair As KeyValuePair(Of TypeParameterSymbol, TypeSymbol) In _fixedTypeParameters
-                If TypeSymbol.Equals(pair.Key, reducedFromTypeParameter, TypeCompareKind.ConsiderEverything2) Then
+                If TypeSymbol.Equals(pair.Key, reducedFromTypeParameter, TypeCompareKind.ConsiderEverything) Then
                     Return pair.Value
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
@@ -449,7 +449,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
                     Dim newArg = New TypeWithModifiers(DirectCast(arg.Type.Accept(Me, RetargetOptions.RetargetPrimitiveTypesByTypeCode), TypeSymbol),
                                                        RetargetModifiers(arg.CustomModifiers, modifiersHaveChanged))
 
-                    If Not anythingRetargeted AndAlso (modifiersHaveChanged OrElse newArg.Type <> arg.Type) Then
+                    If Not anythingRetargeted AndAlso (modifiersHaveChanged OrElse Not TypeSymbol.Equals(newArg.Type, arg.Type, TypeCompareKind.ConsiderEverything2)) Then
                         anythingRetargeted = True
                     End If
 
@@ -1022,7 +1022,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
                     If retargetedMember.Kind = SymbolKind.Event Then
                         Dim retargetedEvent = DirectCast(retargetedMember, EventSymbol)
 
-                        If retargetedEvent.Type = retargetedEventType Then
+                        If TypeSymbol.Equals(retargetedEvent.Type, retargetedEventType, TypeCompareKind.ConsiderEverything2) Then
                             Return retargetedEvent
                         End If
                     End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
@@ -449,7 +449,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
                     Dim newArg = New TypeWithModifiers(DirectCast(arg.Type.Accept(Me, RetargetOptions.RetargetPrimitiveTypesByTypeCode), TypeSymbol),
                                                        RetargetModifiers(arg.CustomModifiers, modifiersHaveChanged))
 
-                    If Not anythingRetargeted AndAlso (modifiersHaveChanged OrElse Not TypeSymbol.Equals(newArg.Type, arg.Type, TypeCompareKind.ConsiderEverything2)) Then
+                    If Not anythingRetargeted AndAlso (modifiersHaveChanged OrElse Not TypeSymbol.Equals(newArg.Type, arg.Type, TypeCompareKind.ConsiderEverything)) Then
                         anythingRetargeted = True
                     End If
 
@@ -1022,7 +1022,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
                     If retargetedMember.Kind = SymbolKind.Event Then
                         Dim retargetedEvent = DirectCast(retargetedMember, EventSymbol)
 
-                        If TypeSymbol.Equals(retargetedEvent.Type, retargetedEventType, TypeCompareKind.ConsiderEverything2) Then
+                        If TypeSymbol.Equals(retargetedEvent.Type, retargetedEventType, TypeCompareKind.ConsiderEverything) Then
                             Return retargetedEvent
                         End If
                     End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
@@ -210,7 +210,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Debug.Assert(parameterType IsNot Nothing)
 
                     If Me.MethodKind = MethodKind.EventAdd Then
-                        If Not eventType.IsErrorType AndAlso eventType <> parameterType Then
+                        If Not eventType.IsErrorType AndAlso Not TypeSymbol.Equals(eventType, parameterType, TypeCompareKind.ConsiderEverything2) Then
                             Dim errid As ERRID = If(_event.IsWindowsRuntimeEvent, ERRID.ERR_AddParamWrongForWinRT, ERRID.ERR_AddRemoveParamNotEventType)
                             diagnostics.Add(errid, location)
                         End If
@@ -223,18 +223,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 binder.Compilation.GetWellKnownType(WellKnownType.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationToken)
 
                             Dim firstImplementedEvent As EventSymbol = _event.ExplicitInterfaceImplementations(0)
-                            If Not registrationTokenType.IsErrorType AndAlso firstImplementedEvent.IsWindowsRuntimeEvent <> (parameterType = registrationTokenType) Then
+                            If Not registrationTokenType.IsErrorType AndAlso firstImplementedEvent.IsWindowsRuntimeEvent <> (TypeSymbol.Equals(parameterType, registrationTokenType, TypeCompareKind.ConsiderEverything2)) Then
                                 diagnostics.Add(ERRID.ERR_EventImplRemoveHandlerParamWrong, location, _event.Name, firstImplementedEvent.Name, firstImplementedEvent.ContainingType)
                             End If
                         ElseIf _event.IsWindowsRuntimeEvent Then
                             ' Reporting diagnostics when this type is missing will only ever result in cascading, so don't bother.
                             Dim registrationTokenType As NamedTypeSymbol =
                                 binder.Compilation.GetWellKnownType(WellKnownType.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationToken)
-                            If Not registrationTokenType.IsErrorType AndAlso parameterType <> registrationTokenType Then
+                            If Not registrationTokenType.IsErrorType AndAlso Not TypeSymbol.Equals(parameterType, registrationTokenType, TypeCompareKind.ConsiderEverything2) Then
                                 diagnostics.Add(ERRID.ERR_RemoveParamWrongForWinRT, location)
                             End If
                         Else
-                            If Not eventType.IsErrorType AndAlso eventType <> parameterType Then
+                            If Not eventType.IsErrorType AndAlso Not TypeSymbol.Equals(eventType, parameterType, TypeCompareKind.ConsiderEverything2) Then
                                 diagnostics.Add(ERRID.ERR_AddRemoveParamNotEventType, location)
                             End If
                         End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
@@ -210,7 +210,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Debug.Assert(parameterType IsNot Nothing)
 
                     If Me.MethodKind = MethodKind.EventAdd Then
-                        If Not eventType.IsErrorType AndAlso Not TypeSymbol.Equals(eventType, parameterType, TypeCompareKind.ConsiderEverything2) Then
+                        If Not eventType.IsErrorType AndAlso Not TypeSymbol.Equals(eventType, parameterType, TypeCompareKind.ConsiderEverything) Then
                             Dim errid As ERRID = If(_event.IsWindowsRuntimeEvent, ERRID.ERR_AddParamWrongForWinRT, ERRID.ERR_AddRemoveParamNotEventType)
                             diagnostics.Add(errid, location)
                         End If
@@ -223,18 +223,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 binder.Compilation.GetWellKnownType(WellKnownType.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationToken)
 
                             Dim firstImplementedEvent As EventSymbol = _event.ExplicitInterfaceImplementations(0)
-                            If Not registrationTokenType.IsErrorType AndAlso firstImplementedEvent.IsWindowsRuntimeEvent <> (TypeSymbol.Equals(parameterType, registrationTokenType, TypeCompareKind.ConsiderEverything2)) Then
+                            If Not registrationTokenType.IsErrorType AndAlso firstImplementedEvent.IsWindowsRuntimeEvent <> (TypeSymbol.Equals(parameterType, registrationTokenType, TypeCompareKind.ConsiderEverything)) Then
                                 diagnostics.Add(ERRID.ERR_EventImplRemoveHandlerParamWrong, location, _event.Name, firstImplementedEvent.Name, firstImplementedEvent.ContainingType)
                             End If
                         ElseIf _event.IsWindowsRuntimeEvent Then
                             ' Reporting diagnostics when this type is missing will only ever result in cascading, so don't bother.
                             Dim registrationTokenType As NamedTypeSymbol =
                                 binder.Compilation.GetWellKnownType(WellKnownType.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationToken)
-                            If Not registrationTokenType.IsErrorType AndAlso Not TypeSymbol.Equals(parameterType, registrationTokenType, TypeCompareKind.ConsiderEverything2) Then
+                            If Not registrationTokenType.IsErrorType AndAlso Not TypeSymbol.Equals(parameterType, registrationTokenType, TypeCompareKind.ConsiderEverything) Then
                                 diagnostics.Add(ERRID.ERR_RemoveParamWrongForWinRT, location)
                             End If
                         Else
-                            If Not eventType.IsErrorType AndAlso Not TypeSymbol.Equals(eventType, parameterType, TypeCompareKind.ConsiderEverything2) Then
+                            If Not eventType.IsErrorType AndAlso Not TypeSymbol.Equals(eventType, parameterType, TypeCompareKind.ConsiderEverything) Then
                                 diagnostics.Add(ERRID.ERR_AddRemoveParamNotEventType, location)
                             End If
                         End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
@@ -287,7 +287,7 @@ Next_i:
                                     Continue For ' has been eliminated already
                                 End If
 
-                                If TypeSymbol.Equals(first.ContainingType, second.ContainingType, TypeCompareKind.ConsiderEverything2) Then
+                                If TypeSymbol.Equals(first.ContainingType, second.ContainingType, TypeCompareKind.ConsiderEverything) Then
                                     ' type substitution can create two methods with same signature in the same type
                                     ' report ambiguity
                                     Binder.ReportDiagnostic(diagBag, implementedMemberSyntax, ERRID.ERR_AmbiguousImplements3,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
@@ -287,7 +287,7 @@ Next_i:
                                     Continue For ' has been eliminated already
                                 End If
 
-                                If first.ContainingType = second.ContainingType Then
+                                If TypeSymbol.Equals(first.ContainingType, second.ContainingType, TypeCompareKind.ConsiderEverything2) Then
                                     ' type substitution can create two methods with same signature in the same type
                                     ' report ambiguity
                                     Binder.ReportDiagnostic(diagBag, implementedMemberSyntax, ERRID.ERR_AmbiguousImplements3,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
@@ -826,7 +826,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim memberContainingType As NamedTypeSymbol = member.ContainingType
             For i = 0 To builder.Count - 1
                 Dim exactMatchIgnoringCustomModifiers As Boolean = False
-                If builder(i).ContainingType <> memberContainingType AndAlso
+                If Not TypeSymbol.Equals(builder(i).ContainingType, memberContainingType, TypeCompareKind.ConsiderEverything2) AndAlso
                         SignaturesMatch(builder(i), member, Nothing, exactMatchIgnoringCustomModifiers) AndAlso exactMatchIgnoringCustomModifiers Then
                     ' Do NOT add
                     Exit Sub
@@ -955,7 +955,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                         ' Two original definitions with identical signatures in same containing types are compared by accessibility, and
                         ' more accessible wins.
-                        If originalSym.ContainingType = originalOther.ContainingType AndAlso
+                        If TypeSymbol.Equals(originalSym.ContainingType, originalOther.ContainingType, TypeCompareKind.ConsiderEverything2) AndAlso
                            DetailedSignatureCompare(originalSym, originalOther, significantDifferences) = 0 AndAlso
                            LookupResult.CompareAccessibilityOfSymbolsConflictingInSameContainer(originalSym, originalOther) < 0 Then
                             ' sym is worse than otherSym

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
@@ -826,7 +826,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim memberContainingType As NamedTypeSymbol = member.ContainingType
             For i = 0 To builder.Count - 1
                 Dim exactMatchIgnoringCustomModifiers As Boolean = False
-                If Not TypeSymbol.Equals(builder(i).ContainingType, memberContainingType, TypeCompareKind.ConsiderEverything2) AndAlso
+                If Not TypeSymbol.Equals(builder(i).ContainingType, memberContainingType, TypeCompareKind.ConsiderEverything) AndAlso
                         SignaturesMatch(builder(i), member, Nothing, exactMatchIgnoringCustomModifiers) AndAlso exactMatchIgnoringCustomModifiers Then
                     ' Do NOT add
                     Exit Sub
@@ -955,7 +955,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                         ' Two original definitions with identical signatures in same containing types are compared by accessibility, and
                         ' more accessible wins.
-                        If TypeSymbol.Equals(originalSym.ContainingType, originalOther.ContainingType, TypeCompareKind.ConsiderEverything2) AndAlso
+                        If TypeSymbol.Equals(originalSym.ContainingType, originalOther.ContainingType, TypeCompareKind.ConsiderEverything) AndAlso
                            DetailedSignatureCompare(originalSym, originalOther, significantDifferences) = 0 AndAlso
                            LookupResult.CompareAccessibilityOfSymbolsConflictingInSameContainer(originalSym, originalOther) < 0 Then
                             ' sym is worse than otherSym

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -234,7 +234,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Else
                 ' Duplicate attributes with same attribute type are not allowed.
                 ' Check if there is an existing assembly attribute with same attribute type.
-                If uniqueAttributes Is Nothing OrElse Not uniqueAttributes.Contains(Function(a) a.AttributeClass = attributeClass) Then
+                If uniqueAttributes Is Nothing OrElse Not uniqueAttributes.Contains(Function(a) TypeSymbol.Equals(a.AttributeClass, attributeClass, TypeCompareKind.ConsiderEverything2)) Then
                     ' Attribute with unique attribute type, not a duplicate.
                     Dim success As Boolean = AddUniqueAssemblyAttribute(attribute, uniqueAttributes)
                     Debug.Assert(success)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -234,7 +234,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Else
                 ' Duplicate attributes with same attribute type are not allowed.
                 ' Check if there is an existing assembly attribute with same attribute type.
-                If uniqueAttributes Is Nothing OrElse Not uniqueAttributes.Contains(Function(a) TypeSymbol.Equals(a.AttributeClass, attributeClass, TypeCompareKind.ConsiderEverything2)) Then
+                If uniqueAttributes Is Nothing OrElse Not uniqueAttributes.Contains(Function(a) TypeSymbol.Equals(a.AttributeClass, attributeClass, TypeCompareKind.ConsiderEverything)) Then
                     ' Attribute with unique attribute type, not a duplicate.
                     Dim success As Boolean = AddUniqueAssemblyAttribute(attribute, uniqueAttributes)
                     Debug.Assert(success)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -492,7 +492,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             directInterface = Nothing
 
             For Each iface In Me.InterfacesNoUseSiteDiagnostics
-                If TypeSymbol.Equals(iface, implementedInterface, TypeCompareKind.ConsiderEverything2) Then
+                If TypeSymbol.Equals(iface, implementedInterface, TypeCompareKind.ConsiderEverything) Then
                     directInterface = iface
                     Exit For
                 ElseIf directInterface Is Nothing AndAlso iface.ImplementsInterface(implementedInterface, comparer:=Nothing, useSiteDiagnostics:=Nothing) Then
@@ -2990,7 +2990,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             If definedTypes.Length > 0 Then
                 Dim type = definedTypes(0)
-                If Not Equals(TryCast(sym, TypeSymbol), type, TypeCompareKind.ConsiderEverything2) Then
+                If Not Equals(TryCast(sym, TypeSymbol), type, TypeCompareKind.ConsiderEverything) Then
                     Return CheckIfMemberNameIsDuplicate(sym, type, members, diagBag, includeKind:=True)
                 End If
             End If
@@ -3797,7 +3797,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         Dim i2 As Integer = 0
                         For Each interface2 In kvp.Value
                             If i2 > i1 Then
-                                Debug.Assert(interface2.IsGenericType AndAlso TypeSymbol.Equals(interface1.OriginalDefinition, interface2.OriginalDefinition, TypeCompareKind.ConsiderEverything2))
+                                Debug.Assert(interface2.IsGenericType AndAlso TypeSymbol.Equals(interface1.OriginalDefinition, interface2.OriginalDefinition, TypeCompareKind.ConsiderEverything))
 
                                 ' Check for interface unification, then variance ambiguity
                                 If TypeUnification.CanUnify(Me, interface1, interface2) Then
@@ -3886,22 +3886,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim isInterface As Boolean = Me.IsInterfaceType()
             Dim diag As DiagnosticInfo
 
-            If (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
+            If (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything)) Then
                 diag = ErrorFactory.ErrorInfo(If(isInterface, ERRID.ERR_InterfaceUnifiesWithInterface2, ERRID.ERR_InterfacePossiblyImplTwice2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1))
-            ElseIf (Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
+            ElseIf (Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything)) Then
                 diag = ErrorFactory.ErrorInfo(If(isInterface, ERRID.ERR_InterfaceUnifiesWithBase3, ERRID.ERR_ClassInheritsInterfaceUnifiesWithBase3),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface1))
-            ElseIf (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
+            ElseIf (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything)) Then
                 diag = ErrorFactory.ErrorInfo(If(isInterface, ERRID.ERR_BaseUnifiesWithInterfaces3, ERRID.ERR_ClassInheritsBaseUnifiesWithInterfaces3),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1))
             Else
-                Debug.Assert(Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything))
                 diag = ErrorFactory.ErrorInfo(If(isInterface, ERRID.ERR_InterfaceBaseUnifiesWithBase4, ERRID.ERR_ClassInheritsInterfaceBaseUnifiesWithBase4),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
@@ -3965,22 +3965,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Dim diag As DiagnosticInfo
 
-            If (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
+            If (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything)) Then
                 diag = ErrorFactory.ErrorInfo(If(IsInterface, ERRID.ERR_InterfaceInheritedTwiceWithDifferentTupleNames2, ERRID.ERR_InterfaceImplementedTwiceWithDifferentTupleNames2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1))
-            ElseIf (Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
+            ElseIf (Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything)) Then
                 diag = ErrorFactory.ErrorInfo(If(IsInterface, ERRID.ERR_InterfaceInheritedTwiceWithDifferentTupleNames3, ERRID.ERR_InterfaceImplementedTwiceWithDifferentTupleNames3),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface1))
-            ElseIf (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
+            ElseIf (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything)) Then
                 diag = ErrorFactory.ErrorInfo(If(IsInterface, ERRID.ERR_InterfaceInheritedTwiceWithDifferentTupleNamesReverse3, ERRID.ERR_InterfaceImplementedTwiceWithDifferentTupleNamesReverse3),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1))
             Else
-                Debug.Assert(Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything))
                 diag = ErrorFactory.ErrorInfo(If(IsInterface, ERRID.ERR_InterfaceInheritedTwiceWithDifferentTupleNames4, ERRID.ERR_InterfaceImplementedTwiceWithDifferentTupleNames4),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface2),

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -492,7 +492,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             directInterface = Nothing
 
             For Each iface In Me.InterfacesNoUseSiteDiagnostics
-                If iface = implementedInterface Then
+                If TypeSymbol.Equals(iface, implementedInterface, TypeCompareKind.ConsiderEverything2) Then
                     directInterface = iface
                     Exit For
                 ElseIf directInterface Is Nothing AndAlso iface.ImplementsInterface(implementedInterface, comparer:=Nothing, useSiteDiagnostics:=Nothing) Then
@@ -3797,7 +3797,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         Dim i2 As Integer = 0
                         For Each interface2 In kvp.Value
                             If i2 > i1 Then
-                                Debug.Assert(interface2.IsGenericType AndAlso interface1.OriginalDefinition = interface2.OriginalDefinition)
+                                Debug.Assert(interface2.IsGenericType AndAlso TypeSymbol.Equals(interface1.OriginalDefinition, interface2.OriginalDefinition, TypeCompareKind.ConsiderEverything2))
 
                                 ' Check for interface unification, then variance ambiguity
                                 If TypeUnification.CanUnify(Me, interface1, interface2) Then
@@ -3886,22 +3886,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim isInterface As Boolean = Me.IsInterfaceType()
             Dim diag As DiagnosticInfo
 
-            If (directInterface1 = interface1 AndAlso directInterface2 = interface2) Then
+            If (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
                 diag = ErrorFactory.ErrorInfo(If(isInterface, ERRID.ERR_InterfaceUnifiesWithInterface2, ERRID.ERR_InterfacePossiblyImplTwice2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1))
-            ElseIf (directInterface1 <> interface1 AndAlso directInterface2 = interface2) Then
+            ElseIf (Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
                 diag = ErrorFactory.ErrorInfo(If(isInterface, ERRID.ERR_InterfaceUnifiesWithBase3, ERRID.ERR_ClassInheritsInterfaceUnifiesWithBase3),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface1))
-            ElseIf (directInterface1 = interface1 AndAlso directInterface2 <> interface2) Then
+            ElseIf (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
                 diag = ErrorFactory.ErrorInfo(If(isInterface, ERRID.ERR_BaseUnifiesWithInterfaces3, ERRID.ERR_ClassInheritsBaseUnifiesWithInterfaces3),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1))
             Else
-                Debug.Assert(directInterface1 <> interface1 AndAlso directInterface2 <> interface2)
+                Debug.Assert(Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2))
                 diag = ErrorFactory.ErrorInfo(If(isInterface, ERRID.ERR_InterfaceBaseUnifiesWithBase4, ERRID.ERR_ClassInheritsInterfaceBaseUnifiesWithBase4),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
@@ -3965,22 +3965,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Dim diag As DiagnosticInfo
 
-            If (directInterface1 = interface1 AndAlso directInterface2 = interface2) Then
+            If (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
                 diag = ErrorFactory.ErrorInfo(If(IsInterface, ERRID.ERR_InterfaceInheritedTwiceWithDifferentTupleNames2, ERRID.ERR_InterfaceImplementedTwiceWithDifferentTupleNames2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1))
-            ElseIf (directInterface1 <> interface1 AndAlso directInterface2 = interface2) Then
+            ElseIf (Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
                 diag = ErrorFactory.ErrorInfo(If(IsInterface, ERRID.ERR_InterfaceInheritedTwiceWithDifferentTupleNames3, ERRID.ERR_InterfaceImplementedTwiceWithDifferentTupleNames3),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface1))
-            ElseIf (directInterface1 = interface1 AndAlso directInterface2 <> interface2) Then
+            ElseIf (TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2)) Then
                 diag = ErrorFactory.ErrorInfo(If(IsInterface, ERRID.ERR_InterfaceInheritedTwiceWithDifferentTupleNamesReverse3, ERRID.ERR_InterfaceImplementedTwiceWithDifferentTupleNamesReverse3),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface1))
             Else
-                Debug.Assert(directInterface1 <> interface1 AndAlso directInterface2 <> interface2)
+                Debug.Assert(Not TypeSymbol.Equals(directInterface1, interface1, TypeCompareKind.ConsiderEverything2) AndAlso Not TypeSymbol.Equals(directInterface2, interface2, TypeCompareKind.ConsiderEverything2))
                 diag = ErrorFactory.ErrorInfo(If(IsInterface, ERRID.ERR_InterfaceInheritedTwiceWithDifferentTupleNames4, ERRID.ERR_InterfaceImplementedTwiceWithDifferentTupleNames4),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(interface2),
                                               CustomSymbolDisplayFormatter.ShortNameWithTypeArgsAndContainingTypes(directInterface2),

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -2990,7 +2990,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             If definedTypes.Length > 0 Then
                 Dim type = definedTypes(0)
-                If sym <> type Then
+                If Not Equals(TryCast(sym, TypeSymbol), type, TypeCompareKind.ConsiderEverything2) Then
                     Return CheckIfMemberNameIsDuplicate(sym, type, members, diagBag, includeKind:=True)
                 End If
             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -3771,7 +3771,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         For Each [interface] In keySetPair.Value
                             If other IsNot [interface] Then
                                 Debug.Assert(EqualsIgnoringComparer.InstanceIgnoringTupleNames.Equals([interface], other))
-                                Debug.Assert([interface] <> other)
+                                Debug.Assert(Not TypeSymbol.Equals([interface], other, TypeCompareKind.ConsiderEverything))
 
                                 ReportDuplicateInterfaceWithDifferentTupleNames(diagnostics, [interface], other)
                             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberMethodSymbol.vb
@@ -686,7 +686,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
 
                 ' if was found in one of bases, need to override it
-                If witheventsProperty.ContainingType <> Me.ContainingType Then
+                If Not TypeSymbol.Equals(witheventsProperty.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything2) Then
                     witheventsPropertyInCurrentClass = DirectCast(Me.ContainingType, SourceNamedTypeSymbol).GetOrAddWithEventsOverride(witheventsProperty)
                 Else
                     witheventsPropertyInCurrentClass = witheventsProperty

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberMethodSymbol.vb
@@ -686,7 +686,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
 
                 ' if was found in one of bases, need to override it
-                If Not TypeSymbol.Equals(witheventsProperty.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything2) Then
+                If Not TypeSymbol.Equals(witheventsProperty.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything) Then
                     witheventsPropertyInCurrentClass = DirectCast(Me.ContainingType, SourceNamedTypeSymbol).GetOrAddWithEventsOverride(witheventsProperty)
                 Else
                     witheventsPropertyInCurrentClass = witheventsProperty

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -1344,7 +1344,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                     For Each typeSyntax In types
                         Dim bt = binder.BindTypeSyntax(typeSyntax, diag, suppressUseSiteError:=True)
-                        If bt = base Then
+                        If TypeSymbol.Equals(bt, base, TypeCompareKind.ConsiderEverything2) Then
                             Return typeSyntax.GetLocation()
                         End If
                     Next
@@ -1761,7 +1761,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     If Interlocked.CompareExchange(Me._lazyEnumUnderlyingType, underlyingType, Nothing) Is Nothing Then
                         ContainingSourceModule.AddDiagnostics(tempDiags, CompilationStage.Declare)
                     Else
-                        Debug.Assert(underlyingType = Me._lazyEnumUnderlyingType)
+                        Debug.Assert(TypeSymbol.Equals(underlyingType, Me._lazyEnumUnderlyingType, TypeCompareKind.ConsiderEverything2))
                         underlyingType = Me._lazyEnumUnderlyingType
                     End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -1344,7 +1344,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                     For Each typeSyntax In types
                         Dim bt = binder.BindTypeSyntax(typeSyntax, diag, suppressUseSiteError:=True)
-                        If TypeSymbol.Equals(bt, base, TypeCompareKind.ConsiderEverything2) Then
+                        If TypeSymbol.Equals(bt, base, TypeCompareKind.ConsiderEverything) Then
                             Return typeSyntax.GetLocation()
                         End If
                     Next
@@ -1761,7 +1761,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     If Interlocked.CompareExchange(Me._lazyEnumUnderlyingType, underlyingType, Nothing) Is Nothing Then
                         ContainingSourceModule.AddDiagnostics(tempDiags, CompilationStage.Declare)
                     Else
-                        Debug.Assert(TypeSymbol.Equals(underlyingType, Me._lazyEnumUnderlyingType, TypeCompareKind.ConsiderEverything2))
+                        Debug.Assert(TypeSymbol.Equals(underlyingType, Me._lazyEnumUnderlyingType, TypeCompareKind.ConsiderEverything))
                         underlyingType = Me._lazyEnumUnderlyingType
                     End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedMethodSymbol.vb
@@ -433,7 +433,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Friend Function SetAssociatedPropertyOrEvent(propertyOrEventSymbol As Symbol) As Boolean
             If _propertyOrEventSymbolOpt Is Nothing Then
-                Debug.Assert(propertyOrEventSymbol.ContainingType = Me.ContainingType)
+                Debug.Assert(TypeSymbol.Equals(propertyOrEventSymbol.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything2))
 
                 ' No locking required since SetAssociatedProperty will only be called by the
                 ' thread that created the method symbol (and will be called before the method

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedMethodSymbol.vb
@@ -433,7 +433,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Friend Function SetAssociatedPropertyOrEvent(propertyOrEventSymbol As Symbol) As Boolean
             If _propertyOrEventSymbolOpt Is Nothing Then
-                Debug.Assert(TypeSymbol.Equals(propertyOrEventSymbol.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(propertyOrEventSymbol.ContainingType, Me.ContainingType, TypeCompareKind.ConsiderEverything))
 
                 ' No locking required since SetAssociatedProperty will only be called by the
                 ' thread that created the method symbol (and will be called before the method

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
@@ -430,7 +430,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ' Given a member from the original type of this type, substitute into it and get the corresponding member in this type.
         Friend Function GetMemberForDefinition(member As Symbol) As Symbol
             Debug.Assert(member.IsDefinition)
-            Debug.Assert(member.ContainingType = Me.OriginalDefinition)
+            Debug.Assert(TypeSymbol.Equals(member.ContainingType, Me.OriginalDefinition, TypeCompareKind.ConsiderEverything2))
 
             Return SubstituteTypeParametersInMember(member)
         End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
@@ -430,7 +430,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ' Given a member from the original type of this type, substitute into it and get the corresponding member in this type.
         Friend Function GetMemberForDefinition(member As Symbol) As Symbol
             Debug.Assert(member.IsDefinition)
-            Debug.Assert(TypeSymbol.Equals(member.ContainingType, Me.OriginalDefinition, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(member.ContainingType, Me.OriginalDefinition, TypeCompareKind.ConsiderEverything))
 
             Return SubstituteTypeParametersInMember(member)
         End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedIntrinsicOperatorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedIntrinsicOperatorSymbol.vb
@@ -62,11 +62,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If _isCheckedBuiltin = other._isCheckedBuiltin AndAlso
                _parameters.Length = other._parameters.Length AndAlso
                String.Equals(_name, other._name, StringComparison.Ordinal) AndAlso
-               m_containingType = other.m_containingType AndAlso
-               _returnType = other._returnType Then
+               TypeSymbol.Equals(m_containingType, other.m_containingType, TypeCompareKind.ConsiderEverything2) AndAlso
+               TypeSymbol.Equals(_returnType, other._returnType, TypeCompareKind.ConsiderEverything2) Then
 
                 For i As Integer = 0 To _parameters.Length - 1
-                    If _parameters(i).Type <> other._parameters(i).Type Then
+                    If Not TypeSymbol.Equals(_parameters(i).Type, other._parameters(i).Type, TypeCompareKind.ConsiderEverything2) Then
                         Return False
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedIntrinsicOperatorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedIntrinsicOperatorSymbol.vb
@@ -62,11 +62,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If _isCheckedBuiltin = other._isCheckedBuiltin AndAlso
                _parameters.Length = other._parameters.Length AndAlso
                String.Equals(_name, other._name, StringComparison.Ordinal) AndAlso
-               TypeSymbol.Equals(m_containingType, other.m_containingType, TypeCompareKind.ConsiderEverything2) AndAlso
-               TypeSymbol.Equals(_returnType, other._returnType, TypeCompareKind.ConsiderEverything2) Then
+               TypeSymbol.Equals(m_containingType, other.m_containingType, TypeCompareKind.ConsiderEverything) AndAlso
+               TypeSymbol.Equals(_returnType, other._returnType, TypeCompareKind.ConsiderEverything) Then
 
                 For i As Integer = 0 To _parameters.Length - 1
-                    If Not TypeSymbol.Equals(_parameters(i).Type, other._parameters(i).Type, TypeCompareKind.ConsiderEverything2) Then
+                    If Not TypeSymbol.Equals(_parameters(i).Type, other._parameters(i).Type, TypeCompareKind.ConsiderEverything) Then
                         Return False
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
@@ -133,7 +133,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overloads Function Equals(other As TupleErrorFieldSymbol) As Boolean
             Return other Is Me OrElse
-                (other IsNot Nothing AndAlso Me._tupleElementIndex = other._tupleElementIndex AndAlso Me.ContainingType = other.ContainingType)
+                (other IsNot Nothing AndAlso Me._tupleElementIndex = other._tupleElementIndex AndAlso TypeSymbol.Equals(Me.ContainingType, other.ContainingType, TypeCompareKind.ConsiderEverything2))
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
@@ -133,7 +133,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overloads Function Equals(other As TupleErrorFieldSymbol) As Boolean
             Return other Is Me OrElse
-                (other IsNot Nothing AndAlso Me._tupleElementIndex = other._tupleElementIndex AndAlso TypeSymbol.Equals(Me.ContainingType, other.ContainingType, TypeCompareKind.ConsiderEverything2))
+                (other IsNot Nothing AndAlso Me._tupleElementIndex = other._tupleElementIndex AndAlso TypeSymbol.Equals(Me.ContainingType, other.ContainingType, TypeCompareKind.ConsiderEverything))
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleEventSymbol.vb
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overloads Function Equals(other As TupleEventSymbol) As Boolean
             Return other Is Me OrElse
-                (other IsNot Nothing AndAlso Me._containingType = other._containingType AndAlso Me._underlyingEvent = other._underlyingEvent)
+                (other IsNot Nothing AndAlso TypeSymbol.Equals(Me._containingType, other._containingType, TypeCompareKind.ConsiderEverything2) AndAlso Me._underlyingEvent = other._underlyingEvent)
         End Function
 
         Public Overrides Function GetAttributes() As ImmutableArray(Of VisualBasicAttributeData)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleEventSymbol.vb
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overloads Function Equals(other As TupleEventSymbol) As Boolean
             Return other Is Me OrElse
-                (other IsNot Nothing AndAlso TypeSymbol.Equals(Me._containingType, other._containingType, TypeCompareKind.ConsiderEverything2) AndAlso Me._underlyingEvent = other._underlyingEvent)
+                (other IsNot Nothing AndAlso TypeSymbol.Equals(Me._containingType, other._containingType, TypeCompareKind.ConsiderEverything) AndAlso Me._underlyingEvent = other._underlyingEvent)
         End Function
 
         Public Overrides Function GetAttributes() As ImmutableArray(Of VisualBasicAttributeData)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overloads Function Equals(other As TupleFieldSymbol) As Boolean
             Return other IsNot Nothing AndAlso
                 _tupleElementIndex = other._tupleElementIndex AndAlso
-                _containingTuple = other._containingTuple
+                TypeSymbol.Equals(_containingTuple, other._containingTuple, TypeCompareKind.ConsiderEverything2)
         End Function
     End Class
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overloads Function Equals(other As TupleFieldSymbol) As Boolean
             Return other IsNot Nothing AndAlso
                 _tupleElementIndex = other._tupleElementIndex AndAlso
-                TypeSymbol.Equals(_containingTuple, other._containingTuple, TypeCompareKind.ConsiderEverything2)
+                TypeSymbol.Equals(_containingTuple, other._containingTuple, TypeCompareKind.ConsiderEverything)
         End Function
     End Class
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleMethodSymbol.vb
@@ -142,7 +142,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overloads Function Equals(other As TupleMethodSymbol) As Boolean
             Return other Is Me OrElse
-                (other IsNot Nothing AndAlso Me._containingType = other._containingType AndAlso Me._underlyingMethod.ConstructedFrom = other._underlyingMethod.ConstructedFrom)
+                (other IsNot Nothing AndAlso TypeSymbol.Equals(Me._containingType, other._containingType, TypeCompareKind.ConsiderEverything2) AndAlso Me._underlyingMethod.ConstructedFrom = other._underlyingMethod.ConstructedFrom)
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleMethodSymbol.vb
@@ -142,7 +142,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overloads Function Equals(other As TupleMethodSymbol) As Boolean
             Return other Is Me OrElse
-                (other IsNot Nothing AndAlso TypeSymbol.Equals(Me._containingType, other._containingType, TypeCompareKind.ConsiderEverything2) AndAlso Me._underlyingMethod.ConstructedFrom = other._underlyingMethod.ConstructedFrom)
+                (other IsNot Nothing AndAlso TypeSymbol.Equals(Me._containingType, other._containingType, TypeCompareKind.ConsiderEverything) AndAlso Me._underlyingMethod.ConstructedFrom = other._underlyingMethod.ConstructedFrom)
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TuplePropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TuplePropertySymbol.vb
@@ -124,7 +124,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overloads Function Equals(other As TuplePropertySymbol) As Boolean
             Return other Is Me OrElse
-                (other IsNot Nothing AndAlso Me._containingType = other._containingType AndAlso Me._underlyingProperty = other._underlyingProperty)
+                (other IsNot Nothing AndAlso TypeSymbol.Equals(Me._containingType, other._containingType, TypeCompareKind.ConsiderEverything2) AndAlso Me._underlyingProperty = other._underlyingProperty)
         End Function
 
         Public Overrides Function GetAttributes() As ImmutableArray(Of VisualBasicAttributeData)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TuplePropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TuplePropertySymbol.vb
@@ -124,7 +124,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overloads Function Equals(other As TuplePropertySymbol) As Boolean
             Return other Is Me OrElse
-                (other IsNot Nothing AndAlso TypeSymbol.Equals(Me._containingType, other._containingType, TypeCompareKind.ConsiderEverything2) AndAlso Me._underlyingProperty = other._underlyingProperty)
+                (other IsNot Nothing AndAlso TypeSymbol.Equals(Me._containingType, other._containingType, TypeCompareKind.ConsiderEverything) AndAlso Me._underlyingProperty = other._underlyingProperty)
         End Function
 
         Public Overrides Function GetAttributes() As ImmutableArray(Of VisualBasicAttributeData)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -972,7 +972,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             Dim otherUnderlying = otherTuple.TupleUnderlyingType
-            If (Me.TupleUnderlyingType <> otherUnderlying) Then
+            If (Not TypeSymbol.Equals(Me.TupleUnderlyingType, otherUnderlying, TypeCompareKind.ConsiderEverything2)) Then
                 Return False
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -972,7 +972,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             Dim otherUnderlying = otherTuple.TupleUnderlyingType
-            If (Not TypeSymbol.Equals(Me.TupleUnderlyingType, otherUnderlying, TypeCompareKind.ConsiderEverything2)) Then
+            If (Not TypeSymbol.Equals(Me.TupleUnderlyingType, otherUnderlying, TypeCompareKind.ConsiderEverything)) Then
                 Return False
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSubstitution.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSubstitution.vb
@@ -880,7 +880,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim modifier = DirectCast(customModifiers(i).Modifier, NamedTypeSymbol)
                 Dim substituted = DirectCast(modifier.InternalSubstituteTypeParameters(Me).AsTypeSymbolOnly(), NamedTypeSymbol)
 
-                If modifier <> substituted Then
+                If Not TypeSymbol.Equals(modifier, substituted, TypeCompareKind.ConsiderEverything2) Then
                     Dim builder = ArrayBuilder(Of CustomModifier).GetInstance(customModifiers.Length)
                     builder.AddRange(customModifiers, i)
                     builder.Add(If(customModifiers(i).IsOptional, VisualBasicCustomModifier.CreateOptional(substituted), VisualBasicCustomModifier.CreateRequired(substituted)))
@@ -889,7 +889,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         modifier = DirectCast(customModifiers(j).Modifier, NamedTypeSymbol)
                         substituted = DirectCast(modifier.InternalSubstituteTypeParameters(Me).AsTypeSymbolOnly(), NamedTypeSymbol)
 
-                        If modifier <> substituted Then
+                        If Not TypeSymbol.Equals(modifier, substituted, TypeCompareKind.ConsiderEverything2) Then
                             builder.Add(If(customModifiers(j).IsOptional, VisualBasicCustomModifier.CreateOptional(substituted), VisualBasicCustomModifier.CreateRequired(substituted)))
                         Else
                             builder.Add(customModifiers(j))

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSubstitution.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSubstitution.vb
@@ -880,7 +880,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim modifier = DirectCast(customModifiers(i).Modifier, NamedTypeSymbol)
                 Dim substituted = DirectCast(modifier.InternalSubstituteTypeParameters(Me).AsTypeSymbolOnly(), NamedTypeSymbol)
 
-                If Not TypeSymbol.Equals(modifier, substituted, TypeCompareKind.ConsiderEverything2) Then
+                If Not TypeSymbol.Equals(modifier, substituted, TypeCompareKind.ConsiderEverything) Then
                     Dim builder = ArrayBuilder(Of CustomModifier).GetInstance(customModifiers.Length)
                     builder.AddRange(customModifiers, i)
                     builder.Add(If(customModifiers(i).IsOptional, VisualBasicCustomModifier.CreateOptional(substituted), VisualBasicCustomModifier.CreateRequired(substituted)))
@@ -889,7 +889,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         modifier = DirectCast(customModifiers(j).Modifier, NamedTypeSymbol)
                         substituted = DirectCast(modifier.InternalSubstituteTypeParameters(Me).AsTypeSymbolOnly(), NamedTypeSymbol)
 
-                        If Not TypeSymbol.Equals(modifier, substituted, TypeCompareKind.ConsiderEverything2) Then
+                        If Not TypeSymbol.Equals(modifier, substituted, TypeCompareKind.ConsiderEverything) Then
                             builder.Add(If(customModifiers(j).IsOptional, VisualBasicCustomModifier.CreateOptional(substituted), VisualBasicCustomModifier.CreateRequired(substituted)))
                         Else
                             builder.Add(customModifiers(j))

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -298,6 +298,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return other.Is(Me)
         End Function
 
+        <Obsolete("Use TypeSymbol.Equals method.", True)>
+        Public Overloads Shared Operator =(left As TypeSymbol, right As TypeSymbol) As Boolean
+            Throw ExceptionUtilities.Unreachable
+        End Operator
+
+        <Obsolete("Use TypeSymbol.Equals method.", True)>
+        Public Overloads Shared Operator <>(left As TypeSymbol, right As TypeSymbol) As Boolean
+            Throw ExceptionUtilities.Unreachable
+        End Operator
+
+        Public Overloads Shared Function Equals(left As TypeSymbol, right As TypeSymbol, comparison As TypeCompareKind) As Boolean
+            If comparison = TypeCompareKind.ConsiderEverything AndAlso right Is Nothing Then
+                Return left Is Nothing
+            End If
+
+            Return (comparison = TypeCompareKind.ConsiderEverything AndAlso left Is right) OrElse right.IsSameType(left, comparison)
+            Return True
+        End Function
+
         ''' <summary>
         ''' Lookup an immediately nested type referenced from metadata, names should be
         ''' compared case-sensitively.

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -298,23 +298,42 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return other.Is(Me)
         End Function
 
-        <Obsolete("Use TypeSymbol.Equals method.", True)>
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
         Public Overloads Shared Operator =(left As TypeSymbol, right As TypeSymbol) As Boolean
             Throw ExceptionUtilities.Unreachable
         End Operator
 
-        <Obsolete("Use TypeSymbol.Equals method.", True)>
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
         Public Overloads Shared Operator <>(left As TypeSymbol, right As TypeSymbol) As Boolean
             Throw ExceptionUtilities.Unreachable
         End Operator
 
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
+        Public Overloads Shared Operator =(left As Symbol, right As TypeSymbol) As Boolean
+            Throw ExceptionUtilities.Unreachable
+        End Operator
+
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
+        Public Overloads Shared Operator <>(left As Symbol, right As TypeSymbol) As Boolean
+            Throw ExceptionUtilities.Unreachable
+        End Operator
+
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
+        Public Overloads Shared Operator =(left As TypeSymbol, right As Symbol) As Boolean
+            Throw ExceptionUtilities.Unreachable
+        End Operator
+
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
+        Public Overloads Shared Operator <>(left As TypeSymbol, right As Symbol) As Boolean
+            Throw ExceptionUtilities.Unreachable
+        End Operator
+
         Public Overloads Shared Function Equals(left As TypeSymbol, right As TypeSymbol, comparison As TypeCompareKind) As Boolean
-            If comparison = TypeCompareKind.ConsiderEverything AndAlso right Is Nothing Then
-                Return left Is Nothing
+            If left Is Nothing Then
+                Return right Is Nothing
             End If
 
-            Return (comparison = TypeCompareKind.ConsiderEverything AndAlso left Is right) OrElse right.IsSameType(left, comparison)
-            Return True
+            Return left.IsSameType(right, comparison)
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -298,32 +298,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return other.Is(Me)
         End Function
 
-        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSymbol, TypeCompareKind) method.", True)>
         Public Overloads Shared Operator =(left As TypeSymbol, right As TypeSymbol) As Boolean
             Throw ExceptionUtilities.Unreachable
         End Operator
 
-        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSymbol, TypeCompareKind) method.", True)>
         Public Overloads Shared Operator <>(left As TypeSymbol, right As TypeSymbol) As Boolean
             Throw ExceptionUtilities.Unreachable
         End Operator
 
-        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSymbol, TypeCompareKind) method.", True)>
         Public Overloads Shared Operator =(left As Symbol, right As TypeSymbol) As Boolean
             Throw ExceptionUtilities.Unreachable
         End Operator
 
-        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSymbol, TypeCompareKind) method.", True)>
         Public Overloads Shared Operator <>(left As Symbol, right As TypeSymbol) As Boolean
             Throw ExceptionUtilities.Unreachable
         End Operator
 
-        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSymbol, TypeCompareKind) method.", True)>
         Public Overloads Shared Operator =(left As TypeSymbol, right As Symbol) As Boolean
             Throw ExceptionUtilities.Unreachable
         End Operator
 
-        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSybmol, TypeCompareKind) method.", True)>
+        <Obsolete("Use TypeSymbol.Equals(TypeSymbol, TypeSymbol, TypeCompareKind) method.", True)>
         Public Overloads Shared Operator <>(left As TypeSymbol, right As Symbol) As Boolean
             Throw ExceptionUtilities.Unreachable
         End Operator

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -329,10 +329,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Operator
 
         Public Overloads Shared Function Equals(left As TypeSymbol, right As TypeSymbol, comparison As TypeCompareKind) As Boolean
-            If left Is Nothing Then
-                Return right Is Nothing
-            End If
-
             Return left.IsSameType(right, comparison)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -243,12 +243,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Function IsSameType(t1 As TypeSymbol, t2 As TypeSymbol, compareKind As TypeCompareKind) As Boolean
             Debug.Assert((compareKind And Not (TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds Or TypeCompareKind.IgnoreTupleNames)) = 0)
 
-            If compareKind = TypeCompareKind.ConsiderEverything Then
-                Return t1.Equals(t2)
-            End If
-
             If t1 Is t2 Then
                 Return True
+            ElseIf t1 Is Nothing OrElse t2 Is Nothing Then
+                Return False
+            End If
+
+            If compareKind = TypeCompareKind.ConsiderEverything Then
+                Return t1.Equals(t2)
             End If
 
             Dim kind = t1.Kind
@@ -291,7 +293,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 If Not (t1IsDefinition AndAlso t2IsDefinition) Then ' This is a generic instantiation case
 
-                    If Not TypeSymbol.Equals(t1.OriginalDefinition, t2.OriginalDefinition, TypeCompareKind.ConsiderEverything) Then
+                    If Not t1.OriginalDefinition.Equals(t2.OriginalDefinition) Then
                         Return False ' different definition
                     End If
 
@@ -336,7 +338,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
             End If
 
-            Return (TypeSymbol.Equals(t1, t2, TypeCompareKind.ConsiderEverything))
+            Return t1.Equals(t2)
         End Function
 
         Private Function HasSameTypeArgumentCustomModifiers(type1 As NamedTypeSymbol, type2 As NamedTypeSymbol) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -291,7 +291,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 If Not (t1IsDefinition AndAlso t2IsDefinition) Then ' This is a generic instantiation case
 
-                    If t1.OriginalDefinition <> t2.OriginalDefinition Then
+                    If Not TypeSymbol.Equals(t1.OriginalDefinition, t2.OriginalDefinition, TypeCompareKind.ConsiderEverything2) Then
                         Return False ' different definition
                     End If
 
@@ -336,7 +336,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
             End If
 
-            Return (t1 = t2)
+            Return (TypeSymbol.Equals(t1, t2, TypeCompareKind.ConsiderEverything2))
         End Function
 
         Private Function HasSameTypeArgumentCustomModifiers(type1 As NamedTypeSymbol, type2 As NamedTypeSymbol) As Boolean
@@ -644,7 +644,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         <Extension()>
         Public Function IsSameOrNestedWithin(inner As NamedTypeSymbol, outer As NamedTypeSymbol) As Boolean
             Do
-                If inner = outer Then
+                If TypeSymbol.Equals(inner, outer, TypeCompareKind.ConsiderEverything2) Then
                     Return True
                 End If
 
@@ -1040,7 +1040,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             Return type.GetEnumUnderlyingTypeOrSelf.SpecialType.IsValidTypeForAttributeArgument() OrElse
-                type = compilation.GetWellKnownType(WellKnownType.System_Type) ' don't call the version with diagnostics
+                TypeSymbol.Equals(type, compilation.GetWellKnownType(WellKnownType.System_Type), TypeCompareKind.ConsiderEverything2) ' don't call the version with diagnostics
         End Function
 
         <Extension()>
@@ -1184,7 +1184,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim namedType = DirectCast(type, NamedTypeSymbol)
 
                 ' Note that if the compilation doesn't have the Expression(Of T) well-known type, then the below test just fails correctly.
-                If namedType.Arity = 1 AndAlso namedType.OriginalDefinition = compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T) Then
+                If namedType.Arity = 1 AndAlso TypeSymbol.Equals(namedType.OriginalDefinition, compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything2) Then
                     Dim typeArgument = namedType.TypeArgumentsNoUseSiteDiagnostics(0)
                     If typeArgument.TypeKind = TypeKind.Delegate Then
                         Return DirectCast(typeArgument, NamedTypeSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -291,7 +291,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 If Not (t1IsDefinition AndAlso t2IsDefinition) Then ' This is a generic instantiation case
 
-                    If Not TypeSymbol.Equals(t1.OriginalDefinition, t2.OriginalDefinition, TypeCompareKind.ConsiderEverything2) Then
+                    If Not TypeSymbol.Equals(t1.OriginalDefinition, t2.OriginalDefinition, TypeCompareKind.ConsiderEverything) Then
                         Return False ' different definition
                     End If
 
@@ -336,7 +336,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
             End If
 
-            Return (TypeSymbol.Equals(t1, t2, TypeCompareKind.ConsiderEverything2))
+            Return (TypeSymbol.Equals(t1, t2, TypeCompareKind.ConsiderEverything))
         End Function
 
         Private Function HasSameTypeArgumentCustomModifiers(type1 As NamedTypeSymbol, type2 As NamedTypeSymbol) As Boolean
@@ -644,7 +644,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         <Extension()>
         Public Function IsSameOrNestedWithin(inner As NamedTypeSymbol, outer As NamedTypeSymbol) As Boolean
             Do
-                If TypeSymbol.Equals(inner, outer, TypeCompareKind.ConsiderEverything2) Then
+                If TypeSymbol.Equals(inner, outer, TypeCompareKind.ConsiderEverything) Then
                     Return True
                 End If
 
@@ -1040,7 +1040,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             Return type.GetEnumUnderlyingTypeOrSelf.SpecialType.IsValidTypeForAttributeArgument() OrElse
-                TypeSymbol.Equals(type, compilation.GetWellKnownType(WellKnownType.System_Type), TypeCompareKind.ConsiderEverything2) ' don't call the version with diagnostics
+                TypeSymbol.Equals(type, compilation.GetWellKnownType(WellKnownType.System_Type), TypeCompareKind.ConsiderEverything) ' don't call the version with diagnostics
         End Function
 
         <Extension()>
@@ -1184,7 +1184,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim namedType = DirectCast(type, NamedTypeSymbol)
 
                 ' Note that if the compilation doesn't have the Expression(Of T) well-known type, then the below test just fails correctly.
-                If namedType.Arity = 1 AndAlso TypeSymbol.Equals(namedType.OriginalDefinition, compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything2) Then
+                If namedType.Arity = 1 AndAlso TypeSymbol.Equals(namedType.OriginalDefinition, compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything) Then
                     Dim typeArgument = namedType.TypeArgumentsNoUseSiteDiagnostics(0)
                     If typeArgument.TypeKind = TypeKind.Delegate Then
                         Return DirectCast(typeArgument, NamedTypeSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeWithModifiers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeWithModifiers.vb
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Public Function [Is](other As TypeSymbol) As Boolean
-            Return Me.Type = other AndAlso Me.CustomModifiers.IsEmpty
+            Return TypeSymbol.Equals(Me.Type, other, TypeCompareKind.ConsiderEverything2) AndAlso Me.CustomModifiers.IsEmpty
         End Function
 
         <Obsolete("Use Is method.", True)>

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeWithModifiers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeWithModifiers.vb
@@ -58,7 +58,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Public Function [Is](other As TypeSymbol) As Boolean
-            Return TypeSymbol.Equals(Me.Type, other, TypeCompareKind.ConsiderEverything2) AndAlso Me.CustomModifiers.IsEmpty
+            Return TypeSymbol.Equals(Me.Type, other, TypeCompareKind.ConsiderEverything) AndAlso Me.CustomModifiers.IsEmpty
         End Function
 
         <Obsolete("Use Is method.", True)>

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -331,7 +331,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Overrides Function IsSystemTypeReference(type As ITypeSymbol) As Boolean
-            Return DirectCast(type, TypeSymbol) = GetWellKnownType(WellKnownType.System_Type)
+            Return TypeSymbol.Equals(DirectCast(type, TypeSymbol), GetWellKnownType(WellKnownType.System_Type), TypeCompareKind.ConsiderEverything2)
         End Function
 
         Friend Overrides Function CommonGetWellKnownTypeMember(member As WellKnownMember) As ISymbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -331,7 +331,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Overrides Function IsSystemTypeReference(type As ITypeSymbol) As Boolean
-            Return TypeSymbol.Equals(DirectCast(type, TypeSymbol), GetWellKnownType(WellKnownType.System_Type), TypeCompareKind.ConsiderEverything2)
+            Return TypeSymbol.Equals(DirectCast(type, TypeSymbol), GetWellKnownType(WellKnownType.System_Type), TypeCompareKind.ConsiderEverything)
         End Function
 
         Friend Overrides Function CommonGetWellKnownTypeMember(member As WellKnownMember) As ISymbol

--- a/src/Compilers/VisualBasic/Portable/Utilities/TypeUnification.vb
+++ b/src/Compilers/VisualBasic/Portable/Utilities/TypeUnification.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return False
             End If
 
-            If t1 = t2 Then
+            If TypeSymbol.Equals(t1, t2, TypeCompareKind.ConsiderEverything2) Then
                 Return True
             End If
 
@@ -117,13 +117,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     If Not nt1.IsGenericType Then
-                        Return Not nt2.IsGenericType AndAlso nt1 = nt2
+                        Return Not nt2.IsGenericType AndAlso TypeSymbol.Equals(nt1, nt2, TypeCompareKind.ConsiderEverything2)
                     ElseIf Not nt2.IsGenericType Then
                         Return False
                     End If
 
                     Dim arity As Integer = nt1.Arity
-                    If nt2.Arity <> arity OrElse nt2.OriginalDefinition <> nt1.OriginalDefinition Then
+                    If nt2.Arity <> arity OrElse Not TypeSymbol.Equals(nt2.OriginalDefinition, nt1.OriginalDefinition, TypeCompareKind.ConsiderEverything2) Then
                         Return False
                     End If
 
@@ -256,7 +256,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Return False
                 Case SymbolKind.TypeParameter
-                    Return type = typeParam
+                    Return TypeSymbol.Equals(type, typeParam, TypeCompareKind.ConsiderEverything2)
                 Case Else
                     Return False
             End Select

--- a/src/Compilers/VisualBasic/Portable/Utilities/TypeUnification.vb
+++ b/src/Compilers/VisualBasic/Portable/Utilities/TypeUnification.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return False
             End If
 
-            If TypeSymbol.Equals(t1, t2, TypeCompareKind.ConsiderEverything2) Then
+            If TypeSymbol.Equals(t1, t2, TypeCompareKind.ConsiderEverything) Then
                 Return True
             End If
 
@@ -117,13 +117,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     If Not nt1.IsGenericType Then
-                        Return Not nt2.IsGenericType AndAlso TypeSymbol.Equals(nt1, nt2, TypeCompareKind.ConsiderEverything2)
+                        Return Not nt2.IsGenericType AndAlso TypeSymbol.Equals(nt1, nt2, TypeCompareKind.ConsiderEverything)
                     ElseIf Not nt2.IsGenericType Then
                         Return False
                     End If
 
                     Dim arity As Integer = nt1.Arity
-                    If nt2.Arity <> arity OrElse Not TypeSymbol.Equals(nt2.OriginalDefinition, nt1.OriginalDefinition, TypeCompareKind.ConsiderEverything2) Then
+                    If nt2.Arity <> arity OrElse Not TypeSymbol.Equals(nt2.OriginalDefinition, nt1.OriginalDefinition, TypeCompareKind.ConsiderEverything) Then
                         Return False
                     End If
 
@@ -256,7 +256,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Return False
                 Case SymbolKind.TypeParameter
-                    Return TypeSymbol.Equals(type, typeParam, TypeCompareKind.ConsiderEverything2)
+                    Return TypeSymbol.Equals(type, typeParam, TypeCompareKind.ConsiderEverything)
                 Case Else
                     Return False
             End Select

--- a/src/Compilers/VisualBasic/Portable/Utilities/VarianceAmbiguity.vb
+++ b/src/Compilers/VisualBasic/Portable/Utilities/VarianceAmbiguity.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function HasVarianceAmbiguity(containingType As NamedTypeSymbol, i1 As NamedTypeSymbol, i2 As NamedTypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
             Debug.Assert(i1.IsInterfaceType() AndAlso i2.IsInterfaceType())
             Debug.Assert(i1.IsGenericType AndAlso i2.IsGenericType)
-            Debug.Assert(i1.OriginalDefinition = i2.OriginalDefinition)
+            Debug.Assert(TypeSymbol.Equals(i1.OriginalDefinition, i2.OriginalDefinition, TypeCompareKind.ConsiderEverything2))
 
             ' Go through all type arguments of all containing types. Order doesn't matters, so we 
             ' go inside-out.

--- a/src/Compilers/VisualBasic/Portable/Utilities/VarianceAmbiguity.vb
+++ b/src/Compilers/VisualBasic/Portable/Utilities/VarianceAmbiguity.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function HasVarianceAmbiguity(containingType As NamedTypeSymbol, i1 As NamedTypeSymbol, i2 As NamedTypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
             Debug.Assert(i1.IsInterfaceType() AndAlso i2.IsInterfaceType())
             Debug.Assert(i1.IsGenericType AndAlso i2.IsGenericType)
-            Debug.Assert(TypeSymbol.Equals(i1.OriginalDefinition, i2.OriginalDefinition, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(i1.OriginalDefinition, i2.OriginalDefinition, TypeCompareKind.ConsiderEverything))
 
             ' Go through all type arguments of all containing types. Order doesn't matters, so we 
             ' go inside-out.

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -18431,6 +18431,9 @@ additionalRefs:=s_valueTupleRefs)
             Assert.True(underlying1.IsSameType(tuple1, TypeCompareKind.IgnoreTupleNames))
             Assert.True(underlying1.IsSameType(underlying1, TypeCompareKind.IgnoreTupleNames))
 
+            Assert.False(tuple1.IsSameType(Nothing, TypeCompareKind.ConsiderEverything))
+            Assert.False(tuple1.IsSameType(Nothing, TypeCompareKind.IgnoreTupleNames))
+
             Dim m2 = comp.GetMember(Of MethodSymbol)("C.M2")
             Dim tuple2 As TypeSymbol = m2.Parameters(0).Type
             Dim underlying2 As NamedTypeSymbol = tuple2.TupleUnderlyingType

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
@@ -1092,7 +1092,7 @@ End Class
                (leftSpecial = SpecialType.None OrElse rightSpecial = SpecialType.None OrElse
                 (op = BinaryOperatorKind.Subtract AndAlso leftSpecial = SpecialType.System_DateTime AndAlso rightSpecial = SpecialType.System_DateTime)) Then
 
-                If leftSpecial = SpecialType.System_Object OrElse rightSpecial = SpecialType.System_Object OrElse leftType = rightType Then
+                If leftSpecial = SpecialType.System_Object OrElse rightSpecial = SpecialType.System_Object OrElse TypeSymbol.Equals(leftType, rightType, TypeCompareKind.ConsiderEverything2) Then
                     If leftSpecial = SpecialType.System_Object OrElse rightSpecial = SpecialType.System_Object Then
                         resultType = SpecialType.System_Object
                     End If
@@ -1104,8 +1104,8 @@ End Class
                             Dim method = DirectCast(m, MethodSymbol)
                             If method.MethodKind = MethodKind.UserDefinedOperator AndAlso
                                method.ParameterCount = 2 AndAlso
-                               method.Parameters(0).Type = nonSpecialType AndAlso
-                               method.Parameters(1).Type = nonSpecialType Then
+                               TypeSymbol.Equals(method.Parameters(0).Type, nonSpecialType, TypeCompareKind.ConsiderEverything2) AndAlso
+                               TypeSymbol.Equals(method.Parameters(1).Type, nonSpecialType, TypeCompareKind.ConsiderEverything2) Then
                                 userDefined = method
                                 resultType = SpecialType.None
                             End If
@@ -1186,7 +1186,7 @@ End Class
                     End If
 
                 Case BinaryOperatorKind.Xor, BinaryOperatorKind.And, BinaryOperatorKind.Or
-                    If leftType.IsEnumType() AndAlso leftType = rightType Then
+                    If leftType.IsEnumType() AndAlso TypeSymbol.Equals(leftType, rightType, TypeCompareKind.ConsiderEverything2) Then
                         containerName = leftType.ToTestDisplayString()
                         rightName = containerName
                         returnName = containerName

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
@@ -1222,15 +1222,15 @@ End Class
             Assert.Same(symbol1.ContainingSymbol, symbol1.Parameters(0).Type)
 
             Dim match As Integer = 0
-            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.ReturnType, TypeCompareKind.ConsiderEverything) Then
+            If TypeSymbol.Equals(symbol1.ContainingType, symbol1.ReturnType, TypeCompareKind.ConsiderEverything) Then
                 match += 1
             End If
 
-            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.Parameters(0).Type, TypeCompareKind.ConsiderEverything) Then
+            If TypeSymbol.Equals(symbol1.ContainingType, symbol1.Parameters(0).Type, TypeCompareKind.ConsiderEverything) Then
                 match += 1
             End If
 
-            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.Parameters(1).Type, TypeCompareKind.ConsiderEverything) Then
+            If TypeSymbol.Equals(symbol1.ContainingType, symbol1.Parameters(1).Type, TypeCompareKind.ConsiderEverything) Then
                 match += 1
             End If
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
@@ -1222,15 +1222,15 @@ End Class
             Assert.Same(symbol1.ContainingSymbol, symbol1.Parameters(0).Type)
 
             Dim match As Integer = 0
-            If symbol1.ContainingSymbol = symbol1.ReturnType Then
+            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.ReturnType, TypeCompareKind.ConsiderEverything2) Then
                 match += 1
             End If
 
-            If symbol1.ContainingSymbol = symbol1.Parameters(0).Type Then
+            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.Parameters(0).Type, TypeCompareKind.ConsiderEverything2) Then
                 match += 1
             End If
 
-            If symbol1.ContainingSymbol = symbol1.Parameters(1).Type Then
+            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.Parameters(1).Type, TypeCompareKind.ConsiderEverything2) Then
                 match += 1
             End If
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
@@ -1092,7 +1092,7 @@ End Class
                (leftSpecial = SpecialType.None OrElse rightSpecial = SpecialType.None OrElse
                 (op = BinaryOperatorKind.Subtract AndAlso leftSpecial = SpecialType.System_DateTime AndAlso rightSpecial = SpecialType.System_DateTime)) Then
 
-                If leftSpecial = SpecialType.System_Object OrElse rightSpecial = SpecialType.System_Object OrElse TypeSymbol.Equals(leftType, rightType, TypeCompareKind.ConsiderEverything2) Then
+                If leftSpecial = SpecialType.System_Object OrElse rightSpecial = SpecialType.System_Object OrElse TypeSymbol.Equals(leftType, rightType, TypeCompareKind.ConsiderEverything) Then
                     If leftSpecial = SpecialType.System_Object OrElse rightSpecial = SpecialType.System_Object Then
                         resultType = SpecialType.System_Object
                     End If
@@ -1104,8 +1104,8 @@ End Class
                             Dim method = DirectCast(m, MethodSymbol)
                             If method.MethodKind = MethodKind.UserDefinedOperator AndAlso
                                method.ParameterCount = 2 AndAlso
-                               TypeSymbol.Equals(method.Parameters(0).Type, nonSpecialType, TypeCompareKind.ConsiderEverything2) AndAlso
-                               TypeSymbol.Equals(method.Parameters(1).Type, nonSpecialType, TypeCompareKind.ConsiderEverything2) Then
+                               TypeSymbol.Equals(method.Parameters(0).Type, nonSpecialType, TypeCompareKind.ConsiderEverything) AndAlso
+                               TypeSymbol.Equals(method.Parameters(1).Type, nonSpecialType, TypeCompareKind.ConsiderEverything) Then
                                 userDefined = method
                                 resultType = SpecialType.None
                             End If
@@ -1186,7 +1186,7 @@ End Class
                     End If
 
                 Case BinaryOperatorKind.Xor, BinaryOperatorKind.And, BinaryOperatorKind.Or
-                    If leftType.IsEnumType() AndAlso TypeSymbol.Equals(leftType, rightType, TypeCompareKind.ConsiderEverything2) Then
+                    If leftType.IsEnumType() AndAlso TypeSymbol.Equals(leftType, rightType, TypeCompareKind.ConsiderEverything) Then
                         containerName = leftType.ToTestDisplayString()
                         rightName = containerName
                         returnName = containerName
@@ -1222,15 +1222,15 @@ End Class
             Assert.Same(symbol1.ContainingSymbol, symbol1.Parameters(0).Type)
 
             Dim match As Integer = 0
-            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.ReturnType, TypeCompareKind.ConsiderEverything2) Then
+            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.ReturnType, TypeCompareKind.ConsiderEverything) Then
                 match += 1
             End If
 
-            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.Parameters(0).Type, TypeCompareKind.ConsiderEverything2) Then
+            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.Parameters(0).Type, TypeCompareKind.ConsiderEverything) Then
                 match += 1
             End If
 
-            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.Parameters(1).Type, TypeCompareKind.ConsiderEverything2) Then
+            If TypeSymbol.Equals(TryCast(symbol1.ContainingSymbol, TypeSymbol), symbol1.Parameters(1).Type, TypeCompareKind.ConsiderEverything) Then
                 match += 1
             End If
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetingCustomAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetingCustomAttributes.vb
@@ -94,10 +94,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Retargeting
                 Assert.NotSame(OldMsCorLib_debuggerTypeProxyAttributeType, NewMsCorLib_debuggerTypeProxyAttributeType)
 
                 OldMsCorLib_debuggerTypeProxyAttributeCtor = DirectCast(OldMsCorLib_debuggerTypeProxyAttributeType.GetMembers(".ctor").
-                    Where(Function(m) DirectCast(m, MethodSymbol).ParameterCount = 1 AndAlso DirectCast(m, MethodSymbol).Parameters(0).Type = OldMsCorLib_systemType).[Single](), MethodSymbol)
+                    Where(Function(m) DirectCast(m, MethodSymbol).ParameterCount = 1 AndAlso TypeSymbol.Equals(DirectCast(m, MethodSymbol).Parameters(0).Type, OldMsCorLib_systemType, TypeCompareKind.ConsiderEverything2)).[Single](), MethodSymbol)
 
                 NewMsCorLib_debuggerTypeProxyAttributeCtor = DirectCast(NewMsCorLib_debuggerTypeProxyAttributeType.GetMembers(".ctor").
-                    Where(Function(m) DirectCast(m, MethodSymbol).ParameterCount = 1 AndAlso DirectCast(m, MethodSymbol).Parameters(0).Type = NewMsCorLib_systemType).[Single](), MethodSymbol)
+                    Where(Function(m) DirectCast(m, MethodSymbol).ParameterCount = 1 AndAlso TypeSymbol.Equals(DirectCast(m, MethodSymbol).Parameters(0).Type, NewMsCorLib_systemType, TypeCompareKind.ConsiderEverything2)).[Single](), MethodSymbol)
 
                 Assert.NotSame(OldMsCorLib_debuggerTypeProxyAttributeCtor, NewMsCorLib_debuggerTypeProxyAttributeCtor)
             End Sub

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetingCustomAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetingCustomAttributes.vb
@@ -94,10 +94,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Retargeting
                 Assert.NotSame(OldMsCorLib_debuggerTypeProxyAttributeType, NewMsCorLib_debuggerTypeProxyAttributeType)
 
                 OldMsCorLib_debuggerTypeProxyAttributeCtor = DirectCast(OldMsCorLib_debuggerTypeProxyAttributeType.GetMembers(".ctor").
-                    Where(Function(m) DirectCast(m, MethodSymbol).ParameterCount = 1 AndAlso TypeSymbol.Equals(DirectCast(m, MethodSymbol).Parameters(0).Type, OldMsCorLib_systemType, TypeCompareKind.ConsiderEverything2)).[Single](), MethodSymbol)
+                    Where(Function(m) DirectCast(m, MethodSymbol).ParameterCount = 1 AndAlso TypeSymbol.Equals(DirectCast(m, MethodSymbol).Parameters(0).Type, OldMsCorLib_systemType, TypeCompareKind.ConsiderEverything)).[Single](), MethodSymbol)
 
                 NewMsCorLib_debuggerTypeProxyAttributeCtor = DirectCast(NewMsCorLib_debuggerTypeProxyAttributeType.GetMembers(".ctor").
-                    Where(Function(m) DirectCast(m, MethodSymbol).ParameterCount = 1 AndAlso TypeSymbol.Equals(DirectCast(m, MethodSymbol).Parameters(0).Type, NewMsCorLib_systemType, TypeCompareKind.ConsiderEverything2)).[Single](), MethodSymbol)
+                    Where(Function(m) DirectCast(m, MethodSymbol).ParameterCount = 1 AndAlso TypeSymbol.Equals(DirectCast(m, MethodSymbol).Parameters(0).Type, NewMsCorLib_systemType, TypeCompareKind.ConsiderEverything)).[Single](), MethodSymbol)
 
                 Assert.NotSame(OldMsCorLib_debuggerTypeProxyAttributeCtor, NewMsCorLib_debuggerTypeProxyAttributeCtor)
             End Sub

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ImplementsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ImplementsTests.vb
@@ -2556,8 +2556,8 @@ End Class
             Dim fooOfIntString = fooOfIntY.Construct(comp.GetSpecialType(SpecialType.System_String))
 
             Dim iFooOfIntIntListOfStringMethods = iFooOfIntIntListOfString.GetMembers("SayItWithStyle").AsEnumerable().Cast(Of MethodSymbol)()
-            Dim ifooOfIntIntStringSay1 = (From m In iFooOfIntIntListOfStringMethods Where m.Parameters(0).Type = comp.GetSpecialType(SpecialType.System_Int32)).First()
-            Dim ifooOfIntIntStringSay2 = (From m In iFooOfIntIntListOfStringMethods Where m.Parameters(0).Type <> comp.GetSpecialType(SpecialType.System_Int32)).First()
+            Dim ifooOfIntIntStringSay1 = (From m In iFooOfIntIntListOfStringMethods Where TypeSymbol.Equals(m.Parameters(0).Type, comp.GetSpecialType(SpecialType.System_Int32), TypeCompareKind.ConsiderEverything2)).First()
+            Dim ifooOfIntIntStringSay2 = (From m In iFooOfIntIntListOfStringMethods Where Not TypeSymbol.Equals(m.Parameters(0).Type, comp.GetSpecialType(SpecialType.System_Int32), TypeCompareKind.ConsiderEverything2)).First()
 
             Dim fooOfIntStringM1 = DirectCast(fooOfIntString.GetMembers("M1").First(), MethodSymbol)
             Dim fooOfIntStringM2 = DirectCast(fooOfIntString.GetMembers("M2").First(), MethodSymbol)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ImplementsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ImplementsTests.vb
@@ -2556,8 +2556,8 @@ End Class
             Dim fooOfIntString = fooOfIntY.Construct(comp.GetSpecialType(SpecialType.System_String))
 
             Dim iFooOfIntIntListOfStringMethods = iFooOfIntIntListOfString.GetMembers("SayItWithStyle").AsEnumerable().Cast(Of MethodSymbol)()
-            Dim ifooOfIntIntStringSay1 = (From m In iFooOfIntIntListOfStringMethods Where TypeSymbol.Equals(m.Parameters(0).Type, comp.GetSpecialType(SpecialType.System_Int32), TypeCompareKind.ConsiderEverything2)).First()
-            Dim ifooOfIntIntStringSay2 = (From m In iFooOfIntIntListOfStringMethods Where Not TypeSymbol.Equals(m.Parameters(0).Type, comp.GetSpecialType(SpecialType.System_Int32), TypeCompareKind.ConsiderEverything2)).First()
+            Dim ifooOfIntIntStringSay1 = (From m In iFooOfIntIntListOfStringMethods Where TypeSymbol.Equals(m.Parameters(0).Type, comp.GetSpecialType(SpecialType.System_Int32), TypeCompareKind.ConsiderEverything)).First()
+            Dim ifooOfIntIntStringSay2 = (From m In iFooOfIntIntListOfStringMethods Where Not TypeSymbol.Equals(m.Parameters(0).Type, comp.GetSpecialType(SpecialType.System_Int32), TypeCompareKind.ConsiderEverything)).First()
 
             Dim fooOfIntStringM1 = DirectCast(fooOfIntString.GetMembers("M1").First(), MethodSymbol)
             Dim fooOfIntStringM2 = DirectCast(fooOfIntString.GetMembers("M2").First(), MethodSymbol)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -23288,8 +23288,10 @@ End Class
             Dim errortyp = DirectCast(typ, ErrorTypeSymbol)
             Assert.Equal(CandidateReason.Ambiguous, errortyp.CandidateReason)
             Assert.Equal(2, errortyp.CandidateSymbols.Length)
-            Assert.True((classB1 = errortyp.CandidateSymbols(0) AndAlso classB2 = errortyp.CandidateSymbols(1)) OrElse
-                        (classB2 = errortyp.CandidateSymbols(0) AndAlso classB1 = errortyp.CandidateSymbols(1)), "should have B1 and B2 in some order")
+            Assert.True((TypeSymbol.Equals(classB1, TryCast(errortyp.CandidateSymbols(0), TypeSymbol), TypeCompareKind.ConsiderEverything2) AndAlso
+                        TypeSymbol.Equals(classB2, TryCast(errortyp.CandidateSymbols(1), TypeSymbol), TypeCompareKind.ConsiderEverything2)) OrElse
+                        (TypeSymbol.Equals(classB2, TryCast(errortyp.CandidateSymbols(0), TypeSymbol), TypeCompareKind.ConsiderEverything2) AndAlso
+                        TypeSymbol.Equals(classB1, TryCast(errortyp.CandidateSymbols(1), TypeSymbol), TypeCompareKind.ConsiderEverything2)), "should have B1 and B2 in some order")
         End Sub
 
         <Fact()>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -23288,10 +23288,10 @@ End Class
             Dim errortyp = DirectCast(typ, ErrorTypeSymbol)
             Assert.Equal(CandidateReason.Ambiguous, errortyp.CandidateReason)
             Assert.Equal(2, errortyp.CandidateSymbols.Length)
-            Assert.True((TypeSymbol.Equals(classB1, TryCast(errortyp.CandidateSymbols(0), TypeSymbol), TypeCompareKind.ConsiderEverything2) AndAlso
-                        TypeSymbol.Equals(classB2, TryCast(errortyp.CandidateSymbols(1), TypeSymbol), TypeCompareKind.ConsiderEverything2)) OrElse
-                        (TypeSymbol.Equals(classB2, TryCast(errortyp.CandidateSymbols(0), TypeSymbol), TypeCompareKind.ConsiderEverything2) AndAlso
-                        TypeSymbol.Equals(classB1, TryCast(errortyp.CandidateSymbols(1), TypeSymbol), TypeCompareKind.ConsiderEverything2)), "should have B1 and B2 in some order")
+            Assert.True((TypeSymbol.Equals(classB1, TryCast(errortyp.CandidateSymbols(0), TypeSymbol), TypeCompareKind.ConsiderEverything) AndAlso
+                        TypeSymbol.Equals(classB2, TryCast(errortyp.CandidateSymbols(1), TypeSymbol), TypeCompareKind.ConsiderEverything)) OrElse
+                        (TypeSymbol.Equals(classB2, TryCast(errortyp.CandidateSymbols(0), TypeSymbol), TypeCompareKind.ConsiderEverything) AndAlso
+                        TypeSymbol.Equals(classB1, TryCast(errortyp.CandidateSymbols(1), TypeSymbol), TypeCompareKind.ConsiderEverything)), "should have B1 and B2 in some order")
         End Sub
 
         <Fact()>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 For i As Integer = 0 To symbols.Count - 1
                     Dim symbol = symbols(i)
                     If symbol.Kind = SymbolKind.TypeParameter Then
-                        Debug.Assert(TypeSymbol.Equals(DirectCast(symbol.OriginalDefinition.ContainingSymbol, TypeSymbol), substitutedSourceType.OriginalDefinition, TypeCompareKind.ConsiderEverything))
+                        Debug.Assert(TypeSymbol.Equals(symbol.OriginalDefinition.ContainingType, substitutedSourceType.OriginalDefinition, TypeCompareKind.ConsiderEverything))
                         Dim ordinal = DirectCast(symbol, TypeParameterSymbol).Ordinal
                         symbols(i) = substitutedSourceType.TypeArgumentsNoUseSiteDiagnostics(ordinal)
                         Debug.Assert(symbols(i).Kind = SymbolKind.TypeParameter)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 For i As Integer = 0 To symbols.Count - 1
                     Dim symbol = symbols(i)
                     If symbol.Kind = SymbolKind.TypeParameter Then
-                        Debug.Assert(symbol.OriginalDefinition.ContainingSymbol = substitutedSourceType.OriginalDefinition)
+                        Debug.Assert(TypeSymbol.Equals(DirectCast(symbol.OriginalDefinition.ContainingSymbol, TypeSymbol), substitutedSourceType.OriginalDefinition, TypeCompareKind.ConsiderEverything))
                         Dim ordinal = DirectCast(symbol, TypeParameterSymbol).Ordinal
                         symbols(i) = substitutedSourceType.TypeArgumentsNoUseSiteDiagnostics(ordinal)
                         Debug.Assert(symbols(i).Kind = SymbolKind.TypeParameter)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
@@ -61,13 +61,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                         Nothing,
                         GetRewrittenMeParameter(syntax, New BoundMeReference(syntax, _targetMethodMeParameter.Type)))
                     Dim result = staticLocal.ToBoundExpression(receiver, syntax, node.IsLValue)
-                    Debug.Assert(node.Type = result.Type)
+                    Debug.Assert(TypeSymbol.Equals(node.Type, result.Type, TypeCompareKind.ConsiderEverything2))
                     Return result
                 End If
                 Dim variable = GetVariable(local.Name)
                 If variable IsNot Nothing Then
                     Dim result = variable.ToBoundExpression(syntax, node.IsLValue, node.SuppressVirtualCalls)
-                    Debug.Assert(node.Type = result.Type)
+                    Debug.Assert(TypeSymbol.Equals(node.Type, result.Type, TypeCompareKind.ConsiderEverything2))
                     Return result
                 End If
             End If
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 constantValueOpt:=Nothing,
                 relaxationLambdaOpt:=Nothing,
                 type:=baseType)
-            Debug.Assert(result.Type = node.Type)
+            Debug.Assert(TypeSymbol.Equals(result.Type, node.Type, TypeCompareKind.ConsiderEverything2))
             Return result
         End Function
 
@@ -147,7 +147,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End If
 
             Dim result = variable.ToBoundExpression(syntax, node.IsLValue, node.SuppressVirtualCalls)
-            Debug.Assert(result.Type = node.Type OrElse result.Type.BaseTypeNoUseSiteDiagnostics = node.Type)
+            Debug.Assert(TypeSymbol.Equals(result.Type, node.Type, TypeCompareKind.ConsiderEverything2) OrElse
+                         TypeSymbol.Equals(result.Type.BaseTypeNoUseSiteDiagnostics, node.Type, TypeCompareKind.ConsiderEverything2))
             Return result
         End Function
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
@@ -61,13 +61,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                         Nothing,
                         GetRewrittenMeParameter(syntax, New BoundMeReference(syntax, _targetMethodMeParameter.Type)))
                     Dim result = staticLocal.ToBoundExpression(receiver, syntax, node.IsLValue)
-                    Debug.Assert(TypeSymbol.Equals(node.Type, result.Type, TypeCompareKind.ConsiderEverything2))
+                    Debug.Assert(TypeSymbol.Equals(node.Type, result.Type, TypeCompareKind.ConsiderEverything))
                     Return result
                 End If
                 Dim variable = GetVariable(local.Name)
                 If variable IsNot Nothing Then
                     Dim result = variable.ToBoundExpression(syntax, node.IsLValue, node.SuppressVirtualCalls)
-                    Debug.Assert(TypeSymbol.Equals(node.Type, result.Type, TypeCompareKind.ConsiderEverything2))
+                    Debug.Assert(TypeSymbol.Equals(node.Type, result.Type, TypeCompareKind.ConsiderEverything))
                     Return result
                 End If
             End If
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 constantValueOpt:=Nothing,
                 relaxationLambdaOpt:=Nothing,
                 type:=baseType)
-            Debug.Assert(TypeSymbol.Equals(result.Type, node.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(result.Type, node.Type, TypeCompareKind.ConsiderEverything))
             Return result
         End Function
 
@@ -147,8 +147,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End If
 
             Dim result = variable.ToBoundExpression(syntax, node.IsLValue, node.SuppressVirtualCalls)
-            Debug.Assert(TypeSymbol.Equals(result.Type, node.Type, TypeCompareKind.ConsiderEverything2) OrElse
-                         TypeSymbol.Equals(result.Type.BaseTypeNoUseSiteDiagnostics, node.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(result.Type, node.Type, TypeCompareKind.ConsiderEverything) OrElse
+                         TypeSymbol.Equals(result.Type.BaseTypeNoUseSiteDiagnostics, node.Type, TypeCompareKind.ConsiderEverything))
             Return result
         End Function
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Public Overrides Function VisitLocal(node As BoundLocal) As BoundNode
             Dim result = RewriteLocal(node, _diagnostics)
-            Debug.Assert(result.Type = node.Type)
+            Debug.Assert(TypeSymbol.Equals(result.Type, node.Type, TypeCompareKind.ConsiderEverything2))
             Debug.Assert(result.IsLValue = node.IsLValue)
             Return result
         End Function

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/PlaceholderLocalRewriter.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Public Overrides Function VisitLocal(node As BoundLocal) As BoundNode
             Dim result = RewriteLocal(node, _diagnostics)
-            Debug.Assert(TypeSymbol.Equals(result.Type, node.Type, TypeCompareKind.ConsiderEverything2))
+            Debug.Assert(TypeSymbol.Equals(result.Type, node.Type, TypeCompareKind.ConsiderEverything))
             Debug.Assert(result.IsLValue = node.IsLValue)
             Return result
         End Function

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -104,7 +104,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Dim substitutedSourceHasMeParameter = substitutedSourceMeParameter IsNot Nothing
             If substitutedSourceHasMeParameter Then
                 _meParameter = MakeParameterSymbol(0, GeneratedNames.MakeStateMachineCapturedMeName(), substitutedSourceMeParameter) ' NOTE: Name doesn't actually matter.
-                Debug.Assert(_meParameter.Type = Me.SubstitutedSourceMethod.ContainingType)
+                Debug.Assert(TypeSymbol.Equals(_meParameter.Type, Me.SubstitutedSourceMethod.ContainingType, TypeCompareKind.ConsiderEverything2))
                 parameterBuilder.Add(_meParameter)
             End If
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             generateMethodBody As GenerateMethodBody)
 
             Debug.Assert(sourceMethod.IsDefinition)
-            Debug.Assert(sourceMethod.ContainingSymbol = container.SubstitutedSourceType.OriginalDefinition)
+            Debug.Assert(TypeSymbol.Equals(TryCast(sourceMethod.ContainingSymbol, TypeSymbol), container.SubstitutedSourceType.OriginalDefinition, TypeCompareKind.ConsiderEverything))
             Debug.Assert(sourceLocals.All(Function(l) l.ContainingSymbol = sourceMethod))
 
             _compilation = compilation
@@ -104,7 +104,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Dim substitutedSourceHasMeParameter = substitutedSourceMeParameter IsNot Nothing
             If substitutedSourceHasMeParameter Then
                 _meParameter = MakeParameterSymbol(0, GeneratedNames.MakeStateMachineCapturedMeName(), substitutedSourceMeParameter) ' NOTE: Name doesn't actually matter.
-                Debug.Assert(TypeSymbol.Equals(_meParameter.Type, Me.SubstitutedSourceMethod.ContainingType, TypeCompareKind.ConsiderEverything2))
+                Debug.Assert(TypeSymbol.Equals(_meParameter.Type, Me.SubstitutedSourceMethod.ContainingType, TypeCompareKind.ConsiderEverything))
                 parameterBuilder.Add(_meParameter)
             End If
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             generateMethodBody As GenerateMethodBody)
 
             Debug.Assert(sourceMethod.IsDefinition)
-            Debug.Assert(TypeSymbol.Equals(TryCast(sourceMethod.ContainingSymbol, TypeSymbol), container.SubstitutedSourceType.OriginalDefinition, TypeCompareKind.ConsiderEverything))
+            Debug.Assert(TypeSymbol.Equals(sourceMethod.ContainingType, container.SubstitutedSourceType.OriginalDefinition, TypeCompareKind.ConsiderEverything))
             Debug.Assert(sourceLocals.All(Function(l) l.ContainingSymbol = sourceMethod))
 
             _compilation = compilation


### PR DESCRIPTION
This is the VB equivalent of https://github.com/dotnet/roslyn/pull/31814
I used the same process (added some obsolete operators, ran a custom fixer, then did some manual adjustments).

Note: this does not track down all collections that use type symbols (`Dictionary<TypeSymbol, ...>`).

Relates to https://github.com/dotnet/roslyn/issues/31742