### PR TITLE
Fix and validate compiler extension VSIX

### DIFF
--- a/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
+++ b/src/Compilers/Extension/Roslyn.Compilers.Extension.csproj
@@ -50,6 +50,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Scripting\Core\Microsoft.CodeAnalysis.Scripting.csproj">
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
+    </ProjectReference>
     <ProjectReference Include="..\..\Scripting\CSharp\Microsoft.CodeAnalysis.CSharp.Scripting.csproj">
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -50,7 +50,7 @@ namespace BuildBoss
             }
             catch (Exception ex)
             {
-                textWriter.WriteLine($"Error verifying NuPkg files: {ex.Message}");
+                textWriter.WriteLine($"Error verifying: {ex.Message}");
                 return false;
             }
         }
@@ -94,6 +94,11 @@ namespace BuildBoss
                         textWriter,
                         FindNuGetPackage(Path.Combine(ArtifactsDirectory, "VSSetup", Configuration, "DevDivPackages"), "VS.Tools.Roslyn"),
                         string.Empty,
+                        dllRelativeNames);
+
+            allGood &= VerifyVsix(
+                        textWriter,
+                        FindVsix("Roslyn.Compilers.Extension"),
                         dllRelativeNames);
             return allGood;
         }
@@ -234,6 +239,17 @@ namespace BuildBoss
             TextWriter textWriter,
             string nupkgFilePath,
             string folderRelativePath,
+            IEnumerable<string> dllFileNames) => VerifyCore(textWriter, nupkgFilePath, folderRelativePath, dllFileNames);
+
+        private static bool VerifyVsix(
+            TextWriter textWriter,
+            string vsixFilePath,
+            IEnumerable<string> dllFileNames) => VerifyCore(textWriter, vsixFilePath, folderRelativePath: "", dllFileNames);
+
+        private static bool VerifyCore(
+            TextWriter textWriter,
+            string packageFilePath,
+            string folderRelativePath,
             IEnumerable<string> dllFileNames)
         {
             Debug.Assert(string.IsNullOrEmpty(folderRelativePath) || folderRelativePath[0] != '\\');
@@ -242,7 +258,7 @@ namespace BuildBoss
             // are in any child folder
             IEnumerable<string> getPartsInFolder()
             {
-                using (var package = Package.Open(nupkgFilePath, FileMode.Open, FileAccess.Read))
+                using (var package = Package.Open(packageFilePath, FileMode.Open, FileAccess.Read))
                 {
                     foreach (var part in package.GetParts())
                     {
@@ -275,9 +291,9 @@ namespace BuildBoss
                     elementSelector: _ => false,
                     comparer: PathComparer);
             var allGood = true;
-            var nupkgFileName = Path.GetFileName(nupkgFilePath);
+            var packageFileName = Path.GetFileName(packageFilePath);
 
-            textWriter.WriteLine($"Verifying NuPkg {nupkgFileName}");
+            textWriter.WriteLine($"Verifying {packageFileName}");
             foreach (var relativeName in getPartsInFolder())
             {
                 var name = Path.GetFileName(relativeName);
@@ -313,6 +329,14 @@ namespace BuildBoss
         {
             var file = Directory.EnumerateFiles(directory, partialName + "*.nupkg").SingleOrDefault();
             return file ?? throw new Exception($"Unable to find '{partialName}*.nupkg' in '{directory}'");
+        }
+
+        private string FindVsix(string fileName)
+        {
+            fileName = fileName + ".vsix";
+            var directory = Path.Combine(ArtifactsDirectory, "VSSetup", Configuration);
+            var file = Directory.EnumerateFiles(directory, fileName).SingleOrDefault();
+            return file ?? throw new Exception($"Unable to find '{fileName}' in '{directory}'");
         }
     }
 }

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -99,7 +99,7 @@ namespace BuildBoss
             allGood &= VerifyVsix(
                         textWriter,
                         FindVsix("Roslyn.Compilers.Extension"),
-                        dllRelativeNames);
+                        dllRelativeNames.Concat(new[] { "Roslyn.Compilers.Extension.dll" }));
             return allGood;
         }
 

--- a/src/Tools/BuildBoss/Program.cs
+++ b/src/Tools/BuildBoss/Program.cs
@@ -148,7 +148,7 @@ namespace BuildBoss
         private static bool ProcessPackages(string repositoryDirectory, string artifactsDirectory, string configuration)
         {
             var util = new PackageContentsChecker(repositoryDirectory, artifactsDirectory, configuration);
-            return CheckCore(util, $"NuPkg and SWR files");
+            return CheckCore(util, $"NuPkg and VSIX files");
         }
     }
 }


### PR DESCRIPTION
This adds validation to Roslyn.Compilers.Extension.vsix to verify all of the correct DLLs are present. This is essentially the same list we have for Microsoft.Net.Compilers.nupkg as it's logically the same deployment. 

This also fixes up the missing DLL that it found. 

Follow up to #32115