### PR TITLE
Exposes additional compilation options to the scripting API

### DIFF
--- a/src/Scripting/CSharp/CSharpScriptCompiler.cs
+++ b/src/Scripting/CSharp/CSharpScriptCompiler.cs
@@ -54,11 +54,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting
                     mainTypeName: null,
                     scriptClassName: submissionTypeName,
                     usings: script.Options.Imports,
-                    optimizationLevel: OptimizationLevel.Debug, // TODO
-                    checkOverflow: false,                       // TODO
-                    allowUnsafe: true,                          // TODO
+                    optimizationLevel: script.Options.OptimizationLevel,
+                    checkOverflow: script.Options.CheckOverflow,
+                    allowUnsafe: script.Options.AllowUnsafe,
                     platform: Platform.AnyCpu,
-                    warningLevel: 4,
+                    warningLevel: script.Options.WarningLevel,
                     xmlReferenceResolver: null, // don't support XML file references in interactive (permissions & doc comment includes)
                     sourceReferenceResolver: script.Options.SourceResolver,
                     metadataReferenceResolver: script.Options.MetadataResolver,

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -155,7 +155,11 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 metadataResolver: metadataResolver,
                 sourceResolver: sourceResolver,
                 emitDebugInformation: emitDebugInformation,
-                fileEncoding: null);
+                fileEncoding: null,
+                optimizationLevel: OptimizationLevel.Debug,
+                allowUnsafe: true,
+                checkOverflow: false,
+                warningLevel: 4);
         }
 
         internal static MetadataReferenceResolver GetMetadataReferenceResolver(CommandLineArguments arguments, TouchedFileLogger loggerOpt)

--- a/src/Scripting/Core/PublicAPI.Unshipped.txt
+++ b/src/Scripting/Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,8 @@
-
+Microsoft.CodeAnalysis.Scripting.ScriptOptions.AllowUnsafe.get -> bool
+Microsoft.CodeAnalysis.Scripting.ScriptOptions.CheckOverflow.get -> bool
+Microsoft.CodeAnalysis.Scripting.ScriptOptions.OptimizationLevel.get -> Microsoft.CodeAnalysis.OptimizationLevel
+Microsoft.CodeAnalysis.Scripting.ScriptOptions.WarningLevel.get -> int
+Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithAllowUnsafe(bool allowUnsafe) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
+Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithCheckOverflow(bool checkOverflow) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
+Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithOptimizationLevel(Microsoft.CodeAnalysis.OptimizationLevel optimizationLevel) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions
+Microsoft.CodeAnalysis.Scripting.ScriptOptions.WithWarningLevel(int warningLevel) -> Microsoft.CodeAnalysis.Scripting.ScriptOptions

