### PR TITLE
Fix compiler extension VSIX dependencies

### DIFF
--- a/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
+++ b/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
@@ -34,9 +34,10 @@
     <NuGetPackageToIncludeInVsix Include="System.Collections.Immutable" />
     <NuGetPackageToIncludeInVsix Include="System.Memory" />
     <NuGetPackageToIncludeInVsix Include="System.Numerics.Vectors" />
-    <NuGetPackageToIncludeInVsix Include="System.Reflection" />
     <NuGetPackageToIncludeInVsix Include="System.Reflection.Metadata" />
     <NuGetPackageToIncludeInVsix Include="System.Text.Encoding.CodePages" />
+    <NuGetPackageToIncludeInVsix Include="System.Runtime.CompilerServices.Unsafe" />
+    <NuGetPackageToIncludeInVsix Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
We did not include required dependencies in Compiler Extension VSIX.