### PR TITLE
Dispose pattern based enumerators in foreach:

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2383,6 +2383,11 @@ moreArguments:
                     // just say it does not escape anywhere, so that we do not get false errors.
                     return scopeOfTheContainingExpression;
 
+                case BoundKind.DisposableValuePlaceholder:
+                    // Disposable value placeholder is only ever used to lookup a pattern dispose method
+                    // then immediately discarded. The actual expression will be generated during lowering 
+                    return scopeOfTheContainingExpression;
+
                 case BoundKind.PointerElementAccess:
                 case BoundKind.PointerIndirectionOperator:
                     // Unsafe code will always be allowed to escape.

--- a/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public AwaitableInfo DisposeAwaitableInfo;
 
         // When using pattern-based Dispose, this stores the method to invoke to Dispose
-        public MethodSymbol DisposeMethod;
+        public readonly MethodSymbol DisposeMethod;
 
         // Conversions that will be required when the foreach is lowered.
         public readonly Conversion CollectionConversion; //collection expression to collection type

--- a/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             public MethodSymbol CurrentPropertyGetter;
             public MethodSymbol MoveNextMethod;
 
-            public bool NeedsDisposeMethod;
+            public bool NeedsDisposal;
             public AwaitableInfo DisposeAwaitableInfo;
             public MethodSymbol DisposeMethod;
 
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     GetEnumeratorMethod,
                     CurrentPropertyGetter,
                     MoveNextMethod,
-                    NeedsDisposeMethod,
+                    NeedsDisposal,
                     DisposeAwaitableInfo,
                     DisposeMethod,
                     CollectionConversion,

--- a/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
@@ -21,14 +21,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         public readonly MethodSymbol CurrentPropertyGetter;
         public readonly MethodSymbol MoveNextMethod;
 
-        // Dispose method to be called on the enumerator (may be null).
+        // True if the enumerator needs disposal once used. 
+        // Will be either IDisposable/IAsyncDisposable, or use DisposeMethod below if set
         // Computed during initial binding so that we can expose it in the semantic model.
-        public readonly bool NeedsDisposeMethod;
+        public readonly bool NeedsDisposal;
 
         // When async and needs disposal, this stores the information to await the DisposeAsync() invocation
         public AwaitableInfo DisposeAwaitableInfo;
 
-        // When using pattern based Dispose, this stores the method to invoke to Dispose
+        // When using pattern-based Dispose, this stores the method to invoke to Dispose
         public MethodSymbol DisposeMethod;
 
         // Conversions that will be required when the foreach is lowered.
@@ -67,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.GetEnumeratorMethod = getEnumeratorMethod;
             this.CurrentPropertyGetter = currentPropertyGetter;
             this.MoveNextMethod = moveNextMethod;
-            this.NeedsDisposeMethod = needsDisposeMethod;
+            this.NeedsDisposal = needsDisposeMethod;
             this.DisposeAwaitableInfo = disposeAwaitableInfo;
             this.DisposeMethod = disposeMethod;
             this.CollectionConversion = collectionConversion;

--- a/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
@@ -28,6 +28,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         // When async and needs disposal, this stores the information to await the DisposeAsync() invocation
         public AwaitableInfo DisposeAwaitableInfo;
 
+        // When using pattern based Dispose, this stores the method to invoke to Dispose
+        public MethodSymbol DisposeMethod;
+
         // Conversions that will be required when the foreach is lowered.
         public readonly Conversion CollectionConversion; //collection expression to collection type
         public readonly Conversion CurrentConversion; // current to element type
@@ -47,6 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol moveNextMethod,
             bool needsDisposeMethod,
             AwaitableInfo disposeAwaitableInfo,
+            MethodSymbol disposeMethod,
             Conversion collectionConversion,
             Conversion currentConversion,
             Conversion enumeratorConversion,
@@ -65,6 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.MoveNextMethod = moveNextMethod;
             this.NeedsDisposeMethod = needsDisposeMethod;
             this.DisposeAwaitableInfo = disposeAwaitableInfo;
+            this.DisposeMethod = disposeMethod;
             this.CollectionConversion = collectionConversion;
             this.CurrentConversion = currentConversion;
             this.EnumeratorConversion = enumeratorConversion;
@@ -83,6 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public bool NeedsDisposeMethod;
             public AwaitableInfo DisposeAwaitableInfo;
