### PR TITLE
Ensure we react to metadata reference adds and deletes too

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
@@ -13,8 +13,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
     internal sealed class FileChangeTracker : IVsFileChangeEvents, IDisposable
     {
-        private const uint FileChangeFlags = (uint)(_VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Add | _VSFILECHANGEFLAGS.VSFILECHG_Del | _VSFILECHANGEFLAGS.VSFILECHG_Size);
-
         private static readonly Lazy<uint?> s_none = new Lazy<uint?>(() => null, LazyThreadSafetyMode.ExecutionAndPublication);
 
         private readonly IVsFileChangeEx _fileChangeService;
@@ -105,7 +103,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 try
                 {
                     Marshal.ThrowExceptionForHR(
-                        _fileChangeService.AdviseFileChange(_filePath, FileChangeFlags, this, out var newCookie));
+                        _fileChangeService.AdviseFileChange(_filePath, FileChangeWatcher.FileChangeFlags, this, out var newCookie));
                     return newCookie;
                 }
                 catch (Exception e) when (ReportException(e))

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeWatcher.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeWatcher.cs
@@ -13,6 +13,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
     /// </summary>
     internal sealed class FileChangeWatcher
     {
+        internal const uint FileChangeFlags = (uint)(_VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Add | _VSFILECHANGEFLAGS.VSFILECHG_Del | _VSFILECHANGEFLAGS.VSFILECHG_Size);
+
         /// <summary>
         /// Gate that is used to guard modifications to <see cref="_taskQueue"/>.
         /// </summary>
@@ -189,7 +191,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _fileChangeWatcher.EnqueueWork(service =>
                 {
                     uint cookie;
-                    ErrorHandler.ThrowOnFailure(service.AdviseFileChange(filePath, (uint)(_VSFILECHANGEFLAGS.VSFILECHG_Size | _VSFILECHANGEFLAGS.VSFILECHG_Time), this, out cookie));
+                    ErrorHandler.ThrowOnFailure(service.AdviseFileChange(filePath, FileChangeFlags, this, out cookie));
 
                     token.Cookie = cookie;
                 });


### PR DESCRIPTION
FileChangeWatcher wasn't specifying all the file watcher flags it should have been. Reuse the constant that already existed for FileChangeTracker so we get the same behavior.

FileChangeTracker is eventually going to be retired, and so I'm moving over the constant to the long-term home.

<details><summary>Ask Mode template</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

The user opens a solution where a project is directly referencing some output path that they expect their build to produce. For example, they have some project autogenerating binaries that should get picked up by another project. If they don't do a build before they open the solution, the IDE might not refresh when the binaries get created.

### Bugs this fixes

No bug, noticed this as I was testing #32649.

### Workarounds, if any

Only workaround would be to unload and reload your solution.

### Risk

Low.

### Performance impact

None.

### Is this a regression from a previous update?

Yes, this was broken in 16.0 Preview 1.

### Root cause analysis

We weren't specifying the right file watcher flags, a mistake it looks like we've made before. When I was refactoring this it was just my fault to not carry that code forward. We don't have tests on this since the system is pretty heavily asynchronous and since it's mocking some VS interfaces we haven't gone through the trouble.

### How was the bug found?

Doing regression testing for another bug.

</details>
