### PR TITLE
Add support for ??= to NullableWalker

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1880,11 +1880,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var leftState = this.State.Clone();
 
-            if (leftSlot > 0)
-            {
-                leftState[leftSlot] = NullableAnnotation.NotNullable;
-            }
-
             TypeSymbolWithAnnotations rightResult = VisitOptionalImplicitConversion(rightOperand, targetType, UseLegacyWarnings(leftOperand), AssignmentKind.Assignment);
             TrackNullableStateForAssignment(rightOperand, targetType, leftSlot, rightResult, MakeSlot(rightOperand));
             Join(ref this.State, ref leftState);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1891,6 +1891,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (leftResult.ValueCanBeNull() == false)
             {
                 ReportNonSafetyDiagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, leftOperand.Syntax);
+                SetUnreachable();
             }
 
             bool leftIsConstant = leftOperand.ConstantValue != null;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -18030,6 +18030,28 @@ class C
         }
 
         [Fact]
+        public void NullCoalescingOperator_RightIsUnreachable()
+        {
+            var source = @"
+class C
+{
+    object? F = null;
+    void M(C? c1, C c2)
+    {
+        if (c1?.F == null) return;
+        _ = c1 ?? (c1 = c2);
+        c1.F.ToString();
+    }
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (8,13): hidden CS8607: Expression is probably never null.
+                //         _ = c1 ?? (c1 = c2);
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c1").WithLocation(8, 13));
+        }
+
+        [Fact]
         public void IdentityConversion_NullCoalescingOperator_01()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -4142,7 +4142,7 @@ class C
 
         foreach (var ns1 in NCollection())
         {
-            ns1 /*T:string?*/ .ToString(); // 2 
+            ns1 /*T:string?*/ .ToString(); // 2
         }
 
         foreach (string s in FalseCollection())
@@ -4190,7 +4190,7 @@ class C
                 //             ns /*T:string?*/ .ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns").WithLocation(16, 13),
                 // (26,13): warning CS8602: Possible dereference of a null reference.
-                //             ns1 /*T:string?*/ .ToString(); // 2 
+                //             ns1 /*T:string?*/ .ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns1").WithLocation(26, 13),
                 // (36,13): warning CS8602: Possible dereference of a null reference.
                 //             ns /*T:string?*/ .ToString(); // 3
@@ -5476,7 +5476,7 @@ class B : A
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             compilation.VerifyDiagnostics(
                 // (8,23): error CS8627: A nullable type parameter must be known to be a value type or non-nullable reference type. Consider adding a 'class', 'struct', or type constraint.
-                //     public void M2<T>(T? x) 
+                //     public void M2<T>(T? x)
                 Diagnostic(ErrorCode.ERR_NullableUnconstrainedTypeParameter, "T?").WithLocation(8, 23),
                 // (27,26): error CS0506: 'B.M2<T>(T?)': cannot override inherited member 'A.M2<T>(T?)' because it is not marked virtual, abstract, or override
                 //     public override void M2<T>(T? x)
@@ -6024,7 +6024,7 @@ public abstract class A
 " + NonNullTypesOff() + @"
     public abstract System.Action<string> Oblivious1(System.Action<string> x);
 " + NonNullTypesOn() + @"
-    
+
     public abstract System.Action<string> Oblivious2(System.Action<string> x);
     public abstract System.Action<string> M3(System.Action<string> x);
     public abstract System.Action<string> M4(System.Action<string> x);
@@ -6042,13 +6042,13 @@ public class B1 : A
 
 public class B2 : A
 {
-    
+
     public override System.Action<string> Oblivious1(System.Action<string> x) => throw null;
     public override System.Action<string> Oblivious2(System.Action<string> x) => throw null;
 " + NonNullTypesOff() + @"
     public override System.Action<string> M3(System.Action<string> x) => throw null;
 " + NonNullTypesOn() + @"
-    
+
     public override System.Action<string> M4(System.Action<string> x) => throw null;
 " + NonNullTypesOff() + @"
     public override System.Action<string> M5(System.Action<string> x) => throw null;
@@ -6533,7 +6533,7 @@ class B2 : A2
 
             compilation.VerifyDiagnostics(
                  // (28,31): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                 //     public override string[]? P2 {get; set;} 
+                 //     public override string[]? P2 {get; set;}
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "P2").WithLocation(28, 31),
                  // (30,30): warning CS8608: Nullability of reference types in type doesn't match overridden member.
                  //     public override string[] this[int x] // 1
@@ -6542,7 +6542,7 @@ class B2 : A2
                  //     public override string[]? this[short x] // 2
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "this").WithLocation(36, 31),
                  // (27,30): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                 //     public override string[] P1 {get; set;} 
+                 //     public override string[] P1 {get; set;}
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "P1").WithLocation(27, 30)
                 );
 
@@ -6595,20 +6595,20 @@ class B1 : A1
     public override string[] P1 {get; set;}
 " + NonNullTypesOff() + @"
     public override string[]? P2 {get; set;} // 3
-    
+
 " + NonNullTypesOff() + @"
     public override string[] this[int x]
     {
         get {throw new System.NotImplementedException();}
         set {}
-    } 
-    
+    }
+
 " + NonNullTypesOff() + @"
     public override string[]? this[short x] // 4
     {
         get {throw new System.NotImplementedException();}
         set {}
-    } 
+    }
 }
 ";
             var compilation = CreateCompilation(new[] { source });
@@ -6681,7 +6681,7 @@ class B : IA, IA2
 
             compilation.VerifyDiagnostics(
                  // (23,22): warning CS8612: Nullability of reference types in type doesn't match implicitly implemented member 'string[] IA.P2'.
-                 //     public string[]? P2 {get; set;} 
+                 //     public string[]? P2 {get; set;}
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnImplicitImplementation, "P2").WithArguments("string[] IA.P2").WithLocation(23, 22),
                  // (26,21): warning CS8612: Nullability of reference types in type doesn't match implicitly implemented member 'string?[] IA.this[int x]'.
                  //     public string[] this[int x] // 1
@@ -6690,7 +6690,7 @@ class B : IA, IA2
                  //     public string[]? this[short x] // 2
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnImplicitImplementation, "this").WithArguments("string[] IA.this[short x]").WithLocation(32, 22),
                  // (22,21): warning CS8612: Nullability of reference types in type doesn't match implicitly implemented member 'string?[] IA.P1'.
-                 //     public string[] P1 {get; set;} 
+                 //     public string[] P1 {get; set;}
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnImplicitImplementation, "P1").WithArguments("string?[] IA.P1").WithLocation(22, 21)
                 );
 
@@ -6772,10 +6772,10 @@ class B : IA, IA2
 
             compilation.VerifyDiagnostics(
                  // (22,17): warning CS8615: Nullability of reference types in type doesn't match implemented member 'string?[] IA.P1'.
-                 //     string[] IA.P1 {get; set;} 
+                 //     string[] IA.P1 {get; set;}
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation, "P1").WithArguments("string?[] IA.P1").WithLocation(22, 17),
                  // (23,18): warning CS8615: Nullability of reference types in type doesn't match implemented member 'string[] IA.P2'.
-                 //     string[]? IA.P2 {get; set;} 
+                 //     string[]? IA.P2 {get; set;}
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation, "P2").WithArguments("string[] IA.P2").WithLocation(23, 18),
                  // (26,17): warning CS8615: Nullability of reference types in type doesn't match implemented member 'string?[] IA.this[int x]'.
                  //     string[] IA.this[int x] // 1
@@ -6895,13 +6895,13 @@ class B : A
     public override string?[] M1()
     {
         return new string?[] {};
-    } 
+    }
 
 " + NonNullTypesOff() + @"
     public override S?[] M2<S>()
     {
         return new S?[] {};
-    } 
+    }
 }
 ";
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
@@ -7035,7 +7035,7 @@ class B : IA
 
             compilation.VerifyDiagnostics(
                  // (23,13): warning CS8616: Nullability of reference types in return type doesn't match implemented member 'T[] IA.M2<T>()'.
-                 //     S?[] IA.M2<S>() 
+                 //     S?[] IA.M2<S>()
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation, "M2").WithArguments("T[] IA.M2<T>()").WithLocation(23, 13),
                  // (18,18): warning CS8616: Nullability of reference types in return type doesn't match implemented member 'string[] IA.M1()'.
                  //     string?[] IA.M1()
@@ -7277,8 +7277,8 @@ class B : A
 
 abstract class A
 {
-    public abstract void M1(string[] x); 
-    public abstract void M2<T>(T[] x) where T : class; 
+    public abstract void M1(string[] x);
+    public abstract void M2<T>(T[] x) where T : class;
 }
 
 class B : A
@@ -7286,12 +7286,12 @@ class B : A
 " + NonNullTypesOff() + @"
     public override void M1(string?[] x)
     {
-    } 
+    }
 
 " + NonNullTypesOff() + @"
     public override void M2<T>(T?[] x)
     {
-    } 
+    }
 }
 ";
             var compilation = CreateCompilation(new[] { source });
@@ -7529,7 +7529,7 @@ class B : IA
 
             compilation.VerifyDiagnostics(
                  // (20,13): warning CS8617: Nullability of reference types in type of parameter 'x' doesn't match implemented member 'void IA.M2<T>(T[] x)'.
-                 //     void IA.M2<T>(T?[] x)  
+                 //     void IA.M2<T>(T?[] x)
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation, "M2").WithArguments("x", "void IA.M2<T>(T[] x)").WithLocation(20, 13),
                  // (16,13): warning CS8617: Nullability of reference types in type of parameter 'x' doesn't match implemented member 'void IA.M1(string[] x)'.
                  //     void IA.M1(string?[] x)
