### PR TITLE
Fix regression where renaming a CodeElement didn't update node keys

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -488,30 +488,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         public abstract string GetFullyQualifiedName(string name, int position, SemanticModel semanticModel);
 
-        public void Rename(ISymbol symbol, string newName, Solution solution)
+        public void Rename(ISymbol symbol, string newName, Workspace workspace, ProjectCodeModelFactory projectCodeModelFactory)
         {
-            // TODO: (tomescht) make this testable through unit tests.
-            // Right now we have to go through the project system to find all
-            // the outstanding CodeElements which might be affected by the
-            // rename. This is silly. This functionality should be moved down
-            // into the service layer.
-
-            var workspace = solution.Workspace as VisualStudioWorkspace;
-            if (workspace == null)
-            {
-                throw Exceptions.ThrowEFail();
-            }
-
             // Save the node keys.
-            var nodeKeyValidation = new NodeKeyValidation();
-            foreach (var project in workspace.CurrentSolution.Projects)
-            {
-                nodeKeyValidation.AddProject(project);
-            }
+            var nodeKeyValidation = new NodeKeyValidation(projectCodeModelFactory);
 
             // Rename symbol.
-            var newSolution = Renamer.RenameSymbolAsync(solution, symbol, newName, solution.Options).WaitAndGetResult_CodeModel(CancellationToken.None);
-            var changedDocuments = newSolution.GetChangedDocuments(solution);
+            var oldSolution = workspace.CurrentSolution;
+            var newSolution = Renamer.RenameSymbolAsync(oldSolution, symbol, newName, oldSolution.Options).WaitAndGetResult_CodeModel(CancellationToken.None);
+            var changedDocuments = newSolution.GetChangedDocuments(oldSolution);
 
             // Notify third parties of the coming rename operation and let exceptions propagate out
             _refactorNotifyServices.TryOnBeforeGlobalSymbolRenamed(workspace, changedDocuments, symbol, newName, throwOnFailure: true);

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -46,8 +46,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         private string _incomingFilePath;
         private Document _previousDocument;
 
-        private readonly ITextManagerAdapter _textManagerAdapter;
-
         private readonly CleanableWeakComHandleTable<SyntaxNodeKey, EnvDTE.CodeElement> _codeElementTable;
 
         // These are used during batching.
@@ -73,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
             _parentHandle = new ComHandle<object, object>(parent);
             _documentId = documentId;
-            _textManagerAdapter = textManagerAdapter;
+            TextManagerAdapter = textManagerAdapter;
 
             _codeElementTable = new CleanableWeakComHandleTable<SyntaxNodeKey, EnvDTE.CodeElement>(state.ThreadingContext);
 
@@ -84,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         internal ITextManagerAdapter TextManagerAdapter
         {
-            get { return _textManagerAdapter; }
+            get; set;
         }
 
         /// <summary>

--- a/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         /// </summary>
         string GetFullyQualifiedName(string name, int position, SemanticModel semanticModel);
 
-        void Rename(ISymbol symbol, string newName, Solution solution);
+        void Rename(ISymbol symbol, string newName, Workspace workspace, ProjectCodeModelFactory projectCodeModelFactory);
 
         /// <summary>
         /// Returns true if the given <paramref name="symbol"/> can be used to create an external code element; otherwise, false.

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeElement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeElement.cs
@@ -259,7 +259,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
                 throw new ArgumentException();
             }
 
-            CodeModelService.Rename(LookupSymbol(), newName, this.Workspace.CurrentSolution);
+            CodeModelService.Rename(LookupSymbol(), newName, this.Workspace, this.State.ProjectCodeModelFactory);
         }
 
         protected virtual Document DeleteCore(Document document)

--- a/src/VisualStudio/Core/Impl/CodeModel/NodeKeyValidation.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/NodeKeyValidation.cs
@@ -8,17 +8,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 {
     internal sealed class NodeKeyValidation
     {
-        private readonly Dictionary<ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>, List<GlobalNodeKey>> _nodeKeysMap;
+        private readonly Dictionary<ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>, List<GlobalNodeKey>> _nodeKeysMap =
+            new Dictionary<ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>, List<GlobalNodeKey>>();
 
         public NodeKeyValidation()
         {
-            _nodeKeysMap = new Dictionary<ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>, List<GlobalNodeKey>>();
         }
 
-        public void AddProject(Project project)
+        public NodeKeyValidation(ProjectCodeModelFactory projectCodeModelFactory)
         {
-            /*
-            if (project.ProjectCodeModel is ProjectCodeModel projectCodeModel)
+            foreach (var projectCodeModel in projectCodeModelFactory.GetAllProjectCodeModels())
             {
                 var fcms = projectCodeModel.GetCachedFileCodeModelInstances();
 
@@ -29,7 +28,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                     _nodeKeysMap.Add(fcm, globalNodeKeys);
                 }
             }
-            */
         }
 
         public void AddFileCodeModel(FileCodeModel fileCodeModel)

--- a/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -17,6 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         private readonly VisualStudioWorkspace _visualStudioWorkspace;
         private readonly IServiceProvider _serviceProvider;
+
         private readonly IThreadingContext _threadingContext;
 
         [ImportingConstructor]
@@ -46,6 +48,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
 
             return projectCodeModel;
+        }
+
+        public IEnumerable<ProjectCodeModel> GetAllProjectCodeModels()
+        {
+            return _projectCodeModels.Values;
         }
 
         internal void OnProjectClosed(ProjectId projectId)

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -1230,6 +1230,29 @@ class C
             End Using
         End Function
 
+        <WorkItem(31735, "https://github.com/dotnet/roslyn/issues/31735")>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub RenameShouldWorkAndElementsShouldBeUsableAfter()
+            Dim code =
+<code>
+class C
+{
+}
+</code>
+
+            TestOperation(code,
+                Sub(fileCodeModel)
+                    Dim codeElement = DirectCast(fileCodeModel.CodeElements(0), EnvDTE80.CodeElement2)
+                    Assert.Equal("C", codeElement.Name)
+
+                    codeElement.RenameSymbol("D")
+
+                    ' This not only asserts that the rename happened successfully, but that the element was correctly updated
+                    ' so the underlying node key is still valid.
+                    Assert.Equal("D", codeElement.Name)
+                End Sub)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
@@ -1252,6 +1252,29 @@ End Class
                 End Sub)
         End Sub
 
