### PR TITLE
Add support for expanding of alias of value tuple types

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4586,8 +4586,8 @@ class C
 }");
         }
 
-        [Fact]
         [WorkItem(24791, "https://github.com/dotnet/roslyn/issues/24791")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task InlineVariableDoesNotAddUnnecessaryCast()
         {
             await TestInRegularAndScriptAsync(
@@ -4611,7 +4611,7 @@ class C
         }
 
         [WorkItem(16819, "https://github.com/dotnet/roslyn/issues/16819")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task InlineVariableDoesNotAddsDuplicateCast()
         {
             await TestInRegularAndScriptAsync(
@@ -4632,6 +4632,32 @@ class C
     void M()
     {
         Console.Write((Exception)null == new Exception());
+    }
+}");
+        }
+
+        [WorkItem(30903, "https://github.com/dotnet/roslyn/issues/30903")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task InlineVariableContainsAliasOfValueTupleType()
+        {
+            await TestInRegularAndScriptAsync(
+@"using X = System.ValueTuple<int, int>;
+
+class C
+{
+    void M()
+    {
+        var [|x|] = (X)(0, 0);
+        var x2 = x;
+    }
+}",
+@"using X = System.ValueTuple<int, int>;
+
+class C
+{
+    void M()
+    {
+        var x2 = (System.ValueTuple<int, int>)(0, 0);
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4650,16 +4650,42 @@ class C
         var [|x|] = (X)(0, 0);
         var x2 = x;
     }
-}",
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs,
 @"using X = System.ValueTuple<int, int>;
 
 class C
 {
     void M()
     {
-        var x2 = (System.ValueTuple<int, int>)(0, 0);
+        var x2 = (X)(0, 0);
     }
-}");
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
+        }
+
+        [WorkItem(30903, "https://github.com/dotnet/roslyn/issues/30903")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task InlineVariableContainsAliasOfMixedValueTupleType()
+        {
+            await TestInRegularAndScriptAsync(
+@"using X = System.ValueTuple<int, (int, int)>;
+
+class C
+{
+    void M()
+    {
+        var [|x|] = (X)(0, (0, 0));
+        var x2 = x;
+    }
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs,
+@"using X = System.ValueTuple<int, (int, int)>;
+
+class C
+{
+    void M()
+    {
+        var x2 = (X)(0, (0, 0));
+    }
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -576,6 +576,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                             return replacement;
                         }
 
+                        if (replacement.IsKind(SyntaxKind.TupleType))
+                        {
+                            replacement = replacement.WithAdditionalAnnotations(identifier.GetAnnotations());
+
+                            if (_annotationForReplacedAliasIdentifier != null)
+                            {
+                                replacement = replacement.WithAdditionalAnnotations(_annotationForReplacedAliasIdentifier);
+                            }
+
+                            var aliasAnnotationInfo = AliasAnnotation.Create(aliasInfo.Name);
+
+                            replacement = replacement.WithAdditionalAnnotations(aliasAnnotationInfo);
+
+                            replacement = newNode.CopyAnnotationsTo(replacement);
+
+                            replacement = AppendElasticTriviaIfNecessary(replacement, originalSimpleName);
+
+                            return replacement;
+                        }
+
                         throw new NotImplementedException();
                     }
                 }

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -500,11 +500,48 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                         // We replace the simple name completely, so we can't continue and rename the token
                         // with a RenameLocationAnnotation.
                         // There's also no way of removing annotations, so we just add a DoNotRenameAnnotation.
-                        if (replacement.Kind() == SyntaxKind.AliasQualifiedName)
+                        switch (replacement.Kind())
                         {
-                            var qualifiedReplacement = (AliasQualifiedNameSyntax)replacement;
+                            case SyntaxKind.AliasQualifiedName:
+                                var aliasQualifiedReplacement = (AliasQualifiedNameSyntax)replacement;
+                                replacement = replacement.ReplaceNode(
+                                        aliasQualifiedReplacement.Name,
+                                        aliasQualifiedReplacement.Name.WithIdentifier(
+                                            GetNewIdentifier(aliasQualifiedReplacement.Name.Identifier)));
 
-                            var newIdentifier = identifier.CopyAnnotationsTo(qualifiedReplacement.Name.Identifier);
+                                var firstReplacementToken = replacement.GetFirstToken(true, false, true, true);
+                                var firstOriginalToken = originalSimpleName.GetFirstToken(true, false, true, true);
+                                if (TryAddLeadingElasticTriviaIfNecessary(firstReplacementToken, firstOriginalToken, out var tokenWithLeadingWhitespace))
+                                {
+                                    replacement = replacement.ReplaceToken(firstOriginalToken, tokenWithLeadingWhitespace);
+                                }
+                                break;
+
+                            case SyntaxKind.QualifiedName:
+                                var qualifiedReplacement = (QualifiedNameSyntax)replacement;
+                                replacement = replacement.ReplaceNode(
+                                        qualifiedReplacement.Right,
+                                        qualifiedReplacement.Right.WithIdentifier(
+                                            GetNewIdentifier(qualifiedReplacement.Right.Identifier)));
+                                break;
+
+                            case SyntaxKind.IdentifierName:
+                                var identifierReplacement = (IdentifierNameSyntax)replacement;
+                                replacement = replacement.ReplaceToken(identifier, GetNewIdentifier(identifierReplacement.Identifier));
+                                break;
+
+                            default:
+                                throw new NotImplementedException();
+                        }
+
+                        replacement = newNode.CopyAnnotationsTo(replacement);
+                        replacement = AppendElasticTriviaIfNecessary(replacement, originalSimpleName);
+
+                        return replacement;
+
+                        SyntaxToken GetNewIdentifier(SyntaxToken _identifier)
+                        {
+                            var newIdentifier = identifier.CopyAnnotationsTo(_identifier);
 
                             if (_annotationForReplacedAliasIdentifier != null)
                             {
@@ -512,78 +549,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                             }
 
                             var aliasAnnotationInfo = AliasAnnotation.Create(aliasInfo.Name);
-
-                            newIdentifier = newIdentifier.WithAdditionalAnnotations(aliasAnnotationInfo);
-
-                            replacement = replacement.ReplaceNode(
-                                    qualifiedReplacement.Name,
-                                    qualifiedReplacement.Name.WithIdentifier(newIdentifier));
-
-                            replacement = newNode.CopyAnnotationsTo(replacement);
-
-                            var firstReplacementToken = replacement.GetFirstToken(true, false, true, true);
-                            var firstOriginalToken = originalSimpleName.GetFirstToken(true, false, true, true);
-                            if (TryAddLeadingElasticTriviaIfNecessary(firstReplacementToken, firstOriginalToken, out var tokenWithLeadingWhitespace))
-                            {
-                                replacement = replacement.ReplaceToken(firstOriginalToken, tokenWithLeadingWhitespace);
-                            }
-
-                            replacement = AppendElasticTriviaIfNecessary(replacement, originalSimpleName);
-
-                            return replacement;
+                            return newIdentifier.WithAdditionalAnnotations(aliasAnnotationInfo);
                         }
-
-                        if (replacement.Kind() == SyntaxKind.QualifiedName)
-                        {
-                            var qualifiedReplacement = (QualifiedNameSyntax)replacement;
-
-                            var newIdentifier = identifier.CopyAnnotationsTo(qualifiedReplacement.Right.Identifier);
-
-                            if (_annotationForReplacedAliasIdentifier != null)
-                            {
-                                newIdentifier = newIdentifier.WithAdditionalAnnotations(_annotationForReplacedAliasIdentifier);
-                            }
-
-                            var aliasAnnotationInfo = AliasAnnotation.Create(aliasInfo.Name);
-
-                            newIdentifier = newIdentifier.WithAdditionalAnnotations(aliasAnnotationInfo);
-
-                            replacement = replacement.ReplaceNode(
-                                    qualifiedReplacement.Right,
-                                    qualifiedReplacement.Right.WithIdentifier(newIdentifier));
-
-                            replacement = newNode.CopyAnnotationsTo(replacement);
-
-                            replacement = AppendElasticTriviaIfNecessary(replacement, originalSimpleName);
-
-                            return replacement;
-                        }
-
-                        if (replacement.IsKind(SyntaxKind.IdentifierName))
-                        {
-                            var identifierReplacement = (IdentifierNameSyntax)replacement;
-
-                            var newIdentifier = identifier.CopyAnnotationsTo(identifierReplacement.Identifier);
-
-                            if (_annotationForReplacedAliasIdentifier != null)
-                            {
-                                newIdentifier = newIdentifier.WithAdditionalAnnotations(_annotationForReplacedAliasIdentifier);
-                            }
-
-                            var aliasAnnotationInfo = AliasAnnotation.Create(aliasInfo.Name);
-
-                            newIdentifier = newIdentifier.WithAdditionalAnnotations(aliasAnnotationInfo);
-
-                            replacement = replacement.ReplaceToken(identifier, newIdentifier);
-
-                            replacement = newNode.CopyAnnotationsTo(replacement);
-
-                            replacement = AppendElasticTriviaIfNecessary(replacement, originalSimpleName);
-
-                            return replacement;
-                        }
-
-                        throw new NotImplementedException();
                     }
                 }
 


### PR DESCRIPTION
Fix #30903 
This also fixed the crash when renaming the alias name for a ValueTuple type.

@jcouv @dotnet/roslyn-ide @CyrusNajmabadi 