### PR TITLE
Use PipeOptions.CurrentUserOnly

### DIFF
--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
     <Compile Include="..\..\Shared\BuildClient.cs">
       <Link>BuildClient.cs</Link>
     </Compile>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -34,6 +34,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
     <Compile Include="..\..\Shared\BuildServerConnection.cs">
       <Link>BuildServerConnection.cs</Link>
     </Compile>

--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
@@ -47,7 +47,17 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             // as Windows refusing to create the pipe for some reason 
             // (out of handles?), or the pipe was disconnected before we 
             // starting listening.
-            NamedPipeServerStream pipeStream = ConstructPipe(_pipeName);
+            CompilerServerLogger.Log("Constructing pipe '{0}'.", _pipeName);
+            var pipeOptions = PipeOptions.Asynchronous | PipeOptions.WriteThrough;
+            var pipeStream = NamedPipeUtil.CreateServer(
+                _pipeName,
+                PipeDirection.InOut,
+                NamedPipeServerStream.MaxAllowedServerInstances,
+                PipeTransmissionMode.Byte,
+                pipeOptions,
+                PipeBufferSize,
+                PipeBufferSize);
+            CompilerServerLogger.Log("Successfully constructed pipe '{0}'.", _pipeName);
 
             CompilerServerLogger.Log("Waiting for new connection");
             await pipeStream.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
@@ -61,76 +71,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
             pipeStream.Close();
             throw new Exception("Insufficient resources to process new connection.");
-        }
-
-        /// <summary>
-        /// Create an instance of the pipe. This might be the first instance, or a subsequent instance.
-        /// There always needs to be an instance of the pipe created to listen for a new client connection.
-        /// </summary>
-        /// <returns>The pipe instance or throws an exception.</returns>
-        private NamedPipeServerStream ConstructPipe(string pipeName)
-        {
-            CompilerServerLogger.Log("Constructing pipe '{0}'.", pipeName);
-
-#if NET472
-            PipeSecurity security;
-            PipeOptions pipeOptions = PipeOptions.Asynchronous | PipeOptions.WriteThrough;
-
-            if (!PlatformInformation.IsRunningOnMono)
-            {
-                security = new PipeSecurity();
-                SecurityIdentifier identifier = WindowsIdentity.GetCurrent().Owner;
-
-                // Restrict access to just this account.  
-                PipeAccessRule rule = new PipeAccessRule(identifier, PipeAccessRights.ReadWrite | PipeAccessRights.CreateNewInstance, AccessControlType.Allow);
-                security.AddAccessRule(rule);
-                security.SetOwner(identifier);
-            }
-            else
-            {
-                // Pipe security and additional access rights constructor arguments
-                //  are not supported by Mono 
-                // https://github.com/dotnet/roslyn/pull/30810
-                // https://github.com/mono/mono/issues/11406
-                security = null;
-                // This enum value is implemented by Mono to restrict pipe access to
-                //  the current user
-                const int CurrentUserOnly = unchecked((int)0x20000000);
-                pipeOptions |= (PipeOptions)CurrentUserOnly;
-            }
-
-            NamedPipeServerStream pipeStream = new NamedPipeServerStream(
-                pipeName,
-                PipeDirection.InOut,
-                NamedPipeServerStream.MaxAllowedServerInstances, // Maximum connections.
-                PipeTransmissionMode.Byte,
-                pipeOptions,
-                PipeBufferSize, // Default input buffer
-                PipeBufferSize, // Default output buffer
-                security,
-                HandleInheritability.None);
-#else
-            // The overload of NamedPipeServerStream with the PipeAccessRule
-            // parameter was removed in netstandard. However, the default
-            // constructor does not provide WRITE_DAC, so attempting to use
-            // SetAccessControl will always fail. So, completely ignore ACLs on
-            // netcore, and trust that our `ClientAndOurIdentitiesMatch`
-            // verification will catch any invalid connections.
-            // Issue to add WRITE_DAC support:
-            // https://github.com/dotnet/corefx/issues/24040
-            NamedPipeServerStream pipeStream = new NamedPipeServerStream(
-                pipeName,
-                PipeDirection.InOut,
-                NamedPipeServerStream.MaxAllowedServerInstances, // Maximum connections.
-                PipeTransmissionMode.Byte,
-                PipeOptions.Asynchronous | PipeOptions.WriteThrough,
-                PipeBufferSize, // Default input buffer
-                PipeBufferSize);// Default output buffer
-#endif
-
-            CompilerServerLogger.Log("Successfully constructed pipe '{0}'.", pipeName);
-
-            return pipeStream;
         }
     }
 
