### PR TITLE
Add bail out cases for unused members analyzer

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -916,41 +916,76 @@ class MyClass
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(32488, "https://github.com/dotnet/roslyn/issues/32488")]
         public async Task FieldInNameOf()
         {
-            await TestDiagnosticsAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|_goo|];
     private string _goo2 = nameof(_goo);
-}",
-    expected: Diagnostic("IDE0052"));
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         [WorkItem(31581, "https://github.com/dotnet/roslyn/issues/31581")]
         public async Task MethodInNameOf()
         {
-            await TestDiagnosticsAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private void [|M|]() { }
     private string _goo = nameof(M);
-}",
-    expected: Diagnostic("IDE0052"));
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         [WorkItem(31581, "https://github.com/dotnet/roslyn/issues/31581")]
         public async Task PropertyInNameOf()
         {
-            await TestDiagnosticsAsync(
+            await TestDiagnosticMissingAsync(
 @"class MyClass
 {
     private int [|P|] { get; }
     private string _goo = nameof(P);
-}",
-    expected: Diagnostic("IDE0052"));
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(32522, "https://github.com/dotnet/roslyn/issues/32522")]
+        public async Task TestDynamicInvocation()
+        {
+            await TestDiagnosticMissingAsync(
+@"class MyClass
+{
+    private void [|M|](dynamic d) { }
+    public void M2(dynamic d) => M(d);
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(32522, "https://github.com/dotnet/roslyn/issues/32522")]
+        public async Task TestDynamicObjectCreation()
+        {
+            await TestDiagnosticMissingAsync(
+@"class MyClass
+{
+    private [|MyClass|](int i) { }
+    public static MyClass Create(dynamic d) => new MyClass(d);
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(32522, "https://github.com/dotnet/roslyn/issues/32522")]
+        public async Task TestDynamicIndexerAccess()
+        {
+            await TestDiagnosticMissingAsync(
+@"class MyClass
+{
+    private int[] _list;
+    private int [|this|][int index] => _list[index];
+    public int M2(dynamic d) => this[d];
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
@@ -639,36 +639,34 @@ End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        <WorkItem(32488, "https://github.com/dotnet/roslyn/issues/32488")>
         Public Async Function FieldInNameOf() As Task
-            Await TestDiagnosticsAsync(
+            Await TestDiagnosticMissingAsync(
 "Class C
     Private [|_goo|] As Integer
     Private _goo2 As String = NameOf(_goo)
-End Class", parameters:=Nothing,
-    Diagnostic("IDE0052"))
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
         <WorkItem(31581, "https://github.com/dotnet/roslyn/issues/31581")>
         Public Async Function MethodInNameOf() As Task
-            Await TestDiagnosticsAsync(
+            Await TestDiagnosticMissingAsync(
 "Class C
     Private Sub [|M|]()
     End Sub
     Private _goo2 As String = NameOf(M)
-End Class", parameters:=Nothing,
-    Diagnostic("IDE0052"))
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
         <WorkItem(31581, "https://github.com/dotnet/roslyn/issues/31581")>
         Public Async Function PropertyInNameOf() As Task
-            Await TestDiagnosticsAsync(
+            Await TestDiagnosticMissingAsync(
 "Class C
     Private ReadOnly Property [|P|] As Integer
     Private _goo2 As String = NameOf(P)
-End Class", parameters:=Nothing,
-    Diagnostic("IDE0052"))
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>


### PR DESCRIPTION
1. Usages as an argument to `nameof`: We have multiple reports of these being false positives in presence of reflection based usages and in variour test frameworks. Fixes #32488.
2. Presence of 'dynamic' in C# - Conservatively bail out in presence of any dynamic operations. Fixes #32522.