### PR TITLE
Fix assert in UsePatternMatching.CSharpAsAndNullCheckDiagnosticAnalyzer

### DIFF
--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -1375,5 +1375,26 @@ public static class C
     }
 }");
         }
+
+        [WorkItem(31388, "https://github.com/dotnet/roslyn/issues/31388")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        public async Task TestUseBetweenAssignmentAndIfCondition()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class C
+{
+    void M(object o)
+    {
+        [|var|] c = o as C;
+        M2(c != null);
+        if (c == null)
+        {
+            return;
+        }
+    }
+
+    void M2(bool b) { }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.Analyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.Analyzer.cs
@@ -227,9 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                             return CheckStatement(statement);
                     }
 
-                    // We shouldn't normally get here but if we do, it's
-                    // either an error in the code or an unhandled case.
-                    Debug.Assert(false, "unhandled case.");
+                    // Bail out for error cases and unhandled cases.
                     break;
                 }
 

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             //
             // It's no longer safe to use pattern-matching because 'field is string s' would never be true.
             // 
-            // Additionally, also bail out if the assigned local is referenced (read or write) up to the point of null check.
+            // Additionally, also bail out if the assigned local is referenced (i.e. read/write/nameof) up to the point of null check.
             //      var s = field as string;
             //      MethodCall(flag: s == null);
             //      if (s != null) { ... }
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                         return;
                     }
 
-                    // Check if this is a reference to the assigned local.
+                    // Check is a reference of any sort (i.e. read/write/nameof) to the local.
                     if (identifierName.Identifier.ValueText == localSymbol.Name)
                     {
                         return;

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -145,30 +145,41 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             //      if (s != null) { ... }
             //
             // It's no longer safe to use pattern-matching because 'field is string s' would never be true.
+            // 
+            // Additionally, also bail out if the assigned local is referenced (read or write) up to the point of null check.
+            //      var s = field as string;
+            //      MethodCall(flag: s == null);
+            //      if (s != null) { ... }
+            //
             var asOperand = semanticModel.GetSymbolInfo(asExpression.Left, cancellationToken).Symbol;
-            var symbolName = asOperand?.Name;
-            if (symbolName != null)
+            var localStatementStart = localStatement.SpanStart;
+            var comparisonSpanStart = comparison.SpanStart;
+
+            foreach (var descendentNode in enclosingBlock.DescendantNodes())
             {
-                var localStatementStart = localStatement.SpanStart;
-                var comparisonSpanStart = comparison.SpanStart;
-
-                foreach (var descendentNode in enclosingBlock.DescendantNodes())
+                var descendentNodeSpanStart = descendentNode.SpanStart;
+                if (descendentNodeSpanStart <= localStatementStart)
                 {
-                    var descendentNodeSpanStart = descendentNode.SpanStart;
-                    if (descendentNodeSpanStart <= localStatementStart)
-                    {
-                        continue;
-                    }
+                    continue;
+                }
 
-                    if (descendentNodeSpanStart >= comparisonSpanStart)
-                    {
-                        break;
-                    }
+                if (descendentNodeSpanStart >= comparisonSpanStart)
+                {
+                    break;
+                }
 
-                    if (descendentNode.IsKind(SyntaxKind.IdentifierName, out IdentifierNameSyntax identifierName) &&
-                        identifierName.Identifier.ValueText == symbolName &&
+                if (descendentNode.IsKind(SyntaxKind.IdentifierName, out IdentifierNameSyntax identifierName))
+                {
+                    // Check if this is a 'write' to the asOperand.
+                    if (identifierName.Identifier.ValueText == asOperand?.Name &&
                         asOperand.Equals(semanticModel.GetSymbolInfo(identifierName, cancellationToken).Symbol) &&
                         identifierName.IsWrittenTo())
+                    {
+                        return;
+                    }
+
+                    // Check if this is a reference to the assigned local.
+                    if (identifierName.Identifier.ValueText == localSymbol.Name)
                     {
                         return;
                     }


### PR DESCRIPTION
1. Bail out early if there is a reference to assigned local between the declaration and null check being replaced with pattern matching.
2. Remove assert for bail out in presence of errors/unhandled cases.

Fixes #31388