### PR TITLE
Recommend keyword static for static local functions

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                 }
                 else
                 {
-                    var result = (await RecommendKeywordsAsync(position, context)).Single();
+                    var result = (await RecommendKeywordsAsync(position, context)).SingleOrDefault();
                     Assert.True(result != null, "No recommended keywords");
                     Assert.Equal(keywordText, result.Keyword);
                     if (matchPriority != null)

--- a/src/EditorFeatures/CSharpTest2/Recommendations/StaticKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StaticKeywordRecommenderTests.cs
@@ -277,12 +277,17 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(32214, "https://github.com/dotnet/roslyn/issues/32214")]
         public async Task TestNotBetweenUsings()
         {
-            await VerifyKeywordAsync(AddInsideMethod(
-@"using Goo;
+            var source = @"using Goo;
 $$
-using Bar;"));
+using Bar;";
+
+            await VerifyWorkerAsync(source, absent: true);
+
+            // Recommendation in scripting is not stable. See https://github.com/dotnet/roslyn/issues/32214
+            //await VerifyWorkerAsync(source, absent: true, Options.Script);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]

--- a/src/EditorFeatures/CSharpTest2/Recommendations/StaticKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StaticKeywordRecommenderTests.cs
@@ -48,9 +48,10 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotInEmptyStatement()
+        [WorkItem(32174, "https://github.com/dotnet/roslyn/issues/32174")]
+        public async Task TestInEmptyStatement()
         {
-            await VerifyAbsenceAsync(AddInsideMethod(
+            await VerifyKeywordAsync(AddInsideMethod(
 @"$$"));
         }
 
@@ -278,7 +279,7 @@ $$");
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotBetweenUsings()
         {
-            await VerifyAbsenceAsync(AddInsideMethod(
+            await VerifyKeywordAsync(AddInsideMethod(
 @"using Goo;
 $$
 using Bar;"));
@@ -342,6 +343,29 @@ using Bar;"));
 @"class C {
     void M() {
         using $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(32174, "https://github.com/dotnet/roslyn/issues/32174")]
+        public async Task TestLocalFunction()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@" $$ void local() { }"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInCase()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"
+switch (i)
+{
+    case 0:
+        $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInFor()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(@" for (int i = 0; i < 0; $$) "));
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StaticKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StaticKeywordRecommender.cs
@@ -55,6 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             return
                 context.IsGlobalStatementContext ||
                 context.TargetToken.IsUsingKeywordInUsingDirective() ||
+                context.IsStatementContext ||
                 IsValidContextForType(context, cancellationToken) ||
                 IsValidContextForMember(context, cancellationToken);
         }


### PR DESCRIPTION
**Customer scenario**
User types a static local function (C# 8.0 beta).
Completion gets in the way of typing `static`, by auto-completing to `System.ContextStaticAttribute`.

**Bugs this fixes**
Fixes https://github.com/dotnet/roslyn/issues/32174

**Workarounds, if any**
You can dismiss the incorrect completion, but more often than not, you'll need to delete `System.ContextStaticAttribute` and type `static` and dismiss the incorrect completion.

**Risk**
**Performance impact**
Low. This is a one-line fix in the recommender for `static` keyword.

**Is this a regression from a previous update?**
No, this is the result of a feature introduced in preview2.

**Root cause analysis**
New feature requires some adjustments to tooling. 

**How was the bug found?**
Ad-hoc IDE validation as part of compiler test plan for new language features.

----

Filed https://devdiv.visualstudio.com/DevDiv/_workitems/edit/763373 for shiproom purpose

----

@dotnet/roslyn-ide for review. Thanks

CC @cston 
Relates to https://github.com/dotnet/roslyn/issues/32069

![image](https://user-images.githubusercontent.com/12466233/50718663-d5aab380-1046-11e9-838b-7a4419446aa2.png)
