### PR TITLE
Publish NuPkg as artifact

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,10 +145,10 @@ jobs:
       condition: not(succeeded())
 
     - task: PublishBuildArtifacts@1
-      displayName: NuPkg
+      displayName: Publish Artifact Packages
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\Release\PreRelease'
-        ArtifactName: 'NuPkg'
+        ArtifactName: 'Packages - PreRelease'
         publishLocation: Container
       condition: succeeded()
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,6 +144,14 @@ jobs:
       continueOnError: true
       condition: not(succeeded())
 
+    - task: PublishBuildArtifacts@1
+      displayName: NuPkg
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\Release\PreRelease'
+        ArtifactName: 'NuPkg'
+        publishLocation: Container
+      condition: succeeded()
+
 - job: Linux_Test
   pool: DotNetCore-Linux
   strategy:


### PR DESCRIPTION
This changes our build so that it publishes our NuPkg files on PR and CI
builds. This enables both us to inspect our artifacts when debugging
failures as well as other services, like sharplab, to download them
without having to go through the trouble of building them themselves.