### PR TITLE
Don't offer "Generate Equals/GetHashCode" on ref structs

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -1319,6 +1319,20 @@ parameters: CSharp6);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        [WorkItem(25708, "https://github.com/dotnet/roslyn/issues/25708")]
+        public async Task TestDoNotOfferOnRefStruct()
+        {
+            await TestMissingAsync(
+@"
+ref struct R
+{
+    private int i;
+    [||]
+}",
+parameters: new TestParameters(parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_2)));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public async Task TestMissingReferences()
         {
             await TestWithPickMembersDialogAsync(

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
@@ -90,6 +90,13 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 return;
             }
 
+            // We should not offer this for ref structs, because the auto-generated code does not work well with
+            // ref structs and the restrictions placed on them at all.
+            if (containingType.TypeKind == TypeKind.Struct && containingType.IsRefLikeType)
+            {
+                return;
+            }
+
             // No overrides in static classes.
             if (containingType.IsStatic)
             {


### PR DESCRIPTION
Fixes #25708.

The family of *Generate Equals/GetHashCode* refactorings does not work for ref structs at all: they generate code with unfixable errors due to the [constraints placed on ref structs](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/ref#ref-struct-types) (casting from Object, implementing interfaces, using it as a type argument are all forbidden).

This PR disables these refactorings on ref structs.