### PR TITLE
Correct XML summary on ITypeSymbol.AllInterfaces

### DIFF
--- a/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 
@@ -42,7 +43,7 @@ namespace Microsoft.CodeAnalysis
         /// relationship: if interface type A extends interface type B, then A precedes B in the
         /// list. This is not quite the same as "all interfaces of which this type is a proper
         /// subtype" because it does not take into account variance: AllInterfaces for
-        /// <c><![CDATA[IEnumerable<string>]]></c> will not include <c><![CDATA[IEnumerable<object>]]></c>;
+        /// IEnumerable&lt;string&gt; will not include IEnumerable&lt;object&gt;.
         /// </summary>
         ImmutableArray<INamedTypeSymbol> AllInterfaces { get; }
 


### PR DESCRIPTION
Currently the intellisense for ITypeSymbol.AllInterfaces looks like this
![image](https://user-images.githubusercontent.com/1007631/50360321-f4497e80-055f-11e9-8635-0da15d7d5c11.png)
This PR improve the XML summary such that the resulting intellisense is useful.

I also tried `<see cref="IEnumerable{String}">IEnumerable&lt;string&gt;</see>`, but that gave `IEnumerable<out T>` in the intellisense.

EDIT: After the change it looks like this
![image](https://user-images.githubusercontent.com/1007631/50362086-953b3800-0566-11e9-95a0-629035034ee5.png)