--- a/src/Scripting/Core/ScriptOptions.cs
+++ b/src/Scripting/Core/ScriptOptions.cs
@@ -6,10 +6,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
-using Microsoft.CodeAnalysis.Emit;
-using Microsoft.CodeAnalysis.Scripting.Hosting;
 using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
 
 namespace Microsoft.CodeAnalysis.Scripting
 {
@@ -21,13 +20,17 @@ namespace Microsoft.CodeAnalysis.Scripting
     public sealed class ScriptOptions
     {
         public static ScriptOptions Default { get; } = new ScriptOptions(
-            filePath: "",
+            filePath: string.Empty,
             references: GetDefaultMetadataReferences(),
             namespaces: ImmutableArray<string>.Empty,
             metadataResolver: RuntimeMetadataReferenceResolver.Default,
             sourceResolver: SourceFileResolver.Default,
             emitDebugInformation: false,
-            fileEncoding: null);
+            fileEncoding: null,
+            OptimizationLevel.Debug,
+            checkOverflow: false,
+            allowUnsafe: true,
+            warningLevel: 4);
 
         private static ImmutableArray<MetadataReference> GetDefaultMetadataReferences()
         {
@@ -111,6 +114,26 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// </summary>
         public string FilePath { get; private set; }
 
+        /// <summary>
+        /// Specifies whether or not optimizations should be performed on the output IL.
+        /// </summary>
+        public OptimizationLevel OptimizationLevel { get; private set; }
+
+        /// <summary>
+        /// Whether bounds checking on integer arithmetic is enforced by default or not.
+        /// </summary>
+        public bool CheckOverflow { get; private set; }
+
+        /// <summary>
+        /// Allow unsafe regions (i.e. unsafe modifiers on members and unsafe blocks).
+        /// </summary>
+        public bool AllowUnsafe { get; private set; }
+
+        /// <summary>
+        /// Global warning level (from 0 to 4).
+        /// </summary>
+        public int WarningLevel { get; private set; }
+
         internal ScriptOptions(
             string filePath,
             ImmutableArray<MetadataReference> references,
@@ -118,7 +141,11 @@ namespace Microsoft.CodeAnalysis.Scripting
             MetadataReferenceResolver metadataResolver,
             SourceReferenceResolver sourceResolver,
             bool emitDebugInformation,
-            Encoding fileEncoding)
+            Encoding fileEncoding,
+            OptimizationLevel optimizationLevel,
+            bool checkOverflow,
+            bool allowUnsafe,
+            int warningLevel)
         {
             Debug.Assert(filePath != null);
             Debug.Assert(!references.IsDefault);
@@ -133,6 +160,10 @@ namespace Microsoft.CodeAnalysis.Scripting
             SourceResolver = sourceResolver;
             EmitDebugInformation = emitDebugInformation;
             FileEncoding = fileEncoding;
+            OptimizationLevel = optimizationLevel;
+            CheckOverflow = checkOverflow;
+            AllowUnsafe = allowUnsafe;
+            WarningLevel = warningLevel;
         }
 
         private ScriptOptions(ScriptOptions other)
@@ -142,7 +173,11 @@ namespace Microsoft.CodeAnalysis.Scripting
                    metadataResolver: other.MetadataResolver,
                    sourceResolver: other.SourceResolver,
                    emitDebugInformation: other.EmitDebugInformation,
-                   fileEncoding: other.FileEncoding)
+                   fileEncoding: other.FileEncoding,
+                   optimizationLevel: other.OptimizationLevel,
+                   checkOverflow: other.CheckOverflow,
+                   allowUnsafe: other.AllowUnsafe,
+                   warningLevel: other.WarningLevel)
         {
         }
 
@@ -315,5 +350,30 @@ namespace Microsoft.CodeAnalysis.Scripting
         /// </summary>
         public ScriptOptions WithFileEncoding(Encoding encoding) =>
             encoding == FileEncoding ? this : new ScriptOptions(this) { FileEncoding = encoding };
+
+        /// <summary>
+        /// Create a new <see cref="ScriptOptions"/> with the specified <see cref="OptimizationLevel"/>.
+        /// </summary>
+        /// <returns></returns>
+        public ScriptOptions WithOptimizationLevel(OptimizationLevel optimizationLevel) =>
+            optimizationLevel == OptimizationLevel ? this : new ScriptOptions(this) { OptimizationLevel = optimizationLevel };
+
+        /// <summary>
+        /// Create a new <see cref="ScriptOptions"/> with unsafe code regions allowed.
+        /// </summary>
+        public ScriptOptions WithAllowUnsafe(bool allowUnsafe) =>
+            allowUnsafe == AllowUnsafe ? this : new ScriptOptions(this) { AllowUnsafe = allowUnsafe };
+
+        /// <summary>
+        /// Create a new <see cref="ScriptOptions"/> with bounds checking on integer arithmetic enforced.
+        /// </summary>
+        public ScriptOptions WithCheckOverflow(bool checkOverflow) =>
+            checkOverflow == CheckOverflow ? this : new ScriptOptions(this) { CheckOverflow = checkOverflow };
+
+        /// <summary>
+        /// Create a new <see cref="ScriptOptions"/> with the specific <see cref="WarningLevel"/>.
+        /// </summary>
+        public ScriptOptions WithWarningLevel(int warningLevel) =>
+            warningLevel == WarningLevel ? this : new ScriptOptions(this) { WarningLevel = warningLevel };
     }
 }

--- a/src/Scripting/CoreTest/ScriptOptionsTests.cs
+++ b/src/Scripting/CoreTest/ScriptOptionsTests.cs
@@ -167,6 +167,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         }
 
         [Fact]
