### PR TITLE
Fix accessibility issues for extract interface dialog

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ExtractInterface/ExtractInterfaceDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/ExtractInterface/ExtractInterfaceDialog.xaml
@@ -122,6 +122,7 @@
                 </Grid.ColumnDefinitions>
                 <u:AutomationDelegatingListView x:Uid="MemberSelectionList"
                           x:Name="Members"
+                          AutomationProperties.Name="Members"
                           Grid.Column="0"
                           Margin="9"
                           SelectionMode="Extended"

--- a/src/VisualStudio/Core/Def/Implementation/Utilities/AutomationDelegatingListView.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Utilities/AutomationDelegatingListView.cs
@@ -69,6 +69,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
 
             return results;
         }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.List;
+        }
     }
 
     internal class AutomationDelegatingListViewItem : ListViewItem


### PR DESCRIPTION
AutomationDelegatingListView did not have the correct AutomationControlType. Refer to [https://review.docs.microsoft.com/en-us/accessibility-tools-docs/items/wpf/customcontrol_localizedcontroltype?branch=master](https://review.docs.microsoft.com/en-us/accessibility-tools-docs/items/wpf/customcontrol_localizedcontroltype?branch=master )

MemberSelectionList uses `x:Name`, which is correct but does not fulfill automation needs. Add `AutomationProperties.Name` directly to be the same name. See [https://review.docs.microsoft.com/en-us/accessibility-tools-docs/items/wpf/customcontrol_name?branch=master](https://review.docs.microsoft.com/en-us/accessibility-tools-docs/items/wpf/customcontrol_name?branch=master)