### PR TITLE
Handle special cases with suppression operator

### DIFF
--- a/docs/features/nullable-reference-types.md
+++ b/docs/features/nullable-reference-types.md
@@ -146,6 +146,9 @@ A warning is reported when using the `!` operator absent a `NonNullTypes` contex
 
 Unnecessary usages of `!` do not produce any diagnostics, including `!!`.
 
+A suppressed expression `e!` can be target-typed if the operand expression `e` can be target-typed.
+A suppressed expression `e!` contributes to method type inference just how `e` does.
+
 ### Explicit cast
 Explicit cast to `?` changes top-level nullability.
 Explicit cast to `!` does not change top-level nullability and may produce W warning.

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -209,8 +209,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var outer = (BoundSuppressNullableWarningExpression)expr;
                         var inner = CheckValue(outer.Expression, valueKind, diagnostics);
-                        return outer.Update(inner, inner.Type);
+                        expr = outer.Update(inner, inner.Type);
                     }
+                    break;
             }
 
             bool hasResolutionErrors = false;
@@ -324,8 +325,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return CheckEventValueKind((BoundEventAccess)expr, valueKind, diagnostics);
 
                 case BoundKind.SuppressNullableWarningExpression:
-                    // https://github.com/dotnet/roslyn/issues/29710 We can reach this assertion
-                    Debug.Assert(false);
+                    if (!IsLegalSuppressionValueKind(valueKind))
+                    {
+                        Error(diagnostics, ErrorCode.ERR_IllegalSuppression, node);
+                        return false;
+                    }
+
                     return CheckValueKind(node, ((BoundSuppressNullableWarningExpression)expr).Expression, valueKind, checkingReceiver, diagnostics);
             }
 
@@ -495,6 +500,23 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // At this point we should have covered all the possible cases for anything that is not a strict RValue.
             Error(diagnostics, GetStandardLvalueError(valueKind), node);
+            return false;
+        }
+
+        private static bool IsLegalSuppressionValueKind(BindValueKind valueKind)
+        {
+            // Need to review allowed uses of the suppression operator
+            // Tracked by https://github.com/dotnet/roslyn/issues/31297
+
+            switch (valueKind)
+            {
+                case BindValueKind.RValue:
+                case BindValueKind.RValueOrMethodGroup:
+                case BindValueKind.RefOrOut:
+                    return true;
+            }
+
+            // all others are illegal
             return false;
         }
 
@@ -2373,6 +2395,10 @@ moreArguments:
                     // only possible in error cases (if possible at all)
                     return scopeOfTheContainingExpression;
 
+                case BoundKind.SuppressNullableWarningExpression:
+                    var suppressed = (BoundSuppressNullableWarningExpression)expr;
+                    return GetValEscape(suppressed.Expression, scopeOfTheContainingExpression);
+
                 default:
                     // in error situations some unexpected nodes could make here
                     // returning "scopeOfTheContainingExpression" seems safer than throwing.
@@ -2703,6 +2729,11 @@ moreArguments:
                 case BoundKind.ArrayAccess:
                     // only possible in error cases (if possible at all)
                     return false;
