### PR TITLE
AsyncCompletion in Debugger: potential commit chars is empty

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -33,7 +33,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         private readonly ITextView _textView;
 
         public IEnumerable<char> PotentialCommitCharacters
-            => GetPotentialCommitCharacters();
+        {
+            get
+            {
+                if (_textView.Properties.TryGetProperty(CompletionSource.PotentialCommitCharacters, out ImmutableArray<char> potentialCommitCharacters))
+                {
+                    return potentialCommitCharacters;
+                }
+                else
+                {
+                    // If we were not initialized with a CompletionService or are called for a wrong textView, we should not make a commit.
+                    return ImmutableArray<char>.Empty;
+                }
+            }
+        }
 
         internal CommitManager(ITextView textView, RecentItemsManager recentItemsManager, IThreadingContext threadingContext, IEditorOperationsFactoryService editorOperationsFactoryService) : base(threadingContext)
         {
@@ -63,12 +76,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             return !(session.Properties.TryGetProperty(CompletionSource.ExcludedCommitCharacters, out ImmutableArray<char> excludedCommitCharacter)
                 && excludedCommitCharacter.Contains(typedChar));
         }
-
-        private ImmutableHashSet<char> GetPotentialCommitCharacters()
-            => _textView.Properties.TryGetProperty(CompletionSource.PotentialCommitCharacters, out ImmutableHashSet<char> potentialCommitCharacters)
-            ? potentialCommitCharacters
-            // If we were not initialized with a CompletionService or are called for a wrong textView, we should not make a commit.
-            : ImmutableHashSet<char>.Empty;
 
         public AsyncCompletionData.CommitResult TryCommit(
             IAsyncCompletionSession session,

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         public IEnumerable<char> PotentialCommitCharacters { get; }
 
-        internal CommitManager(ImmutableArray<char> potentialCommitCharacters, RecentItemsManager recentItemsManager, IThreadingContext threadingContext, IEditorOperationsFactoryService editorOperationsFactoryService) : base(threadingContext)
+        internal CommitManager(ImmutableHashSet<char> potentialCommitCharacters, RecentItemsManager recentItemsManager, IThreadingContext threadingContext, IEditorOperationsFactoryService editorOperationsFactoryService) : base(threadingContext)
         {
             PotentialCommitCharacters = potentialCommitCharacters;
             _recentItemsManager = recentItemsManager;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManagerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManagerProvider.cs
@@ -31,14 +31,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         }
 
         IAsyncCompletionCommitManager IAsyncCompletionCommitManagerProvider.GetOrCreate(ITextView textView)
-        {
-            if (!textView.Properties.TryGetProperty(CompletionSource.PotentialCommitCharacters, out ImmutableHashSet<char> potentialCommitCharacters))
-            {
-                // If we were not initialized with CompletionService or are called for a wrong textView, we should not make a commit.
-                potentialCommitCharacters = ImmutableHashSet<char>.Empty;
-            }
-
-            return new CommitManager(potentialCommitCharacters, _recentItemsManager, _threadingContext, _editorOperationsFactoryService);
-        }
+            => new CommitManager(textView, _recentItemsManager, _threadingContext, _editorOperationsFactoryService);
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManagerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManagerProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManagerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManagerProvider.cs
@@ -32,10 +32,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         IAsyncCompletionCommitManager IAsyncCompletionCommitManagerProvider.GetOrCreate(ITextView textView)
         {
-            if (!textView.TextBuffer.Properties.TryGetProperty(CompletionSource.PotentialCommitCharacters, out ImmutableArray<char> potentialCommitCharacters))
+            if (!textView.Properties.TryGetProperty(CompletionSource.PotentialCommitCharacters, out ImmutableHashSet<char> potentialCommitCharacters))
             {
                 // If we were not initialized with CompletionService or are called for a wrong textView, we should not make a commit.
-                potentialCommitCharacters = ImmutableArray<char>.Empty;
+                potentialCommitCharacters = ImmutableHashSet<char>.Empty;
             }
 
             return new CommitManager(potentialCommitCharacters, _recentItemsManager, _threadingContext, _editorOperationsFactoryService);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -74,13 +74,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 _textView.Options.GlobalOptions.SetOptionValue(NonBlockingCompletionEditorOption, true);
             }
 
-            var commitCharacters = service.GetRules().DefaultCommitCharacters;
-
-            // In case of calls with multiple completion services for the same view (e.g. TypeScript and C#), we should merge potential commit characters together.
-            _textView.Properties[PotentialCommitCharacters] =
-                _textView.Properties.TryGetProperty(PotentialCommitCharacters, out ImmutableHashSet<char> savedCommitCharacters)
-                ? savedCommitCharacters.Union(commitCharacters)
-                : commitCharacters.ToImmutableHashSet();
+            // In case of calls with multiple completion services for the same view (e.g. TypeScript and C#), those completion services must not be called simultaneously for the same session.
+            // Therefore, in each completion session we use a list of commit character for a specific completion service and a specific content type.
+            _textView.Properties[PotentialCommitCharacters] = service.GetRules().DefaultCommitCharacters;
 
             var sourceText = document.GetTextSynchronously(cancellationToken);
 


### PR DESCRIPTION
### Customer scenario

**Scenario**
1. A completion (new completion implementation) happens in a multi-buffer scenario such as Razor, Debugger or TypeScript+C#.
2. Roslyn provides calculates _potential commit characters_ for a content type (using completion service) and put into a subject buffer.
3. Editor does not pass a surface buffer to the Commit Manager. The surface buffer differs from the subject buffer and it does not contains the _potential commit characters_.
4. Later one user presses a commit character.

**Expected**
Editor verifies that a commit character has been pressed and asks Roslyn to TryCommit.

**Actual**
Editor could not find any commit character and does not make any completion commits. 
### Bugs this fixes

Fixes https://github.com/dotnet/roslyn/issues/31922

### Workarounds, if any
None

### Risk
Low

### Performance impact
None

### Is this a regression from a previous update?
No

### Root cause analysis
This functionality is under validation before shipping.
There was a design discussion between the Roslyn team and the Editor team regarding transporting information about potential commit characters from CompletionSource to CommitManager. A decision was made some time ago: use buffers. Some time after that the Editor found that the buffer provided to CompletionSource should be different from one found in the CommitManager. This caused the bug.

Actually, the Editor team and the Roslyn team should think about a better, more reliable transport for this information rather than a property bag. A better solution require changing the API.

### How was the bug found?
Partner team verification