+            public MethodSymbol DisposeMethod;
 
             public Conversion CollectionConversion;
             public Conversion CurrentConversion;
@@ -105,6 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     MoveNextMethod,
                     NeedsDisposeMethod,
                     DisposeAwaitableInfo,
+                    DisposeMethod,
                     CollectionConversion,
                     CurrentConversion,
                     EnumeratorConversion,

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -479,7 +479,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ConstantValue.NotAvailable,
                 builder.CollectionType);
 
-            if (builder.NeedsDisposeMethod && IsAsync)
+            if (builder.NeedsDisposal && IsAsync)
             {
                 hasErrors |= GetAwaitDisposeAsyncInfo(ref builder, diagnostics);
             }
@@ -808,7 +808,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // We don't know the runtime type, so we will have to insert a runtime check for IDisposable (with a conditional call to IDisposable.Dispose).
-                builder.NeedsDisposeMethod = true;
+                builder.NeedsDisposal = true;
                 return EnumeratorResult.Succeeded;
             }
 
@@ -841,7 +841,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     isAsync ? this.Compilation.GetWellKnownType(WellKnownType.System_IAsyncDisposable) : this.Compilation.GetSpecialType(SpecialType.System_IDisposable),
                     ref useSiteDiagnostics).IsImplicit)
             {
-                builder.NeedsDisposeMethod = true;
+                builder.NeedsDisposal = true;
             }
             else if (enumeratorType.IsRefLikeType)
             {
@@ -852,7 +852,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MethodSymbol disposeMethod = TryFindDisposePatternMethod(receiver, _syntax, isAsync, patternDisposeDiags);
                 if (!(disposeMethod is null))
                 {
-                    builder.NeedsDisposeMethod = true;
+                    builder.NeedsDisposal = true;
                     builder.DisposeMethod = disposeMethod;
                 }
                 patternDisposeDiags.Free();
@@ -910,7 +910,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TypeSymbol.Equals(builder.GetEnumeratorMethod.ReturnType.TypeSymbol, this.Compilation.GetSpecialType(SpecialType.System_Collections_IEnumerator), TypeCompareKind.ConsiderEverything2));
 
             // We don't know the runtime type, so we will have to insert a runtime check for IDisposable (with a conditional call to IDisposable.Dispose).
-            builder.NeedsDisposeMethod = true;
+            builder.NeedsDisposal = true;
             return builder;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -712,26 +712,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     builder.ElementType = ((PropertySymbol)builder.CurrentPropertyGetter.AssociatedSymbol).Type;
 
-                    // NOTE: if IDisposable is not available at all, no diagnostics will be reported - we will just assume that
-                    // the enumerator is not disposable.  If it has IDisposable in its interface list, there will be a diagnostic there.
-                    // If IDisposable is available but its Dispose method is not, then diagnostics will be reported only if the enumerator
-                    // is potentially disposable.
+                    GetDisposalInfoForEnumerator(ref builder, collectionExpr, isAsync, diagnostics);
 
-                    var useSiteDiagnosticBag = DiagnosticBag.GetInstance();
-                    TypeSymbol enumeratorType = builder.GetEnumeratorMethod.ReturnType.TypeSymbol;
-                    HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-
-                    if (!enumeratorType.IsSealed ||
-                        this.Conversions.ClassifyImplicitConversionFromType(enumeratorType,
-                            isAsync ? this.Compilation.GetWellKnownType(WellKnownType.System_IAsyncDisposable) : this.Compilation.GetSpecialType(SpecialType.System_IDisposable),
-                            ref useSiteDiagnostics).IsImplicit)
-                    {
-                        builder.NeedsDisposeMethod = true;
-                        diagnostics.AddRange(useSiteDiagnosticBag);
-                    }
-                    useSiteDiagnosticBag.Free();
-
-                    diagnostics.Add(_syntax, useSiteDiagnostics);
                     return EnumeratorResult.Succeeded;
                 }
 
