### PR TITLE
Fix bug with 'add parameter to constructor'

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
@@ -580,5 +580,67 @@ class C
     }
 }");
         }
+
+        [WorkItem(28775, "https://github.com/dotnet/roslyn/issues/28775")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)]
+        public async Task TestMissingIfFieldsAlreadyExistingInConstructor()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    [|string _barBar;
+    int fooFoo;|]
+    public C(string barBar, int fooFoo)
+    {
+    }
+}"
+            );
+        }
+
+        [WorkItem(28775, "https://github.com/dotnet/roslyn/issues/28775")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)]
+        public async Task TestMissingIfPropertyAlreadyExistingInConstructor()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    [|string bar;
+    int HelloWorld { get; set; }|]
+    public C(string bar, int helloWorld)
+    {
+    }
+}"
+            );
+
+        }
+
+        [WorkItem(28775, "https://github.com/dotnet/roslyn/issues/28775")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)]
+        public async Task TestNormalProperty()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    [|int i;
+    int Hello { get; set; }|]
+    public C(int i)
+    {
+    }
+}",
+@"
+class C
+{
+    int i;
+    int Hello { get; set; }
+    public C(int i, int hello)
+    {
+        Hello = hello;
+    }
+}"
+            );
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.cs
@@ -267,7 +267,7 @@ index: 1);
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)]
         public async Task TestTupleWithDifferentNames()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestInRegularAndScriptAsync(
 @"class Program
 {
     [|(int a, string b) i;
@@ -276,6 +276,17 @@ index: 1);
     public Program((int e, string f) i)
     {
         this.i = i;
+    }
+}",
+@"class Program
+{
+    [|(int a, string b) i;
+    (string c, int d) s;|]
+
+    public Program((int e, string f) i, (string c, int d) s)
+    {
+        this.i = i;
+        this.s = s;
     }
 }");
         }
@@ -424,7 +435,7 @@ index: 1);
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)]
         public async Task TestTupleOptionalWithDifferentNames()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestInRegularAndScriptAsync(
 @"class Program
 {
     [|(int a, string b) i;
@@ -434,7 +445,18 @@ index: 1);
     {
         this.i = i;
     }
-}");
+}",
+@"class Program
+{
+    [|(int a, string b) i;
+    (string c, int d) s;|]
+
+    public Program((int e, string f) i, (string c, int d) s = default((string c, int d)))
+    {
+        this.i = i;
+        this.s = s;
+    }
+}", index: 1);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)]
@@ -487,6 +509,74 @@ index: 1);
     {
         this.i = i;
         this.s = s;
+    }
+}");
+        }
+
+        [WorkItem(28775, "https://github.com/dotnet/roslyn/issues/28775")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)]
+        public async Task TestAddParamtersToConstructorBySelectOneMember()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    int i;
+    [|(List<byte>, List<long>) s;|]
+    int j;
+
+    public C(int i, int j)
+    {
+        this.i = i;
+        this.j = j;
+    }
+}",
+@"
+class C
+{
+    int i;
+    (List<byte>, List<long>) s;
+    int j;
+
+    public C(int i, int j, (List<byte>, List<long>) s)
+    {
+        this.i = i;
+        this.j = j;
+        this.s = s;
+    }
+}");
+        }
+
+        [WorkItem(28775, "https://github.com/dotnet/roslyn/issues/28775")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)]
+        public async Task TestParametersAreStillRightIfMembersAreOutOfOrder()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    [|int i;
+    int k;
+    int j;|]
+
+    public C(int i, int j)
+    {
+        this.i = i;
+        this.j = j;
+    }
+}",
+@"
+class C
+{
+    int i;
+    int k;
+    int j;
+
+    public C(int i, int j, int k)
+    {
+        this.i = i;
+        this.j = j;
+        this.k = k;
     }
 }");
         }

--- a/src/EditorFeatures/VisualBasicTest/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.vb
@@ -167,5 +167,40 @@ End Class",
     End Sub
 End Class")
         End Function
