### PR TITLE
async completion: fixing 'Nullable object must have a value' when del…

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -329,8 +329,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             return new FilteredCompletionModel(
                 highlightedList, index, filters,
                 hardSelect ? UpdateSelectionHint.Selected : UpdateSelectionHint.SoftSelected,
-                centerSelection: true, 
-                uniqueItem: matchCount == 1 ? bestFilterResult.Value.VSCompletionItem : default);
+                centerSelection: true,
+                uniqueItem: matchCount == 1 ? bestFilterResult.GetValueOrDefault().VSCompletionItem : default);
         }
 
         private FilteredCompletionModel HandleAllItemsFilteredOut(

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -63,6 +63,40 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         <MemberData(NameOf(AllCompletionImplementations))>
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDeletingWholeWordResetCompletionToTheDefaultItem(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+                              <Document>
+                                  using System;
+
+class C
+{
+    void M()
+    {
+        var replyUri = new Uri("");
+        $$
+    }
+}
+
+                              </Document>)
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+
+                state.SendTypeChars("repl")
+                state.SendTab()
+                For i = 1 To 7
+                    state.SendBackspace()
+                    Await state.WaitForAsynchronousOperationsAsync()
+                Next
+                Await state.AssertCompletionSession()
+
+                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem("AccessViolationException")
+            End Using
+        End Function
+
+        <MemberData(NameOf(AllCompletionImplementations))>
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestNotAtStartOfExistingWord(completionImplementation As CompletionImplementation) As Task
             Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
                               <Document>$$using</Document>)


### PR DESCRIPTION
Scenario:
1. 
```
using System;

class C
{
    void M()
    {
        var replyUri = new Uri("");
        $$
    }
}
```

2. Type 'repl' and press Tab. 'replyUri' appears
3. Hit Backspace 8 times

**Expected**
'replyUri' has been deleted. A new completion appears with the default list

**Actual**
```
System.InvalidOperationException: Nullable object must have a value. at 
System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource) at 
Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion.ItemManager.HandleDeletionTrigger(List`1 filterResults, String filterText, ImmutableArray`1 filters, ImmutableArray`1 highlightedList) at 
Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion.ItemManager.UpdateCompletionList(IAsyncCompletionSession session, AsyncCompletionSessionDataSnapshot data, CancellationToken cancellationToken) at 
Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion.ItemManager.UpdateCompletionListAsync(IAsyncCompletionSession session, AsyncCompletionSessionDataSnapshot data, CancellationToken cancellationToken) at 
Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Implementation.AsyncCompletionSession.<>c__DisplayClass92_0.<UpdateSnapshot>b__0() at 
Microsoft.VisualStudio.Text.Utilities.GuardedOperations.<CallExtensionPointAsync>d__34`1.MoveNext() --- End of stack trace from previous location where exception was thrown --- at 
Microsoft.VisualStudio.Telemetry.WindowsErrorReporting.WatsonReport.GetClrWatsonExceptionInfo(Exception exceptionObject)
```