@@ -842,6 +824,41 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return EnumeratorResult.FailedNotReported;
+        }
+
+        private void GetDisposalInfoForEnumerator(ref ForEachEnumeratorInfo.Builder builder, BoundExpression expr, bool isAsync, DiagnosticBag diagnostics)
+        {
+            // NOTE: if IDisposable is not available at all, no diagnostics will be reported - we will just assume that
+            // the enumerator is not disposable.  If it has IDisposable in its interface list, there will be a diagnostic there.
+            // If IDisposable is available but its Dispose method is not, then diagnostics will be reported only if the enumerator
+            // is potentially disposable.
+
+            TypeSymbol enumeratorType = builder.GetEnumeratorMethod.ReturnType.TypeSymbol;
+            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+
+            if (!enumeratorType.IsSealed ||
+                this.Conversions.ClassifyImplicitConversionFromType(enumeratorType,
+                    isAsync ? this.Compilation.GetWellKnownType(WellKnownType.System_IAsyncDisposable) : this.Compilation.GetSpecialType(SpecialType.System_IDisposable),
+                    ref useSiteDiagnostics).IsImplicit)
+            {
+                builder.NeedsDisposeMethod = true;
+            }
+            else if (enumeratorType.IsValueType && enumeratorType.IsRefLikeType)
+            {
+                // if it wasn't directly convertable to IDisposable, see if it is pattern disposable
+                // again, we throw away any binding diagnostics, and assume it's not disposable if we encounter errors
+                DiagnosticBag patternDisposeDiags = new DiagnosticBag();
+                BoundDisposableValuePlaceholder receiver = new BoundDisposableValuePlaceholder(_syntax, enumeratorType);
+                var disposeMethod = TryFindDisposePatternMethod(receiver, _syntax, isAsync, patternDisposeDiags);
+                if (!(disposeMethod is null))
+                {
+                    builder.NeedsDisposeMethod = true;
+                    builder.DisposeMethod = disposeMethod;
+                }
+                patternDisposeDiags.Free();
+            }
+
+            diagnostics.Add(_syntax, useSiteDiagnostics);
         }
 
         private MethodSymbol GetGetEnumeratorMethod(NamedTypeSymbol collectionType, DiagnosticBag diagnostics, bool isAsync, CSharpSyntaxNode errorLocationSyntax)

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -847,9 +847,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // if it wasn't directly convertable to IDisposable, see if it is pattern disposable
                 // again, we throw away any binding diagnostics, and assume it's not disposable if we encounter errors
-                DiagnosticBag patternDisposeDiags = new DiagnosticBag();
-                BoundDisposableValuePlaceholder receiver = new BoundDisposableValuePlaceholder(_syntax, enumeratorType);
-                var disposeMethod = TryFindDisposePatternMethod(receiver, _syntax, isAsync, patternDisposeDiags);
+                var patternDisposeDiags = new DiagnosticBag();
+                var receiver = new BoundDisposableValuePlaceholder(_syntax, enumeratorType);
+                MethodSymbol disposeMethod = TryFindDisposePatternMethod(receiver, _syntax, isAsync, patternDisposeDiags);
                 if (!(disposeMethod is null))
                 {
                     builder.NeedsDisposeMethod = true;

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -843,7 +843,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 builder.NeedsDisposeMethod = true;
             }