+
+        <WorkItem(28775, "https://github.com/dotnet/roslyn/issues/28775")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)>
+        Public Async Function TestNormalProperty() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Class Program
+    [|Private i As Integer
+    Property Hello As Integer = 1|]
+    Public Sub New(i As Integer)
+    End Sub
+End Class",
+"
+Class Program
+    Private i As Integer
+    Property Hello As Integer = 1
+    Public Sub New(i As Integer, hello As Integer)
+        Me.Hello = hello
+    End Sub
+End Class"
+            )
+        End Function
+
+        <WorkItem(28775, "https://github.com/dotnet/roslyn/issues/28775")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)>
+        Public Async Function TestMissingIfFieldsAndPropertyAlreadyExists() As Task
+            Await TestMissingAsync(
+"
+Class Program
+    [|Private i As Integer
+    Property Hello As Integer = 1|]
+    Public Sub New(i As Integer, hello As Integer)
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersTests.vb
@@ -117,5 +117,55 @@ End Class",
 End Class",
 index:=1)
         End Function
+
+        <WorkItem(28775, "https://github.com/dotnet/roslyn/issues/28775")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)>
+        Public Async Function TestAddParamtersToConstructorBySelectOneMember() As Task
+            Await TestInRegularAndScriptAsync(
+"Class Program
+    Private i As Integer
+    [|Private k As Integer|]
+    Private j As Integer
+    Public Sub New(i As Integer, j As Integer)
+        Me.i = i
+        Me.j = j
+    End Sub
+End Class",
+"Class Program
+    Private i As Integer
+    Private k As Integer
+    Private j As Integer
+    Public Sub New(i As Integer, j As Integer, k As Integer)
+        Me.i = i
+        Me.j = j
+        Me.k = k
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(28775, "https://github.com/dotnet/roslyn/issues/28775")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParametersFromMembers)>
+        Public Async Function TestParametersAreStillRightIfMembersAreOutOfOrder() As Task
+            Await TestInRegularAndScriptAsync(
+"Class Program
+    [|Private i As Integer
+    Private k As Integer
+    Private j As Integer|]
+    Public Sub New(i As Integer, j As Integer)
+        Me.i = i
+        Me.j = j
+    End Sub
+End Class",
+"Class Program
+    [|Private i As Integer
+    Private k As Integer
+    Private j As Integer|]
+    Public Sub New(i As Integer, j As Integer, k As Integer)
+        Me.i = i
+        Me.j = j
+        Me.k = k
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpInitializeMemberFromParameterCodeRefactoringProvider.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
         protected override Accessibility DetermineDefaultPropertyAccessibility()
             => Accessibility.Private;
 
-        protected override SyntaxNode GetBody(SyntaxNode functionDeclaration) 
+        protected override SyntaxNode GetBody(SyntaxNode functionDeclaration)
             => InitializeParameterHelpers.GetBody(functionDeclaration);
     }
 }

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersCodeAction.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersCodeAction.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
             {
                 var workspace = _document.Project.Solution.Workspace;
                 var declarationService = _document.GetLanguageService<ISymbolDeclarationService>();
-                var constructor = declarationService.GetDeclarations(_state.DelegatedConstructor).Select(r => r.GetSyntax(cancellationToken)).First();
+                var constructor = declarationService.GetDeclarations(_state.ConstructorToAddTo).Select(r => r.GetSyntax(cancellationToken)).First();
 
                 var newConstructor = constructor;
                 newConstructor = CodeGenerator.AddParameterDeclarations(newConstructor, _missingParameters, workspace);
@@ -71,9 +71,9 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
             {
                 get
                 {
-                    var parameters = _state.DelegatedConstructor.Parameters.Select(p => p.ToDisplayString(SimpleFormat));
+                    var parameters = _state.ConstructorToAddTo.Parameters.Select(p => p.ToDisplayString(SimpleFormat));
                     var parameterString = string.Join(", ", parameters);
-                    var optional = _missingParameters.First().IsOptional;
+                    var optional = _missingParameters[0].IsOptional;
                     var signature = $"{_state.ContainingType.Name}({parameterString})";
 
                     return optional

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersCodeAction.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersCodeAction.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,18 +22,18 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
             private readonly AddConstructorParametersFromMembersCodeRefactoringProvider _service;
             private readonly Document _document;
             private readonly State _state;
-            private readonly IList<IParameterSymbol> _parameters;
+            private readonly ImmutableArray<IParameterSymbol> _missingParameters;
 
             public AddConstructorParametersCodeAction(
                 AddConstructorParametersFromMembersCodeRefactoringProvider service,
                 Document document,
                 State state,
-                IList<IParameterSymbol> parameters)
+                ImmutableArray<IParameterSymbol> missingParameters)
             {
                 _service = service;
                 _document = document;
                 _state = state;
-                _parameters = parameters;
+                _missingParameters = missingParameters;
             }
 
             protected override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
@@ -42,7 +43,7 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
                 var constructor = declarationService.GetDeclarations(_state.DelegatedConstructor).Select(r => r.GetSyntax(cancellationToken)).First();
 
                 var newConstructor = constructor;
-                newConstructor = CodeGenerator.AddParameterDeclarations(newConstructor, _parameters.Skip(_state.DelegatedConstructor.Parameters.Length), workspace);
+                newConstructor = CodeGenerator.AddParameterDeclarations(newConstructor, _missingParameters, workspace);
                 newConstructor = CodeGenerator.AddStatements(newConstructor, CreateAssignStatements(_state), workspace)
                                                       .WithAdditionalAnnotations(Formatter.Annotation);
 
@@ -52,19 +53,17 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
                 return Task.FromResult(_document.WithSyntaxRoot(newRoot));
             }
 
-            private IEnumerable<SyntaxNode> CreateAssignStatements(
-                State state)
+            private IEnumerable<SyntaxNode> CreateAssignStatements(State state)
             {
                 var factory = _document.GetLanguageService<SyntaxGenerator>();
-                for (int i = state.DelegatedConstructor.Parameters.Length; i < state.Parameters.Length; i++)
+                for (var i = 0; i < _missingParameters.Length; ++i)
                 {
-                    var symbolName = state.SelectedMembers[i].Name;
-                    var parameterName = state.Parameters[i].Name;
-
+                    var memberName = _state.MissingMembers[i].Name;
+                    var paramterName = _missingParameters[i].Name;
                     yield return factory.ExpressionStatement(
                         factory.AssignmentStatement(
-                            factory.MemberAccessExpression(factory.ThisExpression(), factory.IdentifierName(symbolName)),
-                            factory.IdentifierName(parameterName)));
+                            factory.MemberAccessExpression(factory.ThisExpression(), factory.IdentifierName(memberName)),
+                            factory.IdentifierName(paramterName)));
                 }
             }
 
