### PR TITLE
fix rename crash when an invalid for-loop control variable exist in VB syntax tree

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -3129,6 +3129,26 @@ End Class
                     result.AssertLabeledSpansAre("current", type:=RelatedLocationType.NoConflict)
                 End Using
             End Sub
+
+            <Fact>
+            <Trait(Traits.Feature, Traits.Features.Rename)>
+            <WorkItem(32086, "https://github.com/dotnet/roslyn/issues/32086")>
+            Public Sub InvalidControlVariableInForLoopDoNotCrash()
+                Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document><![CDATA[
+Module Program
+    Sub Main()
+        Dim [|$$val|] As Integer = 10
+        For (Int() i = 0; i < val; i++)
+    End Sub
+End Module
+                            ]]></Document>
+                        </Project>
+                    </Workspace>, renameTo:="v")
+                End Using
+            End Sub
         End Class
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Rename/LocalConflictVisitor.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/LocalConflictVisitor.vb
@@ -145,8 +145,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                 tokens.Add(DirectCast(controlVariable, VariableDeclaratorSyntax).Names.First().Identifier)
             Else
                 Dim semanticModel = _newSolution.GetDocument(controlVariable.SyntaxTree).GetSemanticModelAsync(_cancellationToken).WaitAndGetResult_CanCallOnBackground(_cancellationToken)
-                Dim identifierToken = DirectCast(controlVariable, IdentifierNameSyntax).Identifier
-                Dim symbol = semanticModel.GetSymbolInfo(identifierToken).Symbol
+                Dim symbol = semanticModel.GetSymbolInfo(controlVariable).Symbol
 
                 ' if it is a field we don't care
                 If symbol IsNot Nothing AndAlso symbol.IsKind(SymbolKind.Local) Then
@@ -155,7 +154,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                     ' is this local declared in the for or for each loop?
                     ' if not it was already added to the tracker before.
                     If local.IsFor OrElse local.IsForEach Then
-                        tokens.Add(identifierToken)
+                        tokens.Add(DirectCast(controlVariable, IdentifierNameSyntax).Identifier)
                     End If
                 End If
             End If

--- a/src/Workspaces/VisualBasic/Portable/Rename/LocalConflictVisitor.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/LocalConflictVisitor.vb
@@ -154,7 +154,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                     ' is this local declared in the for or for each loop?
                     ' if not it was already added to the tracker before.
                     If local.IsFor OrElse local.IsForEach Then
-                        tokens.Add(DirectCast(controlVariable, IdentifierNameSyntax).Identifier)
+                        If controlVariable.Kind = SyntaxKind.IdentifierName Then
+                            tokens.Add(DirectCast(controlVariable, IdentifierNameSyntax).Identifier)
+                        Else
+                            Debug.Fail($"Unexpected control variable kind '{controlVariable.Kind}'")
+                        End If
                     End If
                 End If
             End If


### PR DESCRIPTION
fix #32086 

@dotnet/roslyn-ide @CyrusNajmabadi 