### PR TITLE
Enable skipped tests that previously failed on AssertIsForeground

### DIFF
--- a/src/EditorFeatures/Test/LinkedFiles/LinkedFileDiffMergingEditorTests.cs
+++ b/src/EditorFeatures/Test/LinkedFiles/LinkedFileDiffMergingEditorTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.LinkedFiles
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
             => new TestCodeRefactoringProvider();
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20370")]
+        [WpfFact()]
         public async Task TestCodeActionPreviewAndApply()
         {
             using (var workspace = TestWorkspace.Create(WorkspaceXml))

--- a/src/EditorFeatures/Test/LinkedFiles/LinkedFileDiffMergingEditorTests.cs
+++ b/src/EditorFeatures/Test/LinkedFiles/LinkedFileDiffMergingEditorTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.LinkedFiles
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
             => new TestCodeRefactoringProvider();
 
-        [WpfFact()]
+        [WpfFact]
         public async Task TestCodeActionPreviewAndApply()
         {
             using (var workspace = TestWorkspace.Create(WorkspaceXml))

--- a/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
             End Using
         End Sub
 
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/24850")>
+        <WpfFact>
         <Trait(Traits.Feature, Traits.Features.Interactive)>
         Public Sub PasteCommandWithOutInteractiveFormat()
             Using workspace = TestWorkspace.Create(


### PR DESCRIPTION
Of the three stack traces included or linked to from #20953 two were being skipped and one had never been marked as skipped.
PeekTests.TestPeekAcrossProjectsInvolvingPortableReferences - Not Skipped
LinkedFileDiffMergingEditorTests.TestCodeActionPreviewAndApply - Skipped
InteractivePasteCommandhandlerTests.PasteCommandWithOutInteractiveFormat - Skipped

I was unable to find any hits on the failures. I recommend removing the skip and seeing if we can collect more data from these tests.

Closes #20953