-            else if (enumeratorType.IsValueType && enumeratorType.IsRefLikeType)
+            else if (enumeratorType.IsRefLikeType)
             {
                 // if it wasn't directly convertable to IDisposable, see if it is pattern disposable
                 // again, we throw away any binding diagnostics, and assume it's not disposable if we encounter errors

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -105,7 +105,7 @@
   </Node>
 
   <!--
-  This node is used to represent an expression of a certain type, when attempting to bind it's pattern dispose method
+  This node is used to represent an expression of a certain type, when attempting to bind its pattern dispose method
   It does not survive past initial binding.
   -->
   <Node Name="BoundDisposableValuePlaceholder" Base="BoundValuePlaceholderBase">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -104,6 +104,13 @@
   <Node Name="BoundAwaitableValuePlaceholder" Base="BoundValuePlaceholderBase">
   </Node>
 
+  <!--
+  This node is used to represent an expression of a certain type, when attempting to bind it's pattern dispose method
+  It does not survive past initial binding.
+  -->
+  <Node Name="BoundDisposableValuePlaceholder" Base="BoundValuePlaceholderBase">
+  </Node>
+
   <!-- only used by codegen -->
   <Node Name="BoundDup" Base="BoundExpression">
     <!-- when duplicating a local or parameter, must remember original ref kind -->

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -862,11 +862,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             // NOTE: we're going to list GetEnumerator, etc for array and string
             // collections, even though we know that's not how the implementation
             // actually enumerates them.
-            MethodSymbol disposeMethod = enumeratorInfoOpt.NeedsDisposeMethod
-                ? enumeratorInfoOpt.IsAsync
+            MethodSymbol disposeMethod = null;
+            if (enumeratorInfoOpt.NeedsDisposal)
+            {
+                if (!(enumeratorInfoOpt.DisposeMethod is null))
+                {
+                    disposeMethod = enumeratorInfoOpt.DisposeMethod;
+                }
+                else
+                {
+                    disposeMethod = enumeratorInfoOpt.IsAsync
                     ? (MethodSymbol)Compilation.GetWellKnownTypeMember(WellKnownMember.System_IAsyncDisposable__DisposeAsync)
-                    : (MethodSymbol)Compilation.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose)
-                : null;
+                    : (MethodSymbol)Compilation.GetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose);
+                }
+            }
 
             return new ForEachStatementInfo(
                 enumeratorInfoOpt.GetEnumeratorMethod,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -927,6 +927,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
+            public override BoundNode VisitDisposableValuePlaceholder(BoundDisposableValuePlaceholder node)
+            {
+                Fail(node);
+                return null;
+            }
+
             private void Fail(BoundNode node)
             {
                 Debug.Assert(false, $"Bound nodes of kind {node.Kind} should not survive past local rewriting");

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundStatement result;
             MethodSymbol disposeMethod = enumeratorInfo.DisposeMethod;
 
-            if (enumeratorInfo.NeedsDisposeMethod && (!(disposeMethod is null) || TryGetDisposeMethod(forEachSyntax, enumeratorInfo, out disposeMethod)))
+            if (enumeratorInfo.NeedsDisposal && (!(disposeMethod is null) || TryGetDisposeMethod(forEachSyntax, enumeratorInfo, out disposeMethod)))
             {
                 BoundStatement tryFinally = WrapWithTryFinallyDispose(forEachSyntax, enumeratorInfo, enumeratorType, boundEnumeratorVar, whileLoop, disposeMethod);
 
@@ -242,19 +242,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
             var isImplicit = conversions.ClassifyImplicitConversionFromType(enumeratorType, idisposableTypeSymbol, ref useSiteDiagnostics).IsImplicit;
             _diagnostics.Add(forEachSyntax, useSiteDiagnostics);
+            var isExtension = disposeMethod?.IsExtensionMethod == true;
 
-            if (isImplicit)
+            if (isImplicit || isExtension)
             {
-                Debug.Assert(enumeratorInfo.NeedsDisposeMethod);
+                Debug.Assert(enumeratorInfo.NeedsDisposal);
 
                 Conversion receiverConversion = enumeratorType.IsStructType() ?
                     Conversion.Boxing :
                     Conversion.ImplicitReference;
 
+                BoundExpression receiver = isExtension ?
+                    boundEnumeratorVar :
+                    ConvertReceiverForInvocation(forEachSyntax, boundEnumeratorVar, disposeMethod, receiverConversion, idisposableTypeSymbol);
+
                 // ((IDisposable)e).Dispose() or e.Dispose() or await ((IAsyncDisposable)e).DisposeAsync() or await e.DisposeAsync()
                 BoundExpression disposeCall = MakeCallWithNoExplicitArgument(
                     forEachSyntax,
-                    ConvertReceiverForInvocation(forEachSyntax, boundEnumeratorVar, disposeMethod, receiverConversion, idisposableTypeSymbol),
+                    receiver,
                     disposeMethod);
 
                 BoundStatement disposeCallStatement;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Conversion.Boxing :
                     Conversion.ImplicitReference;
 
-                BoundExpression receiver = isExtension ?
+                BoundExpression receiver = isExtension || idisposableTypeSymbol.IsRefLikeType ?
                     boundEnumeratorVar :
                     ConvertReceiverForInvocation(forEachSyntax, boundEnumeratorVar, disposeMethod, receiverConversion, idisposableTypeSymbol);
 

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1504,8 +1504,8 @@ namespace Microsoft.CodeAnalysis.Operations
                                                     enumeratorInfoOpt.GetEnumeratorMethod,
                                                     (PropertySymbol)enumeratorInfoOpt.CurrentPropertyGetter.AssociatedSymbol,
                                                     enumeratorInfoOpt.MoveNextMethod,
-                                                    enumeratorInfoOpt.NeedsDisposeMethod,
-                                                    knownToImplementIDisposable: enumeratorInfoOpt.NeedsDisposeMethod && (object)enumeratorInfoOpt.GetEnumeratorMethod != null ?
+                                                    enumeratorInfoOpt.NeedsDisposal,
+                                                    knownToImplementIDisposable: enumeratorInfoOpt.NeedsDisposal && (object)enumeratorInfoOpt.GetEnumeratorMethod != null ?
                                                                                      compilation.Conversions.
                                                                                          ClassifyImplicitConversionFromType(enumeratorInfoOpt.GetEnumeratorMethod.ReturnType.TypeSymbol,
                                                                                                                             compilation.GetSpecialType(SpecialType.System_IDisposable),

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -1592,7 +1592,7 @@ class C
             var memberModel = model.GetMemberModel(foreachSyntax);
             BoundForEachStatement boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.False(internalInfo.NeedsDisposeMethod);
+            Assert.False(internalInfo.NeedsDisposal);
         }
 
         [Fact]
@@ -2046,7 +2046,7 @@ class C
             var memberModel = model.GetMemberModel(foreachSyntax);
             var boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposeMethod);
+            Assert.True(internalInfo.NeedsDisposal);
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly))]
@@ -2365,7 +2365,7 @@ public class C
             var memberModel = model.GetMemberModel(foreachSyntax);
             BoundForEachStatement boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposeMethod);
