### PR TITLE
Disable a few tests on Mono

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -3435,7 +3435,7 @@ namespace Metadata
         }
 
         [WorkItem(540516, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540516")]
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/12422")]
         public void TestCallMethodsWithLeastCustomModifiers()
         {
             var text = @"using Metadata;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/DestructorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/DestructorTests.cs
@@ -295,7 +295,7 @@ public class Program
             compVerifier.VerifyDiagnostics();
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
         public void DestructorOverridesNonDestructor()
         {
             var text = @"


### PR DESCRIPTION
This disables a few tests that have recently turned up as flaky on Mono.

- DestructorOverridesNonDestructor: this test is pretty specific to the
JIT / GC implementation. It doesn't run on CoreClr already due to the
subtle differences. Shouldn't have been run on Mono in the first place.
- TestCallMethodsWithLeastCustomModifiers: there appears to be a runtime
race condition around how overloads that differ by only `modopt`
elements are resolved. Follow up issue
https://github.com/mono/mono/issues/12422