### PR TITLE
IDE0060 doesn't warn about unused params in ISerializable constructors

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -979,6 +979,39 @@ class C
 }}");
         }
 
+        [WorkItem(32133, "https://github.com/dotnet/roslyn/issues/32133")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task Parameter_SerializationConstructor()
+        {
+            await TestDiagnosticMissingAsync(
+@"
+using System;
+using System.Runtime.Serialization;
+
+internal sealed class NonSerializable
+{
+    public NonSerializable(string value) => Value = value;
+
+    public string Value { get; set; }
+}
+
+[Serializable]
+internal sealed class CustomSerializingType : ISerializable
+{
+    private readonly NonSerializable _nonSerializable;
+
+    public CustomSerializingType(SerializationInfo info, StreamingContext [|context|])
+    {
+        _nonSerializable = new NonSerializable(info.GetString(""KEY""));
+    }
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        info.AddValue(""KEY"", _nonSerializable.Value);
+    }
+}");
+        }
+
         [ConditionalFact(typeof(IsEnglishLocal)), Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
         public async Task Parameter_DiagnosticMessages()
         {

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -65,10 +65,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnusedParametersA
         [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
         [InlineData("public", "public")]
         [InlineData("public", "protected")]
-        public async Task Parameter_Unused_NonPrivate_NotApplicable(string typeAccesibility, string methodAccessibility)
+        public async Task Parameter_Unused_NonPrivate_NotApplicable(string typeAccessibility, string methodAccessibility)
         {
             await TestDiagnosticMissingAsync(
-$@"{typeAccesibility} class C
+$@"{typeAccessibility} class C
 {{
     {methodAccessibility} void M(int [|p|])
     {{
@@ -83,10 +83,10 @@ $@"{typeAccesibility} class C
         [InlineData("internal", "public")]
         [InlineData("internal", "internal")]
         [InlineData("internal", "protected")]
-        public async Task Parameter_Unused_NonPublicMethod(string typeAccesibility, string methodAccessibility)
+        public async Task Parameter_Unused_NonPublicMethod(string typeAccessibility, string methodAccessibility)
         {
             await TestDiagnosticsAsync(
-$@"{typeAccesibility} class C
+$@"{typeAccessibility} class C
 {{
     {methodAccessibility} void M(int [|p|])
     {{

--- a/src/Features/CSharp/Portable/RemoveUnusedParametersAndValues/CSharpRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/RemoveUnusedParametersAndValues/CSharpRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -36,8 +36,8 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedParametersAndValues
         {
             switch (unusedDefinition.Syntax)
             {
-                case VariableDeclaratorSyntax variableDeclartor:
-                    return variableDeclartor.Identifier.GetLocation();
+                case VariableDeclaratorSyntax variableDeclarator:
+                    return variableDeclarator.Identifier.GetLocation();
 
                 case DeclarationPatternSyntax declarationPattern:
                     return declarationPattern.Designation.GetLocation();

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
             private readonly Dictionary<ISymbol, ValueUsageInfo> _symbolValueUsageStateMap;
             private readonly INamedTypeSymbol _taskType, _genericTaskType, _debuggerDisplayAttributeType, _structLayoutAttributeType;
             private readonly INamedTypeSymbol _eventArgsType;
-            private readonly SerializationConstructorCheck _serializationConstructorCheck;
+            private readonly DeserializationConstructorCheck _deserializationConstructorCheck;
             private readonly ImmutableHashSet<INamedTypeSymbol> _attributeSetForMethodsToIgnore;
             private readonly AbstractRemoveUnusedMembersDiagnosticAnalyzer<TDocumentationCommentTriviaSyntax, TIdentifierNameSyntax> _analyzer;
 
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 _debuggerDisplayAttributeType = compilation.DebuggerDisplayAttributeType();
                 _structLayoutAttributeType = compilation.StructLayoutAttributeType();
                 _eventArgsType = compilation.EventArgsType();
-                _serializationConstructorCheck = new SerializationConstructorCheck(compilation);
+                _deserializationConstructorCheck = new DeserializationConstructorCheck(compilation);
                 _attributeSetForMethodsToIgnore = ImmutableHashSet.CreateRange(GetAttributesForMethodsToIgnore(compilation));
             }
 
@@ -563,7 +563,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                                     // ISerializable constructor is invoked by the runtime for deserialization
                                     // and it is a common pattern to have a private serialization constructor
                                     // that is not explicitly referenced in code.
-                                    if (_serializationConstructorCheck.IsISerializableConstructor(methodSymbol))
+                                    if (_deserializationConstructorCheck.IsDeserializationConstructor(methodSymbol))
                                     {
                                         return false;
                                     }

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -86,11 +86,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
 
             private void OnSymbolEnd(SymbolAnalysisContext context)
             {
-                foreach (var parameterAndUsageKvp in _unusedParameters)
+                foreach (var (parameter, hasReference) in _unusedParameters)
                 {
-                    var parameter = parameterAndUsageKvp.Key;
-                    bool hasReference = parameterAndUsageKvp.Value;
-
                     ReportUnusedParameterDiagnostic(parameter, hasReference, context.ReportDiagnostic, context.Options, context.CancellationToken);
                 }
             }

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -54,14 +54,14 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
             {
                 var attributeSetForMethodsToIgnore = ImmutableHashSet.CreateRange(GetAttributesForMethodsToIgnore(context.Compilation).WhereNotNull());
                 var eventsArgType = context.Compilation.EventArgsType();
-                var serializationConstructorCheck = new DeserializationConstructorCheck(context.Compilation);
+                var deserializationConstructorCheck = new DeserializationConstructorCheck(context.Compilation);
                 context.RegisterSymbolStartAction(symbolStartContext =>
                 {
                     // Create a new SymbolStartAnalyzer instance for every named type symbol
                     // to ensure there is no shared state (such as identified unused parameters within the type),
                     // as that would lead to duplicate diagnostics being reported from symbol end action callbacks
                     // for unrelated named types.
-                    var symbolAnalyzer = new SymbolStartAnalyzer(analyzer, eventsArgType, attributeSetForMethodsToIgnore, serializationConstructorCheck);
+                    var symbolAnalyzer = new SymbolStartAnalyzer(analyzer, eventsArgType, attributeSetForMethodsToIgnore, deserializationConstructorCheck);
                     symbolAnalyzer.OnSymbolStart(symbolStartContext);
                 }, SymbolKind.NamedType);
             }

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                 AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer compilationAnalyzer,
                 INamedTypeSymbol eventArgsTypeOpt,
                 ImmutableHashSet<INamedTypeSymbol> attributeSetForMethodsToIgnore,
-                in DeserializationConstructorCheck deserializationConstructorCheck)
+                DeserializationConstructorCheck deserializationConstructorCheck)
             {
                 _compilationAnalyzer = compilationAnalyzer;
 

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
 
             private readonly INamedTypeSymbol _eventArgsTypeOpt;
             private readonly ImmutableHashSet<INamedTypeSymbol> _attributeSetForMethodsToIgnore;
-            private readonly SerializationConstructorCheck _serializationConstructorCheck;
+            private readonly DeserializationConstructorCheck _deserializationConstructorCheck;
             private readonly ConcurrentDictionary<IMethodSymbol, bool> _methodsUsedAsDelegates;
 
             /// <summary>
@@ -37,13 +37,13 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                 AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer compilationAnalyzer,
                 INamedTypeSymbol eventArgsTypeOpt,
                 ImmutableHashSet<INamedTypeSymbol> attributeSetForMethodsToIgnore,
-                in SerializationConstructorCheck serializationConstructorCheck)
+                in DeserializationConstructorCheck deserializationConstructorCheck)
             {
                 _compilationAnalyzer = compilationAnalyzer;
 
                 _eventArgsTypeOpt = eventArgsTypeOpt;
                 _attributeSetForMethodsToIgnore = attributeSetForMethodsToIgnore;
-                _serializationConstructorCheck = serializationConstructorCheck;
+                _deserializationConstructorCheck = deserializationConstructorCheck;
                 _unusedParameters = new ConcurrentDictionary<IParameterSymbol, bool>();
                 _methodsUsedAsDelegates = new ConcurrentDictionary<IMethodSymbol, bool>();
             }
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
             {
                 var attributeSetForMethodsToIgnore = ImmutableHashSet.CreateRange(GetAttributesForMethodsToIgnore(context.Compilation).WhereNotNull());
                 var eventsArgType = context.Compilation.EventArgsType();
-                var serializationConstructorCheck = new SerializationConstructorCheck(context.Compilation);
+                var serializationConstructorCheck = new DeserializationConstructorCheck(context.Compilation);
                 context.RegisterSymbolStartAction(symbolStartContext =>
                 {
                     // Create a new SymbolStartAnalyzer instance for every named type symbol
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     method.IsAccessor() ||
                     method.IsAnonymousFunction() ||
                     _compilationAnalyzer.MethodHasHandlesClause(method) ||
-                    _serializationConstructorCheck.IsISerializableConstructor(method))
+                    _deserializationConstructorCheck.IsDeserializationConstructor(method))
                 {
                     return false;
                 }

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -37,10 +37,10 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
     ///        i.e. "_ = Computation();" or "var unused = Computation();"
     ///        This diagnostic configuration is controlled by language specific code style option "UnusedValueAssignment".
     ///     3. Redundant parameters that fall into one of the following two categories:
-    ///         a. Have no references in the executable code block(s) for it's containing method symbol.
-    ///         b. Have one or more references but it's initial value at start of code block is never used.
+    ///         a. Have no references in the executable code block(s) for its containing method symbol.
+    ///         b. Have one or more references but its initial value at start of code block is never used.
     ///            For example, if 'x' in the example for case 2. above was a parameter symbol with RefKind.None
-    ///            and "x = Computation();" is the first statement in the method body, then it's initial value
+    ///            and "x = Computation();" is the first statement in the method body, then its initial value
     ///            is never used. Such a parameter should be removed and 'x' should be converted into a local.
     ///        We provide additional information in the diagnostic message to clarify the above two categories
     ///        and also detect and mention about potential breaking change if the containing method is a public API.

--- a/src/Features/Core/Portable/Shared/Utilities/DeserializationConstructorCheck.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/DeserializationConstructorCheck.cs
@@ -4,20 +4,22 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Shared.Utilities
 {
-    internal readonly struct SerializationConstructorCheck
+    internal readonly struct DeserializationConstructorCheck
     {
-        private readonly INamedTypeSymbol _iSerializableType, _serializationInfoType, _streamingContextType;
+        private readonly INamedTypeSymbol _iSerializableType;
+        private readonly INamedTypeSymbol _serializationInfoType;
+        private readonly INamedTypeSymbol _streamingContextType;
 
-        public SerializationConstructorCheck(Compilation compilation)
+        public DeserializationConstructorCheck(Compilation compilation)
         {
             _iSerializableType = compilation.ISerializableType();
             _serializationInfoType = compilation.SerializationInfoType();
             _streamingContextType = compilation.StreamingContextType();
         }
 
-        // True if the method is a constructor adhereing to the pattern used for custom
-        // deserialisation by types that implement System.Runtime.Serialization.ISerializable
-        public bool IsISerializableConstructor(IMethodSymbol methodSymbol)
+        // True if the method is a constructor adhering to the pattern used for custom
+        // deserialization by types that implement System.Runtime.Serialization.ISerializable
+        public bool IsDeserializationConstructor(IMethodSymbol methodSymbol)
             => _iSerializableType != null &&
                methodSymbol.MethodKind == MethodKind.Constructor &&
                methodSymbol.Parameters.Length == 2 &&

--- a/src/Features/Core/Portable/Shared/Utilities/SerializationConstructorCheck.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/SerializationConstructorCheck.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.Shared.Utilities
+{
+    internal readonly struct SerializationConstructorCheck
+    {
+        private readonly INamedTypeSymbol _iSerializableType, _serializationInfoType, _streamingContextType;
+
+        public SerializationConstructorCheck(Compilation compilation)
+        {
+            _iSerializableType = compilation.ISerializableType();
+            _serializationInfoType = compilation.SerializationInfoType();
+            _streamingContextType = compilation.StreamingContextType();
+        }
+
+        // True if the method is a constructor adhereing to the pattern used for custom
+        // deserialisation by types that implement System.Runtime.Serialization.ISerializable
+        public bool IsISerializableConstructor(IMethodSymbol methodSymbol)
+            => _iSerializableType != null &&
+               methodSymbol.MethodKind == MethodKind.Constructor &&
+               methodSymbol.Parameters.Length == 2 &&
+               methodSymbol.Parameters[0].Type.Equals(_serializationInfoType) &&
+               methodSymbol.Parameters[1].Type.Equals(_streamingContextType) &&
+               methodSymbol.ContainingType.AllInterfaces.Contains(_iSerializableType);
+    }
+}


### PR DESCRIPTION
Fixes #32133.

Logic that tests for such constructors is pulled out to a helper struct, `SerializationConstructorCheck`. I couldn't find existing patterns for this kind of thing, so perhaps a different approach is preferred. It cannot be an extension method as it caches symbols from the compilation for reuse across multiple calls.

Fixed some typos too, in a separate commit.