### PR TITLE
Synthesize record ctor body

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1682,6 +1682,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return null;
                 }
             }
+            else if (method is SynthesizedRecordConstructor recordConstructor)
+            {
+                body = recordConstructor.MakeMethodBody(compilationState, diagnostics);
+            }
             else
             {
                 // synthesized methods should return their bound bodies

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2863,7 +2863,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void AddSynthesizedRecordMembersIfNecessary(ArrayBuilder<Symbol> members, DiagnosticBag diagnostics)
         {
-            Debug.Assert(declaration.Kind == DeclarationKind.Class || declaration.Kind == DeclarationKind.Struct);
+            Debug.Assert(declaration.Kind == DeclarationKind.Class ||
+                declaration.Kind == DeclarationKind.Struct ||
+                declaration.Kind == DeclarationKind.Submission ||
+                declaration.Kind == DeclarationKind.Script);
 
             ParameterListSyntax paramList = null;
             foreach (SingleTypeDeclaration decl in declaration.Declarations)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2355,9 +2355,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     break;
 
                 case TypeKind.Class:
+                    AddSynthesizedRecordMembersIfNecessary(builder.NonTypeNonIndexerMembers, diagnostics);
+                    AddSynthesizedConstructorsIfNecessary(builder.NonTypeNonIndexerMembers, builder.StaticInitializers, diagnostics);
+                    break;
+
                 case TypeKind.Submission:
                     // No additional checking required.
-                    AddSynthesizedRecordMembersIfNecessary(builder.NonTypeNonIndexerMembers, diagnostics);
                     AddSynthesizedConstructorsIfNecessary(builder.NonTypeNonIndexerMembers, builder.StaticInitializers, diagnostics);
                     break;
 
@@ -2863,10 +2866,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void AddSynthesizedRecordMembersIfNecessary(ArrayBuilder<Symbol> members, DiagnosticBag diagnostics)
         {
-            Debug.Assert(declaration.Kind == DeclarationKind.Class ||
-                declaration.Kind == DeclarationKind.Struct ||
-                declaration.Kind == DeclarationKind.Submission ||
-                declaration.Kind == DeclarationKind.Script);
+            Debug.Assert(TypeKind == TypeKind.Class || TypeKind == TypeKind.Struct);
 
             ParameterListSyntax paramList = null;
             foreach (SingleTypeDeclaration decl in declaration.Declarations)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedRecordConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedRecordConstructor.cs
@@ -1,30 +1,85 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    internal sealed class SynthesizedRecordConstructor :  SynthesizedInstanceConstructor
+    internal sealed class SynthesizedRecordConstructor : SynthesizedInstanceConstructor
     {
         public override ImmutableArray<ParameterSymbol> Parameters { get; }
+        public ImmutableArray<SynthesizedRecordPropertySymbol> Properties { get; }
 
         public SynthesizedRecordConstructor(
             NamedTypeSymbol containingType,
-            Binder parameterBinder,
-            ParameterListSyntax parameterList,
+            Binder binder,
+            BaseParameterListSyntax paramList,
             DiagnosticBag diagnostics)
             : base(containingType)
         {
             Parameters = ParameterHelpers.MakeParameters(
-                parameterBinder,
+                binder,
                 this,
-                parameterList,
+                paramList,
                 out _,
                 diagnostics,
                 allowRefOrOut: true,
                 allowThis: false,
                 addRefReadOnlyModifier: false);
+
+            var propertiesBuilder = ArrayBuilder<SynthesizedRecordPropertySymbol>.GetInstance(Parameters.Length);
+            foreach (ParameterSymbol param in Parameters)
+            {
+                propertiesBuilder.Add(new SynthesizedRecordPropertySymbol(containingType, param));
+            }
+            Properties = propertiesBuilder.ToImmutableAndFree();
         }
+
+        internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
+        {
+            //  Method body:
+            //
+            //  {
+            //      Object..ctor();
+            //      this.backingField_1 = arg1;
+            //      ...
+            //      this.backingField_N = argN;
+            //  }
+            var F = new SyntheticBoundNodeFactory(this, this.GetNonNullSyntaxNode(), compilationState, diagnostics);
+            F.CurrentFunction = this;
+
+            int paramCount = this.ParameterCount;
+
+            // List of statements
+            var statements = ArrayBuilder<BoundStatement>.GetInstance(paramCount + 2);
+
+            //  explicit base constructor call
+            Debug.Assert(ContainingType.BaseTypeNoUseSiteDiagnostics.SpecialType == SpecialType.System_Object);
+            BoundExpression call = MethodCompiler.GenerateBaseParameterlessConstructorInitializer(this, diagnostics);
+            if (call == null)
+            {
+                // This may happen if Object..ctor is not found or is inaccessible
+                return;
+            }
+            statements.Add(F.ExpressionStatement(call));
+
+            // Assign fields
+            for (int index = 0; index < paramCount; index++)
+            {
+                // Generate 'field' = 'parameter' statement
+                statements.Add(
+                    F.Assignment(F.Field(F.This(), Properties[index].BackingField), F.Parameter(Parameters[index])));
+            }
+
+            // Final return statement
+            statements.Add(F.Return());
+
+            // Create a bound block 
+            F.CloseMethod(F.Block(statements.ToImmutableAndFree()));
+        }
+
+        internal override bool SynthesizesLoweredBoundBody => true;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedRecordConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedRecordConstructor.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Properties = propertiesBuilder.ToImmutableAndFree();
         }
 
-        internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
+        internal BoundBlock MakeMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
         {
             //  Method body:
             //
@@ -53,17 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             int paramCount = this.ParameterCount;
 
             // List of statements
-            var statements = ArrayBuilder<BoundStatement>.GetInstance(paramCount + 2);
-
-            //  explicit base constructor call
-            Debug.Assert(ContainingType.BaseTypeNoUseSiteDiagnostics.SpecialType == SpecialType.System_Object);
-            BoundExpression call = MethodCompiler.GenerateBaseParameterlessConstructorInitializer(this, diagnostics);
-            if (call == null)
-            {
-                // This may happen if Object..ctor is not found or is inaccessible
-                return;
-            }
-            statements.Add(F.ExpressionStatement(call));
+            var statements = ArrayBuilder<BoundStatement>.GetInstance(paramCount + 1);
 
             // Assign fields
             for (int index = 0; index < paramCount; index++)
@@ -77,9 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             statements.Add(F.Return());
 
             // Create a bound block 
-            F.CloseMethod(F.Block(statements.ToImmutableAndFree()));
+            return F.Block(statements.ToImmutableAndFree());
         }
-
-        internal override bool SynthesizesLoweredBoundBody => true;
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRecords.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRecords.cs
@@ -24,5 +24,25 @@ class C
     }
 }", expectedOutput: "1 3");
         }
