### PR TITLE
workaround for concurrent event causing VS to crash

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceRegistration.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceRegistration.cs
@@ -6,13 +6,14 @@ namespace Microsoft.CodeAnalysis
 {
     public sealed class WorkspaceRegistration
     {
-        private Workspace _registeredWorkspace;
+        private readonly object _gate = new object();
 
         internal WorkspaceRegistration()
         {
         }
 
-        public Workspace Workspace => _registeredWorkspace;
+        public Workspace Workspace { get; private set; }
+
         public event EventHandler WorkspaceChanged;
 
         internal void SetWorkspaceAndRaiseEvents(Workspace workspace)
@@ -23,12 +24,23 @@ namespace Microsoft.CodeAnalysis
 
         internal void SetWorkspace(Workspace workspace)
         {
-            _registeredWorkspace = workspace;
+            Workspace = workspace;
         }
 
         internal void RaiseEvents()
         {
-            WorkspaceChanged?.Invoke(this, EventArgs.Empty);
+            lock (_gate)
+            {
+                // this is a workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/744145
+                // for preview 2.
+                //
+                // it is a workaround since we are calling event handler under a lock to make sure
+                // we don't raise event concurrently
+                //
+                // we have this issue to track proper fix for preview 3 or later
+                // https://github.com/dotnet/roslyn/issues/32551
+                WorkspaceChanged?.Invoke(this, EventArgs.Empty);
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceRegistration.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceRegistration.cs
@@ -39,6 +39,13 @@ namespace Microsoft.CodeAnalysis
                 //
                 // we have this issue to track proper fix for preview 3 or later
                 // https://github.com/dotnet/roslyn/issues/32551
+                //
+                // issue we are working around is the fact this event can happen concurrently
+                // if RegisteryText happens and then UnregisterText happens in perfect timing, 
+                // RegisterText got slightly delayed since it is async event, and UnregisterText happens 
+                // at the same time since it is a synchronous event, and they my happens in 2 different threads, 
+                // cause this event to be raised concurrently.
+                // that can cause some listener to mess up its internal state like the issue linked above
                 WorkspaceChanged?.Invoke(this, EventArgs.Empty);
             }
         }


### PR DESCRIPTION
basically, if RegisteryText happens and then UnregisterText happens in perfect timing, RegisterText got slightly delayed since it is async event, and UnregisterText happens at the same time since it is a synchronous event, and they happens in 2 different threads, boom, we get NRE.

this is a workaround for 16.0.preview 2.

....

**Customer scenario**

a user is using VS, opening and closing files and navigating files in VS and boom VS crashes.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/744145

**Workarounds, if any**

no workaround

**Risk**

I believe the risk is low, but it has a theoretical deadlock possibility. but in practice, that would require a third party extension that does something really bad for it to happen

**Performance impact**

probably none

**Is this a regression from a previous update?**

No

**Root cause analysis:**

WorkspaceRegistration.WorkspaceChanged event could have raised on multiple threads concurrently causing event listeners to mess up their states. this change makes sure we never raise the event concurrently.

we have https://github.com/dotnet/roslyn/issues/32551 to fix the caller side in the post preview.

**How was the bug found?**

Watson