### PR TITLE
Trim sequence point column numbers greater than 0xffff.

### DIFF
--- a/src/Compilers/Core/Portable/CodeGen/RawSequencePoint.cs
+++ b/src/Compilers/Core/Portable/CodeGen/RawSequencePoint.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
     /// Represents a sequence point before translation by #line/ExternalSource directives.
     /// </summary>
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-    internal struct RawSequencePoint
+    internal readonly struct RawSequencePoint
     {
         internal readonly SyntaxTree SyntaxTree;
         internal readonly int ILMarker;

--- a/src/Compilers/Core/Portable/CodeGen/SequencePointList.cs
+++ b/src/Compilers/Core/Portable/CodeGen/SequencePointList.cs
@@ -1,15 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
-using Cci = Microsoft.Cci;
 
 namespace Microsoft.CodeAnalysis.CodeGen
 {
@@ -22,8 +16,6 @@ namespace Microsoft.CodeAnalysis.CodeGen
     /// </summary>
     internal class SequencePointList
     {
-        internal const int HiddenSequencePointLine = 0xFEEFEE;
-
         private readonly SyntaxTree _tree;
         private readonly OffsetAndSpan[] _points;
         private SequencePointList _next;  // Linked list of all points.
@@ -142,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
                     // a hidden sequence point.
 
                     bool isHidden = span == RawSequencePoint.HiddenSequencePointSpan;
-                    FileLinePositionSpan fileLinePositionSpan = default(FileLinePositionSpan);
+                    FileLinePositionSpan fileLinePositionSpan = default;
                     if (!isHidden)
                     {
                         fileLinePositionSpan = currentTree.GetMappedLineSpanAndVisibility(span, out isHidden);
@@ -161,9 +153,9 @@ namespace Microsoft.CodeAnalysis.CodeGen
                             builder.Add(new Cci.SequencePoint(
                                 lastDebugDocument,
                                 offset: offsetAndSpan.Offset,
-                                startLine: HiddenSequencePointLine,
+                                startLine: Cci.SequencePoint.HiddenLine,
                                 startColumn: 0,
-                                endLine: HiddenSequencePointLine,
+                                endLine: Cci.SequencePoint.HiddenLine,
                                 endColumn: 0));
                         }
                     }
@@ -178,13 +170,34 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
                         if (lastDebugDocument != null)
                         {
+                            int startLine = (fileLinePositionSpan.StartLinePosition.Line == -1) ? 0 : fileLinePositionSpan.StartLinePosition.Line + 1;
+                            int endLine = (fileLinePositionSpan.EndLinePosition.Line == -1) ? 0 : fileLinePositionSpan.EndLinePosition.Line + 1;
+                            int startColumn = fileLinePositionSpan.StartLinePosition.Character + 1;
+                            int endColumn = fileLinePositionSpan.EndLinePosition.Character + 1;
+
+                            // Trim column number if necessary.
+                            // Column must be in range [0, 0xffff) and end column must be greater than start column if on the same line.
+                            // The Portable PDB specifies 0x10000, but System.Reflection.Metadata reader has an off-by-one error.
+                            // Windows PDBs allow the same range.
+                            const int MaxColumn = ushort.MaxValue - 1;
+
+                            if (startColumn > MaxColumn)
+                            {
+                                startColumn = (startLine == endLine) ? MaxColumn - 1 : MaxColumn;
+                            }
+
+                            if (endColumn > MaxColumn)
+                            {
+                                endColumn = MaxColumn;
+                            }
+
                             builder.Add(new Cci.SequencePoint(
                                 lastDebugDocument,
                                 offset: offsetAndSpan.Offset,
-                                startLine: (fileLinePositionSpan.StartLinePosition.Line == -1) ? 0 : fileLinePositionSpan.StartLinePosition.Line + 1,
-                                startColumn: fileLinePositionSpan.StartLinePosition.Character + 1,
-                                endLine: (fileLinePositionSpan.EndLinePosition.Line == -1) ? 0 : fileLinePositionSpan.EndLinePosition.Line + 1,
-                                endColumn: fileLinePositionSpan.EndLinePosition.Character + 1
+                                startLine: startLine,
+                                startColumn: (ushort)startColumn,
+                                endLine: endLine,
+                                endColumn: (ushort)endColumn
                             ));
                         }
                     }

--- a/src/Compilers/Core/Portable/PEWriter/SequencePoint.cs
+++ b/src/Compilers/Core/Portable/PEWriter/SequencePoint.cs
@@ -8,22 +8,24 @@ namespace Microsoft.Cci
 {
     [SuppressMessage("Performance", "CA1067", Justification = "Equality not actually implemented")]
     [DebuggerDisplay("{" + nameof(GetDebuggerDisplay) + "(),nq}")]
-    internal struct SequencePoint
+    internal readonly struct SequencePoint
     {
+        public const int HiddenLine = 0xfeefee;
+
         public readonly int Offset;
         public readonly int StartLine;
-        public readonly int StartColumn;
         public readonly int EndLine;
-        public readonly int EndColumn;
+        public readonly ushort StartColumn;
+        public readonly ushort EndColumn;
         public readonly DebugSourceDocument Document;
 
         public SequencePoint(
             DebugSourceDocument document,
             int offset,
             int startLine,
-            int startColumn,
+            ushort startColumn,
             int endLine,
-            int endColumn)
+            ushort endColumn)
         {
             Debug.Assert(document != null);
 
@@ -35,7 +37,7 @@ namespace Microsoft.Cci
             Document = document;
         }
 
-        public bool IsHidden => StartLine == 0xfeefee;
+        public bool IsHidden => StartLine == HiddenLine;
 
         public override int GetHashCode()
         {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/ExpressionCompilerTestHelpers.cs
@@ -758,7 +758,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
                 {
                     var sequencePoints = symMethod.GetSequencePoints();
                     ilOffset = atLineNumber < 0
-                        ? sequencePoints.Where(sp => sp.StartLine != SequencePointList.HiddenSequencePointLine).Select(sp => sp.Offset).FirstOrDefault()
+                        ? sequencePoints.Where(sp => sp.StartLine != Cci.SequencePoint.HiddenLine).Select(sp => sp.Offset).FirstOrDefault()
                         : sequencePoints.First(sp => sp.StartLine == atLineNumber).Offset;
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/20118