### PR TITLE
Fix formatting rule creates new lines inside a tuple

### DIFF
--- a/src/Features/CSharp/Portable/AddObsoleteAttribute/CSharpAddObsoleteAttributeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddObsoleteAttribute/CSharpAddObsoleteAttributeCodeFixProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddObsoleteAttribute
                 "CS1064"  // The best overloaded Add method 'MyCollection.Add(int)' for the collection initializer element is obsolete"
             );
 
-        public CSharpAddObsoleteAttributeCodeFixProvider() 
+        public CSharpAddObsoleteAttributeCodeFixProvider()
             : base(CSharpSyntaxFactsService.Instance, CSharpFeaturesResources.Add_Obsolete)
         {
         }

--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -562,5 +562,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 currentToken.Parent is ParenthesizedVariableDesignationSyntax &&
                 currentToken.Parent.Parent is DeclarationExpressionSyntax;
         }
+
+        /// <summary>
+        /// Check whether the currentToken is a comma and is a delimiter between arguments inside a tuple expression.
+        /// </summary>
+        public static bool IsCommaInTupleExpression(this SyntaxToken currentToken)
+        {
+            return currentToken.IsKind(SyntaxKind.CommaToken) &&
+                currentToken.Parent.IsKind(SyntaxKind.TupleExpression);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -62,6 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                             !currentToken.IsParenInParenthesizedExpression() &&
                             !currentToken.IsCommaInInitializerExpression() &&
                             !currentToken.IsCommaInAnyArgumentsList() &&
+                            !currentToken.IsCommaInTupleExpression() &&
                             !currentToken.IsParenInArgumentList() &&
                             !currentToken.IsDotInMemberAccess() &&
                             !currentToken.IsCloseParenInStatement() &&

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -8871,5 +8871,35 @@ class C
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatCommaAfterCloseBrace_ShouldRemainInTheSameLine()
+        {
+            await AssertFormatAsync(
+                @"
+public class Test
+{
+    public void Foo()
+    {
+        (Action, Action, Action) tuple = (
+            () => { Console.WriteLine(2.997e8); },
+            () => { Console.WriteLine(6.67e-11); },
+            () => { Console.WriteLine(1.602e-19); }
+        );
+    }
+}",
+                @"
+public class Test
+{
+    public void Foo()
+    {
+        (Action, Action, Action) tuple = (
+            () => { Console.WriteLine(2.997e8); },
+            () => { Console.WriteLine(6.67e-11); },
+            () => { Console.WriteLine(1.602e-19); }
+        );
+    }
+}");
+        }
     }
 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -8873,35 +8873,6 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-        public async Task DummyTest()
-        {
-            await AssertFormatAsync(
-               @"
-public class Test
-{
-    public void Foo()
-    {
-        var tuple2 = (
-            1,
-            2,
-            3);
-    }
-}",
-               @"
-public class Test
-{
-    public void Foo()
-    {
-        var tuple2 = (
-            1       ,
-            2  ,
-            3);
-    }
-}");
-        }
-
-
-        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(32113, "https://github.com/dotnet/roslyn/issues/32113")]
         public async Task FormatCommaAfterCloseBrace_ShouldRemainInTheSameLine()
         {

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -8874,7 +8874,38 @@ class C
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(32113, "https://github.com/dotnet/roslyn/issues/32113")]
-        public async Task FormatCommaAfterCloseBrace_ShouldRemainInTheSameLine()
+        public async Task FormatCommaAfterCloseBrace_CommaRemainIntheSameLine()
+        {
+            await AssertFormatAsync(
+                @"
+public class Test
+{
+    public void Foo()
+    {
+        (Action, Action, Action) tuple = (
+            () => { Console.WriteLine(2.997e8); },
+            () => { Console.WriteLine(6.67e-11); },
+            () => { Console.WriteLine(1.602e-19); }
+        );
+    }
+}",
+                @"
+public class Test
+{
+    public void Foo()
+    {
+        (Action, Action, Action) tuple = (
+            () => { Console.WriteLine(2.997e8); },
+            () => { Console.WriteLine(6.67e-11); },
+            () => { Console.WriteLine(1.602e-19); }
+        );
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(32113, "https://github.com/dotnet/roslyn/issues/32113")]
+        public async Task FormatCommaAfterCloseBrace_SpaceSurroundWillBeRemoved()
         {
             await AssertFormatAsync(
                 @"
@@ -8896,7 +8927,7 @@ public class Test
     {
         (Action, Action, Action) tuple = (
             () => { Console.WriteLine(2.997e8); }                             ,        
-            () => { Console.WriteLine(6.67e-11); },
+            () => { Console.WriteLine(6.67e-11); }   ,    
             () => { Console.WriteLine(1.602e-19); }
         );
     }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -8873,6 +8873,35 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task DummyTest()
+        {
+            await AssertFormatAsync(
+               @"
+public class Test
+{
+    public void Foo()
+    {
+        var tuple2 = (
+            1,
+            2,
+            3);
+    }
+}",
+               @"
+public class Test
+{
+    public void Foo()
+    {
+        var tuple2 = (
+            1       ,
+            2  ,
+            3);
+    }
+}");
+        }
+
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(32113, "https://github.com/dotnet/roslyn/issues/32113")]
         public async Task FormatCommaAfterCloseBrace_ShouldRemainInTheSameLine()
         {
@@ -8895,7 +8924,7 @@ public class Test
     public void Foo()
     {
         (Action, Action, Action) tuple = (
-            () => { Console.WriteLine(2.997e8); },
+            () => { Console.WriteLine(2.997e8); }                             ,        
             () => { Console.WriteLine(6.67e-11); },
             () => { Console.WriteLine(1.602e-19); }
         );

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -8873,6 +8873,7 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(32113, "https://github.com/dotnet/roslyn/issues/32113")]
         public async Task FormatCommaAfterCloseBrace_ShouldRemainInTheSameLine()
         {
             await AssertFormatAsync(


### PR DESCRIPTION
Related bugs: [32113](https://github.com/dotnet/roslyn/issues/32113)

Current formatting rule will let this happen:
```
(Action, Action, Action) tuple = (
	() => { },   
	() => { },			
	() => { });
```
```
(Action, Action, Action) tuple = (
	() => { }
,   
	() => { }
,			
	() => { });
```
Seems like caused by we are not checking the case where a comma is the delimiter inside a tuple.