### PR TITLE
Finish the project context implementation for the free-threaded project system shims

### DIFF
--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveWorkspace.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveWorkspace.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             base.ClearSolution();
         }
 
-        internal void ClearOpenDocument(DocumentId documentId)
+        internal new void ClearOpenDocument(DocumentId documentId)
         {
             base.ClearOpenDocument(documentId);
         }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private string _commandLine = "";
         private CommandLineArguments _commandLineArgumentsForCommandLine;
         private string _explicitRuleSetFilePath;
-        private IReferenceCountedDisposable<IRuleSetFile> _ruleSetFile = null;
+        private IReferenceCountedDisposable<ICacheEntry<string, IRuleSetFile>> _ruleSetFile = null;
 
         public VisualStudioProjectOptionsProcessor(VisualStudioProject project, HostWorkspaceServices workspaceServices)
         {
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             var effectiveRuleSetPath = ExplicitRuleSetFilePath ?? _commandLineArgumentsForCommandLine.RuleSetPath;
 
-            if (_ruleSetFile?.Target.FilePath != effectiveRuleSetPath)
+            if (_ruleSetFile?.Target.Value.FilePath != effectiveRuleSetPath)
             {
                 // We're changing in some way. Be careful: this might mean the path is switching to or from null, so either side so far
                 // could be changed.
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             // We've computed what the base values should be; we now give an opportunity for any host-specific settings to be computed
             // before we apply them
-            compilationOptions = ComputeCompilationOptionsWithHostValues(compilationOptions, this._ruleSetFile?.Target);
+            compilationOptions = ComputeCompilationOptionsWithHostValues(compilationOptions, this._ruleSetFile?.Target.Value);
             parseOptions = ComputeParseOptionsWithHostValues(parseOptions);
 
             // For managed projects, AssemblyName has to be non-null, but the command line we get might be a partial command line

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1083,34 +1083,46 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     return;
                 }
 
-                var filePath = CurrentSolution.GetDocument(documentId)?.FilePath;
+                // The hierarchy might be supporting multitargeting; in that case, let's update the context. Unfortunately the IVsHierarchies that support this
+                // don't necessarily let us read it first, so we have to fire-and-forget here.
+                foreach (var (projectSystemName, projects) in _projectSystemNameToProjectsMap)
+                {
+                    if (projects.Any(p => p.Id == documentId.ProjectId))
+                    {
+                        hierarchy.SetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID8.VSHPROPID_ActiveIntellisenseProjectContext, projectSystemName);
+
+                        // We've updated that property, but we still need to continue the rest of this process to ensure the Running Document Table is updated
+                        // and any shared asset projects are also updated.
+                        break;
+                    }
+                }
+
+                var filePath = GetFilePath(documentId);
                 if (filePath == null)
                 {
                     return;
                 }
 
                 var itemId = hierarchy.TryGetItemId(filePath);
