### PR TITLE
add new compilation options to data sync to OOP.

### DIFF
--- a/src/Workspaces/CSharp/Portable/Execution/CSharpOptionsSerializationService.cs
+++ b/src/Workspaces/CSharp/Portable/Execution/CSharpOptionsSerializationService.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -23,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Execution
             var csharpOptions = (CSharpCompilationOptions)options;
             writer.WriteValue(csharpOptions.Usings.ToArray());
             writer.WriteBoolean(csharpOptions.AllowUnsafe);
+            writer.WriteByte((byte)csharpOptions.NullableContextOptions);
         }
 
         public override void WriteTo(ParseOptions options, ObjectWriter writer, CancellationToken cancellationToken)
@@ -81,16 +80,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Execution
                 out var outputKind, out var reportSuppressedDiagnostics, out var moduleName, out var mainTypeName, out var scriptClassName,
                 out var optimizationLevel, out var checkOverflow, out var cryptoKeyContainer, out var cryptoKeyFile, out var cryptoPublicKey,
                 out var delaySign, out var platform, out var generalDiagnosticOption, out var warningLevel, out var specificDiagnosticOptions,
-                out var concurrentBuild, out var deterministic, out var publicSign, out var xmlReferenceResolver, out var sourceReferenceResolver,
-                out var metadataReferenceResolver, out var assemblyIdentityComparer, out var strongNameProvider, cancellationToken);
+                out var concurrentBuild, out var deterministic, out var publicSign, out var metadataImportOptions,
+                out var xmlReferenceResolver, out var sourceReferenceResolver, out var metadataReferenceResolver, out var assemblyIdentityComparer,
+                out var strongNameProvider, cancellationToken);
 
             var usings = reader.ReadArray<string>();
             var allowUnsafe = reader.ReadBoolean();
+            var nullableContextOptions = (NullableContextOptions)reader.ReadByte();
 
             return new CSharpCompilationOptions(
                 outputKind, reportSuppressedDiagnostics, moduleName, mainTypeName, scriptClassName, usings, optimizationLevel, checkOverflow, allowUnsafe,
                 cryptoKeyContainer, cryptoKeyFile, cryptoPublicKey, delaySign, platform, generalDiagnosticOption, warningLevel, specificDiagnosticOptions, concurrentBuild,
-                deterministic, xmlReferenceResolver, sourceReferenceResolver, metadataReferenceResolver, assemblyIdentityComparer, strongNameProvider, publicSign);
+                deterministic, xmlReferenceResolver, sourceReferenceResolver, metadataReferenceResolver, assemblyIdentityComparer, strongNameProvider, publicSign,
+                metadataImportOptions, nullableContextOptions);
         }
 
         public override ParseOptions ReadParseOptionsFrom(ObjectReader reader, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Execution/AbstractOptionsSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractOptionsSerializationService.cs
@@ -65,6 +65,8 @@ namespace Microsoft.CodeAnalysis.Execution
             writer.WriteBoolean(options.Deterministic);
             writer.WriteBoolean(options.PublicSign);
 
+            writer.WriteByte((byte)options.MetadataImportOptions);
+
             // REVIEW: What should I do with these. we probably need to implement either out own one
             //         or somehow share these as service....
             //
@@ -95,6 +97,7 @@ namespace Microsoft.CodeAnalysis.Execution
             out bool concurrentBuild,
             out bool deterministic,
             out bool publicSign,
+            out MetadataImportOptions metadataImportOptions,
             out XmlReferenceResolver xmlReferenceResolver,
             out SourceReferenceResolver sourceReferenceResolver,
             out MetadataReferenceResolver metadataReferenceResolver,
@@ -151,6 +154,8 @@ namespace Microsoft.CodeAnalysis.Execution
             concurrentBuild = reader.ReadBoolean();
             deterministic = reader.ReadBoolean();
             publicSign = reader.ReadBoolean();
+
+            metadataImportOptions = (MetadataImportOptions)reader.ReadByte();
 
             // REVIEW: What should I do with these. are these service required when compilation is built ourselves, not through
             //         compiler.

--- a/src/Workspaces/VisualBasic/Portable/Execution/VisualBasicOptionsSerializationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Execution/VisualBasicOptionsSerializationService.vb
@@ -72,6 +72,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Execution
             Dim concurrentBuild As Boolean
             Dim deterministic As Boolean
             Dim publicSign As Boolean
+            Dim metadataImportOptions As MetadataImportOptions = Nothing
             Dim xmlReferenceResolver As XmlReferenceResolver = Nothing
             Dim sourceReferenceResolver As SourceReferenceResolver = Nothing
             Dim metadataReferenceResolver As MetadataReferenceResolver = Nothing
@@ -81,8 +82,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Execution
             ReadCompilationOptionsFrom(reader, outputKind, reportSuppressedDiagnostics, moduleName, mainTypeName, scriptClassName,
                 optimizationLevel, checkOverflow, cryptoKeyContainer, cryptoKeyFile, cryptoPublicKey, delaySign,
                 platform, generalDiagnosticOption, warningLevel, specificDiagnosticOptions, concurrentBuild, deterministic,
-                publicSign, xmlReferenceResolver, sourceReferenceResolver, metadataReferenceResolver, assemblyIdentityComparer, strongNameProvider,
-                cancellationToken)
+                publicSign, metadataImportOptions, xmlReferenceResolver, sourceReferenceResolver, metadataReferenceResolver,
+                assemblyIdentityComparer, strongNameProvider, cancellationToken)
 
             Dim globalImports = GlobalImport.Parse(reader.ReadArray(Of String)())
             Dim rootNamespace = reader.ReadString()
@@ -102,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Execution
                                                      cryptoKeyContainer, cryptoKeyFile, cryptoPublicKey, delaySign,
                                                      platform, generalDiagnosticOption, specificDiagnosticOptions, concurrentBuild, deterministic,
                                                      xmlReferenceResolver, sourceReferenceResolver, metadataReferenceResolver, assemblyIdentityComparer, strongNameProvider,
-                                                     publicSign, reportSuppressedDiagnostics)
+                                                     publicSign, reportSuppressedDiagnostics, metadataImportOptions)
         End Function
 
         Public Overrides Function ReadParseOptionsFrom(reader As ObjectReader, cancellationToken As CancellationToken) As ParseOptions


### PR DESCRIPTION
2 new options. NullableContextOptions and MetadataImportOptions

if compiler team do this (https://github.com/dotnet/roslyn/issues/12795), IDE side can simply use compiler's serialization rather than doing it in IDE side

fix https://github.com/dotnet/roslyn/issues/31870