@@ -7852,22 +7852,22 @@ public class C4 : I2, I3
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (11,14): warning CS8645: 'I1<A>' is already listed in the interface list on type 'C1' with different nullability of reference types.
-                // public class C1 : I2, I1<A> 
+                // public class C1 : I2, I1<A>
                 Diagnostic(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList, "C1").WithArguments("I1<A>", "C1").WithLocation(11, 14),
                 // (11,14): error CS8646: 'I1<A?>.M()' is explicitly implemented more than once.
-                // public class C1 : I2, I1<A> 
+                // public class C1 : I2, I1<A>
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C1").WithArguments("I1<A?>.M()").WithLocation(11, 14),
                 // (11,14): error CS8646: 'I1<A>.M()' is explicitly implemented more than once.
-                // public class C1 : I2, I1<A> 
+                // public class C1 : I2, I1<A>
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C1").WithArguments("I1<A>.M()").WithLocation(11, 14),
                 // (17,14): warning CS8645: 'I1<A?>' is already listed in the interface list on type 'C2' with different nullability of reference types.
-                // public class C2 : I1<A>, I2 
+                // public class C2 : I1<A>, I2
                 Diagnostic(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList, "C2").WithArguments("I1<A?>", "C2").WithLocation(17, 14),
                 // (17,14): error CS8646: 'I1<A>.M()' is explicitly implemented more than once.
-                // public class C2 : I1<A>, I2 
+                // public class C2 : I1<A>, I2
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C2").WithArguments("I1<A>.M()").WithLocation(17, 14),
                 // (17,14): error CS8646: 'I1<A?>.M()' is explicitly implemented more than once.
-                // public class C2 : I1<A>, I2 
+                // public class C2 : I1<A>, I2
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C2").WithArguments("I1<A?>.M()").WithLocation(17, 14),
                 // (23,14): warning CS8645: 'I1<A?>' is already listed in the interface list on type 'C3' with different nullability of reference types.
                 // public class C3 : I1<A>, I1<A?>
@@ -7968,9 +7968,9 @@ public class C1 : I1<A?>
     void I1<A?>.M2() => System.Console.WriteLine(""C1.M2"");
 }
 
-public class C2 : C1, I1<A> 
-{ 
-    new public void M1() => System.Console.WriteLine(""C2.M1""); 
+public class C2 : C1, I1<A>
+{
+    new public void M1() => System.Console.WriteLine(""C2.M1"");
     void I1<A>.M2() => System.Console.WriteLine(""C2.M2"");
 
     static void Main()
@@ -8049,8 +8049,8 @@ public class C1 : I1<A?>
     public virtual void M2() {}
 }
 
-public class C2 : C1, I1<A> 
-{ 
+public class C2 : C1, I1<A>
+{
     static void Main()
     {
         var x = (C1)new C2();
@@ -8063,7 +8063,7 @@ public class C2 : C1, I1<A>
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue(TestOptions.DebugExe));
             comp.VerifyDiagnostics(
                 // (17,23): warning CS8644: 'C2' does not implement interface member 'I1<A>.M2()'. Nullability of reference types in interface implemented by the base type doesn't match.
-                // public class C2 : C1, I1<A> 
+                // public class C2 : C1, I1<A>
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInInterfaceImplementedByBase, "I1<A>").WithArguments("C2", "I1<A>.M2()").WithLocation(17, 23)
                 );
 
@@ -8138,10 +8138,10 @@ public class C3 : C1, I1<A?>
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (9,19): error CS0535: 'C1' does not implement interface member 'I1<A?>.M1()'
-                // public class C1 : I1<A?> 
+                // public class C1 : I1<A?>
                 Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I1<A?>").WithArguments("C1", "I1<A?>.M1()").WithLocation(9, 19),
                 // (13,23): warning CS8644: 'C2' does not implement interface member 'I1<A>.M1()'. Nullability of reference types in interface implemented by the base type doesn't match.
-                // public class C2 : C1, I1<A> 
+                // public class C2 : C1, I1<A>
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInInterfaceImplementedByBase, "I1<A>").WithArguments("C2", "I1<A>.M1()").WithLocation(13, 23)
                 );
         }
@@ -8164,7 +8164,7 @@ public class C1 : I1<A?>
             var comp1 = CreateCompilation(source1, options: WithNonNullTypesTrue());
             comp1.VerifyDiagnostics(
                 // (9,19): error CS0535: 'C1' does not implement interface member 'I1<A?>.M1()'
-                // public class C1 : I1<A?> 
+                // public class C1 : I1<A?>
                 Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I1<A?>").WithArguments("C1", "I1<A?>.M1()").WithLocation(9, 19)
                 );
 
@@ -8180,7 +8180,7 @@ public class C3 : C1, I1<A?>
             var comp2 = CreateCompilation(source2, references: new[] { comp1.ToMetadataReference() }, options: WithNonNullTypesTrue());
             comp2.VerifyDiagnostics(
                 // (2,23): warning CS8644: 'C2' does not implement interface member 'I1<A>.M1()'. Nullability of reference types in interface implemented by the base type doesn't match.
-                // public class C2 : C1, I1<A> 
+                // public class C2 : C1, I1<A>
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInInterfaceImplementedByBase, "I1<A>").WithArguments("C2", "I1<A>.M1()").WithLocation(2, 23)
                 );
         }
@@ -8224,40 +8224,40 @@ public class C4<T> : I2<T>, I3<T> where T : class
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (10,14): warning CS8645: 'I1<T>' is already listed in the interface list on type 'C1<T>' with different nullability of reference types.
-                // public class C1<T> : I2<T>, I1<T> where T : class 
+                // public class C1<T> : I2<T>, I1<T> where T : class
                 Diagnostic(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList, "C1").WithArguments("I1<T>", "C1<T>").WithLocation(10, 14),
                 // (10,14): error CS8646: 'I1<T?>.M()' is explicitly implemented more than once.
-                // public class C1<T> : I2<T>, I1<T> where T : class 
+                // public class C1<T> : I2<T>, I1<T> where T : class
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C1").WithArguments("I1<T?>.M()").WithLocation(10, 14),
                 // (10,14): error CS8646: 'I1<T>.M()' is explicitly implemented more than once.
-                // public class C1<T> : I2<T>, I1<T> where T : class 
+                // public class C1<T> : I2<T>, I1<T> where T : class
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C1").WithArguments("I1<T>.M()").WithLocation(10, 14),
                 // (16,14): warning CS8645: 'I1<T?>' is already listed in the interface list on type 'C2<T>' with different nullability of reference types.
-                // public class C2<T> : I1<T>, I2<T> where T : class  
+                // public class C2<T> : I1<T>, I2<T> where T : class
                 Diagnostic(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList, "C2").WithArguments("I1<T?>", "C2<T>").WithLocation(16, 14),
                 // (16,14): error CS8646: 'I1<T>.M()' is explicitly implemented more than once.
-                // public class C2<T> : I1<T>, I2<T> where T : class  
+                // public class C2<T> : I1<T>, I2<T> where T : class
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C2").WithArguments("I1<T>.M()").WithLocation(16, 14),
                 // (16,14): error CS8646: 'I1<T?>.M()' is explicitly implemented more than once.
-                // public class C2<T> : I1<T>, I2<T> where T : class  
+                // public class C2<T> : I1<T>, I2<T> where T : class
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C2").WithArguments("I1<T?>.M()").WithLocation(16, 14),
                 // (22,14): warning CS8645: 'I1<T?>' is already listed in the interface list on type 'C3<T>' with different nullability of reference types.
-                // public class C3<T> : I1<T>, I1<T?> where T : class 
+                // public class C3<T> : I1<T>, I1<T?> where T : class
                 Diagnostic(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList, "C3").WithArguments("I1<T?>", "C3<T>").WithLocation(22, 14),
                 // (22,14): error CS8646: 'I1<T>.M()' is explicitly implemented more than once.
-                // public class C3<T> : I1<T>, I1<T?> where T : class 
+                // public class C3<T> : I1<T>, I1<T?> where T : class
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C3").WithArguments("I1<T>.M()").WithLocation(22, 14),
                 // (22,14): error CS8646: 'I1<T?>.M()' is explicitly implemented more than once.
-                // public class C3<T> : I1<T>, I1<T?> where T : class 
+                // public class C3<T> : I1<T>, I1<T?> where T : class
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C3").WithArguments("I1<T?>.M()").WithLocation(22, 14),
                 // (28,14): warning CS8645: 'I1<T>' is already listed in the interface list on type 'C4<T>' with different nullability of reference types.
-                // public class C4<T> : I2<T>, I3<T> where T : class 
+                // public class C4<T> : I2<T>, I3<T> where T : class
                 Diagnostic(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList, "C4").WithArguments("I1<T>", "C4<T>").WithLocation(28, 14),
                 // (28,14): error CS8646: 'I1<T?>.M()' is explicitly implemented more than once.
-                // public class C4<T> : I2<T>, I3<T> where T : class 
+                // public class C4<T> : I2<T>, I3<T> where T : class
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C4").WithArguments("I1<T?>.M()").WithLocation(28, 14),
                 // (28,14): error CS8646: 'I1<T>.M()' is explicitly implemented more than once.
-                // public class C4<T> : I2<T>, I3<T> where T : class 
+                // public class C4<T> : I2<T>, I3<T> where T : class
                 Diagnostic(ErrorCode.ERR_DuplicateExplicitImpl, "C4").WithArguments("I1<T>.M()").WithLocation(28, 14)
                 );
 