-                if (itemId == VSConstants.VSITEMID_NIL)
+                if (itemId != VSConstants.VSITEMID_NIL)
                 {
-                    return;
-                }
-
-                // Is this owned by a shared project? If so, go recursively. We can put this in a loop because in the case of mixed
-                // scenarios where you have shared assets projects and multitargeting projects, this same code works in both cases.
-                // Some shared hierarchies, when queried about items also give themselves back, so we'll only loop if we're actually
-                // going somewhere else.
-                while (SharedProjectUtilities.TryGetItemInSharedAssetsProject(hierarchy, itemId, out IVsHierarchy sharedHierarchy, out uint sharedItemId) &&
-                       hierarchy != sharedHierarchy)
-                {
-                    // Ensure the shared context is set correctly
-                    if (sharedHierarchy.GetActiveProjectContext() != hierarchy)
+                    // Is this owned by a shared asset project? If so, we need to put the shared asset project into the running document table, and need to set the
+                    // current hierarchy as the active context of that shared hierarchy. This is kept as a loop that we do multiple times in the case that you
+                    // have multiple pointers. This used to be the case for multitargeting projects, but that was now handled by setting the active context property
+                    // above. Some project systems out there might still be supporting it, so we'll support it too.
+                    while (SharedProjectUtilities.TryGetItemInSharedAssetsProject(hierarchy, itemId, out var sharedHierarchy, out uint sharedItemId) &&
+                           hierarchy != sharedHierarchy)
                     {
-                        ErrorHandler.ThrowOnFailure(sharedHierarchy.SetActiveProjectContext(hierarchy));
-                    }
+                        // Ensure the shared context is set correctly
+                        if (sharedHierarchy.GetActiveProjectContext() != hierarchy)
+                        {
+                            ErrorHandler.ThrowOnFailure(sharedHierarchy.SetActiveProjectContext(hierarchy));
+                        }
 
-                    // We now need to ensure the outer project is also set up
-                    hierarchy = sharedHierarchy;
-                    itemId = sharedItemId;
+                        // We now need to ensure the outer project is also set up
+                        hierarchy = sharedHierarchy;
+                        itemId = sharedItemId;
+                    }
                 }
 
                 // Update the ownership of the file in the Running Document Table

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioRuleSetTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioRuleSetTests.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Using visualStudioRuleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
                 ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                Dim generalDiagnosticOption = visualStudioRuleSet.Target.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = visualStudioRuleSet.Target.Value.GetGeneralDiagnosticOption()
 
                 fileChangeWatcher.WaitForQueue_TestOnly()
                 Assert.Equal(expected:=1, actual:=fileChangeService.WatchedFileCount)
@@ -90,7 +90,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Using visualStudioRuleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
                 ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                Dim generalDiagnosticOption = visualStudioRuleSet.Target.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = visualStudioRuleSet.Target.Value.GetGeneralDiagnosticOption()
 
                 fileChangeWatcher.WaitForQueue_TestOnly()
                 Assert.Equal(expected:=2, actual:=fileChangeService.WatchedFileCount)
@@ -131,10 +131,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeWatcher, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
             Using ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
                 Dim handlerCalled As Boolean = False
-                AddHandler ruleSet1.Target.UpdatedOnDisk, Sub() handlerCalled = True
+                AddHandler ruleSet1.Target.Value.UpdatedOnDisk, Sub() handlerCalled = True
 
                 ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                Dim generalDiagnosticOption = ruleSet1.Target.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = ruleSet1.Target.Value.GetGeneralDiagnosticOption()
 
                 fileChangeWatcher.WaitForQueue_TestOnly()
                 fileChangeService.FireUpdate(includePath)
@@ -164,14 +164,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Using ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
                 ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                Dim generalDiagnosticOption = ruleSet1.Target.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = ruleSet1.Target.Value.GetGeneralDiagnosticOption()
                 fileChangeWatcher.WaitForQueue_TestOnly()
                 fileChangeService.FireUpdate(ruleSetPath)
 
                 Using ruleSet2 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
                     ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                    generalDiagnosticOption = ruleSet2.Target.GetGeneralDiagnosticOption()
+                    generalDiagnosticOption = ruleSet2.Target.Value.GetGeneralDiagnosticOption()
 
                     fileChangeWatcher.WaitForQueue_TestOnly()
                     Assert.Equal(expected:=1, actual:=fileChangeService.WatchedFileCount)
@@ -205,7 +205,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Using ruleSet1 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
                 ' Signing up for file change notifications is lazy, so read the rule set to force it.
-                Dim generalDiagnosticOption = ruleSet1.Target.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = ruleSet1.Target.Value.GetGeneralDiagnosticOption()
 
                 Using ruleSet2 = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
@@ -240,12 +240,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Dim ruleSetManager = New VisualStudioRuleSetManager(fileChangeWatcher, New TestForegroundNotificationService(), AsynchronousOperationListenerProvider.NullListener)
             Using ruleSet = ruleSetManager.GetOrCreateRuleSet(ruleSetPath)
 
-                Dim generalDiagnosticOption = ruleSet.Target.GetGeneralDiagnosticOption()
+                Dim generalDiagnosticOption = ruleSet.Target.Value.GetGeneralDiagnosticOption()
                 fileChangeWatcher.WaitForQueue_TestOnly()
 
                 Assert.Equal(expected:=ReportDiagnostic.Default, actual:=generalDiagnosticOption)
 