+            Assert.True(internalInfo.NeedsDisposal);
 
             CompileAndVerify(comp,
                 expectedOutput: "NextAsync(0) Current(1) Got(1) NextAsync(1) Current(2) Got(2) NextAsync(2) Current(3) Got(3) NextAsync(3)");
@@ -2428,7 +2428,7 @@ public class C
             var memberModel = model.GetMemberModel(foreachSyntax);
             BoundForEachStatement boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposeMethod);
+            Assert.True(internalInfo.NeedsDisposal);
 
             var verifier = CompileAndVerify(comp,
                 expectedOutput: "NextAsync(0) Current(1) Got(1) NextAsync(1) Current(2) Got(2) NextAsync(2) Current(3) Got(3) NextAsync(3) Dispose(4)");
@@ -2725,7 +2725,7 @@ class C
             var memberModel = model.GetMemberModel(foreachSyntax);
             BoundForEachStatement boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposeMethod);
+            Assert.True(internalInfo.NeedsDisposal);
 
             CompileAndVerify(comp, expectedOutput: "NextAsync(0) Current(1) Got(1) NextAsync(1) Current(2) Got(2) NextAsync(2) Current(3) Got(3) NextAsync(3) Dispose(4)");
         }
@@ -2773,7 +2773,7 @@ class Client
             var memberModel = model.GetMemberModel(foreachSyntax);
             BoundForEachStatement boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.False(internalInfo.NeedsDisposeMethod);
+            Assert.False(internalInfo.NeedsDisposal);
         }
 
         [Fact]
@@ -2906,7 +2906,7 @@ class C : IAsyncEnumerable<int>
             var memberModel = model.GetMemberModel(foreachSyntax);
             var boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposeMethod);
+            Assert.True(internalInfo.NeedsDisposal);
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly))]
@@ -3651,7 +3651,7 @@ class Element
             var memberModel = model.GetMemberModel(foreachSyntax);
             var boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposeMethod);
+            Assert.True(internalInfo.NeedsDisposal);
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly))]
@@ -3724,7 +3724,7 @@ struct C : IAsyncEnumerable<int>
             var memberModel = model.GetMemberModel(foreachSyntax);
             var boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposeMethod);
+            Assert.True(internalInfo.NeedsDisposal);
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly))]
@@ -3834,7 +3834,7 @@ public static class Extensions
             var memberModel = model.GetMemberModel(foreachSyntax);
             var boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposeMethod);
+            Assert.True(internalInfo.NeedsDisposal);
         }
 
         [Fact]
@@ -4160,7 +4160,7 @@ class C
             var memberModel = model.GetMemberModel(foreachSyntax);
             var boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposeMethod);
+            Assert.True(internalInfo.NeedsDisposal);
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
@@ -4241,7 +4241,7 @@ class C
             var memberModel = model.GetMemberModel(foreachSyntax);
             BoundForEachStatement boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposeMethod);
