### PR TITLE
Remove unnecessary test hooks

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
@@ -5,8 +5,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.PlatformUI;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
@@ -17,12 +15,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
     internal partial class ChangeSignatureDialog : DialogWindow
     {
         private readonly ChangeSignatureDialogViewModel _viewModel;
-
-        /// <summary>
-        /// For test purposes only. The integration tests need to know when the dialog is up and
-        /// ready for automation.
-        /// </summary>
-        internal static event Action TEST_DialogLoaded;
 
         // Expose localized strings for binding
         public string ChangeSignatureDialogTitle { get { return ServicesVSResources.Change_Signature; } }
@@ -65,21 +57,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
             DataContext = viewModel;
 
             Loaded += ChangeSignatureDialog_Loaded;
-            IsVisibleChanged += ChangeSignatureDialog_IsVisibleChanged;
         }
 
         private void ChangeSignatureDialog_Loaded(object sender, RoutedEventArgs e)
         {
             Members.Focus();
-        }
-
-        private void ChangeSignatureDialog_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-        {
-            if ((bool)e.NewValue)
-            {
-                IsVisibleChanged -= ChangeSignatureDialog_IsVisibleChanged;
-                TEST_DialogLoaded?.Invoke();
-            }
         }
 
         private void OK_Click(object sender, RoutedEventArgs e)

--- a/src/VisualStudio/Core/Def/Implementation/ExtractInterface/ExtractInterfaceDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ExtractInterface/ExtractInterfaceDialog.xaml.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
@@ -16,12 +15,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ExtractInterfac
     internal partial class ExtractInterfaceDialog : DialogWindow
     {
         private readonly ExtractInterfaceDialogViewModel _viewModel;
-
-        /// <summary>
-        /// For test purposes only. The integration tests need to know when the dialog is up and
-        /// ready for automation.
-        /// </summary>
-        internal static event Action TEST_DialogLoaded;
 
         // Expose localized strings for binding
         public string ExtractInterfaceDialogTitle { get { return ServicesVSResources.Extract_Interface; } }
@@ -47,22 +40,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ExtractInterfac
             DataContext = viewModel;
 
             Loaded += ExtractInterfaceDialog_Loaded;
-            IsVisibleChanged += ExtractInterfaceDialog_IsVisibleChanged;
         }
 
         private void ExtractInterfaceDialog_Loaded(object sender, RoutedEventArgs e)
         {
             interfaceNameTextBox.Focus();
             interfaceNameTextBox.SelectAll();
-        }
-
-        private void ExtractInterfaceDialog_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-        {
-            if ((bool)e.NewValue)
-            {
-                IsVisibleChanged -= ExtractInterfaceDialog_IsVisibleChanged;
-                TEST_DialogLoaded?.Invoke();
-            }
         }
 
         private void SetCommandBindings()

--- a/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialog.xaml.cs
@@ -1,19 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using Microsoft.VisualStudio.PlatformUI;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
@@ -24,12 +13,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
     internal partial class GenerateTypeDialog : DialogWindow
     {
         private readonly GenerateTypeDialogViewModel _viewModel;
-
-        /// <summary>
-        /// For test purposes only. The integration tests need to know when the dialog is up and
-        /// ready for automation.
-        /// </summary>
-        internal static event Action TEST_DialogLoaded;
 
         // Expose localized strings for binding
         public string GenerateTypeDialogTitle { get { return ServicesVSResources.Generate_Type; } }
@@ -53,17 +36,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
 
             InitializeComponent();
             DataContext = viewModel;
-
-            IsVisibleChanged += GenerateTypeDialog_IsVisibleChanged;
-        }
-
-        private void GenerateTypeDialog_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-        {
-            if ((bool)e.NewValue)
-            {
-                IsVisibleChanged -= GenerateTypeDialog_IsVisibleChanged;
-                TEST_DialogLoaded?.Invoke();
-            }
         }
 
         private void SetCommandBindings()

--- a/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PickMembers/PickMembersDialog.xaml.cs
@@ -17,12 +17,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PickMembers
     {
         private readonly PickMembersDialogViewModel _viewModel;
 
-        /// <summary>
-        /// For test purposes only. The integration tests need to know when the dialog is up and
-        /// ready for automation.
-        /// </summary>
-        internal static event Action TEST_DialogLoaded;
-
         // Expose localized strings for binding
         public string PickMembersDialogTitle => ServicesVSResources.Pick_members;
         public string PickMembersTitle { get; }
@@ -40,17 +34,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PickMembers
 
             InitializeComponent();
             DataContext = viewModel;
-
-            IsVisibleChanged += PickMembers_IsVisibleChanged;
-        }
-
-        private void PickMembers_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
-        {
-            if ((bool)e.NewValue)
-            {
-                IsVisibleChanged -= PickMembers_IsVisibleChanged;
-                TEST_DialogLoaded?.Invoke();
-            }
         }
 
         private void SetCommandBindings()


### PR DESCRIPTION
These hooks are unused, and if code ever did want to wait for a dialog to show, there are better ways to do so.