### PR TITLE
Handle GetIntellisenseProjectName returning empty

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsContainedLanguageFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsContainedLanguageFactory.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 }
             }
 
-            if (projectName == null)
+            if (string.IsNullOrEmpty(projectName))
             {
                 if (hierarchy is IVsContainedLanguageProjectNameProvider containedLanguageProjectNameProvider)
                 {


### PR DESCRIPTION
CPS-based projects have moved from a "fake" IVsHierarchy being passed to the Roslyn to returning the "real" hiearchy representing the project. This results in GetItemContext actually returning a real implementation of "IWebApplicationCtxSvc" instead of previously failing.

This implementation returns S_OK and an "empty" project name - to indicate that it doesn't actually handle the call (with a giant TODO). Handle that situation and treated it as failed, so that we proceed onto IVsContainedLanguageProjectNameProvider which provides the real underlying value.

This is blocking https://github.com/dotnet/project-system/pull/4419.