### PR TITLE
fix of the issue #24991

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -640,7 +640,10 @@ namespace Microsoft.CodeAnalysis
                                 if (metadataReference != null)
                                 {
                                     newReferences.Add(metadataReference);
-                                    metadataReferenceToProjectId.Add(metadataReference, projectReference.ProjectId);
+                                    if (!metadataReferenceToProjectId.ContainsKey(metadataReference))
+                                    {
+                                        metadataReferenceToProjectId.Add(metadataReference, projectReference.ProjectId);
+                                    }
                                 }
                                 else
                                 {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -640,7 +640,16 @@ namespace Microsoft.CodeAnalysis
                                 if (metadataReference != null)
                                 {
                                     newReferences.Add(metadataReference);
-                                    if (!metadataReferenceToProjectId.ContainsKey(metadataReference))
+                                    if (metadataReferenceToProjectId.TryGetValue(metadataReference, out var alreadyReferencedProjectId))
+                                    {
+                                        if (alreadyReferencedProjectId != projectReference.ProjectId)
+                                        {
+                                            var alreadyReferencedProject = solution.GetProjectState(alreadyReferencedProjectId);
+
+                                            throw new InvalidOperationException($"Unable to resolve duplicate project references in {this.ProjectState.Name} project. Same metadata reference was obtained for different referenced projects: {alreadyReferencedProject.Name} and {referencedProject.Name}");
+                                        }
+                                    }
+                                    else
                                     {
                                         metadataReferenceToProjectId.Add(metadataReference, projectReference.ProjectId);
                                     }

--- a/src/Workspaces/CoreTest/WorkspaceTests/CompilationTrackerTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/CompilationTrackerTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
+{
+    [UseExportProvider]
+    public class CompilationTrackerTests
+    {
+        [Fact]
+        public async Task CheckProjectWithDuplicateReferencesIsCompiledTest()
+        {
+            using (var workspace = new AdhocWorkspace())
+            {
+                var duplicateProjectId = ProjectId.CreateNewId();
+
+                workspace.AddProject(ProjectInfo.Create(
+                    duplicateProjectId,
+                    VersionStamp.Create(),
+                    "Duplicate",
+                    "Duplicate",
+                    LanguageNames.CSharp));
+
+                var reference = new ProjectReference(duplicateProjectId);
+                var duplicateReference = new ProjectReference(duplicateProjectId);
+
+                var projectInfo = ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                     VersionStamp.Create(),
+                    "TestProject",
+                    "TestProject",
+                    LanguageNames.CSharp,
+                    projectReferences: ImmutableArray.Create(reference, duplicateReference));
+
+                var projectWithDuplicateReferences = workspace.AddProject(projectInfo);
+
+                var compilation = await projectWithDuplicateReferences.GetCompilationAsync();
+
+                Assert.NotNull(compilation);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue #24991 fix.
Avoid duplicates being added to the reference dictionary in SolutionState.CompilationTracker.cs

I'd like to discuss if proposed solution is acceptable. 
The other option is to throw exception with the meaningful error. In this case I think the code can continue to work without trouble, so its not neccessary to throw here. I may be wrong.

Also, the class is private and I can't really add unit tests to it easily. Any suggestions here will be appreciated.

tagging @DustinCampbell here as the one who was involved in the discussion of the issue.