### PR TITLE
Improve error recovery after missing ">" token

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -5439,14 +5439,26 @@ tryAgain:
             // remaining types & commas
             while (true)
             {
+
                 if (this.CurrentToken.Kind == SyntaxKind.GreaterThanToken)
                 {
                     break;
                 }
-                else if (this.CurrentToken.Kind == SyntaxKind.CommaToken || this.IsPossibleType())
+                else if (this.CurrentToken.Kind == SyntaxKind.CommaToken)
                 {
-                    types.AddSeparator(this.EatToken(SyntaxKind.CommaToken));
-                    types.Add(this.ParseTypeArgument());
+                    eatCommaAndTypeArgument();
+                }
+                else if (this.IsPossibleType())
+                {
+                    var nextToken = this.PeekToken(1);
+                    if (nextToken.Kind == SyntaxKind.GreaterThanToken || nextToken.Kind == SyntaxKind.CommaToken) // presumably missing a comma
+                    {
+                        eatCommaAndTypeArgument();
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
                 else if (this.SkipBadTypeArgumentListTokens(types, SyntaxKind.CommaToken) == PostSkipAction.Abort)
                 {
@@ -5455,6 +5467,12 @@ tryAgain:
             }
 
             close = this.EatToken(SyntaxKind.GreaterThanToken);
+
+            void eatCommaAndTypeArgument()
+            {
+                types.AddSeparator(this.EatToken(SyntaxKind.CommaToken));
+                types.Add(this.ParseTypeArgument());
+            }
         }
 
         private PostSkipAction SkipBadTypeArgumentListTokens(SeparatedSyntaxListBuilder<TypeSyntax> list, SyntaxKind expected)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -6274,6 +6274,46 @@ class C
             Assert.Equal((int)ErrorCode.ERR_IdentifierExpected, file.Errors()[0].Code);
         }
 
+        [Fact]
+        public void TestMissingGreaterThanTokenInReturnType()
+        {
+            var text = @"class Class
+{
+    List<int M(string a)
+    {
+        var x = 42;
+    }
+}";
+            SyntaxTree syntaxTree = SyntaxFactory.ParseSyntaxTree(text);
+            Assert.Equal(text, syntaxTree.GetCompilationUnitRoot().ToFullString());
+            
+            Assert.Equal(new [] { "(3,14): error CS1003: Syntax error, '>' expected" },
+                syntaxTree.GetDiagnostics()
+                    .Select(d => ((IFormattable)d).ToString(null, EnsureEnglishUICulture.PreferredOrNull)));
+
+            Assert.Equal(16, syntaxTree.FindNodeOrTokenByKind(SyntaxKind.MethodDeclaration).Position);
+        }
+
+        [Fact]
+        public void TestMissingCommaTokenInReturnType()
+        {
+            var text = @"class Class
+{
+    Dictionary<int string> M(string a)
+    {
+        var x = 42;
+    }
+}";
+            SyntaxTree syntaxTree = SyntaxFactory.ParseSyntaxTree(text);
+            Assert.Equal(text, syntaxTree.GetCompilationUnitRoot().ToFullString());
+
+            Assert.Equal(new[] { "(3,20): error CS1003: Syntax error, ',' expected" },
+                syntaxTree.GetDiagnostics()
+                    .Select(d => ((IFormattable)d).ToString(null, EnsureEnglishUICulture.PreferredOrNull)));
+
+            Assert.Equal(16, syntaxTree.FindNodeOrTokenByKind(SyntaxKind.MethodDeclaration).Position);
+        }
+
         [WorkItem(537210, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537210")]
         [Fact]
         public void RegressException4UseValueInAccessor()


### PR DESCRIPTION
Previously we assumed that when a `>` or `,` token was missing, the missing token was a `,`.

This PR assumes that the missing token is `>`, unless a lookahead of one suggests otherwise.