### PR TITLE
Fix remove parentheses bugs

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateEqualsAndGetHas
 
     public class GenerateEqualsAndGetHashCodeFromMembersTests : AbstractCSharpCodeActionTest
     {
-        private static readonly TestParameters CSharp6 = 
+        private static readonly TestParameters CSharp6 =
             new TestParameters(parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6));
 
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)

--- a/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
@@ -2229,5 +2229,31 @@ offeredWhenRequireForClarityIsEnabled: true);
     }
 }", new TestParameters(options: RemoveAllUnnecessaryParentheses));
         }
+
+        [WorkItem(31103, "https://github.com/dotnet/roslyn/issues/31103")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestMissingForConditionalRef()
+        {
+            await TestMissingAsync(
+@"class Bar
+{
+    void Foo(bool cond, double a, double b)
+    {
+        $$(cond ? ref a : ref b) = 6.67e-11;
+    }
+}", new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
+
+        [WorkItem(32085, "https://github.com/dotnet/roslyn/issues/32085")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestMissingForNestedConditionalExpressionInLambda()
+        {
+            await TestMissingAsync(
+@"class Bar
+{
+    Func<int, string> lambda =
+        number => (number + $""{ [||](a ? ""foo"" : ""bar"") }"");
+}", new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
@@ -2232,7 +2232,7 @@ offeredWhenRequireForClarityIsEnabled: true);
 
         [WorkItem(31103, "https://github.com/dotnet/roslyn/issues/31103")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
-        public async Task TestMissingForConditionalRef()
+        public async Task TestMissingForConditionalRefAsLeftHandSideValue()
         {
             await TestMissingAsync(
 @"class Bar
@@ -2242,6 +2242,28 @@ offeredWhenRequireForClarityIsEnabled: true);
         [||](cond ? ref a : ref b) = 6.67e-11;
     }
 }", new TestParameters(options: RemoveAllUnnecessaryParentheses));
+        }
+
+        [WorkItem(31103, "https://github.com/dotnet/roslyn/issues/31103")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
+        public async Task TestConditionalExpressionAsRightHandSideValue()
+        {
+            await TestInRegularAndScript1Async(
+@"class Bar
+{
+    void Foo(bool cond, double a, double b)
+    {
+        double c = $$(cond ? a : b);
+    }
+}",
+@"class Bar
+{
+    void Foo(bool cond, double a, double b)
+    {
+        double c = cond ? a : b;
+    }
+}",
+parameters: new TestParameters(options: RemoveAllUnnecessaryParentheses));
         }
 
         [WorkItem(32085, "https://github.com/dotnet/roslyn/issues/32085")]

--- a/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.cs
@@ -2239,7 +2239,7 @@ offeredWhenRequireForClarityIsEnabled: true);
 {
     void Foo(bool cond, double a, double b)
     {
-        $$(cond ? ref a : ref b) = 6.67e-11;
+        [||](cond ? ref a : ref b) = 6.67e-11;
     }
 }", new TestParameters(options: RemoveAllUnnecessaryParentheses));
         }
@@ -2251,8 +2251,11 @@ offeredWhenRequireForClarityIsEnabled: true);
             await TestMissingAsync(
 @"class Bar
 {
-    Func<int, string> lambda =
-        number => (number + $""{ [||](a ? ""foo"" : ""bar"") }"");
+    void Test(bool a)
+    {
+        Func<int, string> lambda =
+            number => (number + $""{ ($$a ? ""foo"" : ""bar"") }"");
+    }
 }", new TestParameters(options: RemoveAllUnnecessaryParentheses));
         }
     }

--- a/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -273,13 +273,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
         private static bool RemovalMayIntroduceInterpolationAmbiguity(ParenthesizedExpressionSyntax node)
         {
-            // First, find the parenting interpolation.
-            // If we find a parenthesize expression first, it doesn't mean we can bail, we still need to check : or ::
-            // For example: Func<bool, string> lambda = x => ($"{(x ? "foo" : "bar")}"), the outer parenthesis expression 
-            // will let us wrongly think we can remove the inner parenthesis expression.
+            // First, find the parenting interpolation. If we find a parenthesize expression first,
+            // we can bail out early.
             InterpolationSyntax interpolation = null;
             foreach (var ancestor in node.Parent.AncestorsAndSelf())
             {
+                if (ancestor.IsKind(SyntaxKind.ParenthesizedExpression))
+                {
+                    return false;
+                }
+
                 if (ancestor.IsKind(SyntaxKind.Interpolation))
                 {
                     interpolation = (InterpolationSyntax)ancestor;


### PR DESCRIPTION
Related issue: [31103](https://github.com/dotnet/roslyn/issues/31103) and [32085](https://github.com/dotnet/roslyn/issues/32085)

Two problems of the current remove parentheses analyzer:
1. When conditional expression used as a left hand side value, 
`(x : ref a ? ref b) = c`
The parentheses should not be removed.
2. When conditional expression is used inside a string interpolation expression, and the whole string live inside an parentheses, like
`Func<bool, string> lambda = x => ($"{(x ? "foo" : "bar")}")`
The inner pair should not be removed.
