### PR TITLE
Compile successfully - without IDE0055 - from a fresh checkout

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 symbol.ContainingType.Accept(this.NotFirstVisitor);
                 AddPunctuation(SyntaxKind.DotToken);
             }
-            
+
             if (symbol.ContainingType.TypeKind == TypeKind.Enum)
             {
                 builder.Add(CreatePart(SymbolDisplayPartKind.EnumMemberName, symbol, symbol.Name));

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IUnaryOperatorExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IUnaryOperatorExpression.vb
@@ -2208,7 +2208,7 @@ IUnaryOperation (UnaryOperatorKind.Minus) (OperatorMethod: Function C.op_UnaryNe
 
             VerifyOperationTreeForTest(Of UnaryExpressionSyntax)(source, expectedOperationTree)
         End Sub
-        
+
         <CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)>
         <Fact>
         Public Sub LogicalNotFlow_01()
@@ -2248,7 +2248,7 @@ Block[B2] - Exit
 
             VerifyFlowGraphAndDiagnosticsForTest(Of MethodBlockSyntax)(source, expectedFlowGraph, expectedDiagnostics)
         End Sub
-        
+
         <CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)>
         <Fact>
         Public Sub LogicalNotFlow_02()

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -526,7 +526,7 @@ class C
 class C
 {
 }",
-                Namespace("System"), 
+                Namespace("System"),
                 Class("Obsolete"));
         }
 
@@ -540,7 +540,7 @@ class A
 {
     [Obsolete]
 }",
-                Namespace("System"), 
+                Namespace("System"),
                 Class("Obsolete"));
         }
 
@@ -555,7 +555,7 @@ class A
 class MyAttribute : Attribute
 {
 }",
-                Namespace("System"), 
+                Namespace("System"),
                 Class("My"),
                 Class("Attribute"));
         }
@@ -578,7 +578,7 @@ class Base
 class Derived : Base
 {
 }",
-                Namespace("System"), 
+                Namespace("System"),
                 Class("Base"),
                 Class("My"),
                 Method("My"),
@@ -1118,7 +1118,7 @@ class C
     global::System.String f;
 }",
                 Namespace("System"),
-                Namespace("System"), 
+                Namespace("System"),
                 Class("String"));
         }
 
@@ -1142,9 +1142,9 @@ class C
             await TestAsync(code,
                 code,
                 Options.Regular,
-                Namespace("System"), 
+                Namespace("System"),
                 Class("Str"),
-                Namespace("System"), 
+                Namespace("System"),
                 Class("String"),
                 Class("Str"),
                 Class("Nested"),
@@ -1765,7 +1765,7 @@ class Obsolete : Attribute
 class ObsoleteAttribute : Attribute
 {
 }",
-                Namespace("System"), 
+                Namespace("System"),
                 Class("Serializable"),
                 Class("SerializableAttribute"),
                 Class("Obsolete"),

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             // For Namespace parts, we want don't want to classify the QualifiedNameSyntax
             // nodes, we instead wait for the each IdentifierNameSyntax node to avoid
             // creating overlapping ClassifiedSpans.
-            if (symbol is INamespaceSymbol namespaceSymbol && 
+            if (symbol is INamespaceSymbol namespaceSymbol &&
                 name is IdentifierNameSyntax identifierNameSyntax)
             {
                 // Do not classify the global:: namespace. It is already syntactically classified as a keyword.


### PR DESCRIPTION
When I run `Restore.cmd` and then `Build.cmd` in a fresh clone I get the following formatting errors (all IDE0055): 
```
Build FAILED.

C:\src\DotNet\roslyn\src\Compilers\CSharp\Portable\SymbolDisplay\SymbolDisplayVisitor.Members.cs(52,1): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj]
C:\src\DotNet\roslyn\src\Compilers\VisualBasic\Test\IOperation\IOperation\IOperationTests_IUnaryOperatorExpression.vb(2211,1): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\Compilers\VisualBasic\Test\IOperation\Roslyn.Compilers.VisualBasic.IOperation.UnitTests.vbproj]
C:\src\DotNet\roslyn\src\Compilers\VisualBasic\Test\IOperation\IOperation\IOperationTests_IUnaryOperatorExpression.vb(2251,1): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\Compilers\VisualBasic\Test\IOperation\Roslyn.Compilers.VisualBasic.IOperation.UnitTests.vbproj]
C:\src\DotNet\roslyn\src\Workspaces\CSharp\Portable\Classification\SyntaxClassification\NameSyntaxClassifier.cs(138,62): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\Workspaces\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Workspaces.csproj]
C:\src\DotNet\roslyn\src\Compilers\VisualBasic\Test\IOperation\IOperation\IOperationTests_IUnaryOperatorExpression.vb(2211,1): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\Compilers\VisualBasic\Test\IOperation\Roslyn.Compilers.VisualBasic.IOperation.UnitTests.vbproj]
C:\src\DotNet\roslyn\src\Compilers\VisualBasic\Test\IOperation\IOperation\IOperationTests_IUnaryOperatorExpression.vb(2251,1): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\Compilers\VisualBasic\Test\IOperation\Roslyn.Compilers.VisualBasic.IOperation.UnitTests.vbproj]
C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Classification\SemanticClassifierTests.cs(529,37): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj]
C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Classification\SemanticClassifierTests.cs(543,37): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj]
C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Classification\SemanticClassifierTests.cs(558,37): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj]
C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Classification\SemanticClassifierTests.cs(581,37): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj]
C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Classification\SemanticClassifierTests.cs(1121,37): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj]
C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Classification\SemanticClassifierTests.cs(1145,37): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj]
C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Classification\SemanticClassifierTests.cs(1147,37): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj]
C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Classification\SemanticClassifierTests.cs(1768,37): error IDE0055: Fix formatting [C:\src\DotNet\roslyn\src\EditorFeatures\CSharpTest\Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj]
    0 Warning(s)
    14 Error(s)
```
This PR correct all the errors.