+
+        [Fact]
+        public void RecordWithInitializer()
+        {
+            CompileAndVerify(@"
+using System;
+class Point(int x, int y)
+{
+    public int Z { get; } = 5;
+}
+class C
+{
+
+    public static void Main()
+    {
+        var p = new Point(1, 3);
+        Console.WriteLine(p.x + "" "" + p.y + "" "" + p.Z);
+    }
+}", expectedOutput: "1 3 5");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRecords.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRecords.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
+{
+    [CompilerTrait(CompilerFeature.Records)]
+    public sealed class CodeGenRecords : EmitMetadataTestBase
+    {
+        [Fact]
+        public void SimpleRecordWithProperties()
+        {
+            CompileAndVerify(@"
+using System;
+class Point(int x, int y);
+class C
+{
+
+    public static void Main()
+    {
+        var p = new Point(1, 3);
+        Console.WriteLine(p.x + "" "" + p.y);
+    }
+}", expectedOutput: "1 3");
+        }
+    }
+}

--- a/src/Test/Utilities/Portable/Traits/CompilerFeature.cs
+++ b/src/Test/Utilities/Portable/Traits/CompilerFeature.cs
@@ -34,5 +34,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         NullCoalescingAssignment,
         AsyncStreams,
         NullableReferenceTypes,
+        Records,
     }
 }


### PR DESCRIPTION
Add code to synthesize a record constructor body. Unfortunately this
breaks field initializers in records because the current MethodCompiler
code can only handle 100% synthesized bodies, empty bodies, or
user-written bodies for constructors and initializers are added only for
the last two.