### PR TITLE
Make method body generation not rely on destination type

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -11051,5 +11051,37 @@ class Program
 }";
             await TestExtractMethodAsync(code, expected, allowBestEffort: true);
         }
+
+        [WorkItem(30750, "https://github.com/dotnet/roslyn/issues/30750")]
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        public async Task ExtractMethodInInterface()
+        {
+            var code = @"
+interface Program
+{
+    void Foo();
+
+    void Test()
+    {
+        [|Foo();|]
+    }
+}";
+            var expected = @"
+interface Program
+{
+    void Foo();
+
+    void Test()
+    {
+        NewMethod();
+    }
+
+    void NewMethod()
+    {
+        Foo();
+    }
+}";
+            await TestExtractMethodAsync(code, expected);
+        }
     }
 }

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.Shared.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.Shared.cs
@@ -558,13 +558,15 @@ End Structure";
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGenerationSortDeclarations)]
             public async Task TestDefaultTypeMemberAccessibility2()
             {
+                var codeGenOptionNoBody = new CodeGenerationOptions(generateMethodBodies: false);
+
                 var generationSource = "public class [|C|] { private void B(){} public void C(){}  }";
                 var initial = "public interface [|I|] { void A(); }";
                 var expected = @"public interface I { void A();
     void B();
     void C();
 }";
-                await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true);
+                await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true, codeGenerationOptions: codeGenOptionNoBody);
 
                 initial = "Public Interface [|I|] \n Sub A() \n End Interface";
                 expected = @"Public Interface I 
@@ -572,7 +574,7 @@ End Structure";
     Sub B()
     Sub C()
 End Interface";
-                await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true);
+                await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true, codeGenerationOptions: codeGenOptionNoBody);
 
                 initial = "Public Class [|C|] \n Sub A() \n End Sub \n End Class";
                 expected = @"Public Class C 

--- a/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
+++ b/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
                 interfaceDocument.Project.Solution,
                 interfaceDocumentSemanticModel.GetEnclosingNamespace(0, cancellationToken),
                 extractedInterfaceSymbol.GenerateRootNamespaceOrType(namespaceParts.ToArray()),
-                options: new CodeGenerationOptions(interfaceDocumentSemanticModel.SyntaxTree.GetLocation(new TextSpan())),
+                options: new CodeGenerationOptions(contextLocation: interfaceDocumentSemanticModel.SyntaxTree.GetLocation(new TextSpan()), generateMethodBodies: false),
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             return unformattedInterfaceDocument;

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                         _document.Project.Solution,
                         _state.TypeToGenerateIn,
                         property,
-                        new CodeGenerationOptions(afterThisLocation: _state.IdentifierToken.GetLocation()),
+                        new CodeGenerationOptions(afterThisLocation: _state.IdentifierToken.GetLocation(), generateMethodBodies: !IsInterface(_state.TypeToGenerateIn)),
                         cancellationToken)
                         .ConfigureAwait(false);
 
@@ -86,12 +86,14 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                         _document.Project.Solution,
                         _state.TypeToGenerateIn,
                         method,
-                        new CodeGenerationOptions(afterThisLocation: _state.Location, parseOptions: syntaxTree.Options),
+                        new CodeGenerationOptions(afterThisLocation: _state.Location, generateMethodBodies: !IsInterface(_state.TypeToGenerateIn), parseOptions: syntaxTree.Options),
                         cancellationToken)
                         .ConfigureAwait(false);
 
                     return result;
                 }
+
+                bool IsInterface(INamedTypeSymbol symbol) => symbol.TypeKind == TypeKind.Interface;
             }
 
             public override string Title

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
@@ -72,7 +72,9 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                         _document.Project.Solution,
                         _state.TypeToGenerateIn,
                         property,
-                        new CodeGenerationOptions(afterThisLocation: _state.IdentifierToken.GetLocation(), generateMethodBodies: !IsInterface(_state.TypeToGenerateIn)),
+                        new CodeGenerationOptions(
+                            afterThisLocation: _state.IdentifierToken.GetLocation(),
+                            generateMethodBodies: _state.TypeToGenerateIn.TypeKind != TypeKind.Interface),
                         cancellationToken)
                         .ConfigureAwait(false);
 
@@ -86,14 +88,15 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                         _document.Project.Solution,
                         _state.TypeToGenerateIn,
                         method,
-                        new CodeGenerationOptions(afterThisLocation: _state.Location, generateMethodBodies: !IsInterface(_state.TypeToGenerateIn), parseOptions: syntaxTree.Options),
+                        new CodeGenerationOptions(
+                            afterThisLocation: _state.Location,
+                            generateMethodBodies: _state.TypeToGenerateIn.TypeKind != TypeKind.Interface,
+                            parseOptions: syntaxTree.Options),
                         cancellationToken)
                         .ConfigureAwait(false);
 
                     return result;
                 }
-
-                bool IsInterface(INamedTypeSymbol symbol) => symbol.TypeKind == TypeKind.Interface;
             }
 
             public override string Title

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelObject_CodeGen.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelObject_CodeGen.cs
@@ -146,9 +146,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 typeParameters: default,
                 parameters: default);
 
+            var codeGenerationOptions = GetCodeGenerationOptions(access, containerNode.SyntaxTree.Options);
+            if (destination == CodeGenerationDestination.InterfaceType)
+            {
+                // Generating method with body is allowed when targeting an interface,
+                // so we have to explicitly disable it here.
+                codeGenerationOptions = codeGenerationOptions.With(generateMethodBodies: false);
+            }
+
             return CodeGenerationService.CreateMethodDeclaration(
                 newMethodSymbol, destination,
-                options: GetCodeGenerationOptions(access, containerNode.SyntaxTree.Options));
+                options: codeGenerationOptions);
         }
 
         protected SyntaxNode CreatePropertyDeclaration(SyntaxNode containerNode, string name, bool generateGetter, bool generateSetter, EnvDTE.vsCMAccess access, ITypeSymbol type)

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/MethodGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/MethodGenerator.cs
@@ -84,9 +84,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IMethodSymbol method, CodeGenerationDestination destination,
             Workspace workspace, CodeGenerationOptions options, ParseOptions parseOptions)
         {
-            var hasNoBody = !options.GenerateMethodBodies ||
-                            destination == CodeGenerationDestination.InterfaceType ||
-                            method.IsAbstract;
+            // Don't rely on destination to decide if method body should be generated.
+            // Users of this service need to express their intention explicitly, either by  
+            // setting `CodeGenerationOptions.GenerateMethodBodies` to true, or making 
+            // `method` abstract. This would provide more flexibility.
+            var hasNoBody = !options.GenerateMethodBodies || method.IsAbstract;
 
             var explicitInterfaceSpecifier = GenerateExplicitInterfaceSpecifier(method.ExplicitInterfaceImplementations);
 


### PR DESCRIPTION
Fix #30750.

I think being able to extract method in an interface might be useful during a refactoring (this is how this bug was found), so I opt to make this change instead of disabling the refactoring in this scenario. Thoughts?

@dotnet/roslyn-ide @CyrusNajmabadi 