@@ -8340,7 +8340,7 @@ public class C3<T, U> : I1<T>, I1<U?> where T : class where U : class
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (7,14): error CS0695: 'C3<T, U>' cannot implement both 'I1<T>' and 'I1<U?>' because they may unify for some type parameter substitutions
-                // public class C3<T, U> : I1<T>, I1<U?> where T : class where U : class 
+                // public class C3<T, U> : I1<T>, I1<U?> where T : class where U : class
                 Diagnostic(ErrorCode.ERR_UnifyingInterfaceInstantiations, "C3").WithArguments("C3<T, U>", "I1<T>", "I1<U?>").WithLocation(7, 14)
                 );
 
@@ -8383,7 +8383,7 @@ public class C3 : I1<A>
     {
         System.Console.WriteLine(""C3.M"");
     }
-    
+
     static void Main()
     {
         var x = new C3();
@@ -8458,7 +8458,7 @@ public class C3 : I1<A>, I1<A?>
     {
         System.Console.WriteLine(""C3.M"");
     }
-    
+
     static void Main()
     {
         var x = new C3();
@@ -8541,7 +8541,7 @@ public class C3 : I2, I1<A>
     {
         System.Console.WriteLine(""C3.M"");
     }
-    
+
     static void Main()
     {
         var x = new C3();
@@ -8624,7 +8624,7 @@ public partial class C3 : I1<A>
     {
         System.Console.WriteLine(""C3.M"");
     }
-    
+
     static void Main()
     {
         var x = new C3();
@@ -9024,19 +9024,19 @@ class C
     void Test2()
     {
         string? x2 = """";
-        string z2 = x2; 
+        string z2 = x2;
     }
 
     void Test3()
     {
         string? x3;
-        string z3 = x3; 
+        string z3 = x3;
     }
 
     void Test4()
     {
         string x4;
-        string z4 = x4; 
+        string z4 = x4;
     }
 
     void Test5()
@@ -9044,50 +9044,50 @@ class C
         string? x5 = """";
         x5 = null;
         string? y5;
-        y5 = x5; 
+        y5 = x5;
         string z5;
-        z5 = x5; 
+        z5 = x5;
     }
 
     void Test6()
     {
         string? x6 = """";
         string z6;
-        z6 = x6; 
+        z6 = x6;
     }
 
     void Test7()
     {
         CL1? x7 = null;
-        CL1 y7 = x7.P1; 
+        CL1 y7 = x7.P1;
         CL1 z7 = x7?.P1;
         x7 = new CL1();
-        CL1 u7 = x7.P1; 
+        CL1 u7 = x7.P1;
     }
 
     void Test8()
     {
         CL1? x8 = new CL1();
-        CL1 y8 = x8.M1(); 
+        CL1 y8 = x8.M1();
         x8 = null;
-        CL1 u8 = x8.M1(); 
+        CL1 u8 = x8.M1();
         CL1 z8 = x8?.M1();
     }
 
     void Test9(CL1? x9, CL1 y9)
     {
-        CL1 u9; 
+        CL1 u9;
         u9 = x9;
         u9 = y9;
         x9 = y9;
-        CL1 v9; 
+        CL1 v9;
         v9 = x9;
         y9 = null;
     }
 
     void Test10(CL1 x10)
     {
-        CL1 u10; 
+        CL1 u10;
         u10 = x10.P1;
         u10 = x10.P2;
         u10 = x10.M1();
@@ -9099,7 +9099,7 @@ class C
 
     void Test11(CL1 x11, CL1? y11)
     {
-        CL1 u11; 
+        CL1 u11;
         u11 = x11.F1;
         u11 = x11.F2;
         CL1? v11;
@@ -9113,7 +9113,7 @@ class C
     void Test12(CL1 x12)
     {
         S1 y12;
-        CL1 u12; 
+        CL1 u12;
         u12 = y12.F3;
         u12 = y12.F4;
     }
@@ -9121,7 +9121,7 @@ class C
     void Test13(CL1 x13)
     {
         S1 y13;
-        CL1? u13; 
+        CL1? u13;
         u13 = y13.F3;
         u13 = y13.F4;
     }
@@ -9138,7 +9138,7 @@ class C
     void Test15(CL1 x15)
     {
         S1 y15;
-        CL1 u15; 
+        CL1 u15;
         y15.F3 = null;
         y15.F4 = null;
         u15 = y15.F3;
@@ -9153,7 +9153,7 @@ class C
     void Test16()
     {
         S1 y16;
-        CL1 u16; 
+        CL1 u16;
         y16 = new S1();
         u16 = y16.F3;
         u16 = y16.F4;
@@ -9164,11 +9164,11 @@ class C
         S1 x17;
         x17.F4 = z17;
         S1 y17 = new S1();
-        CL1 u17; 
+        CL1 u17;
         u17 = y17.F4;
 
         y17 = x17;
-        CL1 v17; 
+        CL1 v17;
         v17 = y17.F4;
     }
 
@@ -9177,15 +9177,15 @@ class C
         S1 x18;
         x18.F4 = z18;
         S1 y18 = x18;
-        CL1 u18; 
+        CL1 u18;
         u18 = y18.F4;
     }
 
     void Test19(S1 x19, CL1 z19)
     {
         S1 y19;
-        y19.F4 = null; 
-        CL1 u19; 
+        y19.F4 = null;
+        CL1 u19;
         u19 = y19.F4;
 
         x19.F4 = z19;
@@ -9198,7 +9198,7 @@ class C
     {
         S1 y20;
         y20.F4 = z20;
-        CL1 u20; 
+        CL1 u20;
         u20 = y20.F4;
 
         y20 = x20;
@@ -9214,7 +9214,7 @@ class C
     {
         S1 y21;
         y21.F4 = z21;
-        CL1 u21; 
+        CL1 u21;
         u21 = y21.F4;
 
         y21 = GetS1();
@@ -9225,7 +9225,7 @@ class C
     void Test22()
     {
         S1 y22;
-        CL1 u22; 
+        CL1 u22;
         u22 = y22.F4;
 
         y22 = GetS1();
@@ -9237,7 +9237,7 @@ class C
     {
         S2 y23;
         y23.F5.F4 = z23;
-        CL1 u23; 
+        CL1 u23;
         u23 = y23.F5.F4;
 
         y23 = GetS2();
@@ -9253,7 +9253,7 @@ class C
     void Test24()
     {
         S2 y24;
-        CL1 u24; 
+        CL1 u24;
         u24 = y24.F5.F4; // 1
         u24 = y24.F5.F4; // 2
 
@@ -9359,25 +9359,25 @@ struct S2
 
             c.VerifyDiagnostics(
                 // (12,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         string z1 = x1; 
+                //         string z1 = x1;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1").WithLocation(12, 21),
                 // (24,21): error CS0165: Use of unassigned local variable 'x3'
-                //         string z3 = x3; 
+                //         string z3 = x3;
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x3").WithArguments("x3").WithLocation(24, 21),
                 // (30,21): error CS0165: Use of unassigned local variable 'x4'
-                //         string z4 = x4; 
+                //         string z4 = x4;
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x4").WithArguments("x4").WithLocation(30, 21),
                 // (40,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         z5 = x5; 
+                //         z5 = x5;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x5").WithLocation(40, 14),
                 // (53,18): warning CS8602: Possible dereference of a null reference.
-                //         CL1 y7 = x7.P1; 
+                //         CL1 y7 = x7.P1;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x7").WithLocation(53, 18),
                 // (54,18): hidden CS8607: Expression is probably never null.
                 //         CL1 z7 = x7?.P1;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x7").WithLocation(54, 18),
                 // (64,18): warning CS8602: Possible dereference of a null reference.
-                //         CL1 u8 = x8.M1(); 
+                //         CL1 u8 = x8.M1();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x8").WithLocation(64, 18),
                 // (65,18): hidden CS8607: Expression is probably never null.
                 //         CL1 z8 = x8?.M1();
@@ -10677,10 +10677,10 @@ public struct S2
 
             c.VerifyDiagnostics(
                 // (63,16): warning CS8603: Possible null reference return.
-                //         return y11.F1; 
+                //         return y11.F1;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "y11.F1").WithLocation(63, 16),
                 // (70,16): hidden CS8607: Expression is probably never null.
-                //         return y12.F1 ?? new object(); 
+                //         return y12.F1 ?? new object();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y12.F1").WithLocation(70, 16));
         }
 
@@ -18030,28 +18030,6 @@ class C
         }
 
         [Fact]
-        public void NullCoalescingOperator_RightIsUnreachable()
-        {
-            var source = @"
-class C
-{
-    object? F = null;
-    void M(C? c1, C c2)
-    {
-        if (c1?.F == null) return;
-        _ = c1 ?? (c1 = c2);
-        c1.F.ToString();
-    }
-}";
-
-            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            comp.VerifyDiagnostics(
-                // (8,13): hidden CS8607: Expression is probably never null.
-                //         _ = c1 ?? (c1 = c2);
-                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c1").WithLocation(8, 13));
-        }
-
-        [Fact]
         public void IdentityConversion_NullCoalescingOperator_01()
         {
             var source =
@@ -19977,7 +19955,7 @@ class C
                 //                                    new object[,] {{null}}};
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(25, 52),
                 // (24,36): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-                //         var u7 = new object [][,] {null, 
+                //         var u7 = new object [][,] {null,
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(24, 36),
                 // (26,17): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //         u7[0] = null;
@@ -19989,7 +19967,7 @@ class C
                 //                                     new object[,] {{null}}};
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(33, 53),
                 // (32,37): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-                //         var u8 = new object []?[,] {null, 
+                //         var u8 = new object []?[,] {null,
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(32, 37),
                 // (34,17): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //         u8[0] = null;
@@ -21899,7 +21877,7 @@ struct S1
                 //         x10 = u10.a1.p1; // 5
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u10.a1.p1").WithLocation(99, 15),
                 // (100,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         x10 = u10.a2.p2; // 6 
+                //         x10 = u10.a2.p2; // 6
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u10.a2.p2").WithLocation(100, 15)
                 );
         }
@@ -23776,7 +23754,7 @@ class C
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/30432: Report warnings for combinations of `IIn<object?>` and `IIn<object!>`
             // and combinations of  `IOut<object?>` and `IOut<object!>`.
-            // https://github.com/dotnet/roslyn/issues/30964 - Report warnings about nullability mismatch in conditional operators for: 
+            // https://github.com/dotnet/roslyn/issues/30964 - Report warnings about nullability mismatch in conditional operators for:
             //         F((ref I<object?> a2, ref I<object> b2) => { if (b) return ref a2; return ref b2; });
             //         F((ref I<object> a3, ref I<object?> b3) => { if (b) return ref a3; return ref b3; });
             comp.VerifyDiagnostics(
@@ -28268,10 +28246,10 @@ class CL1
                 //         CL0? u1 = ++x1;
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(10, 21),
                 // (11,18): hidden CS8607: Expression is probably never null.
-                //         CL0 v1 = u1 ?? new CL0(); 
+                //         CL0 v1 = u1 ?? new CL0();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
                 // (12,18): hidden CS8607: Expression is probably never null.
-                //         CL0 w1 = x1 ?? new CL0(); 
+                //         CL0 w1 = x1 ?? new CL0();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x1").WithLocation(12, 18),
                 // (16,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
                 //         CL0 u2 = x2++;
@@ -28292,7 +28270,7 @@ class CL1
                 //         CL1? u4 = x4--; // Result of increment is nullable, storing it in not nullable parameter.
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4--").WithLocation(26, 19),
                 // (27,18): hidden CS8607: Expression is probably never null.
-                //         CL1 v4 = u4 ?? new CL1(); 
+                //         CL1 v4 = u4 ?? new CL1();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 18),
                 // (32,18): warning CS8601: Possible null reference assignment.
                 //         CL1 u5 = --x5;
@@ -28301,10 +28279,10 @@ class CL1
                 //         CL1 u5 = --x5;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x5").WithLocation(32, 18),
                 // (37,9): warning CS8601: Possible null reference assignment.
-                //         x6--; 
+                //         x6--;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6--").WithLocation(37, 9),
                 // (43,9): error CS0165: Use of unassigned local variable 'x7'
-                //         x7--; 
+                //         x7--;
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x7").WithArguments("x7").WithLocation(43, 9)
                 );
         }
@@ -28376,7 +28354,7 @@ class CL1
                 //         CL0? u1 = ++x1;
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(10, 21),
                 // (11,18): hidden CS8607: Expression is probably never null.
-                //         CL0 v1 = u1 ?? new CL0(); 
+                //         CL0 v1 = u1 ?? new CL0();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
                 // (16,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
                 //         CL0 u2 = x2++;
@@ -28391,7 +28369,7 @@ class CL1
                 //         CL1? u4 = x4--; // Result of increment is nullable, storing it in not nullable property.
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4--").WithLocation(26, 19),
                 // (27,18): hidden CS8607: Expression is probably never null.
-                //         CL1 v4 = u4 ?? new CL1(); 
+                //         CL1 v4 = u4 ?? new CL1();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 18),
                 // (32,18): warning CS8601: Possible null reference assignment.
                 //         CL1 u5 = --x5;
@@ -28489,7 +28467,7 @@ class X4
                 //         CL0? u1 = ++x1[0];
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1[0]").WithArguments("x", "CL0 CL0.operator ++(CL0 x)").WithLocation(10, 21),
                 // (11,18): hidden CS8607: Expression is probably never null.
-                //         CL0 v1 = u1 ?? new CL0(); 
+                //         CL0 v1 = u1 ?? new CL0();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
                 // (16,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator ++(CL0 x)'.
                 //         CL0 u2 = x2[0]++;
@@ -28504,7 +28482,7 @@ class X4
                 //         CL1? u4 = x4[0]--; // Result of increment is nullable, storing it in not nullable parameter.
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x4[0]--").WithLocation(26, 19),
                 // (27,18): hidden CS8607: Expression is probably never null.
-                //         CL1 v4 = u4 ?? new CL1(); 
+                //         CL1 v4 = u4 ?? new CL1();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 18),
                 // (32,18): warning CS8601: Possible null reference assignment.
                 //         CL1 u5 = --x5[0];
@@ -28562,7 +28540,7 @@ class C
                 //         dynamic u3 = --x3;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x3").WithLocation(21, 22),
                 // (27,22): hidden CS8607: Expression is probably never null.
-                //         dynamic v4 = u4 ?? new object(); 
+                //         dynamic v4 = u4 ?? new object();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(27, 22)
                 );
         }
@@ -28613,7 +28591,7 @@ class B : A
                  //         B? u1 = ++x1;
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "++x1").WithArguments("x", "C.implicit operator B(C x)").WithLocation(10, 17),
                  // (11,16): hidden CS8607: Expression is probably never null.
-                 //         B v1 = u1 ?? new B(); 
+                 //         B v1 = u1 ?? new B();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 16)
                 );
         }
@@ -28711,7 +28689,7 @@ class Convertible
                  //         Convertible? u1 = ++x1;
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("c", "Convertible.implicit operator int(Convertible c)").WithLocation(10, 29),
                  // (11,26): hidden CS8607: Expression is probably never null.
-                 //         Convertible v1 = u1 ?? new Convertible(); 
+                 //         Convertible v1 = u1 ?? new Convertible();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 26)
                 );
         }
@@ -28756,10 +28734,10 @@ class CL1
                  //         CL1? u1 = x1 += y1;
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL1.implicit operator CL0(CL1 x)").WithLocation(10, 19),
                  // (11,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 v1 = u1 ?? new CL1(); 
+                 //         CL1 v1 = u1 ?? new CL1();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
                  // (12,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 w1 = x1 ?? new CL1(); 
+                 //         CL1 w1 = x1 ?? new CL1();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x1").WithLocation(12, 18)
                 );
         }
@@ -28804,10 +28782,10 @@ class CL1
                  //         CL1? u1 = x1 += y1;
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y1").WithArguments("y", "CL1 CL0.operator +(CL0 x, CL0 y)").WithLocation(10, 25),
                  // (11,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 v1 = u1 ?? new CL1(); 
+                 //         CL1 v1 = u1 ?? new CL1();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
                  // (12,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 w1 = x1 ?? new CL1(); 
+                 //         CL1 w1 = x1 ?? new CL1();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x1").WithLocation(12, 18)
                 );
         }
@@ -28872,10 +28850,10 @@ class CL1
                  //         CL1? u1 = x1 += y1;
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL1 CL0.operator +(CL0 x, CL0? y)").WithLocation(10, 19),
                  // (11,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 v1 = u1 ?? new CL1(); 
+                 //         CL1 v1 = u1 ?? new CL1();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
                  // (12,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 w1 = x1 ?? new CL1(); 
+                 //         CL1 w1 = x1 ?? new CL1();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x1").WithLocation(12, 18),
                  // (17,18): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1 CL0.operator +(CL0 x, CL0? y)'.
                  //         CL0 u2 = x2 += y2;
@@ -28884,16 +28862,16 @@ class CL1
                  //         CL0 u2 = x2 += y2;
                  Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2 += y2").WithLocation(17, 18),
                  // (18,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //         CL0 w2 = x2; 
+                 //         CL0 w2 = x2;
                  Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2").WithLocation(18, 18),
                  // (24,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         CL0 u3 = x3 += y3;
                  Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3 += y3").WithLocation(24, 18),
                  // (25,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //         CL0 w3 = x3; 
+                 //         CL0 w3 = x3;
                  Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3").WithLocation(25, 18),
                  // (32,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //         CL0 w4 = x4; 
+                 //         CL0 w4 = x4;
                  Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x4").WithLocation(32, 18)
                 );
         }
@@ -28968,7 +28946,7 @@ class CL1
                 //         CL1 w1 = x1;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x1").WithLocation(12, 18),
                 // (13,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         w1 = u1; 
+                //         w1 = u1;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u1").WithLocation(13, 14),
                 // (18,18): warning CS8601: Possible null reference assignment.
                 //         CL1 u2 = x2 += y2;
@@ -28977,7 +28955,7 @@ class CL1
                 //         CL1 u2 = x2 += y2;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2 += y2").WithLocation(18, 18),
                 // (19,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         CL1 w2 = x2; 
+                //         CL1 w2 = x2;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2").WithLocation(19, 18),
                 // (24,9): warning CS8601: Possible null reference assignment.
                 //         x3 += y3;
@@ -28989,10 +28967,10 @@ class CL1
                 //         CL0? u4 = x4 += y4;
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x4 += y4").WithArguments("x", "CL1.implicit operator CL0(CL1 x)").WithLocation(29, 19),
                 // (30,18): hidden CS8607: Expression is probably never null.
-                //         CL0 v4 = u4 ?? new CL0(); 
+                //         CL0 v4 = u4 ?? new CL0();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u4").WithLocation(30, 18),
                 // (31,18): hidden CS8607: Expression is probably never null.
-                //         CL0 w4 = x4 ?? new CL0(); 
+                //         CL0 w4 = x4 ?? new CL0();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x4").WithLocation(31, 18),
                 // (36,9): warning CS8604: Possible null reference argument for parameter 'x' in 'CL1.implicit operator CL0(CL1 x)'.
                 //         x5 += y5;
@@ -29094,16 +29072,16 @@ class CL1
                 //         CL1? u1 = x1 += y1;
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL1.implicit operator CL0(CL1 x)").WithLocation(10, 19),
                 // (11,18): hidden CS8607: Expression is probably never null.
-                //         CL1 v1 = u1 ?? new CL1(); 
+                //         CL1 v1 = u1 ?? new CL1();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
                 // (12,18): hidden CS8607: Expression is probably never null.
-                //         CL1 w1 = x1 ?? new CL1(); 
+                //         CL1 w1 = x1 ?? new CL1();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x1").WithLocation(12, 18),
                 // (18,18): hidden CS8607: Expression is probably never null.
-                //         CL1 v2 = u2 ?? new CL1(); 
+                //         CL1 v2 = u2 ?? new CL1();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u2").WithLocation(18, 18),
                 // (19,18): hidden CS8607: Expression is probably never null.
-                //         CL1 w2 = x2 ?? new CL1(); 
+                //         CL1 w2 = x2 ?? new CL1();
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x2").WithLocation(19, 18)
                 );
         }
@@ -29173,13 +29151,13 @@ class CL3
                  //         CL1? u1 = x1[0] += y1;
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1[0]").WithArguments("x", "CL1.implicit operator CL0(CL1 x)").WithLocation(10, 19),
                  // (11,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 v1 = u1 ?? new CL1(); 
+                 //         CL1 v1 = u1 ?? new CL1();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u1").WithLocation(11, 18),
                  // (18,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 v2 = u2 ?? new CL1(); 
+                 //         CL1 v2 = u2 ?? new CL1();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "u2").WithLocation(18, 18),
                  // (19,18): hidden CS8607: Expression is probably never null.
-                 //         CL1 w2 = x2[0] ?? new CL1(); 
+                 //         CL1 w2 = x2[0] ?? new CL1();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x2[0]").WithLocation(19, 18)
                 );
         }
@@ -30302,7 +30280,7 @@ public interface ITest28
 [Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58278"")]
 public abstract class ClassITest28 //: ITest28
 {
-    public ClassITest28(int x){} 
+    public ClassITest28(int x){}
 }
 ";
 
@@ -30582,13 +30560,13 @@ public class C<T> {}
                 //     [Nullable(2)] public string[][,] P2 {get; set;}
                 Diagnostic(ErrorCode.ERR_ExplicitNullableAttribute, "Nullable(2)").WithLocation(8, 6),
                 // (9,13): error CS8623: Explicit application of 'System.Runtime.CompilerServices.NullableAttribute' is not allowed.
-                //     [return:Nullable(0)] public System.Action<string?> M1(string? x) 
+                //     [return:Nullable(0)] public System.Action<string?> M1(string? x)
                 Diagnostic(ErrorCode.ERR_ExplicitNullableAttribute, "Nullable(0)").WithLocation(9, 13),
                 // (11,28): error CS8623: Explicit application of 'System.Runtime.CompilerServices.NullableAttribute' is not allowed.
-                //     public string[][,] M2([Nullable(new byte[] {0})] string[][,] x) 
+                //     public string[][,] M2([Nullable(new byte[] {0})] string[][,] x)
                 Diagnostic(ErrorCode.ERR_ExplicitNullableAttribute, "Nullable(new byte[] {0})").WithLocation(11, 28),
                 // (6,6): error CS8623: Explicit application of 'System.Runtime.CompilerServices.NullableAttribute' is not allowed.
-                //     [Nullable(0)] public string F1; 
+                //     [Nullable(0)] public string F1;
                 Diagnostic(ErrorCode.ERR_ExplicitNullableAttribute, "Nullable(0)").WithLocation(6, 6),
                 // (17,2): error CS8623: Explicit application of 'System.Runtime.CompilerServices.NullableAttribute' is not allowed.
                 // [Nullable(2)] public class F : C<F>
@@ -30721,10 +30699,10 @@ partial class C
 using System;
 
 " + NonNullTypesOff() + @"
-public class CL0 
+public class CL0
 {
 " + NonNullTypesOff() + @"
-    public class CL1 
+    public class CL1
     {
 " + NonNullTypesOn() + @"
         public Action F1;
@@ -30787,10 +30765,10 @@ partial class C
 using System;
 
 " + NonNullTypesOff() + @"
-partial class C 
+partial class C
 {
 " + NonNullTypesOff() + @"
-    partial class B 
+    partial class B
     {
 " + NonNullTypesOn() + @"
         void Test21(CL0.CL1 c, Action? x21)
@@ -31093,9 +31071,9 @@ partial class C
 using System;
 
 " + NonNullTypesOff() + @"
-public class CL0 
+public class CL0
 {
-    public class CL1 
+    public class CL1
     {
 " + NonNullTypesOn() + @"
         public Action F1 = null!;
@@ -31136,7 +31114,7 @@ partial class C
 
         void Test12(Action x12)
         {
-            x12 = E1 ?? x12; // 3 
+            x12 = E1 ?? x12; // 3
         }
 
         void Test13(Action x13)
@@ -31151,22 +31129,22 @@ partial class C
 using System;
 
 " + NonNullTypesOff() + @"
-partial class C 
+partial class C
 {
-    partial class B 
+    partial class B
     {
         void Test21(CL0.CL1 c, Action? x21) // 4
         {
-            c.F1 = x21; // 5 
-            c.P1 = x21; // 6 
-            c.M3(x21); // 7 
+            c.F1 = x21; // 5
+            c.P1 = x21; // 6
+            c.M3(x21); // 7
         }
 
         void Test22(CL0.CL1 c, Action x22)
         {
-            x22 = c.F1 ?? x22; // 8 
-            x22 = c.P1 ?? x22; // 9 
-            x22 = c.M1() ?? x22; // 10 
+            x22 = c.F1 ?? x22; // 8
+            x22 = c.P1 ?? x22; // 9
+            x22 = c.M1() ?? x22; // 10
         }
 
         void Test23(CL0.CL1 c, Action x23)
@@ -31191,7 +31169,7 @@ partial class C
                 //             E1 = x11; // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x11").WithLocation(15, 18),
                 // (20,19): hidden CS8607: Expression is probably never null.
-                //             x12 = E1 ?? x12; // 3 
+                //             x12 = E1 ?? x12; // 3
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "E1").WithLocation(20, 19),
                 // (25,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             x13 = E2;
@@ -31232,10 +31210,10 @@ partial class C
 using System;
 
 " + NonNullTypesOn() + @"
-public class CL0 
+public class CL0
 {
 " + NonNullTypesOff() + @"
-    public class CL1 
+    public class CL1
     {
 " + NonNullTypesOn() + @"
         public Action F1 = null!;
@@ -31291,23 +31269,23 @@ partial class C
 using System;
 
 " + NonNullTypesOn() + @"
-partial class C 
+partial class C
 {
 " + NonNullTypesOff() + @"
-    partial class B 
+    partial class B
     {
         void Test21(CL0.CL1 c, Action? x21) // 4
         {
-            c.F1 = x21; // 5 
-            c.P1 = x21; // 6 
-            c.M3(x21); // 7 
+            c.F1 = x21; // 5
+            c.P1 = x21; // 6
+            c.M3(x21); // 7
         }
 
         void Test22(CL0.CL1 c, Action x22)
         {
-            x22 = c.F1 ?? x22; // 8 
-            x22 = c.P1 ?? x22; // 9 
-            x22 = c.M1() ?? x22; // 10 
+            x22 = c.F1 ?? x22; // 8
+            x22 = c.P1 ?? x22; // 9
+            x22 = c.M1() ?? x22; // 10
         }
 
         void Test23(CL0.CL1 c, Action x23)
@@ -31372,10 +31350,10 @@ partial class C
 using System;
 
 " + NonNullTypesOn() + @"
-public class CL0 
+public class CL0
 {
 " + NonNullTypesOn() + @"
-    public class CL1 
+    public class CL1
     {
 " + NonNullTypesOff() + @"
         public Action F1 = null!;
@@ -31401,10 +31379,10 @@ public class CL0
 using System;
 
 " + NonNullTypesOn() + @"
-partial class C 
+partial class C
 {
 " + NonNullTypesOn() + @"
-    partial class B 
+    partial class B
     {
 " + NonNullTypesOff() + @"
         public event Action E1;
@@ -33101,7 +33079,7 @@ class C
 
     [System.Runtime.CompilerServices.NonNullTypes(false)]
     delegate void D2(CL1<string> x2);
-    
+
     void M2(D2 x2) {}
 
     void Test2()
@@ -33248,12 +33226,12 @@ class C
 }
 
 [System.Runtime.CompilerServices.NonNullTypes(false)]
-delegate void CL0<T>(T x); 
+delegate void CL0<T>(T x);
 
 [System.Runtime.CompilerServices.NonNullTypes(false)]
-delegate void CL1<T>(T? x) where T : class; 
+delegate void CL1<T>(T? x) where T : class;
 
-delegate void CL2<T>(T? x) where T : class; 
+delegate void CL2<T>(T? x) where T : class;
 ";
 
             CSharpCompilation c = CreateCompilation(new[] { source },
@@ -34416,10 +34394,10 @@ class D<T> : IEnumerable
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (19,28): warning CS8620: Nullability of reference types in argument of type 'D<object?>' doesn't match target type 'D<object>' for parameter 'key' in 'void D<int>.Add(D<object>? key, params D<object>?[] value)'.
-                //         _ = new D<int>() { y,  y }; // warn 5 and 6 
+                //         _ = new D<int>() { y,  y }; // warn 5 and 6
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("D<object?>", "D<object>", "key", "void D<int>.Add(D<object>? key, params D<object>?[] value)").WithLocation(19, 28),
                 // (19,32): warning CS8620: Nullability of reference types in argument of type 'D<object?>' doesn't match target type 'D<object>' for parameter 'key' in 'void D<int>.Add(D<object>? key, params D<object>?[] value)'.
-                //         _ = new D<int>() { y,  y }; // warn 5 and 6 
+                //         _ = new D<int>() { y,  y }; // warn 5 and 6
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("D<object?>", "D<object>", "key", "void D<int>.Add(D<object>? key, params D<object>?[] value)").WithLocation(19, 32),
                 // (9,28): warning CS8604: Possible null reference argument for parameter 'key' in 'void C<int>.Add(C<object?> key, params C<object?>[] value)'.
                 //         _ = new C<int>() { x, x }; // warn 1 and 2
@@ -35250,7 +35228,7 @@ class B5 : A<int>
 @"Imports System
 Imports System.Runtime.InteropServices
 <Assembly: PrimaryInteropAssembly(0, 0)> 
-<Assembly: Guid(""165F752D-E9C4-4F7E-B0D0-CDFD7A36E210"")> 
+<Assembly: Guid(""165F752D-E9C4-4F7E-B0D0-CDFD7A36E210"")>
 <ComImport()>
 <Guid(""165F752D-E9C4-4F7E-B0D0-CDFD7A36E211"")>
 Public Class A
@@ -42029,7 +42007,7 @@ class C
     }
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/29972: Should report WRN_NullReferenceReceiver using Enumerable.GetEnumerator. 
+            // https://github.com/dotnet/roslyn/issues/29972: Should report WRN_NullReferenceReceiver using Enumerable.GetEnumerator.
             comp.VerifyDiagnostics();
         }
 
@@ -45083,7 +45061,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,10): warning CS0649: Field 'C.E' is never assigned to, and will always have its default value 
+                // (5,10): warning CS0649: Field 'C.E' is never assigned to, and will always have its default value
                 //     int? E;
                 Diagnostic(ErrorCode.WRN_UnassignedInternalField, "E").WithArguments("C.E", "").WithLocation(5, 10));
         }
@@ -46791,7 +46769,7 @@ class B<T1> where T1 : struct?
 
             comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular7_3, skipUsesIsNullable: true);
             comp.VerifyDiagnostics(expected
-                .Concat(new[] { 
+                .Concat(new[] {
                 // error CS8630: Invalid 'NullableContextOptions' value: 'Enable' for C# 7.3. Please use language version 8.0 or greater.
                 Diagnostic(ErrorCode.ERR_NullableOptionNotAvailable).WithArguments("NullableContextOptions", "Enable", "7.3", "8.0").WithLocation(1, 1)
                 }).ToArray()
@@ -49469,10 +49447,10 @@ public interface IA<TA> where TA : ID<string>
 {
 }
 " + NonNullTypesOn() + @"
-public interface IC : IA<ID<string>?> 
+public interface IC : IA<ID<string>?>
 {}
 
-public interface IE : IA<ID<string>> 
+public interface IE : IA<ID<string>>
 {}
 
 public interface ID<T>
@@ -49491,12 +49469,12 @@ class B
 " + NonNullTypesOn() + @"
     public void Test2(ID<string> b2, ID<string>? c2)
     {
-        M1(b2); 
+        M1(b2);
         M1(c2);
         M1<ID<string>?>(c2);
         M1<ID<string>>(b2);
     }
-    
+
 }
 ";
             var comp1 = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
@@ -49535,12 +49513,12 @@ class B
     public void Test2(string? a2, string b2)
     {
         M1(a2);
-        M1(b2); 
+        M1(b2);
         M1<string?>(a2);
         M1<string?>(b2);
         M1<string>(b2);
     }
-    
+
 }
 ";
             var comp1 = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
@@ -49823,7 +49801,7 @@ class B<TB1, TB2> where TB1 : class? where TB2 : class {
     public void Test2(TB1 a2, TB2 b2)
     {
         M1(a2); // 5
-        M1(b2); // 6 
+        M1(b2); // 6
         M1<TB1>(a2); // 7
         M1<TB2>(b2); // 8
     }
@@ -49842,7 +49820,7 @@ class B<TB1, TB2> where TB1 : class? where TB2 : class {
                 //         M1(a2); // 5
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "M1").WithArguments("B<TB1, TB2>.M1<TM1>(TM1)", "TM1", "TB1").WithLocation(27, 9),
                 // (28,9): warning CS8634: The type 'TB2' cannot be used as type parameter 'TM1' in the generic type or method 'B<TB1, TB2>.M1<TM1>(TM1)'. Nullability of type argument 'TB2' doesn't match 'class' constraint.
-                //         M1(b2); // 6 
+                //         M1(b2); // 6
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "M1").WithArguments("B<TB1, TB2>.M1<TM1>(TM1)", "TM1", "TB2").WithLocation(28, 9),
                 // (29,9): warning CS8634: The type 'TB1' cannot be used as type parameter 'TM1' in the generic type or method 'B<TB1, TB2>.M1<TM1>(TM1)'. Nullability of type argument 'TB1' doesn't match 'class' constraint.
                 //         M1<TB1>(a2); // 7
@@ -49959,15 +49937,15 @@ public interface IE<TIE> : IA<TIE> where TIE : IE?, ID<string>, IF?
 public interface ID<T>
 {}
 
-class B<TB1, TB2, TB3, TB4> 
-    where TB1 : IE?, ID<string?>, IF? 
-    where TB2 : IE?, ID<string>?, IF? 
+class B<TB1, TB2, TB3, TB4>
+    where TB1 : IE?, ID<string?>, IF?
+    where TB2 : IE?, ID<string>?, IF?
     where TB3 : IE?, ID<string>, IF?
     where TB4 : IE, ID<string>?, IF?
 {
     public void Test1()
     {
-        IA<TB1> x1; 
+        IA<TB1> x1;
         IA<TB2> y1;
         IA<TB3> z1;
         IA<TB4> u1;
@@ -49979,11 +49957,11 @@ class B<TB1, TB2, TB3, TB4>
 " + NonNullTypesOn() + @"
     public void Test2(TB1 a2, TB3 b2, TB2 c2, TB4 d2)
     {
-        M1(a2); 
-        M1(b2); 
+        M1(a2);
+        M1(b2);
         M1(c2);
         M1(d2);
-        M1<TB1>(a2); 
+        M1<TB1>(a2);
         M1<TB2>(c2);
         M1<TB3>(b2);
         M1<TB4>(d2);
@@ -50027,9 +50005,9 @@ public interface ID<T>
 {}
 
 " + NonNullTypesOff() + @"
-class B<TB1, TB2, TB3, TB4> 
-    where TB1 : IE?, ID<string?>, IF? 
-    where TB2 : IE?, ID<string>?, IF? 
+class B<TB1, TB2, TB3, TB4>
+    where TB1 : IE?, ID<string?>, IF?
+    where TB2 : IE?, ID<string>?, IF?
     where TB3 : IE?, ID<string>, IF?
     where TB4 : IE, ID<string>?, IF?
 {
@@ -50435,12 +50413,12 @@ class B
     public void Test2(string? a2, string b2)
     {
         M1(a2);
-        M1(b2); 
+        M1(b2);
         M1<string?>(a2);
         M1<string?>(b2);
         M1<string>(b2);
     }
-    
+
 }
 ";
             var comp1 = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
@@ -50599,7 +50577,7 @@ class B<TB1, TB2> where TB2 : object {
     public void Test2(TB1 a2, TB2 b2)
     {
         M1(a2); // 5
-        M1(b2); // 6 
+        M1(b2); // 6
         M1<TB1>(a2); // 7
         M1<TB2>(b2); // 8
     }
@@ -50618,7 +50596,7 @@ class B<TB1, TB2> where TB2 : object {
                 //         M1(a2); // 5
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, "M1").WithArguments("B<TB1, TB2>.M1<TM1>(TM1)", "object", "TM1", "TB1").WithLocation(27, 9),
                 // (28,9): warning CS8631: The type 'TB2' cannot be used as type parameter 'TM1' in the generic type or method 'B<TB1, TB2>.M1<TM1>(TM1)'. Nullability of type argument 'TB2' doesn't match constraint type 'object'.
-                //         M1(b2); // 6 
+                //         M1(b2); // 6
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, "M1").WithArguments("B<TB1, TB2>.M1<TM1>(TM1)", "object", "TM1", "TB2").WithLocation(28, 9),
                 // (29,9): warning CS8631: The type 'TB1' cannot be used as type parameter 'TM1' in the generic type or method 'B<TB1, TB2>.M1<TM1>(TM1)'. Nullability of type argument 'TB1' doesn't match constraint type 'object'.
                 //         M1<TB1>(a2); // 7
@@ -56239,7 +56217,7 @@ $@"
 class A<T1> where T1 : class
 {
 " + NonNullTypesOff() + @"
-    class B<T2> where T2 : T1 
+    class B<T2> where T2 : T1
     {
     }
 
@@ -57451,7 +57429,7 @@ I1<C1<CT1, CT2>>
 
             var expected = new DiagnosticDescription[] {
                 // (2,7): warning CS8645: 'I1<C1<CT1, CT2>>' is already listed in the interface list on type 'C<CT1, CT2>' with different nullability of reference types.
-                // class C<CT1, CT2> : I2<CT1, CT2>, 
+                // class C<CT1, CT2> : I2<CT1, CT2>,
                 Diagnostic(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList, "C").WithArguments("I1<C1<CT1, CT2>>", "C<CT1, CT2>").WithLocation(2, 7),
                 // (7,10): warning CS8643: Nullability of reference types in explicit interface specifier doesn't match interface implemented by the type.
                 //     void I1<C1<CT1, CT2>>.M()
@@ -57555,7 +57533,7 @@ namespace Metadata
                 expectedOutput: @"Hello 3",
                 expectedSignatures: new[]
                 {
-                    // The ILDASM output is following,and Roslyn handles it correctly. 
+                    // The ILDASM output is following,and Roslyn handles it correctly.
                     // Verifier tool gives different output due to the limitation of Reflection
                     // @".method public hidebysig virtual instance System.Void Method<X>(" +
                     // @"System.String modopt([mscorlib]System.Runtime.CompilerServices.IsConst)[] modopt([mscorlib]System.Runtime.CompilerServices.IsConst) x," +
@@ -57628,13 +57606,13 @@ interface I2
 
             compilation4.VerifyDiagnostics(
                 // (4,10): error CS0012: The type 'ValueType' is defined in an assembly that is not referenced. You must add a reference to assembly 'mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2'.
-                //     I1 M(A a, B b, C c, D d); 
+                //     I1 M(A a, B b, C c, D d);
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "A").WithArguments("System.ValueType", "mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2").WithLocation(4, 10),
                 // (4,15): error CS0012: The type 'Enum' is defined in an assembly that is not referenced. You must add a reference to assembly 'mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2'.
-                //     I1 M(A a, B b, C c, D d); 
+                //     I1 M(A a, B b, C c, D d);
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "B").WithArguments("System.Enum", "mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2").WithLocation(4, 15),
                 // (4,25): error CS0012: The type 'MulticastDelegate' is defined in an assembly that is not referenced. You must add a reference to assembly 'mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2'.
-                //     I1 M(A a, B b, C c, D d); 
+                //     I1 M(A a, B b, C c, D d);
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "D").WithArguments("System.MulticastDelegate", "mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2").WithLocation(4, 25)
                 );
 
@@ -57672,13 +57650,13 @@ interface I2
 
             compilation6.VerifyDiagnostics(
                 // (4,10): error CS0012: The type 'ValueType' is defined in an assembly that is not referenced. You must add a reference to assembly 'mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2'.
-                //     I1 M(A a, B b, C c, D d); 
+                //     I1 M(A a, B b, C c, D d);
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "A").WithArguments("System.ValueType", "mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2").WithLocation(4, 10),
                 // (4,15): error CS0012: The type 'Enum' is defined in an assembly that is not referenced. You must add a reference to assembly 'mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2'.
-                //     I1 M(A a, B b, C c, D d); 
+                //     I1 M(A a, B b, C c, D d);
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "B").WithArguments("System.Enum", "mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2").WithLocation(4, 15),
                 // (4,25): error CS0012: The type 'MulticastDelegate' is defined in an assembly that is not referenced. You must add a reference to assembly 'mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2'.
-                //     I1 M(A a, B b, C c, D d); 
+                //     I1 M(A a, B b, C c, D d);
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "D").WithArguments("System.MulticastDelegate", "mincorlib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ce65828c82a341f2").WithLocation(4, 25)
                 );
 
@@ -57717,7 +57695,7 @@ interface I2
 @"Imports System
 Imports System.Runtime.InteropServices
 <Assembly: PrimaryInteropAssembly(0, 0)> 
-<Assembly: Guid(""165F752D-E9C4-4F7E-B0D0-CDFD7A36E210"")> 
+<Assembly: Guid(""165F752D-E9C4-4F7E-B0D0-CDFD7A36E210"")>
 <ComImport()>
 <Guid(""165F752D-E9C4-4F7E-B0D0-CDFD7A36E211"")>
 Public Interface I
@@ -60418,7 +60396,7 @@ class Outer
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (9,9): warning CS8602: Possible dereference of a null reference.
-                //         M2(x0).ToString(); 
+                //         M2(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(x0)").WithLocation(9, 9)
                 );
         }
@@ -64315,6 +64293,223 @@ class Outer<T, U> where T : class, U
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
+        }
+
+        [Fact]
+        public void NullabilityOfTypeParameters_255()
+        {
+            var source = @"
+class Outer
+{
+    void M0<T>(T x0, T y0, T z0)
+    {
+        if (y0 == null) return;
+        z0 ??= y0;
+        M1(z0) = x0;
+
+        M1(z0).ToString();
+        z0.ToString();
+    }
+
+    ref S M1<S>(S x) => throw null;
+}
+";
+
+            CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         M1(z0).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(10, 9));
+        }
+
+        [Fact]
+        public void NullabilityOfTypeParameters_256()
+        {
+            var source = @"
+class Outer
+{
+    void M0<T>(T x0, T y0)
+    {
+        (x0 ??= y0).ToString();
+    }
+}
+";
+
+            CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
+                // (6,10): warning CS8602: Possible dereference of a null reference.
+                //         (x0 ??= y0).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x0 ??= y0").WithLocation(6, 10));
+        }
+
+        [Fact]
+        public void NullabilityOfTypeParameters_257()
+        {
+            var source = @"
+class Outer
+{
+    void M0<T>(T x0, T y0)
+    {
+        if (y0 == null) return;
+        (x0 ??= y0)?.ToString();
+    }
+}
+";
+
+            CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
+                // (7,10): hidden CS8607: Expression is probably never null.
+                //         (x0 ??= y0)?.ToString();
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x0 ??= y0").WithLocation(7, 10)
+                );
+        }
+
+        [Fact]
+        public void NullabilityOfTypeParameters_258()
+        {
+            var source = @"
+class Outer
+{
+    void M0<T>(T x0, T y0)
+    {
+        if (x0 == null) return;
+        x0 ??= y0;
+        M1(x0).ToString();
+        M1(x0) = y0;
+        x0?.ToString();
+        x0.ToString();
+    }
+
+    ref S M1<S>(S x) => throw null;
+}
+";
+
+            CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
+                // (7,9): hidden CS8607: Expression is probably never null.
+                //         x0 ??= y0;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x0").WithLocation(7, 9),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         M1(x0).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(x0)").WithLocation(8, 9),
+                // (10,9): hidden CS8607: Expression is probably never null.
+                //         x0?.ToString();
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x0").WithLocation(10, 9));
+        }
+
+        [Fact]
+        public void NullabilityOfTypeParameters_259()
+        {
+            var source = @"
+class Outer
+{
+    void M0<T>(T x0, T y0, T a0)
+    {
+        if (x0 == null) return;
+        if (y0 == null) return;
+        x0 ??= y0;
+        M1(x0) = a0;
+        x0?.ToString();
+        M1(x0).ToString();
+    }
+
+    ref S M1<S>(S x) => throw null;
+}
+";
+
+            CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
+                // (8,9): hidden CS8607: Expression is probably never null.
+                //         x0 ??= y0;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x0").WithLocation(8, 9),
+                // (10,9): hidden CS8607: Expression is probably never null.
+                //         x0?.ToString();
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x0").WithLocation(10, 9),
+                // (11,9): warning CS8602: Possible dereference of a null reference.
+                //         M1(x0).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(x0)").WithLocation(11, 9));
+        }
+
+        [Fact]
+        public void NullabilityOfTypeParameters_260()
+        {
+            var source = @"
+class Outer<T>
+{
+    void M0(T x0, T y0)
+    {
+        if (y0 == null) return;
+        y0 ??= M2();
+        M1(y0) = x0;
+        M1<T>(y0) = x0;
+
+        M1(y0).ToString();
+        y0.ToString();
+    }
+
+    ref S M1<S>(S x) => throw null;
+
+#nullable disable
+    T M2() => throw null;
+}
+";
+
+            CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
+                // (7,9): hidden CS8607: Expression is probably never null.
+                //         y0 ??= M2();
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y0").WithLocation(7, 9),
+                // (11,9): warning CS8602: Possible dereference of a null reference.
+                //         M1(y0).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(y0)").WithLocation(11, 9));
+        }
+
+        [Fact]
+        public void NullabilityOfTypeParameters_261()
+        {
+            var source = @"
+class Outer<T>
+{
+    void M0(T x0, T y0)
+    {
+        y0 ??= M2();
+        M1(y0) = x0;
+        y0.ToString();
+    }
+
+    ref S M1<S>(S x) => throw null;
+
+#nullable disable
+    T M2() => throw null;
+}
+";
+
+            CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullabilityOfTypeParameters_262()
+        {
+            var source = @"
+class Outer<T1, T2> where T1 : class, T2
+{
+    void M0(T1 t1, T2 t2)
+    {
+        t1 ??= t2 as T1;
+        M1(t1) ??= t2 as T1;
+    }
+
+    ref S M1<S>(S x) => throw null;
+}
+";
+
+            CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
+                // (6,9): hidden CS8607: Expression is probably never null.
+                //         t1 ??= t2 as T1;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "t1").WithLocation(6, 9),
+                // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t1 ??= t2 as T1;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "t2 as T1").WithLocation(6, 16),
+                // (7,9): hidden CS8607: Expression is probably never null.
+                //         M1(t1) ??= t2 as T1;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "M1(t1)").WithLocation(7, 9),
+                // (7,20): warning CS8601: Possible null reference assignment.
+                //         M1(t1) ??= t2 as T1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "t2 as T1").WithLocation(7, 20));
         }
 
         [Fact]
@@ -72506,6 +72701,305 @@ public class Broken<T> : IEnumerable<IEquatable<T>>
 ";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics();
+        }
+
+        [WorkItem(30140, "https://github.com/dotnet/roslyn/issues/30140")]
+        [Fact]
+        public void NullCoalescingAssignment_UseInExpression()
+        {
+            var source = @"
+class C
+{
+    void M(string? s1, string s2)
+    {
+        string s3 = (s1 ??= s2);
+        string? s4 = null, s5 = null;
+        string s6 = (s4 ??= s5); // Warn 1
+        s4.ToString(); // Warn 2
+    }
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (8,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         string s6 = (s4 ??= s5); // Warn 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "s4 ??= s5").WithLocation(8, 22),
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         s4.ToString(); // Warn 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s4").WithLocation(9, 9));
+        }
+
+        [WorkItem(30140, "https://github.com/dotnet/roslyn/issues/30140")]
+        [Fact]
+        public void NullCoalescingAssignment_AssignsState()
+        {
+            var source = @"
+class C
+{
+    object? F = null;
+    void M(C? c1, C c2, C c3)
+    {
+        c1 ??= c2;
+        c1.ToString();
+
+        if (c3.F == null) return;
+
+        c1 = null;
+        c1 ??= c3;
+        c1.F.ToString(); // Warn 1
+
+        c1 = null;
+        c1 ??= c3;
+        c1.ToString();
+        c1.F.ToString(); // Warn 2
+
+        if (c1.F == null) return; // Hidden 3
+        c1 ??= c2; // Hidden 4
+        c1.F.ToString(); // Warn 5
+
+        // We could support this in the future if MakeSlot is made smarter to understand
+        // that the slot of a ??= is the slot of the left-hand side. https://github.com/dotnet/roslyn/issues/32501
+        (c1 ??= c3).F.ToString(); // Warn 6, Hidden 7
+    }
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (14,9): warning CS8602: Possible dereference of a null reference.
+                //         c1.F.ToString(); // Warn 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1.F").WithLocation(14, 9),
+                // (19,9): warning CS8602: Possible dereference of a null reference.
+                //         c1.F.ToString(); // Warn 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1.F").WithLocation(19, 9),
+                // (21,13): hidden CS8606: Result of the comparison is possibly always false.
+                //         if (c1.F == null) return; // Hidden 3
+                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysFalse, "c1.F == null").WithLocation(21, 13),
+                // (22,9): hidden CS8607: Expression is probably never null.
+                //         c1 ??= c2; // Hidden 4
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c1").WithLocation(22, 9),
+                // (23,9): warning CS8602: Possible dereference of a null reference.
+                //         c1.F.ToString(); // Warn 5
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1.F").WithLocation(23, 9),
+                // (27,9): warning CS8602: Possible dereference of a null reference.
+                //         (c1 ??= c3).F.ToString(); // Warn 6, Hidden 7
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(c1 ??= c3).F").WithLocation(27, 9),
+                // (27,10): hidden CS8607: Expression is probably never null.
+                //         (c1 ??= c3).F.ToString(); // Warn 6, Hidden 7
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c1").WithLocation(27, 10));
+        }
+
+        [WorkItem(30140, "https://github.com/dotnet/roslyn/issues/30140")]
+        [Fact]
+        public void NullCoalescingAssignment_RightStateValidInRightOnly()
+        {
+            var source = @"
+class C
+{
+    C GetC(C c) => c;
+    void M(C? c1, C? c2, C c3)
+    {
+        c1 ??= (c2 = c3);
+        c1.ToString();
+        c2.ToString(); // Warn 1
+
+        c1 = null;
+        c2 = null;
+        c1 ??= (c2 = c3).GetC(c2);
+        c1.ToString();
+        c2.ToString(); // Warn 2
+
+        c1 = null;
+        c2 = null;
+        c1 ??= (c2 = c3).GetC(c1); // Warn 3
+        c1.ToString();
+    }
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         c2.ToString(); // Warn 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(9, 9),
+                // (15,9): warning CS8602: Possible dereference of a null reference.
+                //         c2.ToString(); // Warn 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(15, 9),
+                // (19,31): warning CS8604: Possible null reference argument for parameter 'c' in 'C C.GetC(C c)'.
+                //         c1 ??= (c2 = c3).GetC(c1); // Warn 3
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "c1").WithArguments("c", "C C.GetC(C c)").WithLocation(19, 31));
+        }
+
+        [WorkItem(30140, "https://github.com/dotnet/roslyn/issues/30140")]
+        [Fact]
+        public void NullCoalescingAssignment_Contravariant()
+        {
+            var source = @"
+class C
+{
+#nullable disable
+    C GetC() => null;
+#nullable enable
+    void M(C? c1, C c2)
+    {
+        // nullable + oblivious = oblivious
+#nullable disable
+        C c3
+#nullable enable
+                  = (c1 ??= GetC());
+        _ = c1/*T:C*/;
+        _ = c3/*T:C*/;
+
+        // oblivious + nullable = nullable
+        // This one is a little weirder. The ??= on c3 forces it into either nullable or not nullable, so we must
+        // pick the nullable version, meaning the resulting expression is actually nullable + nullable = nullable.
+        c1 = null;
+        var c4 = (c3 ??= c1);
+        _ = c3/*T:C?*/;
+        _ = c4/*T:C?*/;
+
+        // oblivious + not nullable = not nullable
+        c3 = GetC();
+        var c5 = (c3 ??= c2);
+        _ = c3/*T:C!*/;
+        _ = c5/*T:C!*/;
+
+        // not nullable + oblivious = not nullable
+        var c6 = (c2 ??= GetC());
+        _ = c2/*T:C!*/;
+        _ = c6/*T:C!*/;
+    }
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (30,19): hidden CS8607: Expression is probably never null.
+                //         var c6 = (c2 ??= GetC());
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c2").WithLocation(32, 19));
+            comp.VerifyTypes();
+        }
+
+        [WorkItem(30140, "https://github.com/dotnet/roslyn/issues/30140")]
+        [Fact]
+        public void NullCoalescingAssignment_LeftNotTracked()
+        {
+            var source = @"
+class C
+{
+    void M(C?[] c1, C c2)
+    {
+        c1[0] ??= c2;
+        c1[0].ToString(); // Warn
+    }
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (7,9): warning CS8602: Possible dereference of a null reference.
+                //         c1[0].ToString(); // Warn
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1[0]").WithLocation(7, 9));
+        }
+
+        [WorkItem(30140, "https://github.com/dotnet/roslyn/issues/30140")]
+        [Fact]
+        public void NullCoalescingAssignment_RefReturn()
+        {
+            var source = @"
+class C
+{
+    void M1(C c1, C? c2)
+    {
+        M2(c1) ??= c2; // Warn 1, 2
+        M2(c1).ToString();
+
+        M2(c2) ??= c1;
+        M2(c2).ToString(); // Warn 3
+    }
+
+    ref T M2<T>(T t) => throw null;
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (6,9): hidden CS8607: Expression is probably never null.
+                //         M2(c1) ??= c2; // Warn 1, 2
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "M2(c1)").WithLocation(6, 9),
+                // (6,20): warning CS8601: Possible null reference assignment.
+                //         M2(c1) ??= c2; // Warn 1, 2
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c2").WithLocation(6, 20),
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         M2(c2).ToString(); // Warn 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(c2)").WithLocation(10, 9));
+        }
+
+        [WorkItem(30140, "https://github.com/dotnet/roslyn/issues/30140")]
+        [Fact]
+        public void NullCoalescingAssignment_NestedLHS()
+        {
+            var source = @"
+class C
+{
+    object? F = null;
+    void M1(C c1, object f)
+    {
+        c1.F ??= f;
+        c1.F.ToString();
+    }
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+        }
+
+        [WorkItem(30140, "https://github.com/dotnet/roslyn/issues/30140")]
+        [Fact]
+        public void NullCoalescingAssignment_Conversions()
+        {
+            var source = @"
+class C<T>
+{
+    void M1(C<object>? c1, C<object?> c2, C<object?> c3, C<object>? c4)
+    {
+        c1 ??= c2;
+        c3 ??= c4;
+    }
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (6,16): warning CS8619: Nullability of reference types in value of type 'C<object?>' doesn't match target type 'C<object>'.
+                //         c1 ??= c2;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "c2").WithArguments("C<object?>", "C<object>").WithLocation(6, 16),
+                // (7,9): hidden CS8607: Expression is probably never null.
+                //         c3 ??= c4;
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "c3").WithLocation(7, 9),
+                // (7,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         c3 ??= c4;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c4").WithLocation(7, 16),
+                // (7,16): warning CS8619: Nullability of reference types in value of type 'C<object>' doesn't match target type 'C<object?>'.
+                //         c3 ??= c4;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "c4").WithArguments("C<object>", "C<object?>").WithLocation(7, 16));
+        }
+
+        [WorkItem(30140, "https://github.com/dotnet/roslyn/issues/30140")]
+        [Fact]
+        public void NullCoalescingAssignment_LeftStillNullableOnRight()
+        {
+            var source = @"
+class C
+{
+    void M1(C? c1)
+    {
+        c1 ??= M2(c1);
+        c1.ToString();
+    }
+
+    C M2(C c1) => throw null;
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (6,19): warning CS8604: Possible null reference argument for parameter 'c1' in 'C C.M2(C c1)'.
+                //         c1 ??= M2(c1);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "c1").WithArguments("c1", "C C.M2(C c1)").WithLocation(6, 19));
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/30140.

Commit 1 fixes a bug I noticed while coming up with a test matrix for ??=. The fix I took here was my first instinct and may be incorrect, so if there's a better way to accomplish this I would love to know.
Commit 2 implements ??=.
Commit 3 is a bug fix caught by CI.

@dotnet/roslyn-compiler @jcouv @cston @AlekseyTs for review.