-                Dim exception = ruleSet.Target.GetException()
+                Dim exception = ruleSet.Target.Value.GetException()
                 Assert.NotNull(exception)
             End Using
         End Sub

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 Microsoft.CodeAnalysis.Solution.WithProjectDocumentsOrder(Microsoft.CodeAnalysis.ProjectId projectId, System.Collections.Immutable.ImmutableList<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Solution
+Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> void
+Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.DocumentId documentId, bool isSolutionClosing) -> void
+*REMOVED*Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.DocumentId documentId, bool isSolutionClosing = false) -> void
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AliasImportDeclaration(string aliasIdentifierName, Microsoft.CodeAnalysis.SyntaxNode name) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NameExpression(Microsoft.CodeAnalysis.INamespaceOrTypeSymbol namespaceOrTypeSymbol) -> Microsoft.CodeAnalysis.SyntaxNode
 const Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.ControlKeyword = "keyword - control" -> string

--- a/src/Workspaces/Core/Portable/Utilities/ICacheEntry.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ICacheEntry.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Roslyn.Utilities
+{
+    interface ICacheEntry<out TKey, out TValue>
+    {
+        TKey Key { get; }
+        TValue Value { get; }
+    }
+}

--- a/src/Workspaces/Core/Portable/Utilities/ReferenceCountedDisposableCache.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ReferenceCountedDisposableCache.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Roslyn.Utilities
+{
+    /// <summary>
+    /// Implements a reference-counted cache, where key/value pairs are associated with a count. When the count of a pair goes to zero,
+    /// the value is evicted. Values can also be explicitly evicted at any time. In that case, any new calls to <see cref="GetOrCreate"/>
+    /// will return a new value, and the existing holders of the evicted value will still dispose it once they're done with it.
+    /// </summary>
+    internal sealed class ReferenceCountedDisposableCache<TKey, TValue> where TValue : class, IDisposable
+    {
+        private readonly Dictionary<TKey, ReferenceCountedDisposable<Entry>.WeakReference> _cache =
+            new Dictionary<TKey, ReferenceCountedDisposable<Entry>.WeakReference>();
+        private readonly object _gate = new object();
+
+        public IReferenceCountedDisposable<ICacheEntry<TKey, TValue>> GetOrCreate(TKey key, Func<TKey, TValue> valueCreator)
+        {
+            lock (_gate)
+            {
+                ReferenceCountedDisposable<Entry> disposable = null;
+
+                // If we already have one in the map to hand out, great
+                if (_cache.TryGetValue(key, out var weakReference))
+                {
+                    disposable = weakReference.TryAddReference();
+                }
+
+                if (disposable == null)
+                {
+                    // We didn't easily get a disposable, so one of two things is the case:
+                    //
+                    // 1. We have no entry in _cache at all for this.
+                    // 2. We had an entry, but it was disposed and is no longer valid. This could happen if
+                    //    the underlying value was disposed, but _cache hasn't been updated yet. That could happen
+                    //    because the disposal isn't processed under this lock.
+
+                    // In either case, we'll create a new entry and add it to the map
+                    disposable = new ReferenceCountedDisposable<Entry>(new Entry(this, key, valueCreator(key)));
+                    _cache[key] = new ReferenceCountedDisposable<Entry>.WeakReference(disposable);
+                }
+
+                return disposable;
+            }
+        }
+
+        public void Evict(TKey key)
+        {
+            lock (_gate)
+            {
+                _cache.Remove(key);
+            }
+        }
+
+        private sealed class Entry : IDisposable, ICacheEntry<TKey, TValue>
+        {
+            private readonly ReferenceCountedDisposableCache<TKey, TValue> _cache;
+
+            public TKey Key { get; }
+            public TValue Value { get; }
+
+            public Entry(ReferenceCountedDisposableCache<TKey, TValue> cache, TKey key, TValue value)
+            {
+                _cache = cache;
+                Key = key;
+                Value = value;
+            }
+
+            public void Dispose()
+            {
+                // Evict us out of the cache. We already know that cache entry is going to be expired: any further calls on the WeakReference would give nothing,
+                // but we don't want to be holding onto the key either.
+                _cache.Evict(Key);
+
+                // Dispose the underlying value
+                Value.Dispose();
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -52,27 +52,6 @@ namespace Microsoft.CodeAnalysis
         private Action<string> _testMessageLogger;
 
         /// <summary>
-        /// <see cref="OnProjectRemoved"/> takes the <see cref="_serializationLock"/>, but can also
-        /// cause Shared Project IVsHierarchys to notify us that their context hierarchy has
-        /// changed while we are still holding the lock. In response to this, we try to set the new
-        /// active context document for open files, which also tries to take the lock, and we
-        /// deadlock.
-        ///
-        /// For.NET Framework Projects that reference Shared Projects, two things prevent deadlocks
-        /// when projects unload. During solution close, any Shared Projects are disconnected
-        /// before the projects start to unload, so no IVsHierarchy events are fired. During a
-        /// single project unload, we receive notification of the context hierarchy change before
-        /// the project is unloaded, avoiding any IVsHierarchy events if we tell the shared
-        /// hierarchy to set its context hierarchy to what it already is.
-        ///
-        /// Neither of these behaviors are safe to rely on with .NET Standard (CPS) projects, so we
-        /// have to prevent the deadlock ourselves. We do this by remembering if we're already in
-        /// the serialization lock due to project unload, and then not take the lock to update
-        /// document contexts if so (but continuing to lock if it's not during a project unload).
-        /// </summary>
-        private ThreadLocal<bool> _isProjectUnloading = new ThreadLocal<bool>(() => false);
-
-        /// <summary>
         /// Constructs a new workspace instance.
         /// </summary>
         /// <param name="host">The <see cref="HostServices"/> this workspace uses</param>
@@ -432,24 +411,15 @@ namespace Microsoft.CodeAnalysis
         {
             using (_serializationLock.DisposableWait())
             {
-                _isProjectUnloading.Value = true;
+                CheckProjectIsInCurrentSolution(projectId);
+                this.CheckProjectCanBeRemoved(projectId);
 
-                try
-                {
-                    CheckProjectIsInCurrentSolution(projectId);
-                    this.CheckProjectCanBeRemoved(projectId);
+                var oldSolution = this.CurrentSolution;
 
-                    var oldSolution = this.CurrentSolution;
+                this.ClearProjectData(projectId);
+                var newSolution = this.SetCurrentSolution(oldSolution.RemoveProject(projectId));
 
-                    this.ClearProjectData(projectId);
-                    var newSolution = this.SetCurrentSolution(oldSolution.RemoveProject(projectId));
-
-                    this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.ProjectRemoved, oldSolution, newSolution, projectId);
-                }
-                finally
-                {
-                    _isProjectUnloading.Value = false;
-                }
+                this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.ProjectRemoved, oldSolution, newSolution, projectId);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis
         public virtual bool CanOpenDocuments => false;
 
         /// <summary>
-        /// True if this workspace supports manually changing the active context document of a text buffer.
+        /// True if this workspace supports manually changing the active context document of a text buffer by calling <see cref="SetDocumentContext(DocumentId)" />.
         /// </summary>
         internal virtual bool CanChangeActiveContextDocument => false;
 
@@ -299,7 +299,8 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// 
+        /// Call this method to tell the host environment to change the current active context to this document. Only supported if
+        /// <see cref="CanChangeActiveContextDocument"/> returns true.
         /// </summary>
         internal virtual void SetDocumentContext(DocumentId documentId)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -277,10 +277,9 @@ namespace Microsoft.CodeAnalysis
         /// is in the current context. If the <see cref="DocumentId"/> is currently closed, then 
         /// it is returned directly. If it is open, then this returns the same result that 
         /// <see cref="GetDocumentIdInCurrentContext(SourceTextContainer)"/> would return for the
-        /// <see cref="SourceTextContainer"/>. Hosts can override this method to provide more 
-        /// customized behaviors (e.g. special handling of documents in Shared Projects).
+        /// <see cref="SourceTextContainer"/>.
         /// </summary>
-        internal virtual DocumentId GetDocumentIdInCurrentContext(DocumentId documentId)
+        internal DocumentId GetDocumentIdInCurrentContext(DocumentId documentId)
         {
             if (documentId == null)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// 
+        /// Call this method when a document has been made the active context in the host environment.
         /// </summary>
         protected internal void OnDocumentContextUpdated(DocumentId documentId)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -291,8 +291,11 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private SourceTextContainer GetOpenDocumentSourceTextContainer_NoLock(DocumentId documentId) =>
-            _bufferToAssociatedDocumentsMap.Where(kvp => kvp.Value.Contains(documentId)).Select(kvp => kvp.Key).FirstOrDefault();
+        private SourceTextContainer GetOpenDocumentSourceTextContainer_NoLock(DocumentId documentId)
+        {
+            // TODO: remove linear search
+            return _bufferToAssociatedDocumentsMap.Where(kvp => kvp.Value.Contains(documentId)).Select(kvp => kvp.Key).FirstOrDefault();
+        }
 
         private DocumentId GetDocumentIdInCurrentContext_NoLock(SourceTextContainer container)
         {
@@ -321,7 +324,6 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected internal void OnDocumentContextUpdated(DocumentId documentId)
         {
-            // TODO: remove linear search
 
             SourceTextContainer container = null;
             using (_stateLock.DisposableWait())

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -324,30 +324,20 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected internal void OnDocumentContextUpdated(DocumentId documentId)
         {
-
-            SourceTextContainer container = null;
-            using (_stateLock.DisposableWait())
-            {
-                container = GetOpenDocumentSourceTextContainer_NoLock(documentId);
-            }
-
-            if (container != null)
-            {
-                OnDocumentContextUpdated(documentId, container);
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        private void OnDocumentContextUpdated(DocumentId documentId, SourceTextContainer container)
-        {
             using (_serializationLock.DisposableWait())
             {
                 DocumentId oldActiveContextDocumentId;
+                SourceTextContainer container;
 
                 using (_stateLock.DisposableWait())
                 {
+                    container = GetOpenDocumentSourceTextContainer_NoLock(documentId);
+
+                    if (container == null)
+                    {
+                        return;
+                    }
+
                     oldActiveContextDocumentId = _bufferToDocumentInCurrentContextMap[container];
                     if (documentId == oldActiveContextDocumentId)
                     {


### PR DESCRIPTION
The handling for determination of project contexts wasn't finished when we merged the work for free-threaded project system shims. This completes the work and fixes a bunch of issues as well.

This should fix the Roslyn side of #21358, but there are also some project system bugs that have been found too that will impact it.

Reviewers are **strongly** encouraged to go commit-by-commit here.

Work remaining:

- [x] Remove the existing hack around skipping locks when we remove projects, since those don't work correctly if just files are removed.

<details><summary>Ask Mode template</summary>

### Customer scenario

The customer has a multitargeting SDK project, linked files, or is using shared asset projects. If they try to use the dropdown in the editor to change the context, it won't work reliably or at all.

### Bugs this fixes

#31019
#31365
#21358 (but still needs more fixes from the Visual Studio side, it seems)

### Workarounds, if any

Only workaround would be to use 15.9.

### Risk

Moderate: this is a technical area in the code and interacts with a number of Visual Studio components. In the process of writing this we've discovered at least three bugs in _other_ components, to give a sense of how tricky this area is!

### Performance impact

Better; this also fixes a few memory leaks that would have leaked some project information when projects and solutions were closed.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

This was a known limitation when we merged the original free-threaded project initialization code. This only impacts a subset of our users, and when they do hit it is supremely annoying, but it was best to get all the other stuff in their hands and worry about this later. The existing code already had some bugs too; since we were rewriting all of it meant it was a good opportunity to get it right.

### How was the bug found?

Various bugs reported from customers, but this was tracked internally in our own backlog.

</details>