@@ -159,46 +99,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         protected override void ValidateBuildRequest(BuildRequest request)
         {
             // Now that we've read data from the stream we can validate the identity.
-            if (!ClientAndOurIdentitiesMatch(_pipeStream))
+            if (!NamedPipeUtil.CheckClientElevationMatches(_pipeStream))
             {
                 throw new Exception("Client identity does not match server identity.");
             }
-        }
-
-        /// <summary>
-        /// Does the client of "pipeStream" have the same identity and elevation as we do?
-        /// </summary>
-        private static bool ClientAndOurIdentitiesMatch(NamedPipeServerStream pipeStream)
-        {
-            if (PlatformInformation.IsWindows)
-            {
-                var serverIdentity = GetIdentity(impersonating: false);
-
-                (string name, bool admin) clientIdentity = default;
-                pipeStream.RunAsClient(() => { clientIdentity = GetIdentity(impersonating: true); });
-
-                CompilerServerLogger.Log($"Server identity = '{serverIdentity.name}', server elevation='{serverIdentity.admin}'.");
-                CompilerServerLogger.Log($"Client identity = '{clientIdentity.name}', client elevation='{serverIdentity.admin}'.");
-
-                return
-                    StringComparer.OrdinalIgnoreCase.Equals(serverIdentity.name, clientIdentity.name) &&
-                    serverIdentity.admin == clientIdentity.admin;
-            }
-            else
-            {
-                return BuildServerConnection.CheckIdentityUnix(pipeStream);
-            }
-        }
-
-        /// <summary>
-        /// Return the current user name and whether the current user is in the administrator role.
-        /// </summary>
-        private static (string name, bool admin) GetIdentity(bool impersonating)
-        {
-            WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent(impersonating);
-            WindowsPrincipal currentPrincipal = new WindowsPrincipal(currentIdentity);
-            var elevatedToAdmin = currentPrincipal.IsInRole(WindowsBuiltInRole.Administrator);
-            return (currentIdentity.Name, elevatedToAdmin);
         }
 
         public override void Close()

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
     <Compile Include="..\..\Shared\BuildClient.cs">
       <Link>BuildClient.cs</Link>
     </Compile>

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 // The NamedPipeClientStream class handles the "\\.\pipe\" part for us.
                 Log("Attempt to open named pipe '{0}'", pipeName);
 
-                pipeStream = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+                pipeStream = NamedPipeUtil.CreateClient(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
                 cancellationToken.ThrowIfCancellationRequested();
 
                 Log("Attempt to connect named pipe '{0}'", pipeName);
@@ -357,7 +357,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // Verify that we own the pipe.
-                if (!CheckPipeConnectionOwnership(pipeStream))
+                if (!NamedPipeUtil.CheckPipeConnectionOwnership(pipeStream))
                 {
                     Log("Owner of named pipe is incorrect");
                     return null;
@@ -469,76 +469,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     return false;
                 }
             }
