### PR TITLE
Create source locations with FullSpan instead of Span

### DIFF
--- a/src/Compilers/Core/Portable/Diagnostic/SourceLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SourceLocation.cs
@@ -22,22 +22,22 @@ namespace Microsoft.CodeAnalysis
         }
 
         public SourceLocation(SyntaxNode node)
-            : this(node.SyntaxTree, node.Span)
+            : this(node.SyntaxTree, node.FullSpan)
         {
         }
 
         public SourceLocation(in SyntaxToken token)
-            : this(token.SyntaxTree, token.Span)
+            : this(token.SyntaxTree, token.FullSpan)
         {
         }
 
         public SourceLocation(in SyntaxNodeOrToken nodeOrToken)
-            : this(nodeOrToken.SyntaxTree, nodeOrToken.Span)
+            : this(nodeOrToken.SyntaxTree, nodeOrToken.FullSpan)
         {
         }
 
         public SourceLocation(in SyntaxTrivia trivia)
-            : this(trivia.SyntaxTree, trivia.Span)
+            : this(trivia.SyntaxTree, trivia.FullSpan)
         {
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -545,7 +545,7 @@ namespace Microsoft.CodeAnalysis
 
         public Location GetLocation()
         {
-            return this.SyntaxTree.GetLocation(this.Span);
+            return this.SyntaxTree.GetLocation(this.FullSpan);
         }
 
         internal Location Location


### PR DESCRIPTION
`CreateLocation` is meant to be an inverse function to `FindNode`, but sometimes would fail when extra trivia wasn't included. To be inclusive of all trivia, which may directly impact the ability to find a location, use `FullSpan` instead of just `Span`

#29793 