+            Assert.True(internalInfo.NeedsDisposal);
 
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
@@ -1411,17 +1411,17 @@ ref struct DisposableEnumerator
     int x;
     public int Current { get { return x; } }
     public bool MoveNext() { return ++x < 4; }
-    public void Dispose(params object[] args) { System.Console.WriteLine(""Done with DisposableEnumerator""); }
+    public void Dispose(params object[] args) { System.Console.WriteLine($""Done with DisposableEnumerator. args was {args}, length {args.Length}""); }
 }";
             var compilation = CompileAndVerify(source, expectedOutput: @"
 1
 2
 3
-Done with DisposableEnumerator");
+Done with DisposableEnumerator. args was System.Object[], length 0");
         }
 
         [Fact]
-        public void TestForEachPatternDisposableRefStructWithDefaultParameters()
+        public void TestForEachPatternDisposableRefStructWithDefaultArguments()
         {
             var source = @"
 class C
@@ -1445,8 +1445,50 @@ ref struct DisposableEnumerator
     int x;
     public int Current { get { return x; } }
     public bool MoveNext() { return ++x < 4; }
-    public void Dispose(int arg = 1) { System.Console.WriteLine(""Done with DisposableEnumerator""); }
+    public void Dispose(int arg = 1) { System.Console.WriteLine($""Done with DisposableEnumerator. arg was {arg}""); }
 }";
+            var compilation = CompileAndVerify(source, expectedOutput: @"
+1
+2
+3
+Done with DisposableEnumerator. arg was 1");
+        }
+
+        [Fact]
+        public void TestForEachPatternDisposableRefStructWithExtensionMethod()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}
+
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+ref struct DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+}
+
+static class DisposeExtension
+{
+    public static void Dispose(this DisposableEnumerator de) { System.Console.WriteLine(""Done with DisposableEnumerator""); } 
+}
+
+";
+
+
             var compilation = CompileAndVerify(source, expectedOutput: @"
 1
 2
@@ -1454,6 +1496,155 @@ ref struct DisposableEnumerator
 Done with DisposableEnumerator");
         }
 
+        [Fact]
+        public void TestForEachPatternDisposableRefStructWithExtensionMethodAndDefaultArguments()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}
+
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+ref struct DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+}
+
+static class DisposeExtension
+{
+    public static void Dispose(this DisposableEnumerator de, int arg = 4) { System.Console.WriteLine($""Done with DisposableEnumerator. arg was {arg}""); } 
+}
+
+";
+
+
+            var compilation = CompileAndVerify(source, expectedOutput: @"
+1
+2
+3
+Done with DisposableEnumerator. arg was 4");
+        }
+
+        [Fact]
+        public void TestForEachPatternDisposableRefStructWithExtensionMethodAndParams()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}
+
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+ref struct DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+}
+
+static class DisposeExtension
+{
+    public static void Dispose(this DisposableEnumerator de, params object[] args) { System.Console.WriteLine($""Done with DisposableEnumerator. Args was {args}, length {args.Length}""); } 
+}
+
+";
+
+
+            var compilation = CompileAndVerify(source, expectedOutput: @"
+1
+2
+3
+Done with DisposableEnumerator. Args was System.Object[], length 0");
+        }
+
+        [Fact]
+        public void TestForEachPatternDisposableIgnoredForNonRefStruct()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}
+
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+struct DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+    public void Dispose() { System.Console.WriteLine(""Done with DisposableEnumerator""); }
+}";
+            var compilation = CompileAndVerify(source, expectedOutput: @"
+1
+2
+3");
+        }
+
+        [Fact]
+        public void TestForEachPatternDisposableIgnoredForClass()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}
+
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+class DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+    public void Dispose() { System.Console.WriteLine(""Done with DisposableEnumerator""); }
+}";
+            var compilation = CompileAndVerify(source, expectedOutput: @"
+1
+2
+3");
+        }
 
         [Fact]
         public void TestForEachNested()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
@@ -1383,7 +1383,33 @@ ref struct DisposableEnumerator
 1
 2
 3
