### PR TITLE
Handle null value for `IDeclarationPatternOperation.DeclaredSymbol`

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1051,5 +1051,21 @@ internal sealed class CustomSerializingType : ISerializable
                 Assert.Equal("Remove unused parameter 'p4' if it is not part of a shipped public API, its initial value is never used", sortedDiagnostics[3].GetMessage());
             }
         }
+
+        [WorkItem(32287, "https://github.com/dotnet/roslyn/issues/32287")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task Parameter_DeclarationPatternWithNullDeclaredSymbol()
+        {
+            await TestDiagnosticMissingAsync(
+@"class C
+{
+    void M(object [|o|])
+    {
+        if (o is int _)
+        {
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
@@ -96,6 +96,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
 
             private void OnReferenceFound(ISymbol symbol, IOperation operation)
             {
+                Debug.Assert(symbol != null);
+
                 var valueUsageInfo = operation.GetValueUsageInfo();
                 var isReadFrom = valueUsageInfo.IsReadFrom();
                 var isWrittenTo = valueUsageInfo.IsWrittenTo();
@@ -247,7 +249,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
 
             public override void VisitDeclarationPattern(IDeclarationPatternOperation operation)
             {
-                OnReferenceFound(operation.DeclaredSymbol, operation);
+                if (operation.DeclaredSymbol != null)
+                {
+                    OnReferenceFound(operation.DeclaredSymbol, operation);
+                }
             }
 
             public override void VisitInvocation(IInvocationOperation operation)


### PR DESCRIPTION
https://github.com/dotnet/roslyn/commit/6224a5c2feb8c9096cf5765f3d8d2ded396e7e88#diff-b68aa1802251151217571a56d9bfd2b8R31 changed the semantics of `IDeclarationPatternOperation` to allow null `DeclaredSymbol`. Fix SymbolUsageAnalysis invoked by unused parameters/values analyzer to handle this case. Confirmed the NRE in the unit test prior to the fix.

Fixes #32287