### PR TITLE
Issue 31304 Check variables in scope when getting name declaration suggestions

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -1522,6 +1522,147 @@ class Configuration
             }
         }
 
+        [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestCompletionDoesNotUseForeachVariableName()
+        {
+            var markup = @"
+class ClassA
+{
+    class ClassB {}
+
+    readonly List<ClassB> classBList;
+
+    void M()
+    {
+        foreach (var classB in classBList)
+        {
+            ClassB $$
+        }
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "classB");
+        }
+
+        [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestCompletionDoesNotUseParameterName()
+        {
+            var markup = @"
+class ClassA
+{
+    class ClassB { }
+
+    void M(ClassB classB)
+    {
+        ClassB $$
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "classB");
+        }
+
+        [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestCompletionDoesNotUsePropertyName()
+        {
+            var markup = @"
+class ClassA
+{
+    class ClassB { }
+
+    ClassB classB { get; set; }
+
+    void M()
+    {
+        ClassB $$
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "classB");
+        }
+
+        [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestCompletionDoesNotUseFieldName()
+        {
+            var markup = @"
+class ClassA
+{
+    class ClassB { }
+
+    ClassB classB;
+
+    void M()
+    {
+        ClassB $$
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "classB");
+        }
+
+        [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestCompletionDoesNotLocalName()
+        {
+            var markup = @"
+class ClassA
+{
+    class ClassB { }
+
+    void M()
+    {
+        ClassB classB = new ClassB();
+        ClassB $$
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "classB");
+        }
+
+        [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestCompletionCanUseClassName()
+        {
+            var markup = @"
+class classA
+{
+    void M()
+    {
+        classA $$
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "classA", glyph: (int)Glyph.Local,
+                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
+        }
+
+        [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestCompletionCanUseLocalInDifferentScope()
+        {
+            var markup = @"
+class ClassA
+{
+    class ClassB { }
+
+    void M()
+    {
+        ClassB classB = new ClassB(); 
+    }
+
+    void M2()
+    {
+        ClassB $$
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "classB", glyph: (int)Glyph.Local,
+                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
+        }
+
         private static NamingStylePreferences NamesEndWithSuffixPreferences()
         {
             var specificationStyles = new[]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -1655,6 +1655,30 @@ class ClassA
 
         [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestCompletionDoesNotUseLocalInsideIf()
+        {
+            var markup = @"
+class ClassA
+{
+    class ClassB { }
+
+    void M(bool flag)
+    {
+        ClassB $$
+        if (flag)
+        {
+            ClassB classB = new ClassB();
+        }
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "classB");
+            await VerifyItemExistsAsync(markup, "classB1", glyph: (int)Glyph.Local,
+                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
+        }
+
+        [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task TestCompletionCanUseClassName()
         {
             var markup = @"

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -1543,6 +1543,8 @@ class ClassA
 }
 ";
             await VerifyItemIsAbsentAsync(markup, "classB");
+            await VerifyItemExistsAsync(markup, "classB1", glyph: (int)Glyph.Local,
+                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
         }
 
         [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
@@ -1561,11 +1563,13 @@ class ClassA
 }
 ";
             await VerifyItemIsAbsentAsync(markup, "classB");
+            await VerifyItemExistsAsync(markup, "classB1", glyph: (int)Glyph.Local,
+                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
         }
 
         [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task TestCompletionDoesNotUsePropertyName()
+        public async Task TestCompletionCanUsePropertyName()
         {
             var markup = @"
 class ClassA
@@ -1580,12 +1584,13 @@ class ClassA
     }
 }
 ";
-            await VerifyItemIsAbsentAsync(markup, "classB");
+            await VerifyItemExistsAsync(markup, "classB", glyph: (int)Glyph.Local,
+                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
         }
 
         [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task TestCompletionDoesNotUseFieldName()
+        public async Task TestCompletionCanUseFieldName()
         {
             var markup = @"
 class ClassA
@@ -1600,12 +1605,13 @@ class ClassA
     }
 }
 ";
-            await VerifyItemIsAbsentAsync(markup, "classB");
+            await VerifyItemExistsAsync(markup, "classB", glyph: (int)Glyph.Local,
+                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
         }
 
         [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task TestCompletionDoesNotLocalName()
+        public async Task TestCompletionDoesNotUseLocalName()
         {
             var markup = @"
 class ClassA
@@ -1620,6 +1626,8 @@ class ClassA
 }
 ";
             await VerifyItemIsAbsentAsync(markup, "classB");
+            await VerifyItemExistsAsync(markup, "classB1", glyph: (int)Glyph.Local,
+                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
         }
 
         [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -1632,6 +1632,29 @@ class ClassA
 
         [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestCompletionDoesNotUseLocalNameMultiple()
+        {
+            var markup = @"
+class ClassA
+{
+    class ClassB { }
+
+    void M()
+    {
+        ClassB classB = new ClassB();
+        ClassB classB1 = new ClassB();
+        ClassB $$
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "classB");
+            await VerifyItemIsAbsentAsync(markup, "classB1");
+            await VerifyItemExistsAsync(markup, "classB2", glyph: (int)Glyph.Local,
+                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
+        }
+
+        [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task TestCompletionCanUseClassName()
         {
             var markup = @"

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -4077,10 +4077,6 @@ class C
                 state.SendTypeChars("w")
                 Await state.AssertSelectedCompletionItem(displayText:="when", isHardSelected:=False)
 
-                state.SendBackspace()
-                state.SendTypeChars("i")
-                Await state.AssertSelectedCompletionItem(displayText:="identifier", isHardSelected:=False)
-
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -4077,6 +4077,9 @@ class C
                 state.SendTypeChars("w")
                 Await state.AssertSelectedCompletionItem(displayText:="when", isHardSelected:=False)
 
+                state.SendBackspace()
+                state.SendTypeChars("i")
+                Await state.AssertSelectedCompletionItem(displayText:="identifier", isHardSelected:=False)
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -4080,6 +4080,7 @@ class C
                 state.SendBackspace()
                 state.SendTypeChars("i")
                 Await state.AssertSelectedCompletionItem(displayText:="identifier", isHardSelected:=False)
+
             End Using
         End Function
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -258,10 +258,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
-        private ImmutableArray<string> GetPossibleConflictingSymbolNames(CSharpSyntaxContext context)
+        private ImmutableHashSet<string> GetPossibleConflictingSymbolNames(CSharpSyntaxContext context)
         {
             var visibleSymbols = context.SemanticModel.LookupSymbols(context.Position);
-            return visibleSymbols.Where(symbol => IsRelevantSymbolKind(symbol)).Select(symbol => symbol.MetadataName).ToImmutableArray();
+            return visibleSymbols.Where(symbol => IsRelevantSymbolKind(symbol)).Select(symbol => symbol.MetadataName).ToImmutableHashSet();
         }
 
         /// <summary>

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Naming;
@@ -219,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         {
             var rules = await document.GetNamingRulesAsync(FallbackNamingRules.CompletionOfferingRules, cancellationToken).ConfigureAwait(false);
             var result = new Dictionary<string, SymbolKind>();
-            var possibleConflictingSymbolNames = GetPossibleConflictingSymbolNames(context);
+            var semanticFactsService = context.GetLanguageService<ISemanticFactsService>();
 
             foreach (var kind in declarationInfo.PossibleSymbolKinds)
             {
@@ -240,10 +241,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                             var name = rule.NamingStyle.CreateName(baseName).EscapeIdentifier(context.IsInQuery);
                             if (name.Length > 1 && !result.ContainsKey(name)) // Don't add multiple items for the same name
                             {
-                                if (!possibleConflictingSymbolNames.Contains(name))
-                                {
-                                    result.Add(name, symbolKind);
-                                }
+                                var targetToken = context.TargetToken;
+                                var uniqueName = semanticFactsService.GenerateUniqueName(
+                                    context.SemanticModel,
+                                    context.TargetToken.Parent,
+                                    containerOpt: null,
+                                    baseName: name,
+                                    filter: IsRelevantSymbolKind,
+                                    usedNames: Enumerable.Empty<string>(),
+                                    cancellationToken: cancellationToken);
+                                result.Add(uniqueName.Text, symbolKind);
                             }
                         }
                     }
@@ -254,29 +261,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         /// <summary>
-        /// Get symbol names that are visible and could hide or cause a conflict with potential names.
-        /// </summary>
-        /// <param name="context"></param>
-        /// <returns></returns>
-        private ImmutableHashSet<string> GetPossibleConflictingSymbolNames(CSharpSyntaxContext context)
-        {
-            var visibleSymbols = context.SemanticModel.LookupSymbols(context.Position);
-            return visibleSymbols.Where(symbol => IsRelevantSymbolKind(symbol)).Select(symbol => symbol.MetadataName).ToImmutableHashSet();
-        }
-
-        /// <summary>
         /// Check if the symbol is a relevant kind.
-        /// Only relevant if symbol could hide or cause a conflict.
+        /// Only relevant if symbol could cause a conflict with a local variable.
         /// </summary>
-        /// <param name="symbol"></param>
-        /// <returns></returns>
         private bool IsRelevantSymbolKind(ISymbol symbol)
         {
             return symbol.Kind == SymbolKind.Local ||
                 symbol.Kind == SymbolKind.Parameter ||
-                symbol.Kind == SymbolKind.RangeVariable ||
-                symbol.Kind == SymbolKind.Field ||
-                symbol.Kind == SymbolKind.Property;
+                symbol.Kind == SymbolKind.RangeVariable;
         }
 
         CompletionItem CreateCompletionItem(string name, Glyph glyph, string sortText)

--- a/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/AbstractSemanticFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/AbstractSemanticFactsService.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                 semanticModel, location, containerOpt, baseName, filter, usedNames: Enumerable.Empty<string>(), cancellationToken);
         }
 
-        private SyntaxToken GenerateUniqueName(
+        public SyntaxToken GenerateUniqueName(
             SemanticModel semanticModel,
             SyntaxNode location, SyntaxNode containerOpt,
             string baseName, Func<ISymbol, bool> filter,

--- a/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -110,6 +111,10 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         SyntaxToken GenerateUniqueName(
             SemanticModel semanticModel, SyntaxNode location,
             SyntaxNode containerOpt, string baseName, IEnumerable<string> usedNames, CancellationToken cancellationToken);
+
+        SyntaxToken GenerateUniqueName(
+            SemanticModel semanticModel, SyntaxNode location,
+            SyntaxNode containerOpt, string baseName, Func<ISymbol, bool> filter, IEnumerable<string> usedNames, CancellationToken cancellationToken);
 
         SyntaxToken GenerateUniqueLocalName(
             SemanticModel semanticModel, SyntaxNode location,

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
@@ -323,5 +323,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function IsInsideNameOfExpression(semanticModel As SemanticModel, node As SyntaxNode, cancellationToken As CancellationToken) As Boolean Implements ISemanticFactsService.IsInsideNameOfExpression
             Return node.FirstAncestorOrSelf(Of NameOfExpressionSyntax) IsNot Nothing
         End Function
+
+        Private Function ISemanticFactsService_GenerateUniqueName1(
+            semanticModel As SemanticModel, location As SyntaxNode, containerOpt As SyntaxNode, baseName As String, filter As Func(Of ISymbol, Boolean), usedNames As IEnumerable(Of String), cancellationToken As CancellationToken) As SyntaxToken Implements ISemanticFactsService.GenerateUniqueName
+            Return MyBase.GenerateUniqueName(semanticModel, location, containerOpt, baseName, filter, usedNames, cancellationToken)
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #31304

This changes the behavior of the declaration name provider to check to see if the variable name is already defined in the current scope.  

Raising this to get some clarity on a couple issues.
1.  I'm not sure what the performance impact of calling `LookupSymbols` on the location is when providing the suggestions.  It should only be called once every time the suggestion list is generated.
2.  What symbols should be considered as conflicting?  Parameters and locals seem to be a definite, but I've also included ones like fields (which could be shadowed).