@@ -74,7 +73,7 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
                 {
                     var parameters = _state.DelegatedConstructor.Parameters.Select(p => p.ToDisplayString(SimpleFormat));
                     var parameterString = string.Join(", ", parameters);
-                    var optional = _parameters.First().IsOptional;
+                    var optional = _missingParameters.First().IsOptional;
                     var signature = $"{_state.ContainingType.Name}({parameterString})";
 
                     return optional

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersCodeAction.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersCodeAction.cs
@@ -59,11 +59,11 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
                 for (var i = 0; i < _missingParameters.Length; ++i)
                 {
                     var memberName = _state.MissingMembers[i].Name;
-                    var paramterName = _missingParameters[i].Name;
+                    var parameterName = _missingParameters[i].Name;
                     yield return factory.ExpressionStatement(
                         factory.AssignmentStatement(
                             factory.MemberAccessExpression(factory.ThisExpression(), factory.IdentifierName(memberName)),
-                            factory.IdentifierName(paramterName)));
+                            factory.IdentifierName(parameterName)));
                 }
             }
 

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.cs
@@ -43,8 +43,8 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
                 var info = await this.GetSelectedMemberInfoAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
                 if (info != null)
                 {
-                    var state = State.Generate(this, document, textSpan, info.SelectedMembers, cancellationToken);
-                    if (state != null && state.MatchingConstructor == null)
+                    var state = State.Generate(this, info.SelectedMembers);
+                    if (state != null && state.DelegatedConstructor != null)
                     {
                         return CreateCodeActions(document, state).AsImmutableOrNull();
                     }
@@ -54,24 +54,58 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
             }
         }
 
