### PR TITLE
Incorrect IDE0004 "Cast is redundant" when passing enum cast to int as constructor parameter accepting int

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -4607,5 +4607,30 @@ class Tester
     }
 }");
         }
+
+        [WorkItem(31963, "https://github.com/dotnet/roslyn/issues/31963")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontOfferToRemoveCastInConstructorWhenItNeeded()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+class IntegerWrapper
+{
+    public IntegerWrapper(int value)
+    {
+    }
+}
+enum Goo
+{
+    First,
+    Second
+}
+class Tester
+{
+    public void Test()
+    {
+        var a = new IntegerWrapper([|(int)Goo.First|]);
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -4632,5 +4632,43 @@ class Tester
     }
 }");
         }
+
+        [WorkItem(31963, "https://github.com/dotnet/roslyn/issues/31963")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontOfferToRemoveCastInBaseConstructorInitializerWhenItNeeded()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+class B
+{
+    B(int a)
+    {
+    }
+}
+class C : B
+{
+    C(double a) : base([|(int)a|])
+    {
+    }
+}");
+        }
+
+        [WorkItem(31963, "https://github.com/dotnet/roslyn/issues/31963")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontOfferToRemoveCastInConstructorInitializerWhenItNeeded()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+class B
+{
+    B(int a)
+    {
+    }
+
+    B(double a) : this([|(int)a|])
+    {
+    }
+}");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -510,10 +510,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
         protected override bool ExpressionMightReferenceMember(SyntaxNode node)
         {
-            return node.IsKind(SyntaxKind.InvocationExpression) ||
-                node.IsKind(SyntaxKind.ElementAccessExpression) ||
-                node.IsKind(SyntaxKind.SimpleMemberAccessExpression) ||
-                node.IsKind(SyntaxKind.ImplicitElementAccess);
+            return node.IsKind(
+                SyntaxKind.InvocationExpression,
+                SyntaxKind.ElementAccessExpression,
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxKind.ImplicitElementAccess,
+                SyntaxKind.ObjectCreationExpression);
         }
 
         protected override ImmutableArray<ArgumentSyntax> GetArguments(ExpressionSyntax expression)


### PR DESCRIPTION
This is a fix for #31963

```ReplacementChangesSemanticsForNode``` did not correctly detect that the fixed expression would create an error in the new code.