+
+                case BoundKind.SuppressNullableWarningExpression:
+                    // Need to implement and test escape rules for suppression operator
+                    // Tracked by https://github.com/dotnet/roslyn/issues/31297
+                    goto default;
 
                 default:
                     // in error situations some unexpected nodes could make here

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -68,6 +68,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // nothing else changes
                 if (source.Kind == BoundKind.TupleLiteral)
                 {
+                    // We need to handle suppressed tuple literals as well
+                    // Tracked by https://github.com/dotnet/roslyn/issues/32553
+
                     var sourceTuple = (BoundTupleLiteral)source;
                     TupleTypeSymbol.ReportNamesMismatchesIfAny(destination, sourceTuple, diagnostics);
                     source = new BoundConvertedTupleLiteral(
@@ -93,19 +96,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return CreateMethodGroupConversion(syntax, source, conversion, isCast: isCast, conversionGroupOpt, destination, diagnostics);
             }
 
-            if (conversion.IsAnonymousFunction && source.Kind == BoundKind.UnboundLambda)
+            if (conversion.IsAnonymousFunction && source.KindIgnoringSuppressions() == BoundKind.UnboundLambda)
             {
                 return CreateAnonymousFunctionConversion(syntax, source, conversion, isCast: isCast, conversionGroupOpt, destination, diagnostics);
             }
 
             if (conversion.IsStackAlloc)
             {
+                Debug.Assert(source.Kind != BoundKind.SuppressNullableWarningExpression);
                 return CreateStackAllocConversion(syntax, source, conversion, isCast, conversionGroupOpt, destination, diagnostics);
             }
 
             if (conversion.IsTupleLiteralConversion ||
                 (conversion.IsNullable && conversion.UnderlyingConversions[0].IsTupleLiteralConversion))
             {
+                // We need to handle suppressed tuple literals as well
+                // Tracked by https://github.com/dotnet/roslyn/issues/32553
+
                 return CreateTupleLiteralConversion(syntax, (BoundTupleLiteral)source, conversion, isCast: isCast, conversionGroupOpt, destination, diagnostics);
             }
 
@@ -117,9 +124,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             ConstantValue constantValue = this.FoldConstantConversion(syntax, source, conversion, destination, diagnostics);
-            if (conversion.Kind == ConversionKind.DefaultOrNullLiteral && source.Kind == BoundKind.DefaultExpression)
+            if (conversion.Kind == ConversionKind.DefaultOrNullLiteral && source.KindIgnoringSuppressions() == BoundKind.DefaultExpression)
             {
-                source = ((BoundDefaultExpression)source).Update(constantValue, destination);
+                var result = ((BoundDefaultExpression)source.RemoveSuppressions()).Update(constantValue, destination);
+                source = result.WrapWithSuppressionsFrom(source);
             }
 
             return new BoundConversion(
@@ -298,13 +306,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             // UNDONE: Figure out what to do about the error case, where a lambda
             // UNDONE: is converted to a delegate that does not match. What to surface then?
 
-            var unboundLambda = (UnboundLambda)source;
+            Debug.Assert(source.KindIgnoringSuppressions() == BoundKind.UnboundLambda);
+            var unboundLambda = (UnboundLambda)source.RemoveSuppressions();
             var boundLambda = unboundLambda.Bind((NamedTypeSymbol)destination);
             diagnostics.AddRange(boundLambda.Diagnostics);
 
+            Debug.Assert(unboundLambda.WasCompilerGenerated == source.WasCompilerGenerated);
             return new BoundConversion(
                 syntax,
-                boundLambda,
+                boundLambda.WrapWithSuppressionsFrom(source),
                 conversion,
                 @checked: false,
                 explicitCastInCode: isCast,
@@ -316,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression CreateMethodGroupConversion(SyntaxNode syntax, BoundExpression source, Conversion conversion, bool isCast, ConversionGroup conversionGroup, TypeSymbol destination, DiagnosticBag diagnostics)
         {
-            BoundMethodGroup group = FixMethodGroupWithTypeOrValue((BoundMethodGroup)source, conversion, diagnostics);
+            BoundMethodGroup group = FixMethodGroupWithTypeOrValue((BoundMethodGroup)source.RemoveSuppressions(), conversion, diagnostics);
             BoundExpression receiverOpt = group.ReceiverOpt;
             MethodSymbol method = conversion.Method;
             bool hasErrors = false;
@@ -332,7 +342,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors = true;
             }
 
-            return new BoundConversion(syntax, group, conversion, @checked: false, explicitCastInCode: isCast, conversionGroup, constantValueOpt: ConstantValue.NotAvailable, type: destination, hasErrors: hasErrors) { WasCompilerGenerated = source.WasCompilerGenerated };
+            return new BoundConversion(syntax, group.WrapWithSuppressionsFrom(source), conversion, @checked: false, explicitCastInCode: isCast, conversionGroup, constantValueOpt: ConstantValue.NotAvailable, type: destination, hasErrors: hasErrors) { WasCompilerGenerated = source.WasCompilerGenerated };
         }
 
         private BoundExpression CreateStackAllocConversion(SyntaxNode syntax, BoundExpression source, Conversion conversion, bool isCast, ConversionGroup conversionGroup, TypeSymbol destination, DiagnosticBag diagnostics)
@@ -468,19 +478,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        private static bool IsMethodGroupWithTypeOrValueReceiver(BoundNode node)
-        {
-            if (node.Kind != BoundKind.MethodGroup)
-            {
-                return false;
-            }
-
-            return Binder.IsTypeOrValueExpression(((BoundMethodGroup)node).ReceiverOpt);
-        }
-
         private BoundMethodGroup FixMethodGroupWithTypeOrValue(BoundMethodGroup group, Conversion conversion, DiagnosticBag diagnostics)
         {
-            if (!IsMethodGroupWithTypeOrValueReceiver(group))
+            if (!IsTypeOrValueExpression(group.ReceiverOpt))
             {
                 return group;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -231,7 +231,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool allowUnexpandedForm = true)
         {
             BoundExpression result;
-            NamedTypeSymbol delegateType;
 
             if ((object)boundExpression.Type != null && boundExpression.Type.IsDynamic())
             {
@@ -240,13 +239,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // invocation and let the lowering pass sort it out.
                 result = BindDynamicInvocation(node, boundExpression, analyzedArguments, ImmutableArray<MethodSymbol>.Empty, diagnostics, queryClause);
             }
-            else if (boundExpression.Kind == BoundKind.MethodGroup)
+            else if (boundExpression.KindIgnoringSuppressions() == BoundKind.MethodGroup)
             {
-                result = BindMethodGroupInvocation(
-                    node, expression, methodName, (BoundMethodGroup)boundExpression, analyzedArguments,
-                    diagnostics, queryClause, allowUnexpandedForm: allowUnexpandedForm, anyApplicableCandidates: out _);
+                if (boundExpression.Kind == BoundKind.SuppressNullableWarningExpression)
+                {
+                    diagnostics.Add(new CSDiagnosticInfo(ErrorCode.ERR_IllegalSuppression), expression.Location);
+                    result = CreateBadCall(node, boundExpression, LookupResultKind.NotInvocable, analyzedArguments);
+                }
+                else
+                {
+                    result = BindMethodGroupInvocation(
+                        node, expression, methodName, (BoundMethodGroup)boundExpression, analyzedArguments,
+                        diagnostics, queryClause, allowUnexpandedForm: allowUnexpandedForm, anyApplicableCandidates: out _);
+                }
             }
-            else if ((object)(delegateType = GetDelegateType(boundExpression)) != null)
+            else if (GetDelegateType(boundExpression) is NamedTypeSymbol delegateType)
             {
                 if (ReportDelegateInvokeUseSiteDiagnostic(diagnostics, delegateType, node: node))
                 {
@@ -283,6 +290,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasErrors = false;
             if (expression.Kind == BoundKind.MethodGroup)
             {
+                // We need to decide how to handle suppression operator in the middle of dynamic invocations
+                // Tracked by https://github.com/dotnet/roslyn/issues/32364
+
                 BoundMethodGroup methodGroup = (BoundMethodGroup)expression;
                 BoundExpression receiver = methodGroup.ReceiverOpt;
 
@@ -478,6 +488,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     else if (arg.IsLiteralDefault())
                     {
                         Error(diagnostics, ErrorCode.ERR_BadDynamicMethodArgDefaultLiteral, arg.Syntax);
+                        hasErrors = true;
+                    }
+                    else if (arg.Kind == BoundKind.SuppressNullableWarningExpression)
+                    {
+                        // https://github.com/dotnet/roslyn/issues/32364 Need to clarify behavior of dynamic and nullability
+                        Error(diagnostics, ErrorCode.ERR_IllegalSuppression, arg.Syntax);
                         hasErrors = true;
                     }
                     else
@@ -1338,7 +1354,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             int argumentCount = analyzedArguments.Arguments.Count;
-            ArrayBuilder<BoundExpression> newArguments = ArrayBuilder<BoundExpression>.GetInstance(argumentCount);
+            var newArguments = ArrayBuilder<BoundExpression>.GetInstance(argumentCount);
             newArguments.AddRange(analyzedArguments.Arguments);
             for (int i = 0; i < argumentCount; i++)
             {
@@ -1348,12 +1364,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continue;
                 }
 
-                switch (argument.Kind)
+                switch (argument.KindIgnoringSuppressions())
                 {
                     case BoundKind.UnboundLambda:
                         {
                             // bind the argument against each applicable parameter
-                            var unboundArgument = (UnboundLambda)argument;
+                            var unboundArgument = (UnboundLambda)argument.RemoveSuppressions();
                             foreach (var parameterList in parameterListList)
                             {
                                 var parameterType = GetCorrespondingParameterType(analyzedArguments, i, parameterList);
@@ -1365,12 +1381,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
 
                             // replace the unbound lambda with its best inferred bound version
-                            newArguments[i] = unboundArgument.BindForErrorRecovery();
+                            newArguments[i] = unboundArgument.BindForErrorRecovery().WrapWithSuppressionsFrom(argument);
                             break;
                         }
                     case BoundKind.OutVariablePendingInference:
                     case BoundKind.DiscardExpression:
                         {
+                            Debug.Assert(argument.KindIgnoringSuppressions() == argument.Kind); // no suppressions possible on out vars or discards
                             if (argument.HasExpressionType())
                             {
                                 break;
@@ -1423,6 +1440,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     case BoundKind.OutDeconstructVarPendingInference:
                         {
+                            Debug.Assert(argument.KindIgnoringSuppressions() == argument.Kind); // no suppressions possible on out vars for Deconstruct
                             newArguments[i] = ((OutDeconstructVarPendingInference)argument).FailInference(this);
                             break;
                         }
@@ -1480,7 +1498,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var args = BuildArgumentsForErrorRecovery(analyzedArguments);
             var argNames = analyzedArguments.GetNames();
             var argRefKinds = analyzedArguments.RefKinds.ToImmutableOrNull();
-            var originalMethods = (expr.Kind == BoundKind.MethodGroup) ? ((BoundMethodGroup)expr).Methods : ImmutableArray<MethodSymbol>.Empty;
+            var originalMethods = (expr.KindIgnoringSuppressions() == BoundKind.MethodGroup) ? ((BoundMethodGroup)expr.RemoveSuppressions()).Methods : ImmutableArray<MethodSymbol>.Empty;
 
             return BoundCall.ErrorCall(node, expr, method, args, argNames, argRefKinds, isDelegateCall: false, invokedAsExtensionMethod: false, originalMethods: originalMethods, resultKind: resultKind, binder: this);
         }
@@ -1533,9 +1551,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We relax the instance-vs-static requirement for top-level member access expressions by creating a NameofBinder binder.
             var nameofBinder = new NameofBinder(argument, this);
             var boundArgument = nameofBinder.BindExpression(argument, diagnostics);
-            if (!boundArgument.HasAnyErrors && CheckSyntaxForNameofArgument(argument, out name, diagnostics) && boundArgument.Kind == BoundKind.MethodGroup)
+
+            if (!boundArgument.HasAnyErrors && CheckSyntaxForNameofArgument(argument, out name, diagnostics) && boundArgument.KindIgnoringSuppressions() == BoundKind.MethodGroup)
             {
-                var methodGroup = (BoundMethodGroup)boundArgument;
+                var methodGroup = (BoundMethodGroup)boundArgument.RemoveSuppressions();
                 if (!methodGroup.TypeArgumentsOpt.IsDefaultOrEmpty)
                 {
                     // method group with type parameters not allowed

--- a/src/Compilers/CSharp/Portable/Binder/Binder_QueryErrors.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_QueryErrors.cs
@@ -212,6 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Estimate the return type of Select's lambda argument
             BoundExpression arg = arguments.Argument(arguments.IsExtensionMethodInvocation ? 1 : 0);
+            Debug.Assert(arg.Kind != BoundKind.SuppressNullableWarningExpression);
             TypeSymbol type = null;
             if (arg.Kind == BoundKind.UnboundLambda)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1663,7 +1663,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // error lambdas like "Action<int> f = x=>{ x. };" because IntelliSense
             // needs to know that x is of type int. 
 
-            if (expression.HasAnyErrors && expression.Kind != BoundKind.UnboundLambda)
+            if (expression.HasAnyErrors && expression.KindIgnoringSuppressions() != BoundKind.UnboundLambda)
             {
                 diagnostics = new DiagnosticBag();
             }
@@ -1987,11 +1987,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return;
             }
-            while (operand.Kind == BoundKind.SuppressNullableWarningExpression)
-            {
-                operand = ((BoundSuppressNullableWarningExpression)operand).Expression;
-            }
 
+            operand = operand.RemoveSuppressions();
             switch (operand.Kind)
             {
                 case BoundKind.BadExpression:
@@ -2089,7 +2086,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            Debug.Assert(operand.HasAnyErrors && operand.Kind != BoundKind.UnboundLambda, "Missing a case in implicit conversion error reporting");
+            Debug.Assert(operand.HasAnyErrors && operand.KindIgnoringSuppressions() != BoundKind.UnboundLambda, "Missing a case in implicit conversion error reporting");
         }
 
         private void GenerateImplicitConversionErrorsForTupleLiteralArguments(

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -805,6 +805,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return Conversion.NoConversion;
             }
 
+            // There is a conversion from expression `e!` if there is a conversion from expression `e`
+            sourceExpression = sourceExpression.RemoveSuppressions();
+
             if (HasImplicitEnumerationConversion(sourceExpression, destination))
             {
                 return Conversion.ImplicitEnumeration;
@@ -835,15 +838,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case BoundKind.SuppressNullableWarningExpression:
-                    {
-                        var innerExpression = ((BoundSuppressNullableWarningExpression)sourceExpression).Expression;
-                        var innerConversion = ClassifyImplicitBuiltInConversionFromExpression(innerExpression, innerExpression.Type, destination, ref useSiteDiagnostics);
-                        if (innerConversion.Exists)
-                        {
-                            return innerConversion;
-                        }
-                        break;
-                    }
+                    throw ExceptionUtilities.Unreachable;
 
                 case BoundKind.ExpressionWithNullability:
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression nonDelegate = leftDelegate ? right : left;
 
             if ((kind == BinaryOperatorKind.Equal || kind == BinaryOperatorKind.NotEqual)
-                && nonDelegate.Kind == BoundKind.UnboundLambda)
+                && nonDelegate.KindIgnoringSuppressions() == BoundKind.UnboundLambda)
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2078,7 +2078,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // Determine whether t1 or t2 is a better conversion target from node.
         private BetterResult BetterConversionFromExpression(BoundExpression node, TypeSymbol t1, TypeSymbol t2, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert(node.Kind != BoundKind.UnboundLambda);
+            Debug.Assert(node.KindIgnoringSuppressions() != BoundKind.UnboundLambda);
             bool ignore;
             return BetterConversionFromExpression(
                 node,
@@ -2207,6 +2207,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (node.Kind == BoundKind.TupleLiteral)
             {
+                // We need to handle suppressed tuple literals as well
+                // Tracked by https://github.com/dotnet/roslyn/issues/32553
+
                 // Recurse into tuple constituent arguments.
                 // Even if the tuple literal has a natural type and conversion 
                 // from that type is not identity, we still have to do this 
@@ -2221,12 +2224,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol invoke;
             TypeSymbol y;
 
-            if (node.Kind == BoundKind.UnboundLambda &&
+            if (node.KindIgnoringSuppressions() == BoundKind.UnboundLambda &&
                 (object)(d = t.GetDelegateType()) != null &&
                 (object)(invoke = d.DelegateInvokeMethod) != null &&
                 (y = invoke.ReturnType.TypeSymbol).SpecialType != SpecialType.System_Void)
             {
-                BoundLambda lambda = ((UnboundLambda)node).BindForReturnTypeInference(d);
+                BoundLambda lambda = ((UnboundLambda)node.RemoveSuppressions()).BindForReturnTypeInference(d);
 
                 // - an inferred return type X exists for E in the context of the parameter list of D(§7.5.2.12), and an identity conversion exists from X to Y
                 var x = lambda.GetInferredReturnType(ref useSiteDiagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -984,9 +984,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hadError = false;
             foreach (var argument in arguments.Arguments)
             {
-                if (argument.Kind == BoundKind.UnboundLambda)
+                var argumentWithoutSuppressions = argument.RemoveSuppressions();
+                if (argumentWithoutSuppressions.Kind == BoundKind.UnboundLambda)
                 {
-                    hadError |= ((UnboundLambda)argument).GenerateSummaryErrors(diagnostics);
+                    hadError |= ((UnboundLambda)argumentWithoutSuppressions).GenerateSummaryErrors(diagnostics);
                 }
             }
 
@@ -1120,12 +1121,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // If the problem is that a lambda isn't convertible to the given type, also report why.
                 // The argument and parameter type might match, but may not have same in/out modifiers
-                if (argument.Kind == BoundKind.UnboundLambda && refArg == refParameter)
+                if (argument.KindIgnoringSuppressions() == BoundKind.UnboundLambda && refArg == refParameter)
                 {
-                    ((UnboundLambda)argument).GenerateAnonymousFunctionConversionError(diagnostics, parameterType);
+                    ((UnboundLambda)argument.RemoveSuppressions()).GenerateAnonymousFunctionConversionError(diagnostics, parameterType);
                 }
-                else if (argument.Kind == BoundKind.MethodGroup && parameterType.TypeKind == TypeKind.Delegate &&
-                        Conversions.ReportDelegateMethodGroupDiagnostics(binder, (BoundMethodGroup)argument, parameterType, diagnostics))
+                else if (argument.KindIgnoringSuppressions() == BoundKind.MethodGroup && parameterType.TypeKind == TypeKind.Delegate &&
+                        Conversions.ReportDelegateMethodGroupDiagnostics(binder, (BoundMethodGroup)argument.RemoveSuppressions(), parameterType, diagnostics))
                 {
                     // a diagnostic has been reported by ReportDelegateMethodGroupDiagnostics
                 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -171,6 +171,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     symbols.AddRange(originalIndexers);
                     break;
 
+                case BoundKind.SuppressNullableWarningExpression:
+                    // caller removed suppressions
+                    throw ExceptionUtilities.Unreachable;
+
                 default:
                     var symbol = node.ExpressionSymbol;
                     if ((object)symbol != null)
@@ -295,6 +299,33 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return NullableAnnotation.Unknown;
+        }
+
+        public static BoundKind KindIgnoringSuppressions(this BoundExpression expr)
+        {
+            return RemoveSuppressions(expr).Kind;
+        }
+
+        internal static BoundExpression RemoveSuppressions(this BoundExpression expr)
+        {
+            while (expr.Kind == BoundKind.SuppressNullableWarningExpression)
+            {
+                expr = ((BoundSuppressNullableWarningExpression)expr).Expression;
+            }
+
+            return expr;
+        }
+
+        internal static BoundExpression WrapWithSuppressionsFrom(this BoundExpression expr, BoundExpression suppressionsSource)
+        {
+            if (suppressionsSource.Kind != BoundKind.SuppressNullableWarningExpression)
+            {
+                return expr;
+            }
+
+            var suppression = (BoundSuppressNullableWarningExpression)suppressionsSource;
+            var nested = expr.WrapWithSuppressionsFrom(suppression.Expression);
+            return suppression.Update(nested, nested.Type);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4489,6 +4489,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Expression tree cannot contain a suppression operator..
+        /// </summary>
+        internal static string ERR_ExpressionTreeCantContainSuppressNullableWarning {
+            get {
+                return ResourceManager.GetString("ERR_ExpressionTreeCantContainSuppressNullableWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An expression tree may not contain an anonymous method expression.
         /// </summary>
         internal static string ERR_ExpressionTreeContainsAnonymousMethod {
@@ -5421,6 +5430,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_IllegalStatement {
             get {
                 return ResourceManager.GetString("ERR_IllegalStatement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The suppression operator is not allowed in this context.
+        /// </summary>
+        internal static string ERR_IllegalSuppression {
+            get {
+                return ResourceManager.GetString("ERR_IllegalSuppression", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2815,6 +2815,9 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
   <data name="ERR_BadDelegateLeave" xml:space="preserve">
     <value>Control cannot leave the body of an anonymous method or lambda expression</value>
   </data>
+  <data name="ERR_IllegalSuppression" xml:space="preserve">
+    <value>The suppression operator is not allowed in this context</value>
+  </data>
   <data name="WRN_IllegalPragma" xml:space="preserve">
     <value>Unrecognized #pragma directive</value>
   </data>
@@ -5699,6 +5702,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_ExpressionTreeCantContainRefStruct" xml:space="preserve">
     <value>Expression tree cannot contain value of ref struct or restricted type '{0}'.</value>
+  </data>
+  <data name="ERR_ExpressionTreeCantContainSuppressNullableWarning" xml:space="preserve">
+    <value>Expression tree cannot contain a suppression operator.</value>
   </data>
   <data name="ERR_ElseCannotStartStatement" xml:space="preserve">
     <value>'else' cannot start a statement.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1584,6 +1584,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AltInterpolatedVerbatimStringsNotAvailable = 8401,
         WRN_DefaultLiteralConvertedToNullIsNotIntended = 8402,
         ERR_IteratorMustBeAsync = 8403,
+        ERR_ExpressionTreeCantContainSuppressNullableWarning = 8404,
 
         ERR_NoConvToIAsyncDisp = 8410,
         ERR_AwaitForEachMissingMember = 8411,
@@ -1625,6 +1626,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DiscardPatternInSwitchStatement = 8523,
         #endregion diagnostics introduced for recursive patterns
 
+        ERR_IllegalSuppression = 8598,
         WRN_IllegalPPWarningSafeOnly = 8599,
         WRN_ConvertingNullableToNonNullable = 8600,
         WRN_NullReferenceAssignment = 8601,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1361,7 +1361,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (node.IsExtensionMethod || ((object)node.SymbolOpt != null && !node.SymbolOpt.IsStatic))
                 {
-                    BoundExpression receiver = ((BoundMethodGroup)node.Operand).ReceiverOpt;
+                    BoundExpression receiver = ((BoundMethodGroup)node.Operand.RemoveSuppressions()).ReceiverOpt;
                     // A method group's "implicit this" is only used for instance methods.
                     if (_trackRegions)
                     {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1989,6 +1989,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return ((BoundExpressionWithNullability)expr).NullableAnnotation;
                 case BoundKind.MethodGroup:
                 case BoundKind.UnboundLambda:
+                case BoundKind.SuppressNullableWarningExpression:
                     return NullableAnnotation.Unknown;
                 default:
                     Debug.Assert(false); // unexpected value
@@ -3023,12 +3024,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression getArgumentForMethodTypeInference(BoundExpression argument, TypeSymbolWithAnnotations argumentType)
             {
-                if (argument.Kind == BoundKind.Lambda)
+                if (argument.KindIgnoringSuppressions() == BoundKind.Lambda)
                 {
                     // MethodTypeInferrer must infer nullability for lambdas based on the nullability
                     // from flow analysis rather than the declared nullability. To allow that, we need
                     // to re-bind lambdas in MethodTypeInferrer.
-                    return GetUnboundLambda((BoundLambda)argument, GetVariableState());
+                    return GetUnboundLambda((BoundLambda)argument.RemoveSuppressions(), GetVariableState()).WrapWithSuppressionsFrom(argument);
                 }
                 if (argumentType.IsNull)
                 {
@@ -3114,6 +3115,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
             return (expr, group?.Conversion ?? Conversion.Identity);
+        }
+
+        /// <summary>
+        /// Returns true if the expression had a suppression.
+        /// </summary>
+        bool RemoveSuppressions(ref BoundExpression expression)
+        {
+            var original = expression;
+            expression = expression.RemoveSuppressions();
+            return expression != original;
         }
 
         // See Binder.BindNullCoalescingOperator for initial binding.
@@ -3310,6 +3321,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             (BoundExpression operand, Conversion conversion) = RemoveConversion(expr, includeExplicitConversions: false);
+
             var operandType = VisitRvalueWithResult(operand);
             // If an explicit conversion was used in place of an implicit conversion, the explicit
             // conversion was created by initial binding after reporting "error CS0266:
@@ -3480,18 +3492,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             NullableAnnotation resultAnnotation = NullableAnnotation.Unknown;
             bool forceOperandAnnotationForResult = false;
             bool canConvertNestedNullability = true;
+            bool isSuppressed = false;
 
             if (operandOpt?.Kind == BoundKind.SuppressNullableWarningExpression)
             {
                 reportTopLevelWarnings = false;
                 reportRemainingWarnings = false;
+                operandOpt = operandOpt.RemoveSuppressions();
+                isSuppressed = true;
             }
 
             TypeSymbol targetType = targetTypeWithNullability.TypeSymbol;
             switch (conversion.Kind)
             {
                 case ConversionKind.MethodGroup:
-                    if (!fromExplicitCast)
+                    if (reportRemainingWarnings)
                     {
                         ReportNullabilityMismatchWithTargetDelegate(node.Syntax, targetType.GetDelegateType(), conversion.Method);
                     }
@@ -3508,7 +3523,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Analyze(compilation, lambda, Diagnostics, delegateInvokeMethod: delegateType?.DelegateInvokeMethod, returnTypes: null, initialState: variableState);
                         var unboundLambda = GetUnboundLambda(lambda, variableState);
                         var boundLambda = unboundLambda.Bind(delegateType);
-                        if (!fromExplicitCast)
+                        if (reportRemainingWarnings)
                         {
                             ReportNullabilityMismatchWithTargetDelegate(node.Syntax, delegateType, unboundLambda);
                         }
@@ -3787,6 +3802,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 default:
                     Debug.Assert(targetType.IsValueType);
                     break;
+            }
+
+            if (isSuppressed)
+            {
+                resultAnnotation = NullableAnnotation.NotNullable;
             }
 
             var resultType = TypeSymbolWithAnnotations.Create(targetType, resultAnnotation);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsOperator.cs
@@ -3,8 +3,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -27,21 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Conversion conversion,
             TypeSymbol rewrittenType)
         {
-            if (rewrittenOperand.Kind == BoundKind.MethodGroup)
-            {
-                var methodGroup = (BoundMethodGroup)rewrittenOperand;
-                BoundExpression receiver = methodGroup.ReceiverOpt;
-                if (receiver != null && receiver.Kind != BoundKind.ThisReference)
-                {
-                    // possible side-effect
-                    return RewriteConstantIsOperator(receiver.Syntax, receiver, ConstantValue.False, rewrittenType);
-                }
-                else
-                {
-                    return MakeLiteral(syntax, ConstantValue.False, rewrittenType);
-                }
-            }
-
+            Debug.Assert(rewrittenOperand.Kind != BoundKind.MethodGroup);
             var operandType = rewrittenOperand.Type;
             var targetType = rewrittenTargetType.Type;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -12,7 +12,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(conversion.ConversionKind == ConversionKind.InterpolatedString);
             BoundExpression format;
             ArrayBuilder<BoundExpression> expressions;
-            MakeInterpolatedStringFormat((BoundInterpolatedString)conversion.Operand, out format, out expressions);
+            BoundExpression operand = conversion.Operand.RemoveSuppressions();
+            MakeInterpolatedStringFormat((BoundInterpolatedString)operand, out format, out expressions);
             expressions.Insert(0, format);
             var stringFactory = _factory.WellKnownType(WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory);
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -107,6 +107,11 @@
         <target state="new">Expression tree cannot contain value of ref struct or restricted type '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ExpressionTreeCantContainSuppressNullableWarning">
+        <source>Expression tree cannot contain a suppression operator.</source>
+        <target state="new">Expression tree cannot contain a suppression operator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ExpressionTreeContainsSwitchExpression">
         <source>An expression tree may not contain a switch expression.</source>
         <target state="new">An expression tree may not contain a switch expression.</target>
@@ -145,6 +150,11 @@
       <trans-unit id="ERR_GoToForwardJumpOverUsingVar">
         <source>A goto cannot jump to a location after a using declaration.</source>
         <target state="new">A goto cannot jump to a location after a using declaration.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_IllegalSuppression">
+        <source>The suppression operator is not allowed in this context</source>
+        <target state="new">The suppression operator is not allowed in this context</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -968,7 +968,6 @@ class C
                 // (7,21): error CS8181: 'new' cannot be used with tuple type. Use a tuple literal expression instead.
                 //         var x = new (int, int)(1, arg);
                 Diagnostic(ErrorCode.ERR_NewWithTupleTypeSyntax, "(int, int)").WithLocation(7, 21)
-
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -363,6 +363,31 @@ class C
         }
 
         [Fact]
+        public void SuppressNullableWarning_FakeIndexIndexerArray()
+        {
+            string source = @"
+using System;
+class C
+{
+    public static void Main()
+    {
+        var x = new[] { 1, 2, 3, 11 };
+        M(x);
+    }
+
+    public static void M(int[] array)
+    {
+        Console.Write(array[new Index(1, false)!]);
+        Console.Write(array[(^1)!]);
+    }
+}";
+            // cover case in ConvertToArrayIndex
+            var comp = CreateCompilationWithIndex(source, WithNonNullTypesTrue(TestOptions.DebugExe));
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "211");
+        }
+
+        [Fact]
         public void FakeIndexIndexerArrayNoValue()
         {
             var comp = CreateCompilation(@"

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             expectedOperationTree = expectedOperationTree.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
             expectedOperationTree = expectedOperationTree.Replace("\"", "\"\"");
 
-            AssertEx.AreEqual(expectedOperationTree, actual);
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedOperationTree, actual);
         }
 
         #region Logging helpers


### PR DESCRIPTION
This PR addresses some issues with the suppression operator.

The main thing is that `e` in `e!` should be target-typed. For example, `string s = null!;` or `Func<string?> f = () => { return null; }!`.
In those situations, the suppression is left underneath the BoundConversion. This also properly represents scenarios with casts: `(string)null!`.
But we have lots of locations in the code where we check a conversion kind and then proceed to cast the underlying expression. Now such locations need to expect that a suppression might be there (can't directly cast).
This PR does not address tuple scenarios however.

I started from `ClassifyImplicitBuiltInConversionFromExpression`.
Then I reviewed uses of `BoundKind.UnboundLambda`, `BoundKind.Lambda`, `BoundKind.MethodGroup`, `IsLiteralDefault`, `IsLiterallNull`, `IsLiterallNullOrDefault`, `BoundKind.InterpolatedString`.

Fixed a number of crashes
Fixes https://github.com/dotnet/roslyn/issues/29862 (top-level nullability of !)
Fixes https://github.com/dotnet/roslyn/issues/29903 (`t! = s` should be an error)
I also noticed that we skipped some warnings in cast scenarios (latest [LDM notes](https://github.com/dotnet/csharplang/blob/master/meetings/2018/LDM-2018-08-20.md#11-suppression-of-nested-nullability) on the topic)
Closes https://github.com/dotnet/roslyn/issues/31294 (`throw null!;` isn't allowed)

Follow-ups:
- We'll need to refine where suppressions are allowed (I probably made more cases illegal than strictly necessary, for now)
- https://github.com/dotnet/roslyn/issues/29710 (analysis of ref re-assignment and CheckValueKind)
- https://github.com/dotnet/roslyn/issues/31297 (escape rules and suppressions)
- https://github.com/dotnet/roslyn/issues/32553 (suppressions on tuple literals)
- https://github.com/dotnet/roslyn/issues/32364 (nullable and dynamic)
- https://github.com/dotnet/roslyn/issues/32661 (follow-up on semantic model on suppressed expressions)
- https://github.com/dotnet/roslyn/issues/32697 (need to re-analyze method group conversions)
- https://github.com/dotnet/roslyn/issues/32698 (need to analyze delegate creations)

Notes:
- Although I ended up removing the IOperation test I'd added, I adjusted the comparison logic for IOperation assertions to tolerate whitespaces