+        /// <summary>
+        /// Try to find a constructor in <paramref name="containingType"/> whose parameters is the subset of <paramref name="parameters"/> by comparing name.
+        /// If multiple constructors meet the condition, the one with more parameters will be returned.
+        /// It will not consider those constructors as potential candidates
+        /// 1. Constructor with empty parameter list.
+        /// 2. Constructor's parameter list contains 'ref' or 'params'
+        /// </summary>
+        protected override IMethodSymbol GetDelegatedConstructor(
+            INamedTypeSymbol containingType,
+            ImmutableArray<IParameterSymbol> parameters)
+        {
+            return containingType.InstanceConstructors
+                .WhereAsArray(constructor => IsParamtersContainedInConstructor(constructor, parameters.SelectAsArray(p => p.Name)))
+                .OrderByDescending(constructor => constructor.Parameters.Length)
+                .FirstOrDefault();
+        }
+
+        private bool IsParamtersContainedInConstructor(
+            IMethodSymbol constructor,
+            ImmutableArray<string> parametersName)
+        {
+            var constructorParams = constructor.Parameters;
+            if (constructorParams.Length > 0
+                && constructorParams.All(parameter => parameter.RefKind == RefKind.None)
+                && !constructorParams.Any(p => p.IsParams))
+            {
+                return parametersName.Except(constructorParams.Select(p => p.Name)).Any();
+            }
+            else
+            {
+                return false;
+            }
+        }
+
         private IEnumerable<CodeAction> CreateCodeActions(Document document, State state)
         {
             var lastParameter = state.DelegatedConstructor.Parameters.Last();
             if (!lastParameter.IsOptional)
             {
-                yield return new AddConstructorParametersCodeAction(this, document, state, state.Parameters);
+                yield return new AddConstructorParametersCodeAction(this, document, state, state.MissingParameters);
             }
 
-            var parameters = state.Parameters.Select(p => CodeGenerationSymbolFactory.CreateParameterSymbol(
+            var missingOptionalParameters = state.MissingParameters.SelectAsArray(p => CodeGenerationSymbolFactory.CreateParameterSymbol(
                 attributes: default,
                 refKind: p.RefKind,
                 isParams: p.IsParams,
                 type: p.Type,
                 name: p.Name,
                 isOptional: true,
-                hasDefaultValue: true)).ToList();
+                hasDefaultValue: true));
 
-            yield return new AddConstructorParametersCodeAction(this, document, state, parameters);
+            yield return new AddConstructorParametersCodeAction(this, document, state, missingOptionalParameters);
         }
     }
 }

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
                 if (info != null)
                 {
                     var state = State.Generate(this, info.SelectedMembers);
-                    if (state != null && state.DelegatedConstructor != null)
+                    if (state != null && state.ConstructorToAddTo != null)
                     {
                         return CreateCodeActions(document, state).AsImmutableOrNull();
                     }
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
 
         private IEnumerable<CodeAction> CreateCodeActions(Document document, State state)
         {
-            var lastParameter = state.DelegatedConstructor.Parameters.Last();
+            var lastParameter = state.ConstructorToAddTo.Parameters.Last();
             if (!lastParameter.IsOptional)
             {
                 yield return new AddConstructorParametersCodeAction(this, document, state, state.MissingParameters);

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
         /// 1. Constructor with empty parameter list.
         /// 2. Constructor's parameter list contains 'ref' or 'params'
         /// </summary>
-        protected IMethodSymbol GetDelegatedConstructorBasedOnParameterNames(
+        private IMethodSymbol GetDelegatedConstructorBasedOnParameterNames(
             INamedTypeSymbol containingType,
             ImmutableArray<IParameterSymbol> parameters)
         {

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.cs
@@ -54,35 +54,6 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
             }
         }
 
-        /// <summary>
-        /// Try to find a constructor in <paramref name="containingType"/> whose parameters is the subset of <paramref name="parameters"/> by comparing name.
-        /// If multiple constructors meet the condition, the one with more parameters will be returned.
-        /// It will not consider those constructors as potential candidates if:
-        /// 1. Constructor with empty parameter list.
-        /// 2. Constructor's parameter list contains 'ref' or 'params'
-        /// </summary>
-        private IMethodSymbol GetDelegatedConstructorBasedOnParameterNames(
-            INamedTypeSymbol containingType,
-            ImmutableArray<IParameterSymbol> parameters)
-        {
-            var parameterNames = parameters.SelectAsArray(p => p.Name);
-            return containingType.InstanceConstructors
-                .Where(constructor => AreParametersContainedInConstructor(constructor, parameterNames))
-                .OrderByDescending(constructor => constructor.Parameters.Length)
-                .FirstOrDefault();
-        }
-
-        private bool AreParametersContainedInConstructor(
-            IMethodSymbol constructor,
-            ImmutableArray<string> parametersName)
-        {
-            var constructorParams = constructor.Parameters;
-            return constructorParams.Length > 0
-                && constructorParams.All(parameter => parameter.RefKind == RefKind.None)
-                && !constructorParams.Any(p => p.IsParams)
-                && parametersName.Except(constructorParams.Select(p => p.Name)).Any();
-        }
-
         private IEnumerable<CodeAction> CreateCodeActions(Document document, State state)
         {
             var lastParameter = state.ConstructorToAddTo.Parameters.Last();

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.cs
@@ -54,6 +54,35 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
             }
         }
 
+        /// <summary>
+        /// Try to find a constructor in <paramref name="containingType"/> whose parameters is the subset of <paramref name="parameters"/> by comparing name.
+        /// If multiple constructors meet the condition, the one with more parameters will be returned.
+        /// It will not consider those constructors as potential candidates if:
+        /// 1. Constructor with empty parameter list.
+        /// 2. Constructor's parameter list contains 'ref' or 'params'
+        /// </summary>
+        protected IMethodSymbol GetDelegatedConstructorBasedOnParameterNames(
+            INamedTypeSymbol containingType,
+            ImmutableArray<IParameterSymbol> parameters)
+        {
+            var parameterNames = parameters.SelectAsArray(p => p.Name);
+            return containingType.InstanceConstructors
+                .Where(constructor => AreParametersContainedInConstructor(constructor, parameterNames))
+                .OrderByDescending(constructor => constructor.Parameters.Length)
+                .FirstOrDefault();
+        }
+
+        private bool AreParametersContainedInConstructor(
+            IMethodSymbol constructor,
+            ImmutableArray<string> parametersName)
+        {
+            var constructorParams = constructor.Parameters;
+            return constructorParams.Length > 0
+                && constructorParams.All(parameter => parameter.RefKind == RefKind.None)
+                && !constructorParams.Any(p => p.IsParams)
+                && parametersName.Except(constructorParams.Select(p => p.Name)).Any();
+        }
+
         private IEnumerable<CodeAction> CreateCodeActions(Document document, State state)
         {
             var lastParameter = state.ConstructorToAddTo.Parameters.Last();

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/State.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/State.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
             /// 1. Constructor with empty parameter list.
             /// 2. Constructor's parameter list contains 'ref' or 'params'
             /// </summary>
-            public static IMethodSymbol GetDelegatedConstructorBasedOnParameterNames(
+            private IMethodSymbol GetDelegatedConstructorBasedOnParameterNames(
                 INamedTypeSymbol containingType,
                 ImmutableArray<IParameterSymbol> parameters)
             {
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
                     .FirstOrDefault();
             }
 
-            private static bool AreParametersContainedInConstructor(
+            private bool AreParametersContainedInConstructor(
                 IMethodSymbol constructor,
                 ImmutableArray<string> parametersName)
             {

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/State.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/State.cs
@@ -70,7 +70,8 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
 
                 this.MissingParameters = missingParametersBuilder.ToImmutableAndFree();
                 this.MissingMembers = missingMembersBuilder.ToImmutableAndFree();
-                return true;
+
+                return MissingParameters.Length != 0;
             }
 
             /// <summary>

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/State.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/State.cs
@@ -45,6 +45,9 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
                 }
 
                 var parameters = service.DetermineParameters(selectedMembers);
+                // We are trying to add these parameters into an existing constructor's parameter list.
+                // Comparing parameters based on names to make sure parameter list won't contains duplicate parameters after we
+                // append the new parameters
                 this.ConstructorToAddTo = service.GetDelegatedConstructorBasedOnParameterNames(this.ContainingType, parameters);
 
                 if (this.ConstructorToAddTo == null)

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -167,29 +167,6 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
             return result.ToImmutableAndFree();
         }
 
-        private IMethodSymbol GetDelegatedConstructorBasedOnParameterTypes(
-            INamedTypeSymbol containingType,
-            ImmutableArray<IParameterSymbol> parameters)
-        {
-            var q =
-                from c in containingType.InstanceConstructors
-                orderby c.Parameters.Length descending
-                where c.Parameters.Length > 0 && c.Parameters.Length < parameters.Length
-                where c.Parameters.All(p => p.RefKind == RefKind.None) && !c.Parameters.Any(p => p.IsParams)
-                let constructorTypes = c.Parameters.Select(p => p.Type)
-                let symbolTypes = parameters.Take(c.Parameters.Length).Select(p => p.Type)
-                where constructorTypes.SequenceEqual(symbolTypes)
-                select c;
-
-            return q.FirstOrDefault();
-        }
-
-        private IMethodSymbol GetMatchingConstructor(INamedTypeSymbol containingType, ImmutableArray<IParameterSymbol> parameters)
-            => containingType.InstanceConstructors.FirstOrDefault(c => MatchesConstructor(c, parameters));
-
-        private bool MatchesConstructor(IMethodSymbol constructor, ImmutableArray<IParameterSymbol> parameters)
-            => parameters.Select(p => p.Type).SequenceEqual(constructor.Parameters.Select(p => p.Type));
-
         private static async Task<Document> AddNavigationAnnotationAsync(Document document, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/State.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/State.cs
@@ -59,6 +59,8 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
 
                 this.Parameters = service.DetermineParameters(selectedMembers);
                 this.MatchingConstructor = service.GetMatchingConstructor(this.ContainingType, this.Parameters);
+                // We are going to create a new contructor and pass part of the parameters into DelegatedConstructor,
+                // so parameters should be compared based on types since we don't want get a type mismatch error after the new constructor is genreated.
                 this.DelegatedConstructor = service.GetDelegatedConstructorBasedOnParameterTypes(this.ContainingType, this.Parameters);
                 return true;
             }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/State.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/State.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
 
                 this.Parameters = service.DetermineParameters(selectedMembers);
                 this.MatchingConstructor = service.GetMatchingConstructor(this.ContainingType, this.Parameters);
-                this.DelegatedConstructor = service.GetDelegatedConstructor(this.ContainingType, this.Parameters);
+                this.DelegatedConstructor = service.GetDelegatedConstructorBasedOnParameterTypes(this.ContainingType, this.Parameters);
                 return true;
             }
         }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/State.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/State.cs
@@ -58,12 +58,35 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 }
 
                 this.Parameters = service.DetermineParameters(selectedMembers);
