### PR TITLE
Remove workaround for Navigate To running on old versions of Visual Studio

### DIFF
--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
@@ -99,28 +99,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             StartSearch(callback, searchValue, KindsProvided);
         }
 
-        private bool GetSearchCurrentDocumentOption(INavigateToCallback callback)
-        {
-            try
-            {
-                return GetSearchCurrentDocumentOptionWorker(callback);
-            }
-            catch (TypeLoadException)
-            {
-                // The version of the APIs we call in VS may not match what the 
-                // user currently has on the box (as the APIs have changed during
-                // the VS15 timeframe.  Be resilient to this happening and just
-                // default to searching all documents.
-                return false;
-            }
-        }
-
-        private bool GetSearchCurrentDocumentOptionWorker(INavigateToCallback callback)
-        {
-            var options2 = callback.Options as INavigateToOptions2;
-            return options2?.SearchCurrentDocument ?? false;
-        }
-
         public void StartSearch(INavigateToCallback callback, string searchValue, INavigateToFilterParameters filter)
         {
             StartSearch(callback, searchValue, filter.Kinds.ToImmutableHashSet(StringComparer.Ordinal));
@@ -141,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 kinds = KindsProvided;
             }
 
-            var searchCurrentDocument = GetSearchCurrentDocumentOption(callback);
+            var searchCurrentDocument = (callback.Options as INavigateToOptions2)?.SearchCurrentDocument ?? false;
             var searcher = new Searcher(
                 _workspace.CurrentSolution,
                 _asyncListener,


### PR DESCRIPTION
Our minimum required version is 15.9, so this workaround isn't necessary anymore.