+
         public void WithFileEncoding_SetsWithFileEncoding()
         {
             var options = ScriptOptions.Default.WithFileEncoding(Encoding.ASCII);
@@ -178,6 +179,84 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         {
             var options = ScriptOptions.Default.WithFileEncoding(Encoding.ASCII);
             Assert.Same(options, options.WithFileEncoding(Encoding.ASCII));
+        }
+
+        [Fact]
+        public void WithAllowUnsafe_SetsAllowUnsafe()
+        {
+            Assert.True(ScriptOptions.Default.WithAllowUnsafe(true).AllowUnsafe);
+            Assert.False(ScriptOptions.Default.WithAllowUnsafe(false).AllowUnsafe);
+            Assert.True(ScriptOptions.Default.AllowUnsafe);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WithAllowUnsafe_SameValueTwice_DoesNotCreateNewInstance(bool allowUnsafe)
+        {
+            var options = ScriptOptions.Default.WithAllowUnsafe(allowUnsafe);
+            Assert.Same(options, options.WithAllowUnsafe(allowUnsafe));
+        }
+
+
+        [Fact]
+        public void WithCheckOverflow_SetsCheckOverflow()
+        {
+            Assert.True(ScriptOptions.Default.WithCheckOverflow(true).CheckOverflow);
+            Assert.False(ScriptOptions.Default.WithCheckOverflow(false).CheckOverflow);
+            Assert.False(ScriptOptions.Default.CheckOverflow);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WithCheckOverflow_SameValueTwice_DoesNotCreateNewInstance(bool checkOverflow)
+        {
+            var options = ScriptOptions.Default.WithCheckOverflow(checkOverflow);
+            Assert.Same(options, options.WithCheckOverflow(checkOverflow));
+        }
+
+        [Theory]
+        [InlineData(OptimizationLevel.Debug)]
+        [InlineData(OptimizationLevel.Release)]
+        public void WithOptimizationLevel_SetsOptimizationLevel(OptimizationLevel optimizationLevel)
+        {
+            Assert.Equal(ScriptOptions.Default.WithOptimizationLevel(optimizationLevel).OptimizationLevel, optimizationLevel);
+            Assert.Equal(ScriptOptions.Default.OptimizationLevel, OptimizationLevel.Debug);
+        }
+
+        [Theory]
+        [InlineData(OptimizationLevel.Debug)]
+        [InlineData(OptimizationLevel.Release)]
+        public void WithOptimizationLevel_SameValueTwice_DoesNotCreateNewInstance(OptimizationLevel optimizationLevel)
+        {
+            var options = ScriptOptions.Default.WithOptimizationLevel(optimizationLevel);
+            Assert.Same(options, options.WithOptimizationLevel(optimizationLevel));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void WithWarningLevel_SetsWarningLevel(int warningLevel)
+        {
+            Assert.Equal(ScriptOptions.Default.WithWarningLevel(warningLevel).WarningLevel, warningLevel);
+            Assert.Equal(ScriptOptions.Default.WarningLevel, 4);
+        }
+
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void WithWarningLevel_SameValueTwice_DoesNotCreateNewInstance(int warningLevel)
+        {
+            var options = ScriptOptions.Default.WithWarningLevel(warningLevel);
+            Assert.Same(options, options.WithWarningLevel(warningLevel));
         }
     }
 }

--- a/src/Scripting/CoreTest/ScriptOptionsTests.cs
+++ b/src/Scripting/CoreTest/ScriptOptionsTests.cs
@@ -5,7 +5,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Text;
-using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -152,6 +153,14 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         }
 
         [Fact]
+        public void Imports_Are_AppliedTo_CompilationOption()
+        {
+            var scriptOptions = ScriptOptions.Default.WithImports(new[] { "System", "System.IO" });
+            var compilation = CSharpScript.Create(string.Empty, scriptOptions).GetCompilation();
+            Assert.Equal(scriptOptions.Imports, compilation.Options.GetImports());
+        }
+
+        [Fact]
         public void WithEmitDebugInformation_SetsEmitDebugInformation()
         {
             Assert.True(ScriptOptions.Default.WithEmitDebugInformation(true).EmitDebugInformation);
@@ -167,7 +176,6 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         }
 
         [Fact]
-
         public void WithFileEncoding_SetsWithFileEncoding()
         {
             var options = ScriptOptions.Default.WithFileEncoding(Encoding.ASCII);
@@ -198,6 +206,15 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
             Assert.Same(options, options.WithAllowUnsafe(allowUnsafe));
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AllowUnsafe_Is_AppliedTo_CompilationOption(bool allowUnsafe)
+        {
+            var scriptOptions = ScriptOptions.Default.WithAllowUnsafe(allowUnsafe);
+            var compilation = (CSharpCompilation)CSharpScript.Create(string.Empty, scriptOptions).GetCompilation();
+            Assert.Equal(scriptOptions.AllowUnsafe, compilation.Options.AllowUnsafe);
+        }
 
         [Fact]
         public void WithCheckOverflow_SetsCheckOverflow()
@@ -214,6 +231,16 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         {
             var options = ScriptOptions.Default.WithCheckOverflow(checkOverflow);
             Assert.Same(options, options.WithCheckOverflow(checkOverflow));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CheckOverflow_Is_AppliedTo_CompilationOption(bool checkOverflow)
+        {
+            var scriptOptions = ScriptOptions.Default.WithCheckOverflow(checkOverflow);
+            var compilation = CSharpScript.Create(string.Empty, scriptOptions).GetCompilation();
+            Assert.Equal(scriptOptions.CheckOverflow, compilation.Options.CheckOverflow);
         }
 
         [Theory]
@@ -235,6 +262,16 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         }
 
         [Theory]
+        [InlineData(OptimizationLevel.Debug)]
+        [InlineData(OptimizationLevel.Release)]
+        public void OptimizationLevel_Is_AppliedTo_CompilationOption(OptimizationLevel optimizationLevel)
+        {
+            var scriptOptions = ScriptOptions.Default.WithOptimizationLevel(optimizationLevel);
+            var compilation = CSharpScript.Create(string.Empty, scriptOptions).GetCompilation();
+            Assert.Equal(scriptOptions.OptimizationLevel, compilation.Options.OptimizationLevel);
+        }
+
+        [Theory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
@@ -246,7 +283,6 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
             Assert.Equal(ScriptOptions.Default.WarningLevel, 4);
         }
 
-
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
@@ -257,6 +293,19 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         {
             var options = ScriptOptions.Default.WithWarningLevel(warningLevel);
             Assert.Same(options, options.WithWarningLevel(warningLevel));
+        }
+        
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void WarningLevel_Is_AppliedTo_CompilationOption(int warningLevel)
+        {
+            var scriptOptions = ScriptOptions.Default.WithWarningLevel(warningLevel);
+            var compilation = CSharpScript.Create(string.Empty, scriptOptions).GetCompilation();
+            Assert.Equal(scriptOptions.WarningLevel, compilation.Options.WarningLevel);
         }
     }
 }

