### PR TITLE
Fix Visual Basic classifications for ControlKeyword

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
@@ -1624,7 +1624,7 @@ Dim z6 = New List(Of Integer) With {.Capacity = 2}"
                 Keyword("With"),
                 Punctuation.OpenCurly,
                 Keyword("Key"),
-                Keyword("If"),
+                ControlKeyword("If"),
                 Punctuation.OpenParen,
                 Identifier("k"),
                 Operators.GreaterThan,
@@ -1664,7 +1664,7 @@ Dim z6 = New List(Of Integer) With {.Capacity = 2}"
                 Keyword("With"),
                 Punctuation.OpenCurly,
                 Keyword("Key"),
-                Keyword("If"),
+                ControlKeyword("If"),
                 Punctuation.OpenParen,
                 Keyword("True"),
                 Punctuation.Comma,
@@ -1956,6 +1956,40 @@ End Enum"
                 Punctuation.CloseParen,
                 Keyword("As"),
                 Keyword("Integer"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Classification)>
+        Public Async Function TestTernaryConditionalExpression() As Task
+            Dim code = "Dim i = If(True, 1, 2)"
+
+            Await TestInMethodAsync(code,
+                Keyword("Dim"),
+                Local("i"),
+                Operators.Equals,
+                ControlKeyword("If"),
+                Punctuation.OpenParen,
+                Keyword("True"),
+                Punctuation.Comma,
+                Number("1"),
+                Punctuation.Comma,
+                Number("2"),
+                Punctuation.CloseParen)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Classification)>
+        Public Async Function TestForStatement() As Task
+            Dim code =
+"For i = 0 To 10
+Exit For"
+            Await TestInMethodAsync(code,
+                ControlKeyword("For"),
+                Identifier("i"),
+                Operators.Equals,
+                Number("0"),
+                ControlKeyword("To"),
+                Number("10"),
+                ControlKeyword("Exit"),
+                ControlKeyword("For"))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Classification)>

--- a/src/Workspaces/VisualBasic/Portable/Classification/ClassificationHelpers.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/ClassificationHelpers.vb
@@ -104,7 +104,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
                 SyntaxKind.UntilKeyword,
                 SyntaxKind.EndIfKeyword,
                 SyntaxKind.GosubKeyword,
-                SyntaxKind.YieldKeyword
+                SyntaxKind.YieldKeyword,
+                SyntaxKind.ToKeyword
                     Return True
                 Case Else
                     Return False
@@ -131,7 +132,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
                 SyntaxKind.EndIfStatement,
                 SyntaxKind.EndSelectStatement,
                 SyntaxKind.EndTryStatement,
-                SyntaxKind.EndUsingStatement,
                 SyntaxKind.EndWhileStatement,
                 SyntaxKind.ExitDoStatement,
                 SyntaxKind.ExitForStatement,
@@ -158,7 +158,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
                 SyntaxKind.UntilClause,
                 SyntaxKind.WhileClause,
                 SyntaxKind.WhileStatement,
-                SyntaxKind.YieldStatement
+                SyntaxKind.YieldStatement,
+                SyntaxKind.TernaryConditionalExpression
                     Return True
                 Case Else
                     Return False


### PR DESCRIPTION
Noticed a few issues while working in VB unit tests.

- Stop classifying EndKeyword in EndUsingStatement
- Begin classifying ToKeyword in ForStatement
- Begin classifying IfKeyword in TernaryConditionalExpression