+
+        <WorkItem(31735, "https://github.com/dotnet/roslyn/issues/31735")>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub RenameShouldWorkAndElementsShouldBeUsableAfter()
+            Dim code =
+<code>
+Class C
+End Class
+</code>
+
+            TestOperation(code,
+                Sub(fileCodeModel)
+                    Dim codeElement = DirectCast(fileCodeModel.CodeElements(0), EnvDTE80.CodeElement2)
+                    Assert.Equal("C", codeElement.Name)
+
+                    codeElement.RenameSymbol("D")
+
+                    ' This not only asserts that the rename happened successfully, but that the element was correctly updated
+                    ' so the underlying node key is still valid.
+                    Assert.Equal("D", codeElement.Name)
+                End Sub)
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.VisualBasic

--- a/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
@@ -95,7 +95,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                     Return Me._componentModel
                 End If
 
-                Throw New NotImplementedException()
+                Throw New NotImplementedException("No service exists for " + serviceType.FullName)
             End Function
         End Class
 

--- a/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
@@ -58,13 +58,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                     mockVisualStudioWorkspace,
                     New ProjectCodeModelFactory(mockVisualStudioWorkspace, mockServiceProvider, threadingContext))
 
-                Dim mockTextManagerAdapter = New MockTextManagerAdapter()
-
                 Dim projectCodeModel = DirectCast(state.ProjectCodeModelFactory.CreateProjectCodeModel(project.Id, Nothing), ProjectCodeModel)
 
                 For Each document In project.Documents
                     ' Note that a parent is not specified below. In Visual Studio, this would normally be an EnvDTE.Project instance.
                     Dim fcm = projectCodeModel.GetOrCreateFileCodeModel(document.FilePath, parent:=Nothing)
+                    fcm.Object.TextManagerAdapter = New MockTextManagerAdapter()
                     mockVisualStudioWorkspace.SetFileCodeModel(document.Id, fcm)
                 Next
 
@@ -95,7 +94,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                     Return Me._componentModel
                 End If
 
-                Throw New NotImplementedException("No service exists for " + serviceType.FullName)
+                Throw New NotImplementedException($"No service exists for {serviceType.FullName}")
             End Function
         End Class
 


### PR DESCRIPTION
In a larger refactoring I had commented some code out in NodeKeyValidation.AddProject. This meant that when we did a refactor rename of a CodeElement, we wouldn't end up updating node keys for all the existing CodeElements out there. The expectation is CodeElements are still valid. Uncommenting the code and bringing it back inline with the current design makes everything work again.

Fixes #31735.

<details><summary>Ask Mode template not completed</summary>

**Customer scenario**

Change the name of a control in a Win Forms project. Once you try to save it, you get an error saying your file can't be saved. At this point, all you can do is close the file without saving and try again.

**Bugs this fixes:** 

GitHub Bug: #31735
Feedback link: https://developercommunity.visualstudio.com/content/problem/400702/cant-save-cs-file-after-changing-the-name-attribut.html

**Workarounds, if any**

You'd have to perform the rename manually in the codebehind of the file. This isn't an obvious workaround (the error the customer gives does not give any hint which operation caused you to get into this state), and is also fairly risky since we normally don't want customers tinkering in the codebehind.

**Risk**

Low: this is fixing one particular method which is only used in the rename path for CodeModel elements.

**Performance impact**

None.

**Is this a regression from a previous update?**

Yes. This was broken in Dev16.0 Preview 1.

**Root cause analysis:**

This was broken as a part of a very large refactoring; some code wasn't fixed up correctly and this slipped through code review. There weren't any unit tests covering this, and any integration tests must have since been disabled. Unit tests have now been written to cover this, which were confirmed to correctly catch the bug before the fix was checked in.

**How was the bug found?**

Many customer reports: https://developercommunity.visualstudio.com/content/problem/400702/cant-save-cs-file-after-changing-the-name-attribut.html

</details>