### PR TITLE
Prevent unnecessary cast warning for required casts in with statements 

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
@@ -1362,6 +1362,194 @@ End Module
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(30617, "https://github.com/dotnet/roslyn/issues/30617")>
+        Public Async Function TestDontRemoveNecessaryPredefinedCastInWithStatement() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a as Object
+        With [|CStr(a)|]
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(30617, "https://github.com/dotnet/roslyn/issues/30617")>
+        Public Async Function TestDontRemoveNecessaryDirectCastInWithStatement() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a as Object
+        With [|DirectCast(a, String)|]
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(30617, "https://github.com/dotnet/roslyn/issues/30617")>
+        Public Async Function TestDontRemoveNecessaryCTypeCastInWithStatement() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a as Object
+        With [|CType(a, String)|]
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(30617, "https://github.com/dotnet/roslyn/issues/30617")>
+        Public Async Function TestDontRemoveNecessaryTryCastInWithStatement() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a as Object
+        With [|TryCast(a, String)|]
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(30617, "https://github.com/dotnet/roslyn/issues/30617")>
+        Public Async Function TestRemoveUnnecessaryPredefinedCastInWithStatement() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a as String
+        With [|CStr(a)|]
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+            Dim expected =
+<File>
+Module Program
+    Sub Main()
+        Dim a as String
+        With a
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+
+            Await TestAsync(markup, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(30617, "https://github.com/dotnet/roslyn/issues/30617")>
+        Public Async Function TestRemoveUnnecessaryDirectCastInWithStatement() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a as String
+        With [|DirectCast(a, String)|]
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+            Dim expected =
+<File>
+Module Program
+    Sub Main()
+        Dim a as String
+        With a
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+
+            Await TestAsync(markup, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(30617, "https://github.com/dotnet/roslyn/issues/30617")>
+        Public Async Function TestRemoveUnnecessaryCTypeCastInWithStatement() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a as String
+        With [|CType(a, String)|]
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+            Dim expected =
+<File>
+Module Program
+    Sub Main()
+        Dim a as String
+        With a
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+
+            Await TestAsync(markup, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(30617, "https://github.com/dotnet/roslyn/issues/30617")>
+        Public Async Function TestRemoveUnnecessaryTryCastInWithStatement() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a as String
+        With [|TryCast(a, String)|]
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+            Dim expected =
+<File>
+Module Program
+    Sub Main()
+        Dim a as String
+        With a
+            Dim x as Integer = .Length
+        End With
+    End Sub
+End Module
+</File>
+
+            Await TestAsync(markup, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         Public Async Function TestRemoveCastInFieldInitializer() As Task
             Dim markup =
 <File>

--- a/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
@@ -426,15 +426,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
         End Function
 
         Private Function ReplacementBreaksWithStatement(originalWithStatement As WithStatementSyntax, replacedWithStatement As WithStatementSyntax) As Boolean
-            Dim originalExpression = originalWithStatement.Expression
-            Dim replacedExpression = replacedWithStatement.Expression
-            Return Not IsReplacementSameType(originalExpression, replacedExpression)
-        End Function
-
-        Private Function IsReplacementSameType(originalExpression As ExpressionSyntax, replacedExpression As ExpressionSyntax) As Boolean
-            Dim originalTypeInfo = Me.OriginalSemanticModel.GetTypeInfo(originalExpression)
-            Dim replacedTypeInfo = Me.SpeculativeSemanticModel.GetTypeInfo(replacedExpression)
-            Return originalTypeInfo.Equals(replacedTypeInfo)
+            Dim originalTypeInfo = Me.OriginalSemanticModel.GetTypeInfo(originalWithStatement.Expression)
+            Dim replacedTypeInfo = Me.SpeculativeSemanticModel.GetTypeInfo(replacedWithStatement.Expression)
+            Return Not originalTypeInfo.Equals(replacedTypeInfo)
         End Function
 
         Private Function ReplacementBreaksCollectionInitializerAddMethod(originalInitializer As ExpressionSyntax, newInitializer As ExpressionSyntax) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
@@ -428,19 +428,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
         Private Function ReplacementBreaksWithStatement(originalWithStatement As WithStatementSyntax, replacedWithStatement As WithStatementSyntax) As Boolean
             Dim originalExpression = originalWithStatement.Expression
             Dim replacedExpression = replacedWithStatement.Expression
-            Select Case originalExpression.Kind
-                Case SyntaxKind.CTypeExpression, SyntaxKind.DirectCastExpression, SyntaxKind.TryCastExpression
-                    Dim originalCastExpression = DirectCast(originalExpression, CastExpressionSyntax)
-                    Return Not IsCastReplacementSameType(originalCastExpression, replacedExpression)
-                Case SyntaxKind.PredefinedCastExpression
-                    Dim originalCastExpression = DirectCast(originalExpression, PredefinedCastExpressionSyntax)
-                    Return Not IsCastReplacementSameType(originalCastExpression, replacedExpression)
-                Case Else
-                    Return False
-            End Select
+            Return Not IsReplacementSameType(originalExpression, replacedExpression)
         End Function
 
-        Private Function IsCastReplacementSameType(originalExpression As ExpressionSyntax, replacedExpression As ExpressionSyntax) As Boolean
+        Private Function IsReplacementSameType(originalExpression As ExpressionSyntax, replacedExpression As ExpressionSyntax) As Boolean
             Dim originalTypeInfo = Me.OriginalSemanticModel.GetTypeInfo(originalExpression)
             Dim replacedTypeInfo = Me.SpeculativeSemanticModel.GetTypeInfo(replacedExpression)
             Return originalTypeInfo.Equals(replacedTypeInfo)


### PR DESCRIPTION
Issue - https://github.com/dotnet/roslyn/issues/30617

This adds an additional check for with statements to ensure that invalid cast removal suggestions are not given.

Q:  Currently it will only check if the cast is unnecessary by looking at the type of the cast with and without replacement.  It does not check downward into the with block to see if the resultant type actually references the type.  This means that potentially unnecessary casts will not be suggested to fix when the type is not referenced in the with block.
Should we do this check as well?  