### PR TITLE
Remove more private reflection from compiler

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -1373,7 +1373,7 @@ public class C
                 //confirm file does not claim to be signed
                 Assert.Equal(0, (int)(flags & CorFlags.StrongNameSigned));
 
-                var corlibName = CoreClrShim.IsRunningOnCoreClr ? "netstandard" : "mscorlib";
+                var corlibName = RuntimeUtilities.IsCoreClrRuntime ? "netstandard" : "mscorlib";
                 EntityHandle token = metadata.Module.GetTypeRef(metadata.Module.GetAssemblyRef(corlibName), "System.Runtime.CompilerServices", "AssemblyAttributesGoHere");
                 Assert.False(token.IsNil);   //could the type ref be located? If not then the attribute's not there.
                 var attrInfos = metadata.Module.FindTargetAttributes(token, expectedModuleAttr);

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />
     <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
     <Compile Include="..\..\Shared\BuildClient.cs">
       <Link>BuildClient.cs</Link>

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -29,27 +29,13 @@
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />
     <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
-    <Compile Include="..\..\Shared\BuildClient.cs">
-      <Link>BuildClient.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\BuildServerConnection.cs">
-      <Link>BuildServerConnection.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs">
-      <Link>CoreClrAnalyzerAssemblyLoader.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\DesktopBuildClient.cs">
-      <Link>DesktopBuildClient.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\DesktopAnalyzerAssemblyLoader.cs">
-      <Link>DesktopAnalyzerAssemblyLoader.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\ExitingTraceListener.cs">
-      <Link>ExitingTraceListener.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\Csc.cs">
-      <Link>Csc.cs</Link>
-    </Compile>
+    <Compile Include="..\..\Shared\BuildClient.cs" />
+    <Compile Include="..\..\Shared\BuildServerConnection.cs" />
+    <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs" />
+    <Compile Include="..\..\Shared\DesktopBuildClient.cs" />
+    <Compile Include="..\..\Shared\DesktopAnalyzerAssemblyLoader.cs" />
+    <Compile Include="..\..\Shared\ExitingTraceListener.cs" />
+    <Compile Include="..\..\Shared\Csc.cs" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests" />

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -18,7 +18,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         protected abstract string PathToManagedTool { get; }
 
-        protected string PathToManagedToolWithoutExtension => Path.ChangeExtension(PathToManagedTool, string.Empty);
+        protected string PathToManagedToolWithoutExtension
+        {
+            get
+            {
+                var extension = Path.GetExtension(PathToManagedTool);
+                return PathToManagedTool.Substring(0, PathToManagedTool.Length - extension.Length);
+            }
+        }
 
         /// <summary>
         /// Note: "Native" here does not necessarily mean "native binary".

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         protected sealed override string GenerateFullPathToTool()
         {
             return IsManagedTool
-                ? RuntimeHostInfo.GetProcessInfo(PathToManagedToolWithoutExtension, string.Empty).ProcessFilePath
+                ? RuntimeHostInfo.GetProcessInfo(PathToManagedToolWithoutExtension, string.Empty).processFilePath
                 : PathToNativeTool;
         }
 

--- a/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedToolTask.cs
@@ -80,21 +80,28 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// as the implementation of IsManagedTool calls this property. See the comment in
         /// <see cref="ManagedCompiler.HasToolBeenOverridden"/>.
         /// </remarks>
-        protected sealed override string ToolName
-            => $"{ToolNameWithoutExtension}.{(CoreClrShim.IsRunningOnCoreClr ? "dll" : "exe")}";
+        protected sealed override string ToolName => $"{ToolNameWithoutExtension}.{ToolExtension}";
+
+        private static string ToolExtension =>
+#if NETCOREAPP2_1
+            "dll";
+#elif NET472
+            "exe";
+#else
+#error Unrecognized framework
+#endif
 
         private static bool IsCliHost(out string pathToDotnet)
         {
-            if (CoreClrShim.IsRunningOnCoreClr)
-            {
-                pathToDotnet = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
-                return !string.IsNullOrEmpty(pathToDotnet);
-            }
-            else
-            {
-                pathToDotnet = null;
-                return false;
-            }
+#if NETCOREAPP2_1
+            pathToDotnet = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+            return !string.IsNullOrEmpty(pathToDotnet);
+#elif NET472
+            pathToDotnet = null;
+            return false;
+#else
+#error Unrecognized framework
+#endif
         }
 
         private static string PrependFileToArgs(string pathToTool, string commandLineArgs)

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -35,19 +35,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
-    <Compile Include="..\..\Shared\BuildServerConnection.cs">
-      <Link>BuildServerConnection.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\CoreClrShim.cs">
-      <Link>CoreClrShim.cs</Link>
-    </Compile>
+    <Compile Include="..\..\Shared\BuildServerConnection.cs" Link="BulidServerConnection.cs" />
+    <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />
     <Compile Include="..\Portable\CommitHashAttribute.cs" Link="CommitHashAttribute.cs" />
