### PR TITLE
EnC: Handle full line active statement spans correctly

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioActiveStatementProvider.Utilities.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioActiveStatementProvider.Utilities.cs
@@ -63,7 +63,28 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
             }
         }
 
-        private static LinePositionSpan ToLinePositionSpan(DkmTextSpan span)
-            => new LinePositionSpan(new LinePosition(span.StartLine - 1, span.StartColumn - 1), new LinePosition(span.EndLine - 1, span.EndColumn - 1));
+        // internal for testing
+        internal static LinePositionSpan ToLinePositionSpan(DkmTextSpan span)
+        {
+            // ignore invalid/unsupported spans - they might come from stack frames of non-managed languages
+            if (span.StartLine <= 0 || span.EndLine <= 0)
+            {
+                return default;
+            }
+
+            // C++ produces spans without columns
+            if (span.StartColumn == 0 && span.EndColumn == 0)
+            {
+                return new LinePositionSpan(new LinePosition(span.StartLine - 1, 0), new LinePosition(span.EndLine - 1, 0));
+            }
+
+            // ignore invalid/unsupported spans - they might come from stack frames of non-managed languages
+            if (span.StartColumn <= 0 || span.EndColumn <= 0)
+            {
+                return default;
+            }
+
+            return new LinePositionSpan(new LinePosition(span.StartLine - 1, span.StartColumn - 1), new LinePosition(span.EndLine - 1, span.EndColumn - 1));
+        }
     }
 }

--- a/src/VisualStudio/Core/Test.Next/EditAndContiue/VisualStudioActiveStatementProviderTests.cs
+++ b/src/VisualStudio/Core/Test.Next/EditAndContiue/VisualStudioActiveStatementProviderTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.Symbols;
 using Roslyn.Test.Utilities;
@@ -110,6 +111,28 @@ namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
                     ilOffset: 0,
                     DkmActiveStatementFlags.MidStatement)
             }));
+        }
+
+        [Theory]
+        [InlineData(1, 2, 3, 4, 0, 1, 2, 3)]
+        [InlineData(5, 0, 5, 0, 4, 0, 4, 0)]
+        [InlineData(0, 0, 0, 0, 0, 0, 0, 0)]
+        [InlineData(0, 2, 2, 2, 0, 0, 0, 0)]
+        [InlineData(2, 0, 2, 2, 0, 0, 0, 0)]
+        [InlineData(2, 2, 0, 2, 0, 0, 0, 0)]
+        [InlineData(2, 2, 2, 0, 0, 0, 0, 0)]
+        [InlineData(int.MinValue, 2, 2, 2, 0, 0, 0, 0)]
+        [InlineData(2, int.MinValue, 2, 2, 0, 0, 0, 0)]
+        [InlineData(2, 2, int.MinValue, 2, 0, 0, 0, 0)]
+        [InlineData(2, 2, 2, int.MinValue, 0, 0, 0, 0)]
+        [InlineData(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue - 1, int.MaxValue - 1, int.MaxValue - 1, int.MaxValue - 1)]
+        public void Span(int startLine, int startColumn, int endLine, int endColumn,
+                         int expectedStartLine, int expectedStartColumn, int expectedEndLine, int expectedEndColumn)
+        {
+            var actual = VisualStudioActiveStatementProvider.ToLinePositionSpan(new DkmTextSpan(StartLine: startLine, EndLine: endLine, StartColumn: startColumn, EndColumn: endColumn));
+            var expected = new LinePositionSpan(new LinePosition(expectedStartLine, expectedStartColumn), new LinePosition(expectedEndLine, expectedEndColumn));
+
+            Assert.Equal(expected, actual);
         }
     }
 }


### PR DESCRIPTION
C++ uses _full line_ active statement spans, i.e. spans that span the entire line, with zeroed start and columns. These were not handled correctly in code that enumerates active statements and were causing EnC to fail.

Fixes [DevDiv 672524](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/672524)