### PR TITLE
Fix projects being removed from the Workspace

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LifetimeTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LifetimeTests.cs
@@ -23,6 +23,8 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
 
                 project.UseReference(p => p.Disconnect());
                 project.AssertReleased();
+
+                Assert.Empty(environment.Workspace.CurrentSolution.Projects);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1355,7 +1355,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                             _projectSystemNameToProjectsMap.Remove(projectName);
                         }
 
-                        return;
+                        break;
                     }
                 }
 


### PR DESCRIPTION
We were leaving them in the workspace by accident.

Fixes #32036 and probably a bunch of dupes too.