### PR TITLE
Switch to IVsDropDownBarClient4 to let us handle image monikers directly

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -144,6 +144,7 @@
     <MicrosoftVisualStudioTextManagerInterop100Version>10.0.30320</MicrosoftVisualStudioTextManagerInterop100Version>
     <MicrosoftVisualStudioTextManagerInterop120Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop120Version>
     <MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>12.1.30328</MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>
+    <MicrosoftVisualStudioTextManagerInterop160DesignTimeVersion>16.0.0</MicrosoftVisualStudioTextManagerInterop160DesignTimeVersion>
     <MicrosoftVisualStudioThreadingAnalyzersVersion>15.8.168</MicrosoftVisualStudioThreadingAnalyzersVersion>
     <MicrosoftVisualStudioThreadingVersion>15.8.99-rc</MicrosoftVisualStudioThreadingVersion>
     <MicrosoftVisualStudioValidationVersion>15.3.23</MicrosoftVisualStudioValidationVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -101,7 +101,7 @@
     <MicrosoftVisualStudioDebuggerMetadataimplementationVersion>15.7.2082401</MicrosoftVisualStudioDebuggerMetadataimplementationVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>1.1.4322</MicrosoftVisualStudioDesignerInterfacesVersion>
     <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>16.0.28226-alpha</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>
-    <MicrosoftVisualStudioSDKEmbedInteropTypesVersion>15.0.17</MicrosoftVisualStudioSDKEmbedInteropTypesVersion>
+    <MicrosoftVisualStudioSDKEmbedInteropTypesVersion>15.0.27</MicrosoftVisualStudioSDKEmbedInteropTypesVersion>
     <MicrosoftVisualStudioEditorVersion>16.0.203-g5d5c63964e</MicrosoftVisualStudioEditorVersion>
     <MicrosoftVisualStudioGraphModelVersion>16.0.28226-alpha</MicrosoftVisualStudioGraphModelVersion>
     <MicrosoftVisualStudioImageCatalogVersion>15.0.26730-alpha</MicrosoftVisualStudioImageCatalogVersion>

--- a/eng/targets/VisualStudio.targets
+++ b/eng/targets/VisualStudio.targets
@@ -101,10 +101,6 @@
                              or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.11.0'">
         <EmbedInteropTypes>false</EmbedInteropTypes>
       </ReferencePath>
-
-      <ReferencePath Condition="'%(FileName)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'">
-        <EmbedInteropTypes>true</EmbedInteropTypes>
-      </ReferencePath>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Version="$(MicrosoftCodeAnalysisElfieVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="$(MicrosoftVisualStudioSDKEmbedInteropTypesVersion)" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="InteractiveHost" />

--- a/src/VisualStudio/Core/Def/Implementation/Extensions/VisualStudioWorkspaceImplExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Extensions/VisualStudioWorkspaceImplExtensions.cs
@@ -65,27 +65,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Extensions
             return false;
         }
 
