### PR TITLE
tabs should not trigger completion

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -109,19 +109,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return true;
             }
 
+            //The user may be trying to invoke snippets through question-tab.
+            // We may provide a completion after that.
+            // Otherwise, tab should not be a completion trigger.
+            if (trigger.Reason == AsyncCompletionData.CompletionTriggerReason.Insertion && trigger.Character == '\t')
+            {
+                return TryInvokeSnippetCompletion(completionService, document, sourceText, triggerLocation.Position);
+            }
+
             var roslynTrigger = Helpers.GetRoslynTrigger(trigger, triggerLocation);
 
             // The completion service decides that user may want a completion.
             if (completionService.ShouldTriggerCompletion(sourceText, triggerLocation.Position, roslynTrigger))
-            {
-                return true;
-            }
-
-            // The user may be trying to invoke snippets through question-tab.
-            // We may provide a completion after that.
-            if (trigger.Reason == AsyncCompletionData.CompletionTriggerReason.Insertion &&
-                trigger.Character == '\t' &&
-                TryInvokeSnippetCompletion(completionService, document, sourceText, triggerLocation.Position))
             {
                 return true;
             }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -57,6 +57,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             // We would like to be sure that nobody changes buffers at the same time.
             AssertIsForeground();
 
+            if (trigger.Reason == AsyncCompletionData.CompletionTriggerReason.Insertion && trigger.Character == '\t')
+            {
+                return AsyncCompletionData.CompletionStartData.DoesNotParticipateInCompletion;
+            }
+
             var document = triggerLocation.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
             {
@@ -81,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             var sourceText = document.GetTextSynchronously(cancellationToken);
 
-            return ShouldTriggerCompletion(trigger, triggerLocation, sourceText, document, service) 
+            return ShouldTriggerCompletion(trigger, triggerLocation, sourceText, document, service)
                 ? new AsyncCompletionData.CompletionStartData(
                     participation: AsyncCompletionData.CompletionParticipation.ProvidesItems,
                     applicableToSpan: new SnapshotSpan(

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -57,11 +57,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             // We would like to be sure that nobody changes buffers at the same time.
             AssertIsForeground();
 
-            if (trigger.Reason == AsyncCompletionData.CompletionTriggerReason.Insertion && trigger.Character == '\t')
-            {
-                return AsyncCompletionData.CompletionStartData.DoesNotParticipateInCompletion;
-            }
-
             var document = triggerLocation.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
             {

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -97,7 +97,7 @@ class C
 
         <MemberData(NameOf(AllCompletionImplementations))>
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestMultipleTabsDoNotTriggerCompletion(completionImplementation As CompletionImplementation) As Task
+        Public Async Function TestTabsDoNotTriggerCompletion(completionImplementation As CompletionImplementation) As Task
             Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
                               <Document>
                                   using System;
@@ -107,17 +107,15 @@ class C
     void M()
     {
         var replyUri = new Uri("");
-        $$
+        replyUri$$
     }
 }
 
                               </Document>)
 
-                state.SendTypeChars("repl")
                 state.SendTab()
                 state.SendTab()
-                Await state.AssertNoCompletionSession()
-                state.SendTab()
+                Await state.WaitForAsynchronousOperationsAsync()
                 Assert.Equal("        replyUri" & vbTab & vbTab, state.GetLineTextFromCaretPosition())
             End Using
         End Function

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -97,6 +97,33 @@ class C
 
         <MemberData(NameOf(AllCompletionImplementations))>
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMultipleTabsDoNotTriggerCompletion(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+                              <Document>
+                                  using System;
+
+class C
+{
+    void M()
+    {
+        var replyUri = new Uri("");
+        $$
+    }
+}
+
+                              </Document>)
+
+                state.SendTypeChars("repl")
+                state.SendTab()
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+                state.SendTab()
+                Assert.Equal("        replyUri" & vbTab & vbTab, state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
+        <MemberData(NameOf(AllCompletionImplementations))>
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestNotAtStartOfExistingWord(completionImplementation As CompletionImplementation) As Task
             Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
                               <Document>$$using</Document>)


### PR DESCRIPTION
```
using System;

 class C
{
    void M()
    {
        var replyUri = new Uri("");
        $$
    }
}
```

Start typing 'repl' and hit tab three times

**Expected**
'replyUri' has been added once and two times tab has been added

**Actual**
'replyUri' has been added once and 'uri' was added once from another completion session