--- a/src/Scripting/VisualBasic/VisualBasicScriptCompiler.vb
+++ b/src/Scripting/VisualBasic/VisualBasicScriptCompiler.vb
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting
                     optionExplicit:=True,
                     optionCompareText:=False,
                     embedVbCoreRuntime:=False,
-                    checkOverflow:=False,
+                    checkOverflow:=script.Options.CheckOverflow,
                     xmlReferenceResolver:=Nothing, ' don't support XML file references in interactive (permissions & doc comment includes)
                     sourceReferenceResolver:=SourceFileResolver.Default,
                     metadataReferenceResolver:=script.Options.MetadataResolver,

--- a/src/Scripting/VisualBasic/VisualBasicScriptCompiler.vb
+++ b/src/Scripting/VisualBasic/VisualBasicScriptCompiler.vb
@@ -82,6 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting
                     optionExplicit:=True,
                     optionCompareText:=False,
                     embedVbCoreRuntime:=False,
+                    optimizationLevel:=script.Options.OptimizationLevel,
                     checkOverflow:=script.Options.CheckOverflow,
                     xmlReferenceResolver:=Nothing, ' don't support XML file references in interactive (permissions & doc comment includes)
                     sourceReferenceResolver:=SourceFileResolver.Default,


### PR DESCRIPTION
The values for the properties in the `ScriptOptions` are [the same as before](https://github.com/dotnet/roslyn/blob/master/src/Scripting/CSharp/CSharpScriptCompiler.cs#L57). To ensure no behavior change and being compatible with previous versions.

Closes #32667 

