### PR TITLE
report NFW instead of crash when creating formatting rules if encoutered unexpected state

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
@@ -6,6 +6,7 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -105,7 +106,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                         }
                     }
 
-                    throw new InvalidOperationException();
+                    FatalError.ReportWithoutCrash(
+                        new InvalidOperationException($"Can't find an intersection. Visible spans count: {spans.Count}"));
+
+                    return _noopRule;
                 }
             }
 


### PR DESCRIPTION
Fixing internal bug [753909](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/753909).

I couldn't figure out a repro, so opted for NFW. Tagging @heejaechang @jasonmalinowski, who's more knowledgeable in this area (editor and Razor) and might know how to trigger the crash.

FYI @dotnet/roslyn-ide 