### PR TITLE
Add System.Runtime.CompilerServices.Unsafe to compilers extension

### DIFF
--- a/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
+++ b/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
@@ -36,6 +36,7 @@
     <NuGetPackageToIncludeInVsix Include="System.Numerics.Vectors" />
     <NuGetPackageToIncludeInVsix Include="System.Reflection" />
     <NuGetPackageToIncludeInVsix Include="System.Reflection.Metadata" />
+    <NuGetPackageToIncludeInVsix Include="System.Runtime.CompilerServices.Unsafe" />
     <NuGetPackageToIncludeInVsix Include="System.Text.Encoding.CodePages" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This missing dependency resulted in integration test failures for project build scenarios.