-                this.MatchingConstructor = service.GetMatchingConstructor(this.ContainingType, this.Parameters);
+                this.MatchingConstructor = GetMatchingConstructorBasedOnParameterTypes(this.ContainingType, this.Parameters);
                 // We are going to create a new contructor and pass part of the parameters into DelegatedConstructor,
                 // so parameters should be compared based on types since we don't want get a type mismatch error after the new constructor is genreated.
-                this.DelegatedConstructor = service.GetDelegatedConstructorBasedOnParameterTypes(this.ContainingType, this.Parameters);
+                this.DelegatedConstructor = GetDelegatedConstructorBasedOnParameterTypes(this.ContainingType, this.Parameters);
                 return true;
             }
+
+            public static IMethodSymbol GetDelegatedConstructorBasedOnParameterTypes(
+                INamedTypeSymbol containingType,
+                ImmutableArray<IParameterSymbol> parameters)
+            {
+                var q =
+                    from c in containingType.InstanceConstructors
+                    orderby c.Parameters.Length descending
+                    where c.Parameters.Length > 0 && c.Parameters.Length < parameters.Length
+                    where c.Parameters.All(p => p.RefKind == RefKind.None) && !c.Parameters.Any(p => p.IsParams)
+                    let constructorTypes = c.Parameters.Select(p => p.Type)
+                    let symbolTypes = parameters.Take(c.Parameters.Length).Select(p => p.Type)
+                    where constructorTypes.SequenceEqual(symbolTypes)
+                    select c;
+
+                return q.FirstOrDefault();
+            }
+
+            public static IMethodSymbol GetMatchingConstructorBasedOnParameterTypes(INamedTypeSymbol containingType, ImmutableArray<IParameterSymbol> parameters)
+                => containingType.InstanceConstructors.FirstOrDefault(c => MatchesConstructorBasedOnParameterTypes(c, parameters));
+
+            private static bool MatchesConstructorBasedOnParameterTypes(IMethodSymbol constructor, ImmutableArray<IParameterSymbol> parameters)
+                => parameters.Select(p => p.Type).SequenceEqual(constructor.Parameters.Select(p => p.Type));
         }
     }
 }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/State.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/State.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 return true;
             }
 
