### PR TITLE
Async-streams: Add sequence point after resume label for yield

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
@@ -167,6 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //     _state = <next_state>;
             //     goto _exprReturnLabelTrue;
             //     <next_state_label>: ;
+            //     <hidden sequence point>
             //     this.state = cachedState = NotStartedStateMachine;
             //     if (disposeMode) goto _enclosingFinallyOrExitLabel;
 
@@ -195,6 +196,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             blockBuilder.Add(
                 // <next_state_label>: ;
                 F.Label(resumeLabel));
+
+            blockBuilder.Add(F.HiddenSequencePoint());
 
             blockBuilder.Add(
                 // this.state = cachedState = NotStartedStateMachine

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -315,6 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //     this.state = <next_state>;
             //     return true;
             //     <next_state_label>: ;
+            //     <hidden sequence point>
             //     this.state = finalizeState;
             int stateNumber;
             GeneratedLabelSymbol resumeLabel;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -2037,6 +2037,7 @@ class C
     IL_00bd:  stloc.0
     IL_00be:  stfld      ""int C.<M>d__0.<>1__state""
     IL_00c3:  leave.s    IL_0113
+    // sequence point: <hidden>
     IL_00c5:  ldarg.0
     IL_00c6:  ldc.i4.m1
     IL_00c7:  dup
@@ -2176,6 +2177,7 @@ class C
     IL_00b6:  stloc.0
     IL_00b7:  stfld      ""int C.<M>d__0.<>1__state""
     IL_00bc:  leave.s    IL_0109
+    // sequence point: <hidden>
     IL_00be:  ldarg.0
     IL_00bf:  ldc.i4.m1
     IL_00c0:  dup


### PR DESCRIPTION
This should fix one of the issues in https://github.com/dotnet/roslyn/issues/32246
Specifically, when you reach a `yield return`, the next step correctly goes to the caller, but the next time you step into the async-iterator method, the same `yield return` is highlighted again instead of the statement after it.

~~I'm still exploring out to validate this in VS (I expect the technique used in https://github.com/dotnet/roslyn/pull/31679 should work).~~

Update: that method of testing proved useful and I was able to validate that `yield return` no longer gets highlighted twice after this fix.