### PR TITLE
disable completion for immediate window commands

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/AsyncCompletionService.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/AsyncCompletionService.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
     internal class AsyncCompletionService : ForegroundThreadAffinitizedObject, IAsyncCompletionService
     {
         private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
-        private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService;
         private readonly IFeatureServiceFactory _featureServiceFactory;
         private readonly ITextUndoHistoryRegistry _undoHistoryRegistry;
         private readonly IInlineRenameService _inlineRenameService;
@@ -48,7 +47,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         public AsyncCompletionService(
             IThreadingContext threadingContext,
             IEditorOperationsFactoryService editorOperationsFactoryService,
-            IVsEditorAdaptersFactoryService editorAdaptersFactoryService,
             IFeatureServiceFactory featureServiceFactory,
             ITextUndoHistoryRegistry undoHistoryRegistry,
             IInlineRenameService inlineRenameService,
@@ -58,7 +56,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             : base(threadingContext)
         {
             _editorOperationsFactoryService = editorOperationsFactoryService;
-            _editorAdaptersFactoryService = editorAdaptersFactoryService;
             _featureServiceFactory = featureServiceFactory;
             _undoHistoryRegistry = undoHistoryRegistry;
             _inlineRenameService = inlineRenameService;
@@ -79,9 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 return false;
             }
 
-            var vsTextView = _editorAdaptersFactoryService.GetViewAdapter(textView);
-            var wpfTextView = _editorAdaptersFactoryService.GetWpfTextView(vsTextView);
-            if (!_featureServiceFactory.GetOrCreate(wpfTextView).IsEnabled(PredefinedEditorFeatureNames.Completion))
+            if (!_featureServiceFactory.GetOrCreate(textView).IsEnabled(PredefinedEditorFeatureNames.Completion))
             {
                 controller = null;
                 return false;

--- a/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
@@ -28,6 +28,7 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioImagingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />

--- a/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
@@ -28,7 +28,6 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioImagingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -178,7 +178,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             // Put it into a new workspace, and open it and its related documents
             // with the projection buffer as the text.
             _workspace = new DebuggerIntelliSenseWorkspace(forkedSolution);
-            OpenDocumentAndLinkedDocuments(document);
+            _workspace.OpenDocument(document.Id, _projectionBuffer.AsTextContainer());
+            foreach (var link in document.GetLinkedDocumentIds())
+            {
+                _workspace.OpenDocument(link, _projectionBuffer.AsTextContainer());
+            }
 
             // Start getting the compilation so the PartialSolution will be ready when the user starts typing in the window
             document.Project.GetCompilationAsync(System.Threading.CancellationToken.None);
@@ -189,15 +193,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
 
             _debuggerTextView = new DebuggerTextView(_textView, bufferGraph, _debuggerTextLines, InImmediateWindow);
             return true;
-        }
-
-        internal void OpenDocumentAndLinkedDocuments(Document document)
-        {
-            _workspace.OpenDocument(document.Id, _projectionBuffer.AsTextContainer());
-            foreach (var link in document.GetLinkedDocumentIds())
-            {
-                _workspace.OpenDocument(link, _projectionBuffer.AsTextContainer());
-            }
         }
 
         internal void SetContentType(bool install)

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
 
         protected bool InImmediateWindow { get { return _immediateWindowContext != null; } }
 
-        protected ITextBuffer ContextBuffer { get; private set; }
+        internal ITextBuffer ContextBuffer { get; private set; }
 
         public abstract bool CompletionStartsOnQuestionMark { get; }
 
@@ -185,11 +185,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             // Put it into a new workspace, and open it and its related documents
             // with the projection buffer as the text.
             _workspace = new DebuggerIntelliSenseWorkspace(forkedSolution);
-            _workspace.OpenDocument(document.Id, _projectionBuffer.AsTextContainer());
-            foreach (var link in document.GetLinkedDocumentIds())
-            {
-                _workspace.OpenDocument(link, _projectionBuffer.AsTextContainer());
-            }
+            OpenDocumentAndLinkedDocuments(document);
 
             // Start getting the compilation so the PartialSolution will be ready when the user starts typing in the window
             document.Project.GetCompilationAsync(System.Threading.CancellationToken.None);
@@ -200,6 +196,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
 
             _debuggerTextView = new DebuggerTextView(_textView, bufferGraph, _debuggerTextLines, InImmediateWindow);
             return true;
+        }
+
+        internal void OpenDocumentAndLinkedDocuments(Document document)
+        {
+            _workspace.OpenDocument(document.Id, _projectionBuffer.AsTextContainer());
+            foreach (var link in document.GetLinkedDocumentIds())
+            {
+                _workspace.OpenDocument(link, _projectionBuffer.AsTextContainer());
+            }
         }
 
         internal void SetContentType(bool install)

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -1,23 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
-using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
-using TextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense
 {
@@ -27,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
         private readonly IContentType _contentType;
         private readonly IContentType _originalContentType;
         protected readonly IProjectionBufferFactoryService ProjectionBufferFactoryService;
-        protected readonly Microsoft.VisualStudio.TextManager.Interop.TextSpan CurrentStatementSpan;
+        protected readonly TextManager.Interop.TextSpan CurrentStatementSpan;
         private readonly IVsTextLines _debuggerTextLines;
         private IProjectionBuffer _projectionBuffer;
         private DebuggerTextView _debuggerTextView;
@@ -49,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             IVsTextView vsTextView,
             IVsTextLines vsDebuggerTextLines,
             ITextBuffer contextBuffer,
-            Microsoft.VisualStudio.TextManager.Interop.TextSpan[] currentStatementSpan,
+            TextManager.Interop.TextSpan[] currentStatementSpan,
             IComponentModel componentModel,
             IServiceProvider serviceProvider,
             IContentType contentType)

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
@@ -24,12 +24,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
     {
         private readonly ICommandHandlerServiceFactory _commandFactory;
         private readonly IFeatureServiceFactory _featureServiceFactory;
+        private readonly object _completionDisabledTokenLock = new object();
         private AbstractDebuggerIntelliSenseContext _context;
         private IOleCommandTarget _originalNextCommandFilter;
         private IFeatureDisableToken _completionDisabledToken;
-        private object _completionDisabledTokenLock = new object();
-
-        internal bool Enabled { get; set; }
 
         public DebuggerIntelliSenseFilter(
             AbstractLanguageService<TPackage, TLanguageService> languageService,
@@ -64,8 +62,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
                 {
                     return;
                 }
-
-                _context.OpenDocumentAndLinkedDocuments(document);
             }
         }
 
@@ -127,7 +123,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
         // instead of trying to have our command handlers to work.
         public override int Exec(ref Guid pguidCmdGroup, uint commandId, uint executeInformation, IntPtr pvaIn, IntPtr pvaOut)
         {
-            if (_context == null || !Enabled)
+            if (_context == null)
             {
                 return NextCommandTarget.Exec(pguidCmdGroup, commandId, executeInformation, pvaIn, pvaOut);
             }

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
@@ -42,20 +42,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
 
         internal void EnableCompletion()
         {
-            var featureService = _featureServiceFactory.GetOrCreate(WpfTextView);
-            if (!featureService.IsEnabled(PredefinedEditorFeatureNames.Completion))
+            if (_completionDisabledToken == null)
             {
-                if (_completionDisabledToken == null)
-                {
-                    return;
-                }
-
-                _completionDisabledToken.Dispose();
-                _completionDisabledToken = null;
-
-                // open the document
-                _context.ContextBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+                return;
             }
+
+            _completionDisabledToken.Dispose();
+            _completionDisabledToken = null;
         }
 
         internal void DisableCompletion()

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
@@ -54,7 +54,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
         internal void DisableCompletion()
         {
             var featureService = _featureServiceFactory.GetOrCreate(WpfTextView);
-            _completionDisabledToken = featureService.Disable(PredefinedEditorFeatureNames.Completion, this);
+            if (_completionDisabledToken == null)
+            {
+                _completionDisabledToken = featureService.Disable(PredefinedEditorFeatureNames.Completion, this);
+            }
         }
 
         internal void SetNextFilter(IOleCommandTarget nextFilter)

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
@@ -54,10 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
         internal void DisableCompletion()
         {
             var featureService = _featureServiceFactory.GetOrCreate(WpfTextView);
-            if (featureService.IsEnabled(PredefinedEditorFeatureNames.Completion) && _completionDisabledToken == null)
-            {
-                _completionDisabledToken = featureService.Disable(PredefinedEditorFeatureNames.Completion, this);
-            }
+            _completionDisabledToken = featureService.Disable(PredefinedEditorFeatureNames.Completion, this);
         }
 
         internal void SetNextFilter(IOleCommandTarget nextFilter)

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
@@ -8,11 +8,10 @@ using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense;
-using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
-using Roslyn.Utilities;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 {
@@ -26,8 +25,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             if (filters.TryGetValue(textView, out var filter))
             {
                 filter.Enabled = enable != 0;
+
+                if (enable != 0)
+                {
+                    filter.EnableCompletion();
+                }
+                else
+                {
+                    filter.DisableCompletion();
+                }
             }
 
+            // Debugger wants Roslyn to return OK in all cases, 
+            // for example, even if Rolsyn tried to enable the one already enabled.
             return VSConstants.S_OK;
         }
 
@@ -45,7 +55,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                     filter = new DebuggerIntelliSenseFilter<TPackage, TLanguageService>(this,
                         this.EditorAdaptersFactoryService.GetWpfTextView(textView),
                         this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>(),
-                        this.Package.ComponentModel.GetService<ICommandHandlerServiceFactory>());
+                        this.Package.ComponentModel.GetService<ICommandHandlerServiceFactory>(),
+                        this.Package.ComponentModel.GetService<IFeatureServiceFactory>());
                     this.filters[textView] = filter;
                     Marshal.ThrowExceptionForHR(textView.AddCommandFilter(filter, out var nextFilter));
                     filter.SetNextFilter(nextFilter);
@@ -66,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
         int IVsImmediateStatementCompletion2.SetCompletionContext(string filePath,
             IVsTextLines buffer,
-            Microsoft.VisualStudio.TextManager.Interop.TextSpan[] currentStatementSpan,
+            TextSpan[] currentStatementSpan,
             object punkContext,
             IVsTextView textView)
         {

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
@@ -24,8 +24,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         {
             if (filters.TryGetValue(textView, out var filter))
             {
+                // Disables/enables the old Roslyn completion.
                 filter.Enabled = enable != 0;
 
+                // Disables/enables the new Editor completion.
                 if (enable != 0)
                 {
                     filter.EnableCompletion();

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
@@ -24,10 +24,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         {
             if (filters.TryGetValue(textView, out var filter))
             {
-                // Disables/enables the old Roslyn completion.
-                filter.Enabled = enable != 0;
-
-                // Disables/enables the new Editor completion.
                 if (enable != 0)
                 {
                     filter.EnableCompletion();


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/32724

There is a legacy command completion (not Roslyn old completion) in the Immediate window appearing after one types `>`  there. Code owners of the immediate window said they cannot remove the legacy completion for the case. They want Roslyn to disable/enable regular (both old Roslyn and new Editor) completions when called `EnableStatementCompletion`.