### PR TITLE
Allow skipping tests and opt data in official builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -14,11 +14,13 @@ jobs:
   timeoutInMinutes: 360
 
   variables:
-    BuildPlatform: 'Any CPU'
     VisualStudio.MajorVersion: 16
     VisualStudio.BranchName: 'lab/d16.0stg'
     VisualStudio.ChannelName: 'int.d16.0stg'
     VisualStudio.DropName: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+    SignType: real
+    SkipTests: false
+    SkipApplyOptimizationData: false
 
   steps:
   - task: NuGetToolInstaller@0
@@ -42,8 +44,8 @@ jobs:
 
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
     inputs:
-      signType: real
-    condition: and(succeeded(), in(variables['PB_SignType'], 'test', 'real'))
+      signType: $(SignType)
+    condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
 
   - task: ms-vseng.MicroBuildTasks.965C8DC6-1483-45C9-B384-5AC75DA1F1A4.MicroBuildOptProfPlugin@1
     inputs:
@@ -59,12 +61,12 @@ jobs:
   - script: eng\cibuild.cmd
               -configuration $(BuildConfiguration)
               -officialBuildId $(Build.BuildNumber)
+              -officialSkipTests $(SkipTests)
+              -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
               -vsDropName $(VisualStudio.DropName) 
               -vsBranch $(VisualStudio.BranchName)
               -vsDropAccessToken $(System.AccessToken)
-              -testDesktop 
-              -procdump
-              /p:DotNetSignType=$(PB_SignType)
+              /p:DotNetSignType=$(SignType)
               /p:DotNetPublishToBlobFeed=true
               /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
               /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
@@ -148,7 +150,7 @@ jobs:
       testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
       mergeTestResults: true
       testRunTitle: 'Unit Tests'
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), not(variables['SkipTests']))
 
   # Publishes setup VSIXes to a drop.
   # Note: The insertion tool looks for the display name of this task in the logs.

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -2,6 +2,11 @@ resources:
 - repo: self
   clean: true
 
+variables:
+  SignType: real
+  SkipTests: false
+  SkipApplyOptimizationData: false
+
 jobs:
 - job: OfficialBuild
   displayName: Official Build
@@ -18,9 +23,6 @@ jobs:
     VisualStudio.BranchName: 'lab/d16.0stg'
     VisualStudio.ChannelName: 'int.d16.0stg'
     VisualStudio.DropName: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
-    SignType: real
-    SkipTests: false
-    SkipApplyOptimizationData: false
 
   steps:
   - task: NuGetToolInstaller@0
@@ -150,7 +152,7 @@ jobs:
       testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
       mergeTestResults: true
       testRunTitle: 'Unit Tests'
-    condition: and(succeededOrFailed(), not(variables['SkipTests']))
+    condition: and(succeededOrFailed(), ne(variables['SkipTests'], 'true'))
 
   # Publishes setup VSIXes to a drop.
   # Note: The insertion tool looks for the display name of this task in the logs.


### PR DESCRIPTION
Infrastructure only change.

When queuing an official build it is now possible to set the following variables in the UI:
- `SkipTests` to `true` to skip running tests,
- `SkipApplyOptimizationData` to `true` to skip merging optimization data into binaries.
   The build still triggers training release pipeline and thus produces new set of optimization data.
   This is useful when the currently available data are bad and cause the build to fail.
- `SignType` to `test` 
   Test sign artifacts instead of the default real signing.