-            public static IMethodSymbol GetDelegatedConstructorBasedOnParameterTypes(
+            private IMethodSymbol GetDelegatedConstructorBasedOnParameterTypes(
                 INamedTypeSymbol containingType,
                 ImmutableArray<IParameterSymbol> parameters)
             {
@@ -82,10 +82,10 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 return q.FirstOrDefault();
             }
 
-            public static IMethodSymbol GetMatchingConstructorBasedOnParameterTypes(INamedTypeSymbol containingType, ImmutableArray<IParameterSymbol> parameters)
+            private IMethodSymbol GetMatchingConstructorBasedOnParameterTypes(INamedTypeSymbol containingType, ImmutableArray<IParameterSymbol> parameters)
                 => containingType.InstanceConstructors.FirstOrDefault(c => MatchesConstructorBasedOnParameterTypes(c, parameters));
 
-            private static bool MatchesConstructorBasedOnParameterTypes(IMethodSymbol constructor, ImmutableArray<IParameterSymbol> parameters)
+            private bool MatchesConstructorBasedOnParameterTypes(IMethodSymbol constructor, ImmutableArray<IParameterSymbol> parameters)
                 => parameters.Select(p => p.Type).SequenceEqual(constructor.Parameters.Select(p => p.Type));
         }
     }

