### PR TITLE
Set WarnAsError to false by default for build.cmd script

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -41,7 +41,7 @@ param (
     [switch]$deployExtensions,
     [switch]$prepareMachine,
     [switch]$useGlobalNuGetCache = $true,
-    [switch]$warnAsError = $true,
+    [switch]$warnAsError,
 
     # Test actions
     [switch]$test32,


### PR DESCRIPTION
As requested in https://github.com/dotnet/roslyn/pull/31993#issuecomment-450002539