-        public static bool TryGetImageListAndIndex(this VisualStudioWorkspaceImpl workspace, IVsImageService2 imageService, ProjectId id, out IntPtr imageList, out int index)
-        {
-            var result = TryGetImageListAndIndex(workspace, imageService, id, out imageList, out ushort ushortIndex);
-
-            index = ushortIndex;
-            return result;
-        }
-
-        public static bool TryGetImageListAndIndex(this VisualStudioWorkspaceImpl workspace, IVsImageService2 imageService, ProjectId id, out IntPtr imageList, out ushort index)
-        {
-            var hierarchy = workspace.GetHierarchy(id);
-            if (hierarchy != null)
-            {
-                return TryGetImageListAndIndex(hierarchy, imageService, VSConstants.VSITEMID_ROOT, out imageList, out index);
-            }
-
-            imageList = default;
-            index = 0;
-            return false;
-        }
-
         public static bool TryGetImageListAndIndex(this VisualStudioWorkspaceImpl workspace, IVsImageService2 imageService, DocumentId id, out IntPtr imageList, out ushort index)
         {
             var hierarchy = workspace.GetHierarchy(id.ProjectId);

--- a/src/VisualStudio/Core/Def/Implementation/NavigationBar/NavigationBarClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/NavigationBar/NavigationBarClient.cs
@@ -3,8 +3,10 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.Wpf;
 using Microsoft.Internal.VisualStudio.Shell;
 using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Extensions;
@@ -19,6 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.NavigationBar
     internal class NavigationBarClient :
         IVsDropdownBarClient,
         IVsDropdownBarClient3,
+        IVsDropdownBarClient4,
         IVsDropdownBarClientEx,
         IVsCoTaskMemFreeMyStrings,
         INavigationBarPresenter,
@@ -29,7 +32,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.NavigationBar
         private readonly VisualStudioWorkspaceImpl _workspace;
         private readonly ComEventSink _codeWindowEventsSink;
         private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService;
-        private readonly IntPtr _imageList;
         private readonly IVsImageService2 _imageService;
         private readonly Dictionary<IVsTextView, ITextView> _trackedTextViews = new Dictionary<IVsTextView, ITextView>();
         private IVsDropdownBar _dropdownBar;
@@ -48,9 +50,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.NavigationBar
             _imageService = (IVsImageService2)serviceProvider.GetService(typeof(SVsImageService));
             _projectItems = SpecializedCollections.EmptyList<NavigationBarProjectItem>();
             _currentTypeItems = SpecializedCollections.EmptyList<NavigationBarItem>();
-
-            var vsShell = serviceProvider.GetService(typeof(SVsShell)) as IVsShell;
-            vsShell?.TryGetPropertyValue(__VSSPROPID.VSSPROPID_ObjectMgrTypesImgList, out _imageList);
 
             _codeWindowEventsSink = ComEventSink.Advise<IVsCodeWindowEvents>(codeWindow, this);
             _editorAdaptersFactoryService = serviceProvider.GetMefService<IVsEditorAdaptersFactoryService>();
@@ -107,7 +106,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.NavigationBar
         int IVsDropdownBarClient.GetComboAttributes(int iCombo, out uint pcEntries, out uint puEntryType, out IntPtr phImageList)
         {
             puEntryType = (uint)(DROPDOWNENTRYTYPE.ENTRY_TEXT | DROPDOWNENTRYTYPE.ENTRY_ATTR | DROPDOWNENTRYTYPE.ENTRY_IMAGE);
-            phImageList = _imageList;
+
+            // We no longer need to return an HIMAGELIST, we now use IVsDropdownBarClient4.GetEntryImage which uses monikers directly.
+            phImageList = IntPtr.Zero;
 
             switch (iCombo)
             {
@@ -193,11 +194,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.NavigationBar
 
         int IVsDropdownBarClient.GetEntryImage(int iCombo, int iIndex, out int piImageIndex)
         {
-            var item = GetItem(iCombo, iIndex);
-
-            piImageIndex = item.Glyph.GetGlyphIndex();
-
-            return VSConstants.S_OK;
+            // This class implements IVsDropdownBarClient4 and expects IVsDropdownBarClient4.GetEntryImage() to be called instead
+            piImageIndex = -1;
+            return VSConstants.E_UNEXPECTED;
         }
 
         int IVsDropdownBarClient.GetEntryText(int iCombo, int iIndex, out string ppszText)
@@ -278,23 +277,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.NavigationBar
 
         int IVsDropdownBarClient3.GetEntryImage(int iCombo, int iIndex, out int piImageIndex, out IntPtr phImageList)
         {
+            // This class implements IVsDropdownBarClient4 and expects IVsDropdownBarClient4.GetEntryImage() to be called instead
+            phImageList = IntPtr.Zero;
+            piImageIndex = -1;
+
+            return VSConstants.E_UNEXPECTED;
+        }
+
+        ImageMoniker IVsDropdownBarClient4.GetEntryImage(int iCombo, int iIndex)
+        {
             var item = GetItem(iCombo, iIndex);
 
-            // If this is a project item, try to get the actual proper image from the VSHierarchy it 
-            // represents.  That way the icon will always look right no matter which type of project
-            // it is.  For example, if phone/Windows projects have different icons, then this can 
-            // ensure we get the right icon, and not just a hard-coded C#/VB icon.
             if (item is NavigationBarProjectItem projectItem)
             {
-                if (_workspace.TryGetImageListAndIndex(_imageService, projectItem.DocumentId.ProjectId, out phImageList, out piImageIndex))
+                if (_workspace.TryGetHierarchy(projectItem.DocumentId.ProjectId, out var hierarchy))
                 {
-                    return VSConstants.S_OK;
+                    return _imageService.GetImageMonikerForHierarchyItem(hierarchy, VSConstants.VSITEMID_ROOT, (int)__VSHIERARCHYIMAGEASPECT.HIA_Icon);
                 }
             }
 
-            piImageIndex = GetItem(iCombo, iIndex).Glyph.GetGlyphIndex();
-            phImageList = _imageList;
-            return VSConstants.S_OK;
+            return item.Glyph.GetImageMoniker();
         }
 
         int IVsDropdownBarClientEx.GetEntryIndent(int iCombo, int iIndex, out uint pIndent)

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -184,6 +184,7 @@
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="$(MicrosoftVisualStudioTextManagerInterop100Version)" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="$(MicrosoftVisualStudioTextManagerInterop120Version)" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" Version="$(MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.16.0.DesignTime" Version="$(MicrosoftVisualStudioTextManagerInterop160DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" PrivateAssets="all" />


### PR DESCRIPTION
We had a non-trivial bit of code we would use to fetch ImageMonikers from IVsHierarchies for use in the project drop down, but we would still have to convert them into legacy imagelists because that's what the old API expected. The editor added a new API that we could implement that just works natively with ImageMonikers. Besides being generally ugly, the old code also had lifetime problems where we might reuse image lists between different calls and all sorts of badness would happen.

Unfortunately I can't delete all of the code that was doing the conversion, because there is still one remaining use (the "preview changes" dialog) that is still not moved over yet. I am deleting any
of the helper methods that were exclusively used in this path though.

<details><summary>Ask Mode template</summary>

### Customer scenario

If you are using the editor and have multiple projects in your solution, the icon for the project dropdown might flicker between different project's icons.

### Bugs this fixes

Fixes #28236.

### Workarounds, if any

Don't look at the navbar, and you won't ever notice. :smile:

### Risk

Low, possibly negative. The change is straightforward and is mostly deleting complicated codepaths that were tricky in the first place. The only regression I can imagine is the icon might _not_ appear for projects that don't have an ImageMoniker at all, but in testing I couldn't find a project that met that and that'd be a high DPI/theming bug _anyways_ if such a project exists.

But why "negative?" The code we're no longer calling was tricky and doing manual resource management. The fact that we see this flickering indicates the logic wasn't correct, so it's possible this was one step away from a crash. The editor did see crashes in this area per Watson, so this is removing a source of problems.

### Performance impact

None, possibly improved because we're removing some legacy icon conversion code.

### Is this a regression from a previous update?

No.

### Root cause analysis

We had some really icky code that was introduced when VS moved to Image Monikers, that would convert them back to legacy icons in some cases for legacy APIs. This code doesn't seem to maintain lifetime semantics well (since admittedly it's not even clear what the semantics are it *should* implement) and it causes flickering.

### How was the bug found?

Dogfooding, ad-hoc testing when we've tested other changes.

</details>