### PR TITLE
Filter out wpftemp projects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,6 @@ $RECYCLE.BIN/
 
 # JetBrains Rider
 .idea/
+
+# WPF temp projects
+*wpftmp.*


### PR DESCRIPTION
Tagging @sharwell @dotnet/roslyn-infrastructure 

This is to prevent adding projects like Microsoft.CodeAnalysis.EditorFeatures.Wpf_kjyhhyq3_wpftmp.csproj.  This can happen while performing git operations in the middle of a build AFAICT.