-    <Compile Include="..\Portable\InternalUtilities\CommandLineUtilities.cs">
-      <Link>CommandLineUtilities.cs</Link>
-    </Compile>
-    <Compile Include="..\Portable\InternalUtilities\CompilerOptionParseUtilities.cs">
-      <Link>CompilerOptionParseUtilities.cs</Link>
-    </Compile>
+    <Compile Include="..\Portable\InternalUtilities\CommandLineUtilities.cs" Link="CommandLineUtilities.cs" />
+    <Compile Include="..\Portable\InternalUtilities\CompilerOptionParseUtilities.cs" Link="CompilerOptionParserUtilities.cs" />
     <Compile Include="..\Portable\InternalUtilities\IReadOnlySet.cs">
       <Link>IReadOnlySet.cs</Link>
     </Compile>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -35,23 +35,15 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
-    <Compile Include="..\..\Shared\BuildServerConnection.cs" Link="BulidServerConnection.cs" />
+    <Compile Include="..\..\Shared\BuildServerConnection.cs" />
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />
-    <Compile Include="..\Portable\CommitHashAttribute.cs" Link="CommitHashAttribute.cs" />
-    <Compile Include="..\Portable\InternalUtilities\CommandLineUtilities.cs" Link="CommandLineUtilities.cs" />
-    <Compile Include="..\Portable\InternalUtilities\CompilerOptionParseUtilities.cs" Link="CompilerOptionParserUtilities.cs" />
-    <Compile Include="..\Portable\InternalUtilities\IReadOnlySet.cs">
-      <Link>IReadOnlySet.cs</Link>
-    </Compile>
-    <Compile Include="..\Portable\InternalUtilities\PlatformInformation.cs">
-      <Link>PlatformInformation.cs</Link>
-    </Compile>
-    <Compile Include="..\Portable\InternalUtilities\ReflectionUtilities.cs">
-      <Link>ReflectionUtilities.cs</Link>
-    </Compile>
-    <Compile Include="..\Portable\InternalUtilities\UnicodeCharacterUtilities.cs">
-      <Link>UnicodeCharacterUtilities.cs</Link>
-    </Compile>
+    <Compile Include="..\Portable\CommitHashAttribute.cs" />
+    <Compile Include="..\Portable\InternalUtilities\CommandLineUtilities.cs" />
+    <Compile Include="..\Portable\InternalUtilities\CompilerOptionParseUtilities.cs" />
+    <Compile Include="..\Portable\InternalUtilities\IReadOnlySet.cs" />
+    <Compile Include="..\Portable\InternalUtilities\PlatformInformation.cs" />
+    <Compile Include="..\Portable\InternalUtilities\ReflectionUtilities.cs" />
+    <Compile Include="..\Portable\InternalUtilities\UnicodeCharacterUtilities.cs" />
     <Compile Update="ErrorString.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -191,49 +191,17 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         }
 
         /// <summary>
-        /// Try to get the directory this assembly is in. Returns null if assembly
-        /// was in the GAC or DLL location can not be retrieved.
+        /// Generate the full path to the tool that is deployed with our build tasks.
         /// </summary>
-        public static string GenerateFullPathToTool(string toolName)
+        internal static string GenerateFullPathToTool(string toolName)
         {
-            string toolLocation = null;
-
             var buildTask = typeof(Utilities).GetTypeInfo().Assembly;
-            var assemblyPath = TryGetAssemblyPath(buildTask);
+            var assemblyPath = buildTask.Location;
+            var assemblyDirectory = Path.GetDirectoryName(assemblyPath);
 
-            if (assemblyPath != null)
-            {
-                var assemblyDirectory = Path.GetDirectoryName(assemblyPath);
-                var desktopToolLocalLocation = Path.Combine(assemblyDirectory, toolName);
-                var cliToolLocalLocation = Path.Combine(assemblyDirectory, "bincore", toolName);
-
-                if (File.Exists(desktopToolLocalLocation))
-                {
-                    toolLocation = desktopToolLocalLocation;
-                }
-                else if (File.Exists(cliToolLocalLocation))
-                {
-                    toolLocation = cliToolLocalLocation;
-                }
-            }
-
-            if (toolLocation == null)
-            {
-                // Roslyn only deploys to the 32Bit folder of MSBuild, so request this path on all architectures.
-                var pathToBuildTools = ToolLocationHelper.GetPathToBuildTools(ToolLocationHelper.CurrentToolsVersion, DotNetFrameworkArchitecture.Bitness32);
-
-                if (pathToBuildTools != null)
-                {
-                    var toolMSBuildLocation = Path.Combine(pathToBuildTools, MSBuildRoslynFolderName, toolName);
-
-                    if (File.Exists(toolMSBuildLocation))
-                    {
-                        toolLocation = toolMSBuildLocation;
-                    }
-                }
-            }
-
-            return toolLocation;
+            return RuntimeHostInfo.IsDesktopRuntime
+                ? Path.Combine(assemblyDirectory, toolName)
+                : Path.Combine(assemblyDirectory, "bincore", toolName);
         }
     }
 }

