### PR TITLE
Finish testing for unmanaged constructed types

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -3542,8 +3542,10 @@ public unsafe struct YourStruct<T> where T : unmanaged
     public MyStruct<T>* field;
 }
 ";
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll)
-                .VerifyDiagnostics();
+            var compilation = CreateCompilation(code, options: TestOptions.UnsafeReleaseDll);
+            compilation.VerifyDiagnostics();
+            Assert.False(compilation.GetMember<NamedTypeSymbol>("MyStruct").IsManagedType);
+            Assert.False(compilation.GetMember<NamedTypeSymbol>("YourStruct").IsManagedType);
         }
 
         [Fact]
@@ -3560,8 +3562,11 @@ public unsafe struct YourStruct
     public MyStruct* field;
 }
 ";
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll)
-                .VerifyDiagnostics();
+            var compilation = CreateCompilation(code, options: TestOptions.UnsafeReleaseDll);
+            compilation.VerifyDiagnostics();
+            Assert.False(compilation.GetMember<NamedTypeSymbol>("MyStruct").IsManagedType);
+            Assert.False(compilation.GetMember<NamedTypeSymbol>("YourStruct").IsManagedType);
+
         }
 
         [Fact]
@@ -3578,11 +3583,14 @@ public struct YourStruct<T> where T : unmanaged
     public T field;
 }
 ";
-            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll)
-                .VerifyDiagnostics(
+            var compilation = CreateCompilation(code, options: TestOptions.UnsafeReleaseDll);
+            compilation.VerifyDiagnostics(
                     // (4,46): error CS0523: Struct member 'MyStruct<T>.field' of type 'YourStruct<MyStruct<MyStruct<T>>>' causes a cycle in the struct layout
                     //     public YourStruct<MyStruct<MyStruct<T>>> field;
                     Diagnostic(ErrorCode.ERR_StructLayoutCycle, "field").WithArguments("MyStruct<T>.field", "YourStruct<MyStruct<MyStruct<T>>>").WithLocation(4, 46));
+
+            Assert.False(compilation.GetMember<NamedTypeSymbol>("MyStruct").IsManagedType);
+            Assert.False(compilation.GetMember<NamedTypeSymbol>("YourStruct").IsManagedType);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -3800,6 +3800,8 @@ public struct MyStruct<T>
                     //         var ptr = &ms;
                     Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "&ms").WithArguments("unmanaged constructed types", "8.0").WithLocation(9, 19)
                 );
+
+            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact]
@@ -3831,6 +3833,8 @@ public class MyClass
                     //         fixed (MyStruct<int>* ptr = &c.ms)
                     Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "&c.ms").WithArguments("unmanaged constructed types", "8.0").WithLocation(12, 37)
                 );
+
+            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact]
@@ -3853,6 +3857,8 @@ public struct MyStruct<T>
                     //         var size = sizeof(MyStruct<int>);
                     Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "sizeof(MyStruct<int>)").WithArguments("unmanaged constructed types", "8.0").WithLocation(8, 20)
                 );
+
+            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact]
@@ -3875,6 +3881,8 @@ public struct MyStruct<T>
                     //         var arr = stackalloc[] { new MyStruct<int>() };
                     Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "stackalloc[] { new MyStruct<int>() }").WithArguments("unmanaged constructed types", "8.0").WithLocation(8, 19)
                 );
+
+            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact]
@@ -3897,6 +3905,8 @@ public struct MyStruct<T>
                     //         var arr = stackalloc MyStruct<int>[4];
                     Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "MyStruct<int>").WithArguments("unmanaged constructed types", "8.0").WithLocation(8, 30)
                 );
+
+            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact]
@@ -3919,6 +3929,8 @@ public unsafe struct OtherStruct
                     //     public MyStruct<int>* ms;
                     Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "MyStruct<int>*").WithArguments("unmanaged constructed types", "8.0").WithLocation(9, 12)
                 );
+
+            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact, WorkItem(32103, "https://github.com/dotnet/roslyn/issues/32103")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -3905,7 +3905,7 @@ public unsafe struct OtherStruct
                 );
         }
 
-        [Fact]
+        [Fact, WorkItem(32103, "https://github.com/dotnet/roslyn/issues/32103")]
         public void StructContainingTuple_Unmanaged_RequiresCSharp8()
         {
             var code = @"
@@ -3934,11 +3934,11 @@ public class C
                     //         M<(int, int)>();
                     Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "M<(int, int)>").WithArguments("unmanaged constructed types", "8.0").WithLocation(14, 9)
                 );
-            
+
             CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
-        [Fact]
+        [Fact, WorkItem(32103, "https://github.com/dotnet/roslyn/issues/32103")]
         public void StructContainingGenericTuple_Unmanaged()
         {
             var code = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -3981,7 +3981,7 @@ public class C
         }
 
         [Fact]
-        public void GenericRefStructAddressOf()
+        public void GenericRefStructAddressOf_01()
         {
             var code = @"
 public ref struct MyStruct<T>
@@ -4004,6 +4004,32 @@ public class MyClass
                 options: TestOptions.UnsafeReleaseExe,
                 verify: Verification.Skipped,
                 expectedOutput: "42");
+        }
+
+        [Fact]
+        public void GenericRefStructAddressOf_02()
+        {
+            var code = @"
+public ref struct MyStruct<T>
+{
+    public T field;
+}
+
+public class MyClass
+{
+    public unsafe void M()
+    {
+        var ms = new MyStruct<object>();
+        var ptr = &ms;
+    }
+}
+";
+
+            CreateCompilation(code, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+                // (12,19): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('MyStruct<object>')
+                //         var ptr = &ms;
+                Diagnostic(ErrorCode.ERR_ManagedAddr, "&ms").WithArguments("MyStruct<object>").WithLocation(12, 19)
+            );
         }
 
         [Fact]


### PR DESCRIPTION
Related to #31374 

- Test for struct private field in metadata
- Test ref structs
  - We decided it's legal to allow taking a pointer here
- Test fixed size buffers
  - Mostly just ensuring that a fixed size buffer of generic structs is not allowed
- Add IsManagedType checks in tests related to circular structs
  - Should these change to IsUnmanagedType checks? It didn't look like this API was available on NamedTypeSymbol in the context of the test. Perhaps I was doing something wrong?

Will make another pass tomorrow to make sure I covered as much as possible before opening up for team review.