### PR TITLE
Fix null check combined with nullable bool test

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -18,7 +18,7 @@ jobs:
         _configuration: Debug
       release:
         _configuration: Release
-  timeoutInMinutes: 90
+  timeoutInMinutes: 135
 
   steps:
     - script: eng/cibuild.cmd -configuration $(_configuration) -prepareMachine -testVsi 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -264,7 +264,12 @@ function TestUsingOptimizedRunner() {
     $dlls = $dlls | ?{ -not ($_.FullName -match ".*/ref/.*") }
 
     if ($ci) {
-        $args += " -xml -timeout:65"
+        $args += " -xml"
+        if ($testVsi) {
+            $args += " -timeout:120"
+        } else {
+            $args += " -timeout:65"
+        }
     }
 
     $procdumpPath = Ensure-ProcDump

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticResultSerializer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticResultSerializer.cs
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 if (document?.SupportsDiagnostics() == false)
                 {
-                    // drop diagnostics for document that doesn't support
+                    // drop diagnostics for non-null document that doesn't support
                     // diagnostics
                     continue;
                 }

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
@@ -113,7 +113,12 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
 
         private void AppendDiagnostics(ref Dictionary<DocumentId, List<DiagnosticData>> map, Document documentOpt, Diagnostic diagnostic)
         {
-            if (documentOpt?.SupportsDiagnostics() == false)
+            if (documentOpt is null)
+            {
+                return;
+            }
+
+            if (!documentOpt.SupportsDiagnostics())
             {
                 return;
             }


### PR DESCRIPTION
* Fixes #31739 
* Fixes timeout for integration tests (they took 1:30 locally so I allowed for 2:00 on CI)

### Customer scenario

Visual Studio can crash with a FailFast during editing.

### Bugs this fixes

#31739

### Workarounds, if any

None.

### Risk

Low. The change restores a null check that was unintentionally removed.

### Performance impact

Negligible.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

The issue was caught during code review but not corrected before merge.

### How was the bug found?

Integration tests.

### Test documentation updated?

N/A