--- a/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
+++ b/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
@@ -142,12 +142,12 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
         {
             var parameterNames = parameters.SelectAsArray(p => p.Name);
             return containingType.InstanceConstructors
-                .Where(constructor => IsParamtersContainedInConstructor(constructor, parameterNames))
+                .Where(constructor => IsParametersContainedInConstructor(constructor, parameterNames))
                 .OrderByDescending(constructor => constructor.Parameters.Length)
                 .FirstOrDefault();
         }
 
-        private bool IsParamtersContainedInConstructor(
+        private bool IsParametersContainedInConstructor(
             IMethodSymbol constructor,
             ImmutableArray<string> parametersName)
         {

--- a/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
+++ b/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
 
         private static readonly char[] s_underscore = { '_' };
 
-        protected IMethodSymbol GetDelegatedConstructor(
+        protected virtual IMethodSymbol GetDelegatedConstructor(
             INamedTypeSymbol containingType,
             ImmutableArray<IParameterSymbol> parameters)
         {
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
             return q.FirstOrDefault();
         }
 
-        protected IMethodSymbol GetMatchingConstructor(INamedTypeSymbol containingType, ImmutableArray<IParameterSymbol> parameters)
+        protected virtual IMethodSymbol GetMatchingConstructor(INamedTypeSymbol containingType, ImmutableArray<IParameterSymbol> parameters)
             => containingType.InstanceConstructors.FirstOrDefault(c => MatchesConstructor(c, parameters));
 
         private bool MatchesConstructor(IMethodSymbol constructor, ImmutableArray<IParameterSymbol> parameters)

--- a/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
+++ b/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
             return q.FirstOrDefault();
         }
 
-        protected virtual IMethodSymbol GetMatchingConstructor(INamedTypeSymbol containingType, ImmutableArray<IParameterSymbol> parameters)
+        protected IMethodSymbol GetMatchingConstructor(INamedTypeSymbol containingType, ImmutableArray<IParameterSymbol> parameters)
             => containingType.InstanceConstructors.FirstOrDefault(c => MatchesConstructor(c, parameters));
 
         private bool MatchesConstructor(IMethodSymbol constructor, ImmutableArray<IParameterSymbol> parameters)

--- a/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
+++ b/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
@@ -129,35 +129,6 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
 
         private static readonly char[] s_underscore = { '_' };
 
-        /// <summary>
-        /// Try to find a constructor in <paramref name="containingType"/> whose parameters is the subset of <paramref name="parameters"/> by comparing name.
-        /// If multiple constructors meet the condition, the one with more parameters will be returned.
-        /// It will not consider those constructors as potential candidates if:
-        /// 1. Constructor with empty parameter list.
-        /// 2. Constructor's parameter list contains 'ref' or 'params'
-        /// </summary>
-        protected IMethodSymbol GetDelegatedConstructorBasedOnParameterNames(
-            INamedTypeSymbol containingType,
-            ImmutableArray<IParameterSymbol> parameters)
-        {
-            var parameterNames = parameters.SelectAsArray(p => p.Name);
-            return containingType.InstanceConstructors
-                .Where(constructor => IsParametersContainedInConstructor(constructor, parameterNames))
-                .OrderByDescending(constructor => constructor.Parameters.Length)
-                .FirstOrDefault();
-        }
-
-        private bool IsParametersContainedInConstructor(
-            IMethodSymbol constructor,
-            ImmutableArray<string> parametersName)
-        {
-            var constructorParams = constructor.Parameters;
-            return constructorParams.Length > 0
-                && constructorParams.All(parameter => parameter.RefKind == RefKind.None)
-                && !constructorParams.Any(p => p.IsParams)
-                && parametersName.Except(constructorParams.Select(p => p.Name)).Any();
-        }
-
         protected IMethodSymbol GetDelegatedConstructorBasedOnParameterTypes(
             INamedTypeSymbol containingType,
             ImmutableArray<IParameterSymbol> parameters)

--- a/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
+++ b/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
@@ -129,29 +129,6 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
 
         private static readonly char[] s_underscore = { '_' };
 
-        protected IMethodSymbol GetDelegatedConstructorBasedOnParameterTypes(
-            INamedTypeSymbol containingType,
-            ImmutableArray<IParameterSymbol> parameters)
-        {
-            var q =
-                from c in containingType.InstanceConstructors
-                orderby c.Parameters.Length descending
-                where c.Parameters.Length > 0 && c.Parameters.Length < parameters.Length
-                where c.Parameters.All(p => p.RefKind == RefKind.None) && !c.Parameters.Any(p => p.IsParams)
-                let constructorTypes = c.Parameters.Select(p => p.Type)
-                let symbolTypes = parameters.Take(c.Parameters.Length).Select(p => p.Type)
-                where constructorTypes.SequenceEqual(symbolTypes)
-                select c;
-
-            return q.FirstOrDefault();
-        }
-
-        protected IMethodSymbol GetMatchingConstructor(INamedTypeSymbol containingType, ImmutableArray<IParameterSymbol> parameters)
-            => containingType.InstanceConstructors.FirstOrDefault(c => MatchesConstructor(c, parameters));
-
-        private bool MatchesConstructor(IMethodSymbol constructor, ImmutableArray<IParameterSymbol> parameters)
-            => parameters.Select(p => p.Type).SequenceEqual(constructor.Parameters.Select(p => p.Type));
-
         protected static readonly SymbolDisplayFormat SimpleFormat =
             new SymbolDisplayFormat(
                 typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,


### PR DESCRIPTION
Related bug: [28775](https://github.com/dotnet/roslyn/issues/28775)

Problem:
Add parameter to constructor will lead
```c#
class C
{
    int i;
    int k;
    int j;

    public C(int i, int j)
    {
        this.i = i;
        this.j = j;
    }
}
```
to
```c#
class C
{
    int i;
    int k;
    int j;

    public C(int i, int j, int j)
    {
        this.i = i;
        this.j = j;
        this.j = j;
    }
}
```
Reason:
The currently 'add parameter to constructor' compare parameters by their types. So it leeds to the problem the issue mentioned if `int i, int j, int k` are not in order. I fix this by comparing parameters by their names.