-Done with DisposableEnumerator");
+Done with DisposableEnumerator").VerifyIL("C.Main", @"
+{
+  // Code size       45 (0x2d)
+  .maxstack  1
+  .locals init (DisposableEnumerator V_0)
+  IL_0000:  newobj     ""Enumerable1..ctor()""
+  IL_0005:  call       ""DisposableEnumerator Enumerable1.GetEnumerator()""
+  IL_000a:  stloc.0
+  .try
+  {
+    IL_000b:  br.s       IL_0019
+    IL_000d:  ldloca.s   V_0
+    IL_000f:  call       ""int DisposableEnumerator.Current.get""
+    IL_0014:  call       ""void System.Console.WriteLine(int)""
+    IL_0019:  ldloca.s   V_0
+    IL_001b:  call       ""bool DisposableEnumerator.MoveNext()""
+    IL_0020:  brtrue.s   IL_000d
+    IL_0022:  leave.s    IL_002c
+  }
+  finally
+  {
+    IL_0024:  ldloca.s   V_0
+    IL_0026:  call       ""void DisposableEnumerator.Dispose()""
+    IL_002b:  endfinally
+  }
+  IL_002c:  ret
+}");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
@@ -1353,6 +1353,109 @@ Done with DisposableEnumerator
         }
 
         [Fact]
+        public void TestForEachPatternDisposableRefStruct()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}
+
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+ref struct DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+    public void Dispose() { System.Console.WriteLine(""Done with DisposableEnumerator""); }
+}";
+            var compilation = CompileAndVerify(source, expectedOutput: @"
+1
+2
+3
+Done with DisposableEnumerator");
+        }
+
+        [Fact]
+        public void TestForEachPatternDisposableRefStructWithParams()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}
+
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+ref struct DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+    public void Dispose(params object[] args) { System.Console.WriteLine(""Done with DisposableEnumerator""); }
+}";
+            var compilation = CompileAndVerify(source, expectedOutput: @"
+1
+2
+3
+Done with DisposableEnumerator");
+        }
+
+        [Fact]
+        public void TestForEachPatternDisposableRefStructWithDefaultParameters()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}
+
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+ref struct DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+    public void Dispose(int arg = 1) { System.Console.WriteLine(""Done with DisposableEnumerator""); }
+}";
+            var compilation = CompileAndVerify(source, expectedOutput: @"
+1
+2
+3
+Done with DisposableEnumerator");
+        }
+
+
+        [Fact]
         public void TestForEachNested()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
@@ -1383,7 +1383,10 @@ ref struct DisposableEnumerator
 1
 2
 3
