### PR TITLE
Publish OptProf Data files

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -69,6 +69,15 @@ jobs:
     displayName: 'OPTPROF - Publish to Artifact Services - ProfilingInputs'
     condition: succeededOrFailed()
 
+  # Publish OptProf generated JSON files as a build artifact. This allows for easy inspection from
+  # a build execution.
+  - task: PublishBuildArtifacts@1
+    displayName: Publish OptProf Data Files
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
+      ArtifactName: 'OptProf Data Files'
+    condition: succeeded()
+
   # Created a exe that will install visual studio with this version 
   - task: PowerShell@2
     inputs:


### PR DESCRIPTION
This publishes the OptProf Data files during an official build. This
just allows for us to easily inspect the results without having to do a
download from the drop server.