### PR TITLE
Update DocComment on UnassignedAddressTakenVariablesWalker

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedAddressTakenVariablesWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedAddressTakenVariablesWalker.cs
@@ -9,8 +9,7 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.CSharp
 {
     /// <summary>
-    /// An analysis that computes the set of variables that may be used
-    /// before being assigned anywhere within a method.
+    /// An analysis that computes all cases where the address is taken of a variable that has not yet been assigned
     /// </summary>
     internal class UnassignedAddressTakenVariablesWalker : DefiniteAssignmentPass
     {


### PR DESCRIPTION
The original Doc Comment was copied from UnassignedVariablesWalker, and so was incorrect.

See issue #31483