--- a/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
@@ -36,7 +36,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\Shared\CoreClrShim.cs" Link="InternalUtilities\CoreClrShim.cs" />
     <Compile Include="..\..\Shared\DesktopShim.cs">
       <Link>DesktopShim.cs</Link>
     </Compile>

--- a/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
@@ -36,9 +36,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\Shared\DesktopShim.cs">
-      <Link>DesktopShim.cs</Link>
-    </Compile>
+    <Compile Include="..\..\Shared\DesktopShim.cs" />
     <Compile Update="CodeAnalysisResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />
     <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
     <Compile Include="..\..\Shared\BuildClient.cs">
       <Link>BuildClient.cs</Link>

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -30,27 +30,13 @@
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />
     <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
-    <Compile Include="..\..\Shared\BuildClient.cs">
-      <Link>BuildClient.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\BuildServerConnection.cs">
-      <Link>BuildServerConnection.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs">
-      <Link>CoreClrAnalyzerAssemblyLoader.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\DesktopAnalyzerAssemblyLoader.cs">
-      <Link>DesktopAnalyzerAssemblyLoader.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\DesktopBuildClient.cs">
-      <Link>DesktopBuildClient.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\ExitingTraceListener.cs">
-      <Link>ExitingTraceListener.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\ShadowCopyAnalyzerAssemblyLoader.cs">
-      <Link>ShadowCopyAnalyzerAssemblyLoader.cs</Link>
-    </Compile>
+    <Compile Include="..\..\Shared\BuildClient.cs" />
+    <Compile Include="..\..\Shared\BuildServerConnection.cs" />
+    <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs" />
+    <Compile Include="..\..\Shared\DesktopAnalyzerAssemblyLoader.cs" />
+    <Compile Include="..\..\Shared\DesktopBuildClient.cs" />
+    <Compile Include="..\..\Shared\ExitingTraceListener.cs" />
+    <Compile Include="..\..\Shared\ShadowCopyAnalyzerAssemblyLoader.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -223,7 +223,7 @@ End Module")
 
         private static void RunCompilerOutput(TempFile file, string expectedOutput)
         {
-            if (!CoreClrShim.IsRunningOnCoreClr)
+            if (RuntimeHostInfo.IsDesktopRuntime)
             {
                 var result = ProcessUtilities.Run(file.Path, "", Path.GetDirectoryName(file.Path));
                 Assert.Equal(expectedOutput.Trim(), result.Output.Trim());

--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -14,6 +14,7 @@ using System.Runtime.Loader;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CommandLine
 {
@@ -48,14 +49,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// </summary>
         public static string GetSystemSdkDirectory()
         {
-            if (CoreClrShim.IsRunningOnCoreClr)
-            {
-                return null;
-            }
-            else
-            {
-                return RuntimeEnvironment.GetRuntimeDirectory();
-            }
+            return RuntimeHostInfo.IsCoreClrRuntime
+                ? null
+                : RuntimeEnvironment.GetRuntimeDirectory();
         }
 
         /// <summary>
@@ -236,12 +232,12 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 return false;
             }
 
-            if (Type.GetType("Mono.Runtime") != null)
+            if (PlatformInformation.IsRunningOnMono)
             {
                 return false;
             }
 
-            if (CoreClrShim.IsRunningOnCoreClr)
+            if (RuntimeHostInfo.IsCoreClrRuntime)
             {
                 // The native invoke ends up giving us both CoreRun and the exe file.
                 // We've decided to ignore backcompat for CoreCLR,

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -371,10 +371,10 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         internal static bool TryCreateServerCore(string clientDir, string pipeName)
         {
-            var serverPathWithoutExetnsion = Path.Combine(clientDir, "VBCSCompiler");
-            var serverInfo = RuntimeHostInfo.GetProcessInfo(serverPathWithoutExetnsion, $"-pipename:{pipeName}");
+            var serverPathWithoutExtension = Path.Combine(clientDir, "VBCSCompiler");
+            var serverInfo = RuntimeHostInfo.GetProcessInfo(serverPathWithoutExtension, $"-pipename:{pipeName}");
 
-            if (!File.Exists(serverInfo.ToolFilePath))
+            if (!File.Exists(serverInfo.toolFilePath))
             {
                 return false;
             }
@@ -395,9 +395,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
                 PROCESS_INFORMATION processInfo;
 
-                Log("Attempting to create process '{0}'", serverInfo.ProcessFilePath);
+                Log("Attempting to create process '{0}'", serverInfo.processFilePath);
 
-                var builder = new StringBuilder($@"""{serverInfo.ProcessFilePath}"" {serverInfo.CommandLineArguments}");
+                var builder = new StringBuilder($@"""{serverInfo.processFilePath}"" {serverInfo.commandLineArguments}");
 
                 bool success = CreateProcess(
                     lpApplicationName: null,
@@ -429,8 +429,8 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 {
                     var startInfo = new ProcessStartInfo()
                     {
-                        FileName = serverInfo.ProcessFilePath,
-                        Arguments = serverInfo.CommandLineArguments,
+                        FileName = serverInfo.processFilePath,
+                        Arguments = serverInfo.commandLineArguments,
                         UseShellExecute = false,
                         WorkingDirectory = clientDir,
                         RedirectStandardInput = true,

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -374,32 +374,30 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         internal static bool TryCreateServerCore(string clientDir, string pipeName)
         {
-            bool isRunningOnCoreClr = CoreClrShim.IsRunningOnCoreClr;
             string expectedPath;
             string processArguments;
-            if (isRunningOnCoreClr)
-            {
-                // The server should be in the same directory as the client
-                var expectedCompilerPath = Path.Combine(clientDir, ServerNameCoreClr);
-                expectedPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet";
-                processArguments = $@"""{expectedCompilerPath}"" ""-pipename:{pipeName}""";
+#if NETCOREAPP2_1
+            // The server should be in the same directory as the client
+            var expectedCompilerPath = Path.Combine(clientDir, ServerNameCoreClr);
+            expectedPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet";
+            processArguments = $@"""{expectedCompilerPath}"" ""-pipename:{pipeName}""";
 
-                if (!File.Exists(expectedCompilerPath))
-                {
-                    return false;
-                }
-            }
-            else
+            if (!File.Exists(expectedCompilerPath))
             {
-                // The server should be in the same directory as the client
-                expectedPath = Path.Combine(clientDir, ServerNameDesktop);
-                processArguments = $@"""-pipename:{pipeName}""";
-
-                if (!File.Exists(expectedPath))
-                {
-                    return false;
-                }
+                return false;
             }
+#elif NET472
+            // The server should be in the same directory as the client
+            expectedPath = Path.Combine(clientDir, ServerNameDesktop);
+            processArguments = $@"""-pipename:{pipeName}""";
+
+            if (!File.Exists(expectedPath))
+            {
+                return false;
+            }
+#else
+#error Unrecognized configuration
+#endif
 
             if (PlatformInformation.IsWindows)
             {

--- a/src/Compilers/Shared/CoreClrAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/CoreClrAnalyzerAssemblyLoader.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#if NETCOREAPP1_1 || NETCOREAPP2_1
+#if NETCOREAPP2_1
 
 using System.Diagnostics;
 using System.Reflection;

--- a/src/Compilers/Shared/DesktopBuildClient.cs
+++ b/src/Compilers/Shared/DesktopBuildClient.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         internal static int Run(IEnumerable<string> arguments, RequestLanguage language, CompileFunc compileFunc, IAnalyzerAssemblyLoader analyzerAssemblyLoader)
         {
             var sdkDir = GetSystemSdkDirectory();
-            if (CoreClrShim.IsRunningOnCoreClr)
+            if (RuntimeHostInfo.IsCoreClrRuntime)
             {
                 // Register encodings for console
                 // https://github.com/dotnet/roslyn/issues/10785

--- a/src/Compilers/Shared/NamedPipeUtil.cs
+++ b/src/Compilers/Shared/NamedPipeUtil.cs
@@ -16,8 +16,6 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal static class NamedPipeUtil
     {
-        const int s_currentUserOnlyValue = unchecked((int)0x20000000);
-
         /// <summary>
         /// Create a client for the current user only.
         /// </summary>
@@ -56,6 +54,8 @@ namespace Microsoft.CodeAnalysis
         }
 
 #if NET472
+
+        const int s_currentUserOnlyValue = unchecked((int)0x20000000);
 
         /// <summary>
         /// Mono supports CurrentUserOnly even though it's not exposed on the reference assemblies for net472. This 
@@ -155,7 +155,6 @@ namespace Microsoft.CodeAnalysis
 
 #else
 #error Unsupported configuration
-
 #endif
 
     }

--- a/src/Compilers/Shared/NamedPipeUtil.cs
+++ b/src/Compilers/Shared/NamedPipeUtil.cs
@@ -152,7 +152,6 @@ namespace Microsoft.CodeAnalysis
                 inBufferSize,
                 outBufferSize);
 
-
 #else
 #error Unsupported configuration
 #endif

--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -25,10 +25,10 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert(!toolFilePathWithoutExtension.EndsWith(".dll") && !toolFilePathWithoutExtension.EndsWith(".exe"));
 
             var toolFilePath = $"{toolFilePathWithoutExtension}.{ToolExtension}";
-            if (IsDotnetHost(out string pathToDotnet))
+            if (IsDotNetHost(out string pathToDotNet))
             {
                 commandLineArguments = $@"exec ""{toolFilePath}"" {commandLineArguments}";
-                return (pathToDotnet, commandLineArguments, toolFilePath);
+                return (pathToDotNet, commandLineArguments, toolFilePath);
             }
             else
             {
@@ -39,9 +39,9 @@ namespace Microsoft.CodeAnalysis
 #if NET472
         internal static bool IsDesktopRuntime => true;
 
-        internal static bool IsDotnetHost(out string pathToDotnet)
+        internal static bool IsDotNetHost(out string pathToDotNet)
         {
-            pathToDotnet = null;
+            pathToDotNet = null;
             return false;
         }
 
@@ -51,11 +51,11 @@ namespace Microsoft.CodeAnalysis
 #elif NETCOREAPP2_1
         internal static bool IsDesktopRuntime => false;
 
-        private static string DotnetHostPathEnvironmentName = "DOTNET_HOST_PATH";
+        private static string DotNetHostPathEnvironmentName = "DOTNET_HOST_PATH";
 
-        private static bool IsDotnetHost(out string pathToDotnet)
+        private static bool IsDotNetHost(out string pathToDotNet)
         {
-            pathToDotnet = GetDotnetPathOrDefault();
+            pathToDotNet = GetDotNetPathOrDefault();
             return true;
         }
 
@@ -63,24 +63,24 @@ namespace Microsoft.CodeAnalysis
         /// Get the path to the dotnet executable. This will throw in the case it is not properly setup 
         /// by the environment.
         /// </summary>
-        private static string GetDotnetPath()
+        private static string GetDotNetPath()
         {
-            var pathToDotnet = Environment.GetEnvironmentVariable(DotnetHostPathEnvironmentName);
-            if (string.IsNullOrEmpty(pathToDotnet))
+            var pathToDotNet = Environment.GetEnvironmentVariable(DotNetHostPathEnvironmentName);
+            if (string.IsNullOrEmpty(pathToDotNet))
             {
-                throw new InvalidOperationException($"{DotnetHostPathEnvironmentName} is not set");
+                throw new InvalidOperationException($"{DotNetHostPathEnvironmentName} is not set");
             }
-            return pathToDotnet;
+            return pathToDotNet;
         }
 
         /// <summary>
         /// Get the path to the dotnet executable. In the case the host did not provide this information
         /// in the environment this will return simply "dotnet".
         /// </summary>
-        private static string GetDotnetPathOrDefault()
+        private static string GetDotNetPathOrDefault()
         {
-            var pathToDotnet = Environment.GetEnvironmentVariable(DotnetHostPathEnvironmentName);
-            return pathToDotnet ?? "dotnet";
+            var pathToDotNet = Environment.GetEnvironmentVariable(DotNetHostPathEnvironmentName);
+            return pathToDotNet ?? "dotnet";
         }
 #else
 #error Unsupported configuration

--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -20,15 +20,15 @@ namespace Microsoft.CodeAnalysis
         /// This gets information about invoking a tool on the current runtime. This will attempt to 
         /// execute a tool as an EXE when on desktop and using dotnet when on CoreClr.
         /// </summary>
-        internal static (string ProcessFilePath, string CommandLineArguments, string ToolFilePath) GetProcessInfo(string toolFilePathWithoutExtension, string commandLineArguments)
+        internal static (string processFilePath, string commandLineArguments, string toolFilePath) GetProcessInfo(string toolFilePathWithoutExtension, string commandLineArguments)
         {
             Debug.Assert(!toolFilePathWithoutExtension.EndsWith(".dll") && !toolFilePathWithoutExtension.EndsWith(".exe"));
 
             var toolFilePath = $"{toolFilePathWithoutExtension}.{ToolExtension}";
-            if (IsDotnetHost(out string pathToDotNet))
+            if (IsDotnetHost(out string pathToDotnet))
             {
                 commandLineArguments = $@"exec ""{toolFilePath}"" {commandLineArguments}";
-                return (pathToDotNet, commandLineArguments, toolFilePath);
+                return (pathToDotnet, commandLineArguments, toolFilePath);
             }
             else
             {
@@ -51,9 +51,9 @@ namespace Microsoft.CodeAnalysis
 #elif NETCOREAPP2_1
         internal static bool IsDesktopRuntime => false;
 
-        internal static string DotnetHostPathEnvironmentName = "DOTNET_HOST_PATH";
+        private static string DotnetHostPathEnvironmentName = "DOTNET_HOST_PATH";
 
-        internal static bool IsDotnetHost(out string pathToDotnet)
+        private static bool IsDotnetHost(out string pathToDotnet)
         {
             pathToDotnet = GetDotnetPathOrDefault();
             return true;
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis
         /// Get the path to the dotnet executable. This will throw in the case it is not properly setup 
         /// by the environment.
         /// </summary>
-        internal static string GetDotnetPath()
+        private static string GetDotnetPath()
         {
             var pathToDotnet = Environment.GetEnvironmentVariable(DotnetHostPathEnvironmentName);
             if (string.IsNullOrEmpty(pathToDotnet))
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis
         /// Get the path to the dotnet executable. In the case the host did not provide this information
         /// in the environment this will return simply "dotnet".
         /// </summary>
-        internal static string GetDotnetPathOrDefault()
+        private static string GetDotnetPathOrDefault()
         {
             var pathToDotnet = Environment.GetEnvironmentVariable(DotnetHostPathEnvironmentName);
             return pathToDotnet ?? "dotnet";

--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO.Pipes;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// This type provides information about the runtime which is hosting application. It must be included in a concrete 
+    /// target framework to be used.
+    /// </summary>
+    internal static class RuntimeHostInfo
+    {
+        internal static bool IsCoreClrRuntime => !IsDesktopRuntime;
+
+        internal static string ToolExtension => IsCoreClrRuntime ? "dll" : "exe";
+
+        /// <summary>
+        /// This gets information about invoking a tool on the current runtime. This will attempt to 
+        /// execute a tool as an EXE when on desktop and using dotnet when on CoreClr.
+        /// </summary>
+        internal static (string ProcessFilePath, string CommandLineArguments, string ToolFilePath) GetProcessInfo(string toolFilePathWithoutExtension, string commandLineArguments)
+        {
+            Debug.Assert(!toolFilePathWithoutExtension.EndsWith(".dll") && !toolFilePathWithoutExtension.EndsWith(".exe"));
+
+            var toolFilePath = $"{toolFilePathWithoutExtension}.{ToolExtension}";
+            if (IsDotnetHost(out string pathToDotNet))
+            {
+                commandLineArguments = $@"exec ""{toolFilePath}"" {commandLineArguments}";
+                return (pathToDotNet, commandLineArguments, toolFilePath);
+            }
+            else
+            {
+                return (toolFilePath, commandLineArguments, toolFilePath);
+            }
+        }
+
+#if NET472
+        internal static bool IsDesktopRuntime => true;
+
+        internal static bool IsDotnetHost(out string pathToDotnet)
+        {
+            pathToDotnet = null;
+            return false;
+        }
+
+        internal static NamedPipeClientStream CreateNamedPipeClient(string serverName, string pipeName, PipeDirection direction, PipeOptions options) =>
+            new NamedPipeClientStream(serverName, pipeName, direction, options);
+
+#elif NETCOREAPP2_1
+        internal static bool IsDesktopRuntime => false;
+
+        internal static string DotnetHostPathEnvironmentName = "DOTNET_HOST_PATH";
+
+        internal static bool IsDotnetHost(out string pathToDotnet)
+        {
+            pathToDotnet = GetDotnetPathOrDefault();
+            return true;
+        }
+
+        /// <summary>
+        /// Get the path to the dotnet executable. This will throw in the case it is not properly setup 
+        /// by the environment.
+        /// </summary>
+        internal static string GetDotnetPath()
+        {
+            var pathToDotnet = Environment.GetEnvironmentVariable(DotnetHostPathEnvironmentName);
+            if (string.IsNullOrEmpty(pathToDotnet))
+            {
+                throw new InvalidOperationException($"{DotnetHostPathEnvironmentName} is not set");
+            }
+            return pathToDotnet;
+        }
+
+        /// <summary>
+        /// Get the path to the dotnet executable. In the case the host did not provide this information
+        /// in the environment this will return simply "dotnet".
+        /// </summary>
+        internal static string GetDotnetPathOrDefault()
+        {
+            var pathToDotnet = Environment.GetEnvironmentVariable(DotnetHostPathEnvironmentName);
+            return pathToDotnet ?? "dotnet";
+        }
+#else
+#error Unsupported configuration
+#endif
+    }
+}

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -891,7 +891,7 @@ namespace System.Runtime.CompilerServices
                 string assemblyName = "",
                 string sourceFileName = "")
         {
-            IEnumerable<MetadataReference> allReferences = CoreClrShim.IsRunningOnCoreClr
+            IEnumerable<MetadataReference> allReferences = RuntimeUtilities.IsCoreClrRuntime
                 ? TargetFrameworkUtil.NetStandard20References
                 : TargetFrameworkUtil.Mscorlib461ExtendedReferences.Add(TestReferences.Net461.netstandardRef);
 

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />
     <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
     <Compile Include="..\..\Shared\BuildClient.cs">
       <Link>BuildClient.cs</Link>

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -28,27 +28,13 @@
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />
     <Compile Include="..\..\Shared\NamedPipeUtil.cs" />
-    <Compile Include="..\..\Shared\BuildClient.cs">
-      <Link>BuildClient.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\BuildServerConnection.cs">
-      <Link>BuildServerConnection.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs">
-      <Link>CoreClrAnalyzerAssemblyLoader.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\DesktopBuildClient.cs">
-      <Link>DesktopBuildClient.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\ExitingTraceListener.cs">
-      <Link>ExitingTraceListener.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\DesktopAnalyzerAssemblyLoader.cs">
-      <Link>DesktopAnalyzerAssemblyLoader.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Shared\Vbc.cs">
-      <Link>Vbc.cs</Link>
-    </Compile>
+    <Compile Include="..\..\Shared\BuildClient.cs" />
+    <Compile Include="..\..\Shared\BuildServerConnection.cs" />
+    <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs" />
+    <Compile Include="..\..\Shared\DesktopBuildClient.cs" />
+    <Compile Include="..\..\Shared\ExitingTraceListener.cs" />
+    <Compile Include="..\..\Shared\DesktopAnalyzerAssemblyLoader.cs" />
+    <Compile Include="..\..\Shared\Vbc.cs" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests" />

--- a/src/Scripting/Core/Microsoft.CodeAnalysis.Scripting.csproj
+++ b/src/Scripting/Core/Microsoft.CodeAnalysis.Scripting.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="RoslynTools.LightUp.System.Runtime.Loader" Version="$(RoslynToolsLightUpSystemRuntimeLoaderFixedVersion)" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Compilers\Shared\CoreClrShim.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\FileSystem\RelativePathResolver.cs">
       <Link>Hosting\Resolvers\RelativePathResolver.cs</Link>
     </Compile>

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -137,7 +137,7 @@ namespace Roslyn.Test.Utilities
     {
         public static bool IsWindows => Path.DirectorySeparatorChar == '\\';
         public static bool IsUnix => !IsWindows;
-        public static bool IsDesktop => CoreClrShim.AssemblyLoadContext.Type == null;
+        public static bool IsDesktop => RuntimeUtilities.IsDesktopRuntime;
         public static bool IsWindowsDesktop => IsWindows && IsDesktop;
         public static bool IsMonoDesktop => Type.GetType("Mono.Runtime") != null;
         public static bool IsCoreClr => !IsDesktop;

--- a/src/Test/Utilities/Portable/Assert/UseCultureAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/UseCultureAttribute.cs
@@ -51,16 +51,8 @@ namespace Roslyn.Test.Utilities
         /// <param name="uiCulture">The name of the UI culture.</param>
         public UseCultureAttribute(string culture, string uiCulture)
         {
-#if NET472
             _culture = new Lazy<CultureInfo>(() => new CultureInfo(culture, useUserOverride: false));
             _uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture, useUserOverride: false));
-#elif NETCOREAPP2_1
-            _culture = new Lazy<CultureInfo>(() => new CultureInfo(culture));
-            _uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture));
-#else
-            _culture = new Lazy<CultureInfo>(() => throw new NotSupportedException());
-            _uiCulture = new Lazy<CultureInfo>(() => throw new NotSupportedException());
-#endif
         }
 
         /// <summary>
@@ -83,17 +75,10 @@ namespace Roslyn.Test.Utilities
             _originalCulture = CultureInfo.CurrentCulture;
             _originalUICulture = CultureInfo.CurrentUICulture;
 
-#if NET472 || NETCOREAPP2_1
             CultureInfo.CurrentCulture = Culture;
             CultureInfo.CurrentUICulture = UICulture;
-
-#if NET472
             CultureInfo.CurrentCulture.ClearCachedData();
             CultureInfo.CurrentUICulture.ClearCachedData();
-#endif
-#else
-            throw new NotSupportedException("Cannot set the current culture on this framework target.");
-#endif
         }
 
         /// <summary>
@@ -103,17 +88,10 @@ namespace Roslyn.Test.Utilities
         /// <param name="methodUnderTest">The method under test</param>
         public override void After(MethodInfo methodUnderTest)
         {
-#if NET472 || NETCOREAPP2_1
             CultureInfo.CurrentCulture = _originalCulture;
             CultureInfo.CurrentUICulture = _originalUICulture;
-
-#if NET472
             CultureInfo.CurrentCulture.ClearCachedData();
             CultureInfo.CurrentUICulture.ClearCachedData();
-#endif
-#else
-            throw new NotSupportedException("Cannot set the current culture on this framework target.");
-#endif
         }
     }
 }

--- a/src/Test/Utilities/Portable/Compilation/RuntimeUtilities.cs
+++ b/src/Test/Utilities/Portable/Compilation/RuntimeUtilities.cs
@@ -15,6 +15,18 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     /// </summary>
     public static partial class RuntimeUtilities
     {
+        internal static bool IsDesktopRuntime =>
+#if NET472
+            true;
+#elif NETCOREAPP2_1
+            false;
+#elif NETSTANDARD2_0
+            throw new PlatformNotSupportedException();
+#else
+#error Unsupported configuration
+#endif
+        internal static bool IsCoreClrRuntime => !IsDesktopRuntime;
+
         internal static BuildPaths CreateBuildPaths(string workingDirectory, string sdkDirectory = null, string tempDirectory = null)
         {
             tempDirectory = tempDirectory ?? Path.GetTempPath();

--- a/src/Test/Utilities/Portable/Roslyn.Test.Utilities.csproj
+++ b/src/Test/Utilities/Portable/Roslyn.Test.Utilities.csproj
@@ -73,10 +73,8 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Workspaces.UnitTests" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\..\Compilers\Shared\CoreClrAnalyzerAssemblyLoader.cs" Link="CoreClrAnalyzerAssemblyLoader.cs" />
-    <Compile Include="..\..\..\Compilers\Shared\DesktopAnalyzerAssemblyLoader.cs">
-      <Link>DesktopAnalyzerAssemblyLoader.cs</Link>
-    </Compile>
+    <Compile Include="..\..\..\Compilers\Shared\CoreClrAnalyzerAssemblyLoader.cs" />
+    <Compile Include="..\..\..\Compilers\Shared\DesktopAnalyzerAssemblyLoader.cs" />
     <Compile Update="TestResource.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
+++ b/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using static TestReferences;
 
 namespace Roslyn.Test.Utilities
@@ -55,7 +56,7 @@ namespace Roslyn.Test.Utilities
 
     public static class TargetFrameworkUtil
     {
-        public static MetadataReference StandardCSharpReference => CoreClrShim.IsRunningOnCoreClr ? NetStandard20.MicrosoftCSharpRef : TestBase.CSharpDesktopRef;
+        public static MetadataReference StandardCSharpReference => RuntimeUtilities.IsCoreClrRuntime ? NetStandard20.MicrosoftCSharpRef : TestBase.CSharpDesktopRef;
 
         /*
          * ⚠ Dev note ⚠: properties in TestBase are backed by Lazy<T>. Avoid changes to the following properties
@@ -78,10 +79,10 @@ namespace Roslyn.Test.Utilities
         public static ImmutableArray<MetadataReference> Mscorlib461ExtendedReferences => ImmutableArray.Create<MetadataReference>(Net461.mscorlibRef, Net461.SystemRef, Net461.SystemCoreRef, Net461.SystemValueTupleRef, Net461.SystemRuntimeRef);
         public static ImmutableArray<MetadataReference> NetStandard20References => ImmutableArray.Create<MetadataReference>(NetStandard20.NetStandard, NetStandard20.MscorlibRef, NetStandard20.SystemRuntimeRef, NetStandard20.SystemCoreRef, NetStandard20.SystemDynamicRuntimeRef);
         public static ImmutableArray<MetadataReference> WinRTReferences => ImmutableArray.Create(TestBase.WinRtRefs);
-        public static ImmutableArray<MetadataReference> StandardReferences => CoreClrShim.IsRunningOnCoreClr ? NetStandard20References : Mscorlib46ExtendedReferences;
+        public static ImmutableArray<MetadataReference> StandardReferences => RuntimeUtilities.IsCoreClrRuntime ? NetStandard20References : Mscorlib46ExtendedReferences;
         public static ImmutableArray<MetadataReference> StandardAndCSharpReferences => StandardReferences.Add(StandardCSharpReference);
-        public static ImmutableArray<MetadataReference> StandardAndVBRuntimeReferences => CoreClrShim.IsRunningOnCoreClr ? NetStandard20References.Add(NetStandard20.MicrosoftVisualBasicRef) : Mscorlib46ExtendedReferences.Add(TestBase.MsvbRef_v4_0_30319_17929);
-        public static ImmutableArray<MetadataReference> StandardCompatReferences => CoreClrShim.IsRunningOnCoreClr ? NetStandard20References : Mscorlib40References;
+        public static ImmutableArray<MetadataReference> StandardAndVBRuntimeReferences => RuntimeUtilities.IsCoreClrRuntime ? NetStandard20References.Add(NetStandard20.MicrosoftVisualBasicRef) : Mscorlib46ExtendedReferences.Add(TestBase.MsvbRef_v4_0_30319_17929);
+        public static ImmutableArray<MetadataReference> StandardCompatReferences => RuntimeUtilities.IsCoreClrRuntime ? NetStandard20References : Mscorlib40References;
         public static ImmutableArray<MetadataReference> DefaultVbReferencs => ImmutableArray.Create(TestBase.MscorlibRef, TestBase.SystemRef, TestBase.SystemCoreRef, TestBase.MsvbRef);
 
         public static ImmutableArray<MetadataReference> GetReferences(TargetFramework tf)

--- a/src/Test/Utilities/Portable/TestBase.cs
+++ b/src/Test/Utilities/Portable/TestBase.cs
@@ -76,7 +76,7 @@ namespace Roslyn.Test.Utilities
             LazyThreadSafetyMode.PublicationOnly);
         public static MetadataReference[] LatestVbReferences => s_lazyLatestVbReferences.Value;
 
-        public static readonly AssemblyName RuntimeCorLibName = CoreClrShim.IsRunningOnCoreClr
+        public static readonly AssemblyName RuntimeCorLibName = RuntimeUtilities.IsCoreClrRuntime
             ? new AssemblyName("netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51")
             : new AssemblyName("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
 


### PR DESCRIPTION
This change continues the removal of private reflection code from the compiler code base and instead relying on mulit-targeting to have detect the runtime. This also necessarily cleans up a number of our `#if` checks in the code base. 

Follow up to #31763