### PR TITLE
Fix UseExpressionBodyHelper.GetDiagnosticLocation for indexer declara…

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForAccessorsAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForAccessorsAnalyzerTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.UseExpressionBody;
@@ -296,6 +297,26 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         }
     }
 }", options: UseBlockBodyIncludingPropertiesAndIndexers);
+        }
+
+        [WorkItem(31308, "https://github.com/dotnet/roslyn/issues/31308")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestUseBlockBody5()
+        {
+            var whenOnSingleLineWithNoneEnforcement = new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenOnSingleLine, NotificationOption.None);
+            var options = OptionsSet(
+                SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, whenOnSingleLineWithNoneEnforcement),
+                SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, whenOnSingleLineWithNoneEnforcement),
+                SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, whenOnSingleLineWithNoneEnforcement));
+
+            await TestMissingInRegularAndScriptAsync(
+@"class C
+{
+    C this[int index]
+    {
+        get [|=>|] default;
+    }
+}", new TestParameters(options: options));
         }
 
         [WorkItem(20350, "https://github.com/dotnet/roslyn/issues/20350")]

--- a/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyForIndexersHelper.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyForIndexersHelper.cs
@@ -71,5 +71,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 declaration, options, conversionPreference,
                 out arrowExpression, out semicolonToken);
         }
+
+        protected override Location GetDiagnosticLocation(IndexerDeclarationSyntax declaration)
+        {
+            var body = GetBody(declaration);
+            if (body != null)
+            {
+                return base.GetDiagnosticLocation(declaration);
+            }
+
+            var getAccessor = GetSingleGetAccessor(declaration.AccessorList);
+            return getAccessor.ExpressionBody.GetLocation();
+        }
     }
 }


### PR DESCRIPTION
…tions

Port existing override [UseExpressionBodyForPropertiesHelper.GetDiagnosticLocation](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp.Features/UseExpressionBody/Helpers/UseExpressionBodyForPropertiesHelper.cs,76) to `UseExpressionBodyForIndexersHelper`

Fixes #31308