-Done with DisposableEnumerator").VerifyIL("C.Main", @"
+Done with DisposableEnumerator");
+
+            // IL Should not contain any Box/unbox instructions as we're a ref struct 
+            compilation.VerifyIL("C.Main", @"
 {
   // Code size       45 (0x2d)
   .maxstack  1

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
@@ -1201,7 +1201,7 @@ class C
             Assert.Equal("System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Object System.Collections.IEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.Collections.IEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.ImplicitReference, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Unboxing, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1233,7 +1233,7 @@ class C
             Assert.Equal("System.CharEnumerator System.String.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Char System.CharEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.CharEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.Identity, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1276,7 +1276,7 @@ class Enumerator
             Assert.Equal("Enumerator Enumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Int32 Enumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean Enumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.Identity, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1319,7 +1319,7 @@ struct Enumerator
             Assert.Equal("Enumerator Enumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Int32 Enumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean Enumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.False(info.NeedsDisposeMethod); // Definitely not disposable
+            Assert.False(info.NeedsDisposal); // Definitely not disposable
             Assert.Equal(ConversionKind.Identity, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.EnumeratorConversion.Kind);
@@ -1351,7 +1351,7 @@ class C
             Assert.Equal("System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Object System.Collections.IEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.Collections.IEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.Identity, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1390,7 +1390,7 @@ class Enumerable : System.Collections.Generic.IEnumerable<int>
             Assert.Equal("System.Collections.Generic.IEnumerator<System.Int32> System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Int32 System.Collections.Generic.IEnumerator<System.Int32>.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.Collections.IEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString()); //NB: not on generic interface
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.ImplicitReference, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1431,7 +1431,7 @@ class Enumerable : System.Collections.Generic.IEnumerable<Enumerable.Hidden>
             Assert.Equal("System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Object System.Collections.IEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.Collections.IEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.ImplicitReference, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1469,7 +1469,7 @@ class Enumerable : System.Collections.IEnumerable
             Assert.Equal("System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Object System.Collections.IEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.Collections.IEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.ImplicitReference, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1501,7 +1501,7 @@ class C
             Assert.Equal("System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Object System.Collections.IEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.Collections.IEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.ImplicitReference, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Unboxing, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1531,7 +1531,7 @@ class C
             Assert.Equal("System.CharEnumerator System.String.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Char System.CharEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.CharEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.Identity, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1616,7 +1616,7 @@ class C
             Assert.Equal("System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Object System.Collections.IEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.Collections.IEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.ImplicitReference, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.ExplicitReference, info.CurrentConversion.Kind); //object to C.var
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1646,7 +1646,7 @@ class C
             Assert.Equal("System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Object System.Collections.IEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.Collections.IEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.ImplicitDynamic, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1678,7 +1678,7 @@ class C
             Assert.Equal("System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Object System.Collections.IEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.Collections.IEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.ImplicitDynamic, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -1718,7 +1718,7 @@ public class Enumerable<T>
             Assert.Equal("T Enumerable<T>.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Object System.Collections.IEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.Collections.IEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.Identity, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.Boxing, info.EnumeratorConversion.Kind);
@@ -1801,7 +1801,7 @@ interface MyEnumerator
             Assert.Equal("T Enumerable<T>.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Object MyEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean MyEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.Identity, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.Boxing, info.EnumeratorConversion.Kind);
@@ -1847,7 +1847,7 @@ struct Enumerator
             Assert.Equal("Enumerator Enumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Int32 Enumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean Enumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.False(info.NeedsDisposeMethod); // Definitely not disposable
+            Assert.False(info.NeedsDisposal); // Definitely not disposable
             Assert.Equal(ConversionKind.Identity, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.EnumeratorConversion.Kind);
@@ -3046,7 +3046,7 @@ namespace System.Collections
             Assert.Equal("System.CharEnumerator System.String.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Char System.CharEnumerator.Current.get", info.CurrentPropertyGetter.ToTestDisplayString());
             Assert.Equal("System.Boolean System.CharEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
-            Assert.True(info.NeedsDisposeMethod);
+            Assert.True(info.NeedsDisposal);
             Assert.Equal(ConversionKind.Identity, info.CollectionConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
@@ -3055,7 +3055,39 @@ namespace System.Collections
             Assert.Equal(SpecialType.System_Char, boundNode.IterationVariables.Single().Type.SpecialType);
         }
 
+        [Fact]
+        public void TestPatternDisposeRefStruct()
+        {
+            var text = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}
 
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+ref struct DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+    public void Dispose() {  }
+}";
+
+            var boundNode = GetBoundForEachStatement(text);
+            var enumeratorInfo = boundNode.EnumeratorInfoOpt;
+
+            Assert.Equal("void DisposableEnumerator.Dispose()", enumeratorInfo.DisposeMethod.ToTestDisplayString());
+        }
 
         private static BoundForEachStatement GetBoundForEachStatement(string text, params DiagnosticDescription[] diagnostics)
         {
@@ -3086,9 +3118,21 @@ namespace System.Collections
                 Assert.Equal(enumeratorInfo.CurrentPropertyGetter, statementInfo.CurrentProperty.GetMethod);
                 Assert.Equal(enumeratorInfo.MoveNextMethod, statementInfo.MoveNextMethod);
 
-                if (enumeratorInfo.NeedsDisposeMethod)
+                if (enumeratorInfo.NeedsDisposal)
                 {
-                    Assert.Equal("void System.IDisposable.Dispose()", statementInfo.DisposeMethod.ToTestDisplayString());
+                    if (!(enumeratorInfo.DisposeMethod is null))
+                    {
+                        Assert.Equal(enumeratorInfo.DisposeMethod, statementInfo.DisposeMethod);
+                    }
+                    else if (enumeratorInfo.IsAsync)
+                    {
+                        Assert.Equal("System.ValueTask System.IAsyncDisposable.DisposeAsync()", statementInfo.DisposeMethod.ToTestDisplayString());
+                    }
+                    else
+                    {
+                        Assert.Equal("void System.IDisposable.Dispose()", statementInfo.DisposeMethod.ToTestDisplayString());
+
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
- Introduce a new bound node to represent a disposable placeholder
- Run disposal lookup on ref structs and store the result
- Lower the looked up disposal method if found