-        }
-
-        /// <summary>
-        /// Check to ensure that the named pipe server we connected to is owned by the same
-        /// user.
-        /// </summary>
-        /// <remarks>
-        /// The type is embedded in assemblies that need to run cross platform.  While this particular
-        /// code will never be hit when running on non-Windows platforms it does need to work when
-        /// on Windows.  To facilitate that we use reflection to make the check here to enable it to
-        /// compile into our cross plat assemblies.
-        /// </remarks>
-        private static bool CheckPipeConnectionOwnership(NamedPipeClientStream pipeStream)
-        {
-            try
-            {
-                if (PlatformInformation.IsWindows)
-                {
-                    var currentIdentity = WindowsIdentity.GetCurrent();
-                    var currentOwner = currentIdentity.Owner;
-                    var remotePipeSecurity = GetPipeSecurity(pipeStream);
-                    var remoteOwner = remotePipeSecurity.GetOwner(typeof(SecurityIdentifier));
-                    return currentOwner.Equals(remoteOwner);
-                }
-                else
-                {
-                    return CheckIdentityUnix(pipeStream);
-                }
-            }
-            catch (Exception ex)
-            {
-                LogException(ex, "Checking pipe connection");
-                return false;
-            }
-        }
-
-#if NET472
-        internal static bool CheckIdentityUnix(PipeStream stream)
-        {
-            // Identity verification is unavailable in the MSBuild task,
-            // but verification is not needed client-side so that's okay.
-            return true;
-        }
-#else
-        [DllImport("System.Native", EntryPoint = "SystemNative_GetEUid")]
-        private static extern uint GetEUid();
-
-        [DllImport("System.Native", EntryPoint = "SystemNative_GetPeerID", SetLastError = true)]
-        private static extern int GetPeerID(SafeHandle socket, out uint euid);
-
-        internal static bool CheckIdentityUnix(PipeStream stream)
-        {
-            var flags = BindingFlags.Instance | BindingFlags.NonPublic;
-            var handle = (SafePipeHandle)typeof(PipeStream).GetField("_handle", flags).GetValue(stream);
-            var handle2 = (SafeHandle)typeof(SafePipeHandle).GetField("_namedPipeSocketHandle", flags).GetValue(handle);
-
-            uint myID = GetEUid();
-
-            if (GetPeerID(handle, out uint peerID) == -1)
-            {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-
-            return myID == peerID;
-        }
-#endif
-
-        private static ObjectSecurity GetPipeSecurity(PipeStream pipeStream)
-        {
-            return pipeStream.GetAccessControl();
         }
 
         /// <returns>

--- a/src/Compilers/Shared/NamedPipeUtil.cs
+++ b/src/Compilers/Shared/NamedPipeUtil.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// The compiler needs to take advantage of features on named pipes which require target framework
+    /// specific APIs. This class is meant to provide a simple, universal interface on top of the 
+    /// multi-targeting code that is needed here.
+    /// </summary>
+    internal static class NamedPipeUtil
+    {
+        const int s_currentUserOnlyValue = unchecked((int)0x20000000);
+
+        /// <summary>
+        /// Create a client for the current user only.
+        /// </summary>
+        internal static NamedPipeClientStream CreateClient(string serverName, string pipeName, PipeDirection direction, PipeOptions options) =>
+            new NamedPipeClientStream(serverName, pipeName, direction, options | CurrentUserOption);
+
+        /// <summary>
+        /// Does the client of "pipeStream" have the same identity and elevation as we do? The <see cref="CreateClient"/> and 
+        /// <see cref="CreateServer" /> methods will already guarantee that the identity of the client and server are the 
+        /// same. This method is attempting to validate that the elevation level is the same between both ends of the 
+        /// named pipe (want to disallow low priv session sending compilation requests to an elevated one).
+        /// </summary>
+        internal static bool CheckClientElevationMatches(NamedPipeServerStream pipeStream)
+        {
+            if (PlatformInformation.IsWindows)
+            {
+                var serverIdentity = getIdentity(impersonating: false);
+
+                (string name, bool admin) clientIdentity = default;
+                pipeStream.RunAsClient(() => { clientIdentity = getIdentity(impersonating: true); });
+
+                return
+                    StringComparer.OrdinalIgnoreCase.Equals(serverIdentity.name, clientIdentity.name) &&
+                    serverIdentity.admin == clientIdentity.admin;
+
+                (string name, bool admin) getIdentity(bool impersonating)
+                {
+                    var currentIdentity = WindowsIdentity.GetCurrent(impersonating);
+                    var currentPrincipal = new WindowsPrincipal(currentIdentity);
+                    var elevatedToAdmin = currentPrincipal.IsInRole(WindowsBuiltInRole.Administrator);
+                    return (currentIdentity.Name, elevatedToAdmin);
+                }
+            }
+
+            return true;
+        }
+
+#if NET472
+
+        /// <summary>
+        /// Mono supports CurrentUserOnly even though it's not exposed on the reference assemblies for net472. This 
+        /// must be used because ACL security does not work.
+        /// </summary>
+        private static PipeOptions CurrentUserOption = PlatformInformation.IsRunningOnMono
+            ? (PipeOptions)s_currentUserOnlyValue
+            : PipeOptions.None;
+
+        internal static NamedPipeServerStream CreateServer(
+            string pipeName,
+            PipeDirection direction,
+            int maxNumberOfServerInstances,
+            PipeTransmissionMode transmissionMode,
+            PipeOptions options,
+            int inBufferSize,
+            int outBufferSize) =>
+            new NamedPipeServerStream(
+                pipeName,
+                direction,
+                maxNumberOfServerInstances,
+                transmissionMode,
+                options | CurrentUserOption,
+                inBufferSize,
+                outBufferSize,
+                CreatePipeSecurity(),
+                HandleInheritability.None);
+
+        /// <summary>
+        /// Check to ensure that the named pipe server we connected to is owned by the same
+        /// user.
+        /// </summary>
+        internal static bool CheckPipeConnectionOwnership(NamedPipeClientStream pipeStream)
+        {
+            if (PlatformInformation.IsWindows)
+            {
+                var currentIdentity = WindowsIdentity.GetCurrent();
+                var currentOwner = currentIdentity.Owner;
+                var remotePipeSecurity = pipeStream.GetAccessControl();
+                var remoteOwner = remotePipeSecurity.GetOwner(typeof(SecurityIdentifier));
+                return currentOwner.Equals(remoteOwner);
+            }
+
+            // Client side validation isn't supported on Unix. The model relies on the server side
+            // security here.
+            return true;
+        }
+
+        internal static PipeSecurity CreatePipeSecurity()
+        {
+            if (PlatformInformation.IsRunningOnMono)
+            {
+                // Pipe security and additional access rights constructor arguments
+                //  are not supported by Mono 
+                // https://github.com/dotnet/roslyn/pull/30810
+                // https://github.com/mono/mono/issues/11406
+                return null;
+            }
+
+            var security = new PipeSecurity();
+            SecurityIdentifier identifier = WindowsIdentity.GetCurrent().Owner;
+
+            // Restrict access to just this account.  
+            PipeAccessRule rule = new PipeAccessRule(identifier, PipeAccessRights.ReadWrite | PipeAccessRights.CreateNewInstance, AccessControlType.Allow);
+            security.AddAccessRule(rule);
+            security.SetOwner(identifier);
+            return security;
+        }
+
+#elif NETCOREAPP2_1
+
+        private static PipeOptions CurrentUserOption = PipeOptions.CurrentUserOnly;
+
+        // Validation is handled by CurrentUserOnly
+        internal static bool CheckPipeConnectionOwnership(NamedPipeClientStream pipeStream) => true;
+
+        // Validation is handled by CurrentUserOnly
+        internal static PipeSecurity CreatePipeSecurity() => null;
+
+        internal static NamedPipeServerStream CreateServer(
+            string pipeName,
+            PipeDirection direction,
+            int maxNumberOfServerInstances,
+            PipeTransmissionMode transmissionMode,
+            PipeOptions options,
+            int inBufferSize,
+            int outBufferSize) =>
+            new NamedPipeServerStream(
+                pipeName,
+                direction,
+                maxNumberOfServerInstances,
+                transmissionMode,
+                options | CurrentUserOption,
+                inBufferSize,
+                outBufferSize);
+
+
+#else
+#error Unsupported configuration
+
+#endif
+
+    }
+}

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
     <Compile Include="..\..\Shared\BuildClient.cs">
       <Link>BuildClient.cs</Link>
     </Compile>


### PR DESCRIPTION
Now that we are targetting netcoreapp2.1 we can use the
`PipeOptions.CurrentUserOnly` option:

- https://github.com/dotnet/corefx/issues/25427

This is implemented by both CoreClr and Mono. It covers all of the
identity checking to make sure the same user is connected to both ends
of a named pipe. This is mostly just an implementation of what we were
already doing via ACLS and private reflection. But now it can simply be
delegated to the runtime entirely