### PR TITLE
Async-streams: allow pattern-based disposal in await using and foreach

### DIFF
--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -64,6 +64,9 @@ Just like in iterator methods, there are several restrictions on where a yield s
 
 An asynchronous `using` is lowered just like a regular `using`, except that `Dispose()` is replaced with `await DisposeAsync()`.
 
+Note that pattern-based lookup for `DisposeAsync` binds to instance methods that can be invoked without arguments.
+Extension methods do not contribute. The result of `DisposeAsync` must be awaitable.
+
 ### Detailed design for `await foreach` statement
 
 An `await foreach` is lowered just like a regular `foreach`, except that:
@@ -71,8 +74,9 @@ An `await foreach` is lowered just like a regular `foreach`, except that:
 - `MoveNext()` is replaced with `await MoveNextAsync()`
 - `Dispose()` is replaced with `await DisposeAsync()`
 
-Note that pattern-based lookup for `GetAsyncEnumerator` and `MoveNextAsync` do not place particular requirements on those methods,
-as long as they could be invoked without arguments.
+Note that pattern-based lookup for `GetAsyncEnumerator`, `MoveNextAsync` and `DisposeAsync` binds to instance methods that can be invoked without arguments.
+Extension methods do not contribute. The result of `MoveNextAsync` and `DisposeAsync` must be awaitable.
+Disposal for `await foreach` does not include a fallback to a runtime check for an interface implementation.
 
 Asynchronous foreach loops are disallowed on collections of type dynamic,
 as there is no asynchronous equivalent of the non-generic `IEnumerable` interface.

--- a/src/Compilers/CSharp/Portable/Binder/AwaitableInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/AwaitableInfo.cs
@@ -9,6 +9,8 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     internal sealed class AwaitableInfo
     {
+        public static readonly AwaitableInfo Empty = new AwaitableInfo(getAwaiterMethod: null, isCompletedProperty: null, getResultMethod: null);
+
         public readonly MethodSymbol GetAwaiter;
         public readonly PropertySymbol IsCompleted;
         public readonly MethodSymbol GetResult;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -34,18 +34,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundAwaitExpression(node, expression, info, awaitExpressionType, hasErrors);
         }
 
-        internal AwaitableInfo BindAwaitInfo(BoundExpression expression, SyntaxNode node, Location location, DiagnosticBag diagnostics, ref bool hasErrors)
+        internal AwaitableInfo BindAwaitInfo(BoundExpression expressionOpt, SyntaxNode node, Location location, DiagnosticBag diagnostics, ref bool hasErrors)
         {
-            MethodSymbol getAwaiter;
-            PropertySymbol isCompleted;
-            MethodSymbol getResult;
+            hasErrors |= ReportBadAwaitWithoutAsync(location, diagnostics);
+            hasErrors |= ReportBadAwaitContext(node, location, diagnostics);
 
-            hasErrors |=
-                ReportBadAwaitWithoutAsync(location, diagnostics) |
-                ReportBadAwaitContext(node, location, diagnostics) |
-                !GetAwaitableExpressionInfo(expression, out getAwaiter, out isCompleted, out getResult, out _, node, diagnostics);
+            if (expressionOpt is null)
+            {
+                return AwaitableInfo.Empty;
+            }
+            else
+            {
+                MethodSymbol getAwaiter;
+                PropertySymbol isCompleted;
+                MethodSymbol getResult;
+                hasErrors |= !GetAwaitableExpressionInfo(expressionOpt, out getAwaiter, out isCompleted, out getResult, out _, node, diagnostics);
 
-            return new AwaitableInfo(getAwaiter, isCompleted, getResult);
+                return new AwaitableInfo(getAwaiter, isCompleted, getResult);
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -677,7 +677,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(!(expr is null));
             Debug.Assert(!(expr.Type is null));
-            Debug.Assert((expr.Type.IsValueType && expr.Type.IsRefLikeType) || hasAwait); // pattern dispose lookup is only valid on ref structs or asynchronous usings
+            Debug.Assert(expr.Type.IsRefLikeType || hasAwait); // pattern dispose lookup is only valid on ref structs or asynchronous usings
 
             // Don't try and lookup if we're not enabled
             if (MessageID.IDS_FeatureUsingDeclarations.RequiredVersion() > Compilation.LanguageVersion)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -677,7 +677,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(!(expr is null));
             Debug.Assert(!(expr.Type is null));
-            Debug.Assert(expr.Type.IsValueType && expr.Type.IsRefLikeType); // pattern dispose lookup is only valid on ref structs
+            Debug.Assert((expr.Type.IsValueType && expr.Type.IsRefLikeType) || hasAwait); // pattern dispose lookup is only valid on ref structs or asynchronous usings
 
             // Don't try and lookup if we're not enabled
             if (MessageID.IDS_FeatureUsingDeclarations.RequiredVersion() > Compilation.LanguageVersion)
@@ -692,8 +692,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                     out var disposeMethod);
 
             if ((!hasAwait && disposeMethod?.ReturnsVoid == false)
-                || (hasAwait && disposeMethod?.ReturnType.TypeSymbol.IsNonGenericTaskType(Compilation) == false)
-                || result == PatternLookupResult.NotAMethod)
+                || result == PatternLookupResult.NotAMethod
+                || disposeMethod?.IsExtensionMethod == true)
             {
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                 if (this.IsAccessible(disposeMethod, ref useSiteDiagnostics))

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -691,9 +691,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                     diagnostics,
                                                     out var disposeMethod);
 
-            if ((!hasAwait && disposeMethod?.ReturnsVoid == false)
-                || result == PatternLookupResult.NotAMethod
-                || disposeMethod?.IsExtensionMethod == true)
+            if (disposeMethod?.IsExtensionMethod == true)
+            {
+                // Extension methods should just be ignored, rather than rejected after-the-fact
+                // Tracked by https://github.com/dotnet/roslyn/issues/32767
+
+                // extension methods do not contribute to pattern-based disposal
+                disposeMethod = null;
+            }
+            else if ((!hasAwait && disposeMethod?.ReturnsVoid == false)
+                || result == PatternLookupResult.NotAMethod)
             {
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                 if (this.IsAccessible(disposeMethod, ref useSiteDiagnostics))

--- a/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachEnumeratorInfo.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol getEnumeratorMethod,
             MethodSymbol currentPropertyGetter,
             MethodSymbol moveNextMethod,
-            bool needsDisposeMethod,
+            bool needsDisposal,
             AwaitableInfo disposeAwaitableInfo,
             MethodSymbol disposeMethod,
             Conversion collectionConversion,
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.GetEnumeratorMethod = getEnumeratorMethod;
             this.CurrentPropertyGetter = currentPropertyGetter;
             this.MoveNextMethod = moveNextMethod;
-            this.NeedsDisposal = needsDisposeMethod;
+            this.NeedsDisposal = needsDisposal;
             this.DisposeAwaitableInfo = disposeAwaitableInfo;
             this.DisposeMethod = disposeMethod;
             this.CollectionConversion = collectionConversion;

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -503,8 +503,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool GetAwaitDisposeAsyncInfo(ref ForEachEnumeratorInfo.Builder builder, DiagnosticBag diagnostics)
         {
-            BoundExpression placeholder = new BoundAwaitableValuePlaceholder(_syntax.Expression,
-                this.GetWellKnownType(WellKnownType.System_Threading_Tasks_ValueTask, diagnostics, this._syntax));
+            var awaitableType = builder.DisposeMethod is null
+                ? this.GetWellKnownType(WellKnownType.System_Threading_Tasks_ValueTask, diagnostics, this._syntax)
+                : builder.DisposeMethod.ReturnType.TypeSymbol;
+
+            BoundExpression placeholder = new BoundAwaitableValuePlaceholder(_syntax.Expression, awaitableType);
 
             bool hasErrors = false;
             builder.DisposeAwaitableInfo = BindAwaitInfo(placeholder, _syntax.Expression, _syntax.AwaitKeyword.GetLocation(), diagnostics, ref hasErrors);
@@ -836,16 +839,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol enumeratorType = builder.GetEnumeratorMethod.ReturnType.TypeSymbol;
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
 
-            if (!enumeratorType.IsSealed ||
+            // For async foreach, we don't do the runtime check
+            if ((!enumeratorType.IsSealed && !isAsync) ||
                 this.Conversions.ClassifyImplicitConversionFromType(enumeratorType,
                     isAsync ? this.Compilation.GetWellKnownType(WellKnownType.System_IAsyncDisposable) : this.Compilation.GetSpecialType(SpecialType.System_IDisposable),
                     ref useSiteDiagnostics).IsImplicit)
             {
                 builder.NeedsDisposal = true;
             }
-            else if (enumeratorType.IsRefLikeType)
+            else if (enumeratorType.IsRefLikeType || isAsync)
             {
-                // if it wasn't directly convertable to IDisposable, see if it is pattern disposable
+                // if it wasn't directly convertable to IDisposable, see if it is pattern-disposable
                 // again, we throw away any binding diagnostics, and assume it's not disposable if we encounter errors
                 var patternDisposeDiags = new DiagnosticBag();
                 var receiver = new BoundDisposableValuePlaceholder(_syntax, enumeratorType);

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol getEnumeratorMethod = builder.GetEnumeratorMethod;
             if (IsAsync)
             {
-                BoundExpression placeholder = new BoundAwaitableValuePlaceholder(_syntax.Expression, builder.MoveNextMethod?.ReturnType.TypeSymbol ?? CreateErrorType());
+                var placeholder = new BoundAwaitableValuePlaceholder(_syntax.Expression, builder.MoveNextMethod?.ReturnType.TypeSymbol ?? CreateErrorType());
                 awaitInfo = BindAwaitInfo(placeholder, _syntax.Expression, _syntax.AwaitKeyword.GetLocation(), diagnostics, ref hasErrors);
 
                 if (!hasErrors && awaitInfo.GetResult?.ReturnType.SpecialType != SpecialType.System_Boolean)
@@ -507,7 +507,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ? this.GetWellKnownType(WellKnownType.System_Threading_Tasks_ValueTask, diagnostics, this._syntax)
                 : builder.DisposeMethod.ReturnType.TypeSymbol;
 
-            BoundExpression placeholder = new BoundAwaitableValuePlaceholder(_syntax.Expression, awaitableType);
+            var placeholder = new BoundAwaitableValuePlaceholder(_syntax.Expression, awaitableType);
 
             bool hasErrors = false;
             builder.DisposeAwaitableInfo = BindAwaitInfo(placeholder, _syntax.Expression, _syntax.AwaitKeyword.GetLocation(), diagnostics, ref hasErrors);

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     hasErrors |= ReportUseSiteDiagnostics(awaitableTypeOpt, diagnostics, awaitKeyword);
-                    BoundExpression placeholder = new BoundAwaitableValuePlaceholder(syntax, awaitableTypeOpt).MakeCompilerGenerated();
+                    var placeholder = new BoundAwaitableValuePlaceholder(syntax, awaitableTypeOpt).MakeCompilerGenerated();
                     awaitOpt = originalBinder.BindAwaitInfo(placeholder, syntax, awaitKeyword.GetLocation(), diagnostics, ref hasErrors);
                 }
             }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -7234,7 +7234,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in an async using statement must be implicitly convertible to &apos;System.IAsyncDisposable&apos;.
+        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in an async using statement must be implicitly convertible to &apos;System.IAsyncDisposable&apos; or implement a suitable &apos;DisposeAsync&apos; method..
         /// </summary>
         internal static string ERR_NoConvToIAsyncDisp {
             get {
@@ -7243,7 +7243,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in an async using statement must be implicitly convertible to &apos;System.IAsyncDisposable&apos;. Did you mean &apos;using&apos; rather than &apos;await using&apos;?.
+        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in an async using statement must be implicitly convertible to &apos;System.IAsyncDisposable&apos; or implement a suitable &apos;DisposeAsync&apos; method. Did you mean &apos;using&apos; rather than &apos;await using&apos;?.
         /// </summary>
         internal static string ERR_NoConvToIAsyncDispWrongAsync {
             get {
@@ -7252,7 +7252,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must be implicitly convertible to &apos;System.IDisposable&apos;..
+        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must be implicitly convertible to &apos;System.IDisposable&apos; or implement a suitable &apos;Dispose&apos; method..
         /// </summary>
         internal static string ERR_NoConvToIDisp {
             get {
@@ -7261,7 +7261,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must be implicitly convertible to &apos;System.IDisposable&apos;. Did you mean &apos;await using&apos; rather than &apos;using&apos;?.
+        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must be implicitly convertible to &apos;System.IDisposable&apos; or implement a suitable &apos;Dispose&apos; method. Did you mean &apos;await using&apos; rather than &apos;using&apos;?.
         /// </summary>
         internal static string ERR_NoConvToIDispWrongAsync {
             get {
@@ -15485,7 +15485,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; does not implement the &apos;{1}&apos; pattern. &apos;{2}&apos; has the wrong signature..
+        ///   Looks up a localized string similar to &apos;{0}&apos; does not implement the &apos;{1}&apos; pattern. &apos;{2}&apos; has the wrong signature or is an extension..
         /// </summary>
         internal static string WRN_PatternBadSignature {
             get {
@@ -15494,7 +15494,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type does not implement the collection pattern; member has the wrong signature.
+        ///   Looks up a localized string similar to Type does not implement the collection pattern; member has the wrong signature or is an extension.
         /// </summary>
         internal static string WRN_PatternBadSignature_Title {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -15485,7 +15485,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; does not implement the &apos;{1}&apos; pattern. &apos;{2}&apos; has the wrong signature or is an extension..
+        ///   Looks up a localized string similar to &apos;{0}&apos; does not implement the &apos;{1}&apos; pattern. &apos;{2}&apos; has the wrong signature..
         /// </summary>
         internal static string WRN_PatternBadSignature {
             get {
@@ -15494,7 +15494,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type does not implement the collection pattern; member has the wrong signature or is an extension.
+        ///   Looks up a localized string similar to Type does not implement the collection pattern; member has the wrong signature.
         /// </summary>
         internal static string WRN_PatternBadSignature_Title {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1126,10 +1126,10 @@
     <value>Type does not implement the collection pattern; member is either static or not public</value>
   </data>
   <data name="WRN_PatternBadSignature" xml:space="preserve">
-    <value>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</value>
+    <value>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</value>
   </data>
   <data name="WRN_PatternBadSignature_Title" xml:space="preserve">
-    <value>Type does not implement the collection pattern; member has the wrong signature</value>
+    <value>Type does not implement the collection pattern; member has the wrong signature or is an extension</value>
   </data>
   <data name="ERR_FriendRefNotEqualToThis" xml:space="preserve">
     <value>Friend access was granted by '{0}', but the public key of the output assembly ('{1}') does not match that specified by the InternalsVisibleTo attribute in the granting assembly.</value>
@@ -2981,16 +2981,16 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression or query expression and using the local instead.</value>
   </data>
   <data name="ERR_NoConvToIDisp" xml:space="preserve">
-    <value>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</value>
+    <value>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</value>
   </data>
   <data name="ERR_NoConvToIDispWrongAsync" xml:space="preserve">
-    <value>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</value>
+    <value>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</value>
   </data>
   <data name="ERR_NoConvToIAsyncDisp" xml:space="preserve">
-    <value>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</value>
+    <value>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</value>
   </data>
   <data name="ERR_NoConvToIAsyncDispWrongAsync" xml:space="preserve">
-    <value>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</value>
+    <value>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</value>
   </data>
   <data name="ERR_BadParamRef" xml:space="preserve">
     <value>Parameter {0} must be declared with the '{1}' keyword</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1126,10 +1126,10 @@
     <value>Type does not implement the collection pattern; member is either static or not public</value>
   </data>
   <data name="WRN_PatternBadSignature" xml:space="preserve">
-    <value>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</value>
+    <value>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</value>
   </data>
   <data name="WRN_PatternBadSignature_Title" xml:space="preserve">
-    <value>Type does not implement the collection pattern; member has the wrong signature or is an extension</value>
+    <value>Type does not implement the collection pattern; member has the wrong signature</value>
   </data>
   <data name="ERR_FriendRefNotEqualToThis" xml:space="preserve">
     <value>Friend access was granted by '{0}', but the public key of the output assembly ('{1}') does not match that specified by the InternalsVisibleTo attribute in the granting assembly.</value>

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -182,11 +180,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors: false);
 
             BoundStatement result;
-            MethodSymbol disposeMethod = enumeratorInfo.DisposeMethod;
 
-            if (enumeratorInfo.NeedsDisposal && (!(disposeMethod is null) || TryGetDisposeMethod(forEachSyntax, enumeratorInfo, out disposeMethod)))
+            if (enumeratorInfo.NeedsDisposal)
             {
-                BoundStatement tryFinally = WrapWithTryFinallyDispose(forEachSyntax, enumeratorInfo, enumeratorType, boundEnumeratorVar, whileLoop, disposeMethod);
+                BoundStatement tryFinally = WrapWithTryFinallyDispose(forEachSyntax, enumeratorInfo, enumeratorType, boundEnumeratorVar, whileLoop);
 
                 // E e = ((C)(x)).GetEnumerator();
                 // try {
@@ -225,9 +222,33 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Binder.TryGetSpecialTypeMember(_compilation, SpecialMember.System_IDisposable__Dispose, forEachSyntax, _diagnostics, out disposeMethod);
         }
 
+        /// <summary>
+        /// There are three possible cases where we need disposal:
+        /// - pattern-based disposal (we have a Dispose/DisposeAsync method)
+        /// - interface-based disposal (the enumerator type converts to IDisposable/IAsyncDisposable)
+        /// - we need to do a runtime check for IDisposable
+        /// </summary>
         private BoundStatement WrapWithTryFinallyDispose(CommonForEachStatementSyntax forEachSyntax, ForEachEnumeratorInfo enumeratorInfo,
-            TypeSymbol enumeratorType, BoundLocal boundEnumeratorVar, BoundStatement rewrittenBody, MethodSymbol disposeMethod)
+            TypeSymbol enumeratorType, BoundLocal boundEnumeratorVar, BoundStatement rewrittenBody)
         {
+            Debug.Assert(enumeratorInfo.NeedsDisposal);
+
+            NamedTypeSymbol idisposableTypeSymbol = null;
+            bool isImplicit = false;
+            MethodSymbol disposeMethod = enumeratorInfo.DisposeMethod; // pattern-based
+
+            if (disposeMethod is null)
+            {
+                TryGetDisposeMethod(forEachSyntax, enumeratorInfo, out disposeMethod); // interface-based
+
+                idisposableTypeSymbol = disposeMethod.ContainingType;
+                var conversions = new TypeConversions(_factory.CurrentFunction.ContainingAssembly.CorLibrary);
+
+                HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+                isImplicit = conversions.ClassifyImplicitConversionFromType(enumeratorType, idisposableTypeSymbol, ref useSiteDiagnostics).IsImplicit;
+                _diagnostics.Add(forEachSyntax, useSiteDiagnostics);
+            }
+
             Binder.ReportDiagnosticsIfObsolete(_diagnostics, disposeMethod, forEachSyntax,
                                                hasBaseReceiver: false,
                                                containingMember: _factory.CurrentFunction,
@@ -235,26 +256,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                location: enumeratorInfo.Location);
 
             BoundBlock finallyBlockOpt;
-            var idisposableTypeSymbol = disposeMethod.ContainingType;
-            var conversions = new TypeConversions(_factory.CurrentFunction.ContainingAssembly.CorLibrary);
-            var disposeAwaitableInfoOpt = enumeratorInfo.DisposeAwaitableInfo;
-
-            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-            var isImplicit = conversions.ClassifyImplicitConversionFromType(enumeratorType, idisposableTypeSymbol, ref useSiteDiagnostics).IsImplicit;
-            _diagnostics.Add(forEachSyntax, useSiteDiagnostics);
-            var isExtension = disposeMethod?.IsExtensionMethod == true;
-
-            if (isImplicit || isExtension)
+            if (isImplicit || !(enumeratorInfo.DisposeMethod is null))
             {
-                Debug.Assert(enumeratorInfo.NeedsDisposal);
-
                 Conversion receiverConversion = enumeratorType.IsStructType() ?
                     Conversion.Boxing :
                     Conversion.ImplicitReference;
 
-                BoundExpression receiver = isExtension || idisposableTypeSymbol.IsRefLikeType ?
-                    boundEnumeratorVar :
-                    ConvertReceiverForInvocation(forEachSyntax, boundEnumeratorVar, disposeMethod, receiverConversion, idisposableTypeSymbol);
+                BoundExpression receiver = enumeratorInfo.DisposeMethod is null ?
+                    ConvertReceiverForInvocation(forEachSyntax, boundEnumeratorVar, disposeMethod, receiverConversion, idisposableTypeSymbol) :
+                    boundEnumeratorVar;
 
                 // ((IDisposable)e).Dispose() or e.Dispose() or await ((IAsyncDisposable)e).DisposeAsync() or await e.DisposeAsync()
                 BoundExpression disposeCall = MakeCallWithNoExplicitArgument(
@@ -263,6 +273,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     disposeMethod);
 
                 BoundStatement disposeCallStatement;
+                var disposeAwaitableInfoOpt = enumeratorInfo.DisposeAwaitableInfo;
                 if (disposeAwaitableInfoOpt != null)
                 {
                     // await /* disposeCall */
@@ -316,7 +327,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
+                // If we couldn't find either pattern-based or interface-based disposal, and the enumerator type isn't sealed,
+                // and the loop isn't async, then we include a runtime check.
                 Debug.Assert(!enumeratorType.IsSealed);
+                Debug.Assert(!enumeratorInfo.IsAsync);
 
                 // IDisposable d
                 LocalSymbol disposableVar = _factory.SynthesizedLocal(idisposableTypeSymbol);
@@ -338,19 +352,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // IDisposable d = e as IDisposable;
                 BoundStatement disposableVarDecl = MakeLocalDeclaration(forEachSyntax, disposableVar, disposableVarInitValue);
 
-                // d.Dispose() or async variant
+                // d.Dispose()
                 BoundExpression disposeCall = BoundCall.Synthesized(syntax: forEachSyntax, receiverOpt: boundDisposableVar, method: disposeMethod);
-                BoundStatement disposeCallStatement;
-                if (disposeAwaitableInfoOpt != null)
-                {
-                    // await d.DisposeAsync()
-                    disposeCallStatement = WrapWithAwait(forEachSyntax, disposeCall, disposeAwaitableInfoOpt);
-                    _sawAwaitInExceptionHandler = true;
-                }
-                else
-                {
-                    disposeCallStatement = new BoundExpressionStatement(forEachSyntax, expression: disposeCall);
-                }
+                BoundStatement disposeCallStatement = new BoundExpressionStatement(forEachSyntax, expression: disposeCall);
 
                 // if (d != null) d.Dispose();
                 BoundStatement ifStmt = RewriteIfStatement(

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'{0} neimplementuje vzorek {1}. {2} nemá správný podpis.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">Typ neimplementuje vzorek kolekce. Člen nemá správný podpis.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'{0} neimplementuje vzorek {1}. {2} nemá správný podpis.</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'{0} neimplementuje vzorek {1}. {2} nemá správný podpis.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">Typ neimplementuje vzorek kolekce. Člen nemá správný podpis.</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">Typ neimplementuje vzorek kolekce. Člen nemá správný podpis.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'{0}: Typ použitý v příkazu using musí být implicitně převeditelný na System.IDisposable.</target>
         <note />
       </trans-unit>
@@ -9457,8 +9457,8 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'"{0}" implementiert das Muster "{1}" nicht. "{2}" weist die falsche Signatur auf.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">Der Typ implementiert nicht das Sammlungsmuster. Das Element weist die falsche Signatur auf.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'"{0}" implementiert das Muster "{1}" nicht. "{2}" weist die falsche Signatur auf.</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'"{0}" implementiert das Muster "{1}" nicht. "{2}" weist die falsche Signatur auf.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">Der Typ implementiert nicht das Sammlungsmuster. Das Element weist die falsche Signatur auf.</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">Der Typ implementiert nicht das Sammlungsmuster. Das Element weist die falsche Signatur auf.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'"{0}": Der in einer using-Anweisung verwendete Typ muss implizit in System.IDisposable konvertiert werden können.</target>
         <note />
       </trans-unit>
@@ -9470,8 +9470,8 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'{0}' no implementa el patrón '{1}'. '{2}' tiene una firma incorrecta.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">El tipo no implementa la trama de colección. El miembro tiene la firma incorrecta</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'{0}' no implementa el patrón '{1}'. '{2}' tiene una firma incorrecta.</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'{0}' no implementa el patrón '{1}'. '{2}' tiene una firma incorrecta.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">El tipo no implementa la trama de colección. El miembro tiene la firma incorrecta</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">El tipo no implementa la trama de colección. El miembro tiene la firma incorrecta</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'{0}': el tipo usado en una instrucción using debe poder convertirse implícitamente en 'System.IDisposable'</target>
         <note />
       </trans-unit>
@@ -9444,8 +9444,8 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'{0}' n'implémente pas le modèle '{1}'. '{2}' a une signature erronée.</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'{0}' n'implémente pas le modèle '{1}'. '{2}' a une signature erronée.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">Un type n'implémente pas le modèle de la collection ; un membre n'a pas la bonne signature</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">Un type n'implémente pas le modèle de la collection ; un membre n'a pas la bonne signature</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'{0}' : le type utilisé dans une instruction using doit être implicitement convertible en 'System.IDisposable'</target>
         <note />
       </trans-unit>
@@ -9445,8 +9445,8 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'{0}' n'implémente pas le modèle '{1}'. '{2}' a une signature erronée.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">Un type n'implémente pas le modèle de la collection ; un membre n'a pas la bonne signature</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'{0}' non implementa il modello '{1}'. La firma di '{2}' è errata.</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'{0}' non implementa il modello '{1}'. La firma di '{2}' è errata.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">Il tipo non implementa il modello di raccolta. La firma del membro è errata</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">Il tipo non implementa il modello di raccolta. La firma del membro è errata</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ Un blocco catch() dopo un blocco catch (System.Exception e) è in grado di rilev
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'{0}': il tipo usato in un'istruzione using deve essere convertibile in modo implicito in 'System.IDisposable'</target>
         <note />
       </trans-unit>
@@ -9446,8 +9446,8 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'{0}' non implementa il modello '{1}'. La firma di '{2}' è errata.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">Il tipo non implementa il modello di raccolta. La firma del membro è errata</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'{0}' は、パターン '{1}' を実装しません。'{2}' には正しくないシグネチャが含まれます。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">型は、コレクション パターンを実装しません。メンバーには正しくないシグネチャが含まれます</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'{0}' は、パターン '{1}' を実装しません。'{2}' には正しくないシグネチャが含まれます。</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'{0}' は、パターン '{1}' を実装しません。'{2}' には正しくないシグネチャが含まれます。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">型は、コレクション パターンを実装しません。メンバーには正しくないシグネチャが含まれます</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">型は、コレクション パターンを実装しません。メンバーには正しくないシグネチャが含まれます</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'{0}': using ステートメントで使用される型は、暗黙的に 'System.IDisposable' への変換が可能でなければなりません。</target>
         <note />
       </trans-unit>
@@ -9470,8 +9470,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'{0}'이(가) '{1}' 패턴을 구현하지 않습니다. '{2}'에 잘못된 시그니처가 있습니다.</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'{0}'이(가) '{1}' 패턴을 구현하지 않습니다. '{2}'에 잘못된 시그니처가 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">형식은 컬렉션 패턴을 구현하지 않습니다. 멤버의 서명이 잘못되었습니다.</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">형식은 컬렉션 패턴을 구현하지 않습니다. 멤버의 서명이 잘못되었습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'{0}': using 문에 사용된 형식은 암시적으로 'System.IDisposable'로 변환할 수 있어야 합니다.</target>
         <note />
       </trans-unit>
@@ -9470,8 +9470,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'{0}'이(가) '{1}' 패턴을 구현하지 않습니다. '{2}'에 잘못된 시그니처가 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">형식은 컬렉션 패턴을 구현하지 않습니다. 멤버의 서명이 잘못되었습니다.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'Element „{0}” nie implementuje wzorca „{1}”. Element „{2}” ma nieprawidłową sygnaturę.</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'Element „{0}” nie implementuje wzorca „{1}”. Element „{2}” ma nieprawidłową sygnaturę.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">Typ nie zawiera implementacji wzorca kolekcji; składowa ma niewłaściwą sygnaturę</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">Typ nie zawiera implementacji wzorca kolekcji; składowa ma niewłaściwą sygnaturę</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'„{0}”: musi istnieć możliwość niejawnego przekonwertowania typu użytego w instrukcji using na interfejs „System.IDisposable”</target>
         <note />
       </trans-unit>
@@ -9449,8 +9449,8 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'Element „{0}” nie implementuje wzorca „{1}”. Element „{2}” ma nieprawidłową sygnaturę.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">Typ nie zawiera implementacji wzorca kolekcji; składowa ma niewłaściwą sygnaturę</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'"{0}" não implementa o padrão "{1}". "{2}" tem a assinatura errada.</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'"{0}" não implementa o padrão "{1}". "{2}" tem a assinatura errada.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">O tipo não implementa o padrão de coleção; o membro possui a assinatura incorreta</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">O tipo não implementa o padrão de coleção; o membro possui a assinatura incorreta</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'"{0}": tipo usado em uma instrução using deve ser implicitamente conversível para "System. IDisposable"</target>
         <note />
       </trans-unit>
@@ -9450,8 +9450,8 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'"{0}" não implementa o padrão "{1}". "{2}" tem a assinatura errada.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">O tipo não implementa o padrão de coleção; o membro possui a assinatura incorreta</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'"{0}" не реализует шаблон "{1}". "{2}" имеет неправильную сигнатуру.</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'"{0}" не реализует шаблон "{1}". "{2}" имеет неправильную сигнатуру.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">Тип не реализует шаблон коллекции: член содержит неправильную подпись</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">Тип не реализует шаблон коллекции: член содержит неправильную подпись</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'{0}": тип, использованный в операторе using, должен иметь неявное преобразование в System.IDisposable.</target>
         <note />
       </trans-unit>
@@ -9452,8 +9452,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'"{0}" не реализует шаблон "{1}". "{2}" имеет неправильную сигнатуру.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">Тип не реализует шаблон коллекции: член содержит неправильную подпись</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'{0}', '{1}' kalıbını uygulamaz. '{2}' yanlış imzaya sahip.</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'{0}', '{1}' kalıbını uygulamaz. '{2}' yanlış imzaya sahip.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">Tür koleksiyon desenini uygulamaz; üye yanlış imzaya sahip</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">Tür koleksiyon desenini uygulamaz; üye yanlış imzaya sahip</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'{0}': bir using deyiminde kullanılan tür açıkça 'System.IDisposable' öğesine dönüştürülebilir olmalıdır</target>
         <note />
       </trans-unit>
@@ -9458,8 +9458,8 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'{0}', '{1}' kalıbını uygulamaz. '{2}' yanlış imzaya sahip.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">Tür koleksiyon desenini uygulamaz; üye yanlış imzaya sahip</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'“{0}”不实现“{1}”模式。“{2}”有错误的签名。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">类型不实现集合模式；成员有错误的签名</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'“{0}”不实现“{1}”模式。“{2}”有错误的签名。</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'“{0}”不实现“{1}”模式。“{2}”有错误的签名。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">类型不实现集合模式；成员有错误的签名</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">类型不实现集合模式；成员有错误的签名</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'“{0}”: using 语句中使用的类型必须可隐式转换为“System.IDisposable”</target>
         <note />
       </trans-unit>
@@ -9470,8 +9470,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -193,13 +193,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'. Did you mean 'using' rather than 'await using'?</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDispWrongAsync">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</source>
-        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'. Did you mean 'await using' rather than 'using'?</target>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</source>
+        <target state="new">'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method. Did you mean 'await using' rather than 'using'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NullableDirectiveQualifierExpected">
@@ -2563,13 +2563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
-        <target state="translated">'{0}' 未實作 '{1}' 模式。'{2}' 的簽章錯誤。</target>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <target state="needs-review-translation">'{0}' 未實作 '{1}' 模式。'{2}' 的簽章錯誤。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature</source>
-        <target state="translated">類型未實作集合模式; 成員的簽章錯誤</target>
+        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <target state="needs-review-translation">類型未實作集合模式; 成員的簽章錯誤</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FriendRefNotEqualToThis">
@@ -5571,7 +5571,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIDisp">
-        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable'.</source>
+        <source>'{0}': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.</source>
         <target state="needs-review-translation">'{0}': 在 using 陳述式中所用的類型，必須可以隱含轉換成 'System.IDisposable'。</target>
         <note />
       </trans-unit>
@@ -9470,8 +9470,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDisp">
-        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</source>
-        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'</target>
+        <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</source>
+        <target state="new">'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_BadGetAsyncEnumerator">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -2563,12 +2563,12 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature">
-        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature or is an extension.</source>
+        <source>'{0}' does not implement the '{1}' pattern. '{2}' has the wrong signature.</source>
         <target state="needs-review-translation">'{0}' 未實作 '{1}' 模式。'{2}' 的簽章錯誤。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_PatternBadSignature_Title">
-        <source>Type does not implement the collection pattern; member has the wrong signature or is an extension</source>
+        <source>Type does not implement the collection pattern; member has the wrong signature</source>
         <target state="needs-review-translation">類型未實作集合模式; 成員的簽章錯誤</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -1976,14 +1976,17 @@ class C
             i = i + 100; // Note: side-effects of async methods in structs are lost
             return more;
         }
-        public ValueTask DisposeAsync() => throw null;
+        public async ValueTask DisposeAsync()
+        {
+            Write($""DisposeAsync "");
+            await Task.Yield();
+        }
     }
 }";
             var comp = CreateCompilationWithTasksExtensions(source + s_IAsyncEnumerable, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            // Note: we only look for IAsyncDisposable, we don't look for a pattern-based DisposeAsync
             CompileAndVerify(comp,
-                expectedOutput: "NextAsync(0) Current(0) Got(1) NextAsync(1) Current(1) Got(2) NextAsync(2) Current(2) Got(3) NextAsync(3) Current(3) Got(4) NextAsync(4) Done");
+                expectedOutput: "NextAsync(0) Current(0) Got(1) NextAsync(1) Current(1) Got(2) NextAsync(2) Current(2) Got(3) NextAsync(3) Current(3) Got(4) NextAsync(4) DisposeAsync Done");
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly))]
@@ -2368,7 +2371,7 @@ public class C
             Assert.True(internalInfo.NeedsDisposal);
 
             CompileAndVerify(comp,
-                expectedOutput: "NextAsync(0) Current(1) Got(1) NextAsync(1) Current(2) Got(2) NextAsync(2) Current(3) Got(3) NextAsync(3)");
+                expectedOutput: "NextAsync(0) Current(1) Got(1) NextAsync(1) Current(2) Got(2) NextAsync(2) Current(3) Got(3) NextAsync(3) Dispose(4)");
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
@@ -2410,12 +2413,7 @@ public class C
     }
     public class DerivedEnumerator : Enumerator, System.IAsyncDisposable
     {
-        public async ValueTask DisposeAsync()
-        {
-            Write($""Disp"");
-            await Task.Yield();
-            Write($""ose({i}) "");
-        }
+        public ValueTask DisposeAsync() => throw null;
     }
 }";
             var comp = CreateCompilationWithTasksExtensions(source + s_IAsyncEnumerable, options: TestOptions.DebugExe);
@@ -2426,26 +2424,22 @@ public class C
             var foreachSyntax = tree.GetRoot().DescendantNodes().OfType<ForEachStatementSyntax>().Single();
 
             var memberModel = model.GetMemberModel(foreachSyntax);
-            BoundForEachStatement boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
+            var boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposal);
+            Assert.False(internalInfo.NeedsDisposal);
 
             var verifier = CompileAndVerify(comp,
-                expectedOutput: "NextAsync(0) Current(1) Got(1) NextAsync(1) Current(2) Got(2) NextAsync(2) Current(3) Got(3) NextAsync(3) Dispose(4)");
+                expectedOutput: "NextAsync(0) Current(1) Got(1) NextAsync(1) Current(2) Got(2) NextAsync(2) Current(3) Got(3) NextAsync(3)");
 
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      479 (0x1df)
+  // Code size      260 (0x104)
   .maxstack  3
   .locals init (int V_0,
                 System.Threading.CancellationToken V_1,
                 System.Runtime.CompilerServices.TaskAwaiter<bool> V_2,
                 C.<Main>d__0 V_3,
-                object V_4,
-                System.IAsyncDisposable V_5,
-                System.Runtime.CompilerServices.ValueTaskAwaiter V_6,
-                System.Threading.Tasks.ValueTask V_7,
-                System.Exception V_8)
+                System.Exception V_4)
   // sequence point: <hidden>
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<Main>d__0.<>1__state""
@@ -2454,220 +2448,116 @@ public class C
   {
     // sequence point: <hidden>
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_003e
-    IL_000a:  br.s       IL_000c
-    IL_000c:  ldloc.0
-    IL_000d:  ldc.i4.1
-    IL_000e:  beq        IL_014b
-    IL_0013:  br.s       IL_0015
+    IL_0008:  brfalse    IL_0098
+    IL_000d:  br.s       IL_000f
     // sequence point: {
-    IL_0015:  nop
+    IL_000f:  nop
     // sequence point: foreach
-    IL_0016:  nop
+    IL_0010:  nop
     // sequence point: new C()
-    IL_0017:  ldarg.0
-    IL_0018:  newobj     ""C..ctor()""
-    IL_001d:  ldloca.s   V_1
-    IL_001f:  initobj    ""System.Threading.CancellationToken""
-    IL_0025:  ldloc.1
-    IL_0026:  call       ""C.Enumerator C.GetAsyncEnumerator(System.Threading.CancellationToken)""
-    IL_002b:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_0011:  ldarg.0
+    IL_0012:  newobj     ""C..ctor()""
+    IL_0017:  ldloca.s   V_1
+    IL_0019:  initobj    ""System.Threading.CancellationToken""
+    IL_001f:  ldloc.1
+    IL_0020:  call       ""C.Enumerator C.GetAsyncEnumerator(System.Threading.CancellationToken)""
+    IL_0025:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
     // sequence point: <hidden>
-    IL_0030:  ldarg.0
-    IL_0031:  ldnull
-    IL_0032:  stfld      ""object C.<Main>d__0.<>s__2""
-    IL_0037:  ldarg.0
-    IL_0038:  ldc.i4.0
-    IL_0039:  stfld      ""int C.<Main>d__0.<>s__3""
+    IL_002a:  br.s       IL_005a
+    // sequence point: var i
+    IL_002c:  ldarg.0
+    IL_002d:  ldarg.0
+    IL_002e:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_0033:  callvirt   ""int C.Enumerator.Current.get""
+    IL_0038:  stfld      ""int C.<Main>d__0.<i>5__2""
+    // sequence point: {
+    IL_003d:  nop
+    // sequence point: Write($""Got({i}) "");
+    IL_003e:  ldstr      ""Got({0}) ""
+    IL_0043:  ldarg.0
+    IL_0044:  ldfld      ""int C.<Main>d__0.<i>5__2""
+    IL_0049:  box        ""int""
+    IL_004e:  call       ""string string.Format(string, object)""
+    IL_0053:  call       ""void System.Console.Write(string)""
+    IL_0058:  nop
+    // sequence point: }
+    IL_0059:  nop
+    // sequence point: in
+    IL_005a:  ldarg.0
+    IL_005b:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_0060:  callvirt   ""System.Threading.Tasks.Task<bool> C.Enumerator.MoveNextAsync()""
+    IL_0065:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
+    IL_006a:  stloc.2
     // sequence point: <hidden>
-    IL_003e:  nop
-    .try
-    {
-      // sequence point: <hidden>
-      IL_003f:  ldloc.0
-      IL_0040:  brfalse.s  IL_00b5
-      IL_0042:  br.s       IL_0044
-      // sequence point: <hidden>
-      IL_0044:  br.s       IL_0074
-      // sequence point: var i
-      IL_0046:  ldarg.0
-      IL_0047:  ldarg.0
-      IL_0048:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
-      IL_004d:  callvirt   ""int C.Enumerator.Current.get""
-      IL_0052:  stfld      ""int C.<Main>d__0.<i>5__4""
-      // sequence point: {
-      IL_0057:  nop
-      // sequence point: Write($""Got({i}) "");
-      IL_0058:  ldstr      ""Got({0}) ""
-      IL_005d:  ldarg.0
-      IL_005e:  ldfld      ""int C.<Main>d__0.<i>5__4""
-      IL_0063:  box        ""int""
-      IL_0068:  call       ""string string.Format(string, object)""
-      IL_006d:  call       ""void System.Console.Write(string)""
-      IL_0072:  nop
-      // sequence point: }
-      IL_0073:  nop
-      // sequence point: in
-      IL_0074:  ldarg.0
-      IL_0075:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
-      IL_007a:  callvirt   ""System.Threading.Tasks.Task<bool> C.Enumerator.MoveNextAsync()""
-      IL_007f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
-      IL_0084:  stloc.2
-      // sequence point: <hidden>
-      IL_0085:  ldloca.s   V_2
-      IL_0087:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
-      IL_008c:  brtrue.s   IL_00d1
-      IL_008e:  ldarg.0
-      IL_008f:  ldc.i4.0
-      IL_0090:  dup
-      IL_0091:  stloc.0
-      IL_0092:  stfld      ""int C.<Main>d__0.<>1__state""
-      // async: yield
-      IL_0097:  ldarg.0
-      IL_0098:  ldloc.2
-      IL_0099:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-      IL_009e:  ldarg.0
-      IL_009f:  stloc.3
-      IL_00a0:  ldarg.0
-      IL_00a1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-      IL_00a6:  ldloca.s   V_2
-      IL_00a8:  ldloca.s   V_3
-      IL_00aa:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
-      IL_00af:  nop
-      IL_00b0:  leave      IL_01de
-      // async: resume
-      IL_00b5:  ldarg.0
-      IL_00b6:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-      IL_00bb:  stloc.2
-      IL_00bc:  ldarg.0
-      IL_00bd:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-      IL_00c2:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
-      IL_00c8:  ldarg.0
-      IL_00c9:  ldc.i4.m1
-      IL_00ca:  dup
-      IL_00cb:  stloc.0
-      IL_00cc:  stfld      ""int C.<Main>d__0.<>1__state""
-      IL_00d1:  ldarg.0
-      IL_00d2:  ldloca.s   V_2
-      IL_00d4:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
-      IL_00d9:  stfld      ""bool C.<Main>d__0.<>s__5""
-      IL_00de:  ldarg.0
-      IL_00df:  ldfld      ""bool C.<Main>d__0.<>s__5""
-      IL_00e4:  brtrue     IL_0046
-      // sequence point: <hidden>
-      IL_00e9:  leave.s    IL_00f7
-    }
-    catch object
-    {
-      // sequence point: <hidden>
-      IL_00eb:  stloc.s    V_4
-      IL_00ed:  ldarg.0
-      IL_00ee:  ldloc.s    V_4
-      IL_00f0:  stfld      ""object C.<Main>d__0.<>s__2""
-      IL_00f5:  leave.s    IL_00f7
-    }
-    // sequence point: <hidden>
-    IL_00f7:  ldarg.0
-    IL_00f8:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
-    IL_00fd:  isinst     ""System.IAsyncDisposable""
-    IL_0102:  stloc.s    V_5
-    IL_0104:  ldloc.s    V_5
-    IL_0106:  brfalse.s  IL_0170
-    IL_0108:  ldloc.s    V_5
-    IL_010a:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
-    IL_010f:  stloc.s    V_7
-    IL_0111:  ldloca.s   V_7
-    IL_0113:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
-    IL_0118:  stloc.s    V_6
-    // sequence point: <hidden>
-    IL_011a:  ldloca.s   V_6
-    IL_011c:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
-    IL_0121:  brtrue.s   IL_0168
-    IL_0123:  ldarg.0
-    IL_0124:  ldc.i4.1
-    IL_0125:  dup
-    IL_0126:  stloc.0
-    IL_0127:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_006b:  ldloca.s   V_2
+    IL_006d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
+    IL_0072:  brtrue.s   IL_00b4
+    IL_0074:  ldarg.0
+    IL_0075:  ldc.i4.0
+    IL_0076:  dup
+    IL_0077:  stloc.0
+    IL_0078:  stfld      ""int C.<Main>d__0.<>1__state""
     // async: yield
-    IL_012c:  ldarg.0
-    IL_012d:  ldloc.s    V_6
-    IL_012f:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
-    IL_0134:  ldarg.0
-    IL_0135:  stloc.3
-    IL_0136:  ldarg.0
-    IL_0137:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_013c:  ldloca.s   V_6
-    IL_013e:  ldloca.s   V_3
-    IL_0140:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
-    IL_0145:  nop
-    IL_0146:  leave      IL_01de
+    IL_007d:  ldarg.0
+    IL_007e:  ldloc.2
+    IL_007f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_0084:  ldarg.0
+    IL_0085:  stloc.3
+    IL_0086:  ldarg.0
+    IL_0087:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_008c:  ldloca.s   V_2
+    IL_008e:  ldloca.s   V_3
+    IL_0090:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
+    IL_0095:  nop
+    IL_0096:  leave.s    IL_0103
     // async: resume
-    IL_014b:  ldarg.0
-    IL_014c:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
-    IL_0151:  stloc.s    V_6
-    IL_0153:  ldarg.0
-    IL_0154:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
-    IL_0159:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
-    IL_015f:  ldarg.0
-    IL_0160:  ldc.i4.m1
-    IL_0161:  dup
-    IL_0162:  stloc.0
-    IL_0163:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_0168:  ldloca.s   V_6
-    IL_016a:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
-    IL_016f:  nop
-    // sequence point: <hidden>
-    IL_0170:  ldarg.0
-    IL_0171:  ldfld      ""object C.<Main>d__0.<>s__2""
-    IL_0176:  stloc.s    V_4
-    IL_0178:  ldloc.s    V_4
-    IL_017a:  brfalse.s  IL_0199
-    IL_017c:  ldloc.s    V_4
-    IL_017e:  isinst     ""System.Exception""
-    IL_0183:  stloc.s    V_8
-    IL_0185:  ldloc.s    V_8
-    IL_0187:  brtrue.s   IL_018c
-    IL_0189:  ldloc.s    V_4
-    IL_018b:  throw
-    IL_018c:  ldloc.s    V_8
-    IL_018e:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_0193:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_0198:  nop
-    IL_0199:  ldarg.0
-    IL_019a:  ldfld      ""int C.<Main>d__0.<>s__3""
-    IL_019f:  pop
-    IL_01a0:  ldarg.0
-    IL_01a1:  ldnull
-    IL_01a2:  stfld      ""object C.<Main>d__0.<>s__2""
-    IL_01a7:  ldarg.0
-    IL_01a8:  ldnull
-    IL_01a9:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
-    IL_01ae:  leave.s    IL_01ca
+    IL_0098:  ldarg.0
+    IL_0099:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_009e:  stloc.2
+    IL_009f:  ldarg.0
+    IL_00a0:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_00a5:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
+    IL_00ab:  ldarg.0
+    IL_00ac:  ldc.i4.m1
+    IL_00ad:  dup
+    IL_00ae:  stloc.0
+    IL_00af:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00b4:  ldarg.0
+    IL_00b5:  ldloca.s   V_2
+    IL_00b7:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
+    IL_00bc:  stfld      ""bool C.<Main>d__0.<>s__3""
+    IL_00c1:  ldarg.0
+    IL_00c2:  ldfld      ""bool C.<Main>d__0.<>s__3""
+    IL_00c7:  brtrue     IL_002c
+    IL_00cc:  ldarg.0
+    IL_00cd:  ldnull
+    IL_00ce:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_00d3:  leave.s    IL_00ef
   }
   catch System.Exception
   {
     // sequence point: <hidden>
-    IL_01b0:  stloc.s    V_8
-    IL_01b2:  ldarg.0
-    IL_01b3:  ldc.i4.s   -2
-    IL_01b5:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_01ba:  ldarg.0
-    IL_01bb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_01c0:  ldloc.s    V_8
-    IL_01c2:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_01c7:  nop
-    IL_01c8:  leave.s    IL_01de
+    IL_00d5:  stloc.s    V_4
+    IL_00d7:  ldarg.0
+    IL_00d8:  ldc.i4.s   -2
+    IL_00da:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00df:  ldarg.0
+    IL_00e0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_00e5:  ldloc.s    V_4
+    IL_00e7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00ec:  nop
+    IL_00ed:  leave.s    IL_0103
   }
   // sequence point: }
-  IL_01ca:  ldarg.0
-  IL_01cb:  ldc.i4.s   -2
-  IL_01cd:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_00ef:  ldarg.0
+  IL_00f0:  ldc.i4.s   -2
+  IL_00f2:  stfld      ""int C.<Main>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_01d2:  ldarg.0
-  IL_01d3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_01d8:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_01dd:  nop
-  IL_01de:  ret
+  IL_00f7:  ldarg.0
+  IL_00f8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_00fd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0102:  nop
+  IL_0103:  ret
 }", sequencePoints: "C+<Main>d__0.MoveNext", source: source + s_IAsyncEnumerable);
         }
 
@@ -2771,9 +2661,9 @@ class Client
             var foreachSyntax = tree.GetRoot().DescendantNodes().OfType<ForEachStatementSyntax>().Single();
 
             var memberModel = model.GetMemberModel(foreachSyntax);
-            BoundForEachStatement boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
+            var boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.False(internalInfo.NeedsDisposal);
+            Assert.True(internalInfo.NeedsDisposal);
         }
 
         [Fact]
@@ -4233,29 +4123,25 @@ class C
                 info.MoveNextMethod.ToTestDisplayString());
             Assert.Equal("System.Int32 IMyAsyncEnumerator<System.Int32>.Current { get; }",
                 info.CurrentProperty.ToTestDisplayString());
-            Assert.Equal("System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()", info.DisposeMethod.ToTestDisplayString());
+            Assert.Null(info.DisposeMethod);
             Assert.Equal("System.Int32", info.ElementType.ToTestDisplayString());
             Assert.Equal(ConversionKind.Identity, info.ElementConversion.Kind);
             Assert.Equal(ConversionKind.Identity, info.CurrentConversion.Kind);
 
             var memberModel = model.GetMemberModel(foreachSyntax);
-            BoundForEachStatement boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
+            var boundNode = (BoundForEachStatement)memberModel.GetUpperBoundNode(foreachSyntax);
             ForEachEnumeratorInfo internalInfo = boundNode.EnumeratorInfoOpt;
-            Assert.True(internalInfo.NeedsDisposal);
+            Assert.False(internalInfo.NeedsDisposal);
 
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      475 (0x1db)
+  // Code size      256 (0x100)
   .maxstack  3
   .locals init (int V_0,
                 System.Threading.CancellationToken V_1,
                 System.Runtime.CompilerServices.TaskAwaiter<bool> V_2,
                 C.<Main>d__0 V_3,
-                object V_4,
-                System.IAsyncDisposable V_5,
-                System.Runtime.CompilerServices.ValueTaskAwaiter V_6,
-                System.Threading.Tasks.ValueTask V_7,
-                System.Exception V_8)
+                System.Exception V_4)
   // sequence point: <hidden>
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<Main>d__0.<>1__state""
@@ -4264,222 +4150,188 @@ class C
   {
     // sequence point: <hidden>
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_004a
-    IL_000a:  br.s       IL_000c
-    IL_000c:  ldloc.0
-    IL_000d:  ldc.i4.1
-    IL_000e:  beq        IL_0147
-    IL_0013:  br.s       IL_0015
+    IL_0008:  brfalse    IL_0094
+    IL_000d:  br.s       IL_000f
     // sequence point: {
-    IL_0015:  nop
+    IL_000f:  nop
     // sequence point: ICollection<int> c = new Collection<int>();
-    IL_0016:  ldarg.0
-    IL_0017:  newobj     ""Collection<int>..ctor()""
-    IL_001c:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
+    IL_0010:  ldarg.0
+    IL_0011:  newobj     ""Collection<int>..ctor()""
+    IL_0016:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
     // sequence point: foreach
-    IL_0021:  nop
+    IL_001b:  nop
     // sequence point: c
-    IL_0022:  ldarg.0
-    IL_0023:  ldarg.0
-    IL_0024:  ldfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
-    IL_0029:  ldloca.s   V_1
-    IL_002b:  initobj    ""System.Threading.CancellationToken""
-    IL_0031:  ldloc.1
-    IL_0032:  callvirt   ""IMyAsyncEnumerator<int> ICollection<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
-    IL_0037:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_001c:  ldarg.0
+    IL_001d:  ldarg.0
+    IL_001e:  ldfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
+    IL_0023:  ldloca.s   V_1
+    IL_0025:  initobj    ""System.Threading.CancellationToken""
+    IL_002b:  ldloc.1
+    IL_002c:  callvirt   ""IMyAsyncEnumerator<int> ICollection<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
+    IL_0031:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
     // sequence point: <hidden>
-    IL_003c:  ldarg.0
-    IL_003d:  ldnull
-    IL_003e:  stfld      ""object C.<Main>d__0.<>s__3""
-    IL_0043:  ldarg.0
-    IL_0044:  ldc.i4.0
-    IL_0045:  stfld      ""int C.<Main>d__0.<>s__4""
+    IL_0036:  br.s       IL_0056
+    // sequence point: var i
+    IL_0038:  ldarg.0
+    IL_0039:  ldarg.0
+    IL_003a:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_003f:  callvirt   ""int IMyAsyncEnumerator<int>.Current.get""
+    IL_0044:  stfld      ""int C.<Main>d__0.<i>5__3""
+    // sequence point: {
+    IL_0049:  nop
+    // sequence point: Write($""Got "");
+    IL_004a:  ldstr      ""Got ""
+    IL_004f:  call       ""void System.Console.Write(string)""
+    IL_0054:  nop
+    // sequence point: }
+    IL_0055:  nop
+    // sequence point: in
+    IL_0056:  ldarg.0
+    IL_0057:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_005c:  callvirt   ""System.Threading.Tasks.Task<bool> IMyAsyncEnumerator<int>.MoveNextAsync()""
+    IL_0061:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
+    IL_0066:  stloc.2
     // sequence point: <hidden>
-    IL_004a:  nop
-    .try
-    {
-      // sequence point: <hidden>
-      IL_004b:  ldloc.0
-      IL_004c:  brfalse.s  IL_00b1
-      IL_004e:  br.s       IL_0050
-      // sequence point: <hidden>
-      IL_0050:  br.s       IL_0070
-      // sequence point: var i
-      IL_0052:  ldarg.0
-      IL_0053:  ldarg.0
-      IL_0054:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-      IL_0059:  callvirt   ""int IMyAsyncEnumerator<int>.Current.get""
-      IL_005e:  stfld      ""int C.<Main>d__0.<i>5__5""
-      // sequence point: {
-      IL_0063:  nop
-      // sequence point: Write($""Got "");
-      IL_0064:  ldstr      ""Got ""
-      IL_0069:  call       ""void System.Console.Write(string)""
-      IL_006e:  nop
-      // sequence point: }
-      IL_006f:  nop
-      // sequence point: in
-      IL_0070:  ldarg.0
-      IL_0071:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-      IL_0076:  callvirt   ""System.Threading.Tasks.Task<bool> IMyAsyncEnumerator<int>.MoveNextAsync()""
-      IL_007b:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
-      IL_0080:  stloc.2
-      // sequence point: <hidden>
-      IL_0081:  ldloca.s   V_2
-      IL_0083:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
-      IL_0088:  brtrue.s   IL_00cd
-      IL_008a:  ldarg.0
-      IL_008b:  ldc.i4.0
-      IL_008c:  dup
-      IL_008d:  stloc.0
-      IL_008e:  stfld      ""int C.<Main>d__0.<>1__state""
-      // async: yield
-      IL_0093:  ldarg.0
-      IL_0094:  ldloc.2
-      IL_0095:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-      IL_009a:  ldarg.0
-      IL_009b:  stloc.3
-      IL_009c:  ldarg.0
-      IL_009d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-      IL_00a2:  ldloca.s   V_2
-      IL_00a4:  ldloca.s   V_3
-      IL_00a6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
-      IL_00ab:  nop
-      IL_00ac:  leave      IL_01da
-      // async: resume
-      IL_00b1:  ldarg.0
-      IL_00b2:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-      IL_00b7:  stloc.2
-      IL_00b8:  ldarg.0
-      IL_00b9:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-      IL_00be:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
-      IL_00c4:  ldarg.0
-      IL_00c5:  ldc.i4.m1
-      IL_00c6:  dup
-      IL_00c7:  stloc.0
-      IL_00c8:  stfld      ""int C.<Main>d__0.<>1__state""
-      IL_00cd:  ldarg.0
-      IL_00ce:  ldloca.s   V_2
-      IL_00d0:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
-      IL_00d5:  stfld      ""bool C.<Main>d__0.<>s__6""
-      IL_00da:  ldarg.0
-      IL_00db:  ldfld      ""bool C.<Main>d__0.<>s__6""
-      IL_00e0:  brtrue     IL_0052
-      // sequence point: <hidden>
-      IL_00e5:  leave.s    IL_00f3
-    }
-    catch object
-    {
-      // sequence point: <hidden>
-      IL_00e7:  stloc.s    V_4
-      IL_00e9:  ldarg.0
-      IL_00ea:  ldloc.s    V_4
-      IL_00ec:  stfld      ""object C.<Main>d__0.<>s__3""
-      IL_00f1:  leave.s    IL_00f3
-    }
-    // sequence point: <hidden>
-    IL_00f3:  ldarg.0
-    IL_00f4:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-    IL_00f9:  isinst     ""System.IAsyncDisposable""
-    IL_00fe:  stloc.s    V_5
-    IL_0100:  ldloc.s    V_5
-    IL_0102:  brfalse.s  IL_016c
-    IL_0104:  ldloc.s    V_5
-    IL_0106:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
-    IL_010b:  stloc.s    V_7
-    IL_010d:  ldloca.s   V_7
-    IL_010f:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
-    IL_0114:  stloc.s    V_6
-    // sequence point: <hidden>
-    IL_0116:  ldloca.s   V_6
-    IL_0118:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
-    IL_011d:  brtrue.s   IL_0164
-    IL_011f:  ldarg.0
-    IL_0120:  ldc.i4.1
-    IL_0121:  dup
-    IL_0122:  stloc.0
-    IL_0123:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_0067:  ldloca.s   V_2
+    IL_0069:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
+    IL_006e:  brtrue.s   IL_00b0
+    IL_0070:  ldarg.0
+    IL_0071:  ldc.i4.0
+    IL_0072:  dup
+    IL_0073:  stloc.0
+    IL_0074:  stfld      ""int C.<Main>d__0.<>1__state""
     // async: yield
-    IL_0128:  ldarg.0
-    IL_0129:  ldloc.s    V_6
-    IL_012b:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
-    IL_0130:  ldarg.0
-    IL_0131:  stloc.3
-    IL_0132:  ldarg.0
-    IL_0133:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_0138:  ldloca.s   V_6
-    IL_013a:  ldloca.s   V_3
-    IL_013c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
-    IL_0141:  nop
-    IL_0142:  leave      IL_01da
+    IL_0079:  ldarg.0
+    IL_007a:  ldloc.2
+    IL_007b:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_0080:  ldarg.0
+    IL_0081:  stloc.3
+    IL_0082:  ldarg.0
+    IL_0083:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_0088:  ldloca.s   V_2
+    IL_008a:  ldloca.s   V_3
+    IL_008c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
+    IL_0091:  nop
+    IL_0092:  leave.s    IL_00ff
     // async: resume
-    IL_0147:  ldarg.0
-    IL_0148:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
-    IL_014d:  stloc.s    V_6
-    IL_014f:  ldarg.0
-    IL_0150:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
-    IL_0155:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
-    IL_015b:  ldarg.0
-    IL_015c:  ldc.i4.m1
-    IL_015d:  dup
-    IL_015e:  stloc.0
-    IL_015f:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_0164:  ldloca.s   V_6
-    IL_0166:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
-    IL_016b:  nop
-    // sequence point: <hidden>
-    IL_016c:  ldarg.0
-    IL_016d:  ldfld      ""object C.<Main>d__0.<>s__3""
-    IL_0172:  stloc.s    V_4
-    IL_0174:  ldloc.s    V_4
-    IL_0176:  brfalse.s  IL_0195
-    IL_0178:  ldloc.s    V_4
-    IL_017a:  isinst     ""System.Exception""
-    IL_017f:  stloc.s    V_8
-    IL_0181:  ldloc.s    V_8
-    IL_0183:  brtrue.s   IL_0188
-    IL_0185:  ldloc.s    V_4
-    IL_0187:  throw
-    IL_0188:  ldloc.s    V_8
-    IL_018a:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_018f:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_0194:  nop
-    IL_0195:  ldarg.0
-    IL_0196:  ldfld      ""int C.<Main>d__0.<>s__4""
-    IL_019b:  pop
-    IL_019c:  ldarg.0
-    IL_019d:  ldnull
-    IL_019e:  stfld      ""object C.<Main>d__0.<>s__3""
-    IL_01a3:  ldarg.0
-    IL_01a4:  ldnull
-    IL_01a5:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-    IL_01aa:  leave.s    IL_01c6
+    IL_0094:  ldarg.0
+    IL_0095:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_009a:  stloc.2
+    IL_009b:  ldarg.0
+    IL_009c:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_00a1:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
+    IL_00a7:  ldarg.0
+    IL_00a8:  ldc.i4.m1
+    IL_00a9:  dup
+    IL_00aa:  stloc.0
+    IL_00ab:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00b0:  ldarg.0
+    IL_00b1:  ldloca.s   V_2
+    IL_00b3:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
+    IL_00b8:  stfld      ""bool C.<Main>d__0.<>s__4""
+    IL_00bd:  ldarg.0
+    IL_00be:  ldfld      ""bool C.<Main>d__0.<>s__4""
+    IL_00c3:  brtrue     IL_0038
+    IL_00c8:  ldarg.0
+    IL_00c9:  ldnull
+    IL_00ca:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_00cf:  leave.s    IL_00eb
   }
   catch System.Exception
   {
     // sequence point: <hidden>
-    IL_01ac:  stloc.s    V_8
-    IL_01ae:  ldarg.0
-    IL_01af:  ldc.i4.s   -2
-    IL_01b1:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_01b6:  ldarg.0
-    IL_01b7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_01bc:  ldloc.s    V_8
-    IL_01be:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_01c3:  nop
-    IL_01c4:  leave.s    IL_01da
+    IL_00d1:  stloc.s    V_4
+    IL_00d3:  ldarg.0
+    IL_00d4:  ldc.i4.s   -2
+    IL_00d6:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00db:  ldarg.0
+    IL_00dc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_00e1:  ldloc.s    V_4
+    IL_00e3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00e8:  nop
+    IL_00e9:  leave.s    IL_00ff
   }
   // sequence point: }
-  IL_01c6:  ldarg.0
-  IL_01c7:  ldc.i4.s   -2
-  IL_01c9:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_00eb:  ldarg.0
+  IL_00ec:  ldc.i4.s   -2
+  IL_00ee:  stfld      ""int C.<Main>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_01ce:  ldarg.0
-  IL_01cf:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_01d4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_01d9:  nop
-  IL_01da:  ret
+  IL_00f3:  ldarg.0
+  IL_00f4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_00f9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_00fe:  nop
+  IL_00ff:  ret
 }", sequencePoints: "C+<Main>d__0.MoveNext", source: source);
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        public void TestWithInterfaceImplementingPattern_ChildImplementsDisposeAsync()
+        {
+            string source = @"
+using static System.Console;
+using System.Threading.Tasks;
+
+public interface ICollection<T>
+{
+    IMyAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken token = default);
+}
+public interface IMyAsyncEnumerator<T>
+{
+    T Current { get; }
+    Task<bool> MoveNextAsync();
+}
+
+public class Collection<T> : ICollection<T>
+{
+    public IMyAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken token = default)
+    {
+        return new MyAsyncEnumerator<T>();
+    }
+    public System.Threading.Tasks.ValueTask DisposeAsync()
+        => throw null;
+}
+public sealed class MyAsyncEnumerator<T> : IMyAsyncEnumerator<T>
+{
+    int i = 0;
+    public T Current
+    {
+        get
+        {
+            Write($""Current({i}) "");
+            return default;
+        }
+    }
+    public async Task<bool> MoveNextAsync()
+    {
+        Write($""NextAsync({i}) "");
+        i++;
+        return await Task.FromResult(i < 4);
+    }
+}
+
+class C
+{
+    static async System.Threading.Tasks.Task Main()
+    {
+        ICollection<int> c = new Collection<int>();
+        await foreach (var i in c)
+        {
+            Write($""Got "");
+        }
+    }
+}";
+            // DisposeAsync on derived type is ignored, since we don't do runtime check
+            var comp = CreateCompilationWithTasksExtensions(source + s_IAsyncEnumerable, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+
+            var verifier = CompileAndVerify(comp, expectedOutput: "NextAsync(0) Current(1) Got NextAsync(1) Current(2) Got NextAsync(2) Current(3) Got NextAsync(3)");
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = (SyntaxTreeSemanticModel)comp.GetSemanticModel(tree, ignoreAccessibility: false);
+            var foreachSyntax = tree.GetRoot().DescendantNodes().OfType<ForEachStatementSyntax>().Single();
+            var info = model.GetForEachStatementInfo(foreachSyntax);
+
+            Assert.Null(info.DisposeMethod);
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly))]
@@ -4566,6 +4418,227 @@ class C
             var comp = CreateCompilationWithTasksExtensions(new[] { source, s_IAsyncEnumerable }, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "MoveNextAsync");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void PatternBasedDisposal()
+        {
+            string source = @"
+using System.Threading.Tasks;
+class C
+{
+    public static async Task Main()
+    {
+        await foreach (var i in new C())
+        {
+        }
+        System.Console.Write(""Done"");
+    }
+    public Enumerator GetAsyncEnumerator()
+    {
+        return new Enumerator();
+    }
+    public sealed class Enumerator
+    {
+        public async System.Threading.Tasks.Task<bool> MoveNextAsync()
+        {
+            System.Console.Write(""MoveNextAsync "");
+            await System.Threading.Tasks.Task.Yield();
+            return false;
+        }
+        public int Current
+        {
+            get => throw null;
+        }
+        public async System.Threading.Tasks.ValueTask DisposeAsync()
+        {
+            System.Console.Write(""DisposeAsync "");
+            await System.Threading.Tasks.Task.Yield();
+        }
+    }
+}";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_IAsyncEnumerable }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "MoveNextAsync DisposeAsync Done");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void PatternBasedDisposal_InterfacePreferredToInstanceMethod()
+        {
+            string source = @"
+using System.Threading.Tasks;
+class C
+{
+    public static async Task Main()
+    {
+        await foreach (var i in new C())
+        {
+        }
+        System.Console.Write(""Done"");
+    }
+    public Enumerator GetAsyncEnumerator()
+    {
+        return new Enumerator();
+    }
+    public sealed class Enumerator : System.IAsyncDisposable
+    {
+        public async System.Threading.Tasks.Task<bool> MoveNextAsync()
+        {
+            System.Console.Write(""MoveNextAsync "");
+            await System.Threading.Tasks.Task.Yield();
+            return false;
+        }
+        public int Current
+        {
+            get => throw null;
+        }
+        async System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()
+        {
+            System.Console.Write(""DisposeAsync "");
+            await System.Threading.Tasks.Task.Yield();
+        }
+        public System.Threading.Tasks.ValueTask DisposeAsync() => throw null;
+    }
+}";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_IAsyncEnumerable }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "MoveNextAsync DisposeAsync Done");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void PatternBasedDisposal_ReturnsVoid()
+        {
+            string source = @"
+using System.Threading.Tasks;
+class C
+{
+    public static async Task Main()
+    {
+        await foreach (var i in new C())
+        {
+        }
+    }
+    public Enumerator GetAsyncEnumerator()
+        => throw null;
+    public sealed class Enumerator
+    {
+        public System.Threading.Tasks.Task<bool> MoveNextAsync()
+            => throw null;
+        public int Current
+        {
+            get => throw null;
+        }
+        public void DisposeAsync()
+            => throw null;
+    }
+}";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_IAsyncEnumerable });
+            comp.VerifyDiagnostics(
+                // (7,33): error CS4008: Cannot await 'void'
+                //         await foreach (var i in new C())
+                Diagnostic(ErrorCode.ERR_BadAwaitArgVoidCall, "new C()").WithLocation(7, 33)
+                );
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void PatternBasedDisposal_ReturnsInt()
+        {
+            string source = @"
+using System.Threading.Tasks;
+class C
+{
+    public static async Task Main()
+    {
+        await foreach (var i in new C())
+        {
+        }
+    }
+    public Enumerator GetAsyncEnumerator()
+    {
+        return new Enumerator();
+    }
+    public sealed class Enumerator
+    {
+        public async System.Threading.Tasks.Task<bool> MoveNextAsync()
+        {
+            await System.Threading.Tasks.Task.Yield();
+            return false;
+        }
+        public int Current
+        {
+            get => throw null;
+        }
+        public int DisposeAsync()
+        {
+            throw null;
+        }
+    }
+}";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_IAsyncEnumerable });
+            comp.VerifyDiagnostics(
+                // (7,33): error CS1061: 'int' does not contain a definition for 'GetAwaiter' and no accessible extension method 'GetAwaiter' accepting a first argument of type 'int' could be found (are you missing a using directive or an assembly reference?)
+                //         await foreach (var i in new C())
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "new C()").WithArguments("int", "GetAwaiter").WithLocation(7, 33)
+                );
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void PatternBasedDisposal_ReturnsAwaitable()
+        {
+            string source = @"
+using System.Threading.Tasks;
+class C
+{
+    public static async Task Main()
+    {
+        await foreach (var i in new C())
+        {
+        }
+        System.Console.Write(""Done"");
+    }
+    public Enumerator GetAsyncEnumerator()
+    {
+        return new Enumerator();
+    }
+    public sealed class Enumerator
+    {
+        public async System.Threading.Tasks.Task<bool> MoveNextAsync()
+        {
+            System.Console.Write(""MoveNextAsync "");
+            await System.Threading.Tasks.Task.Yield();
+            return false;
+        }
+        public int Current
+        {
+            get => throw null;
+        }
+        public Awaitable DisposeAsync()
+        {
+            System.Console.Write(""DisposeAsync "");
+            return new Awaitable();
+        }
+    }
+}
+
+public class Awaitable
+{
+    public Awaiter GetAwaiter() { return new Awaiter(); }
+}
+public class Awaiter : System.Runtime.CompilerServices.INotifyCompletion
+{
+    public bool IsCompleted { get { return true; } }
+    public bool GetResult() { return true; }
+    public void OnCompleted(System.Action continuation) { }
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_IAsyncEnumerable }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "MoveNextAsync DisposeAsync Done");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
@@ -570,27 +570,15 @@ class C
                 // (6,9): error CS0518: Predefined type 'System.IAsyncDisposable' is not defined or imported
                 //         await using (new C())
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "await").WithArguments("System.IAsyncDisposable").WithLocation(6, 9),
-                // (6,22): error CS8410: 'C': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'
+                // (6,22): error CS8410: 'C': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.
                 //         await using (new C())
                 Diagnostic(ErrorCode.ERR_NoConvToIAsyncDisp, "new C()").WithArguments("C").WithLocation(6, 22),
-                // (6,9): error CS0518: Predefined type 'System.Threading.Tasks.ValueTask' is not defined or imported
-                //         await using (new C())
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "await").WithArguments("System.Threading.Tasks.ValueTask").WithLocation(6, 9),
-                // (6,9): error CS4032: The 'await' operator can only be used within an async method. Consider marking this method with the 'async' modifier and changing its return type to 'Task<Task<int>>'.
-                //         await using (new C())
-                Diagnostic(ErrorCode.ERR_BadAwaitWithoutAsyncMethod, "await").WithArguments("System.Threading.Tasks.Task<int>").WithLocation(6, 9),
                 // (9,9): error CS0518: Predefined type 'System.IAsyncDisposable' is not defined or imported
                 //         await using (var x = new C())
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "await").WithArguments("System.IAsyncDisposable").WithLocation(9, 9),
-                // (9,22): error CS8410: 'C': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable'
+                // (9,22): error CS8410: 'C': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.
                 //         await using (var x = new C())
                 Diagnostic(ErrorCode.ERR_NoConvToIAsyncDisp, "var x = new C()").WithArguments("C").WithLocation(9, 22),
-                // (9,9): error CS0518: Predefined type 'System.Threading.Tasks.ValueTask' is not defined or imported
-                //         await using (var x = new C())
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "await").WithArguments("System.Threading.Tasks.ValueTask").WithLocation(9, 9),
-                // (9,9): error CS4032: The 'await' operator can only be used within an async method. Consider marking this method with the 'async' modifier and changing its return type to 'Task<Task<int>>'.
-                //         await using (var x = new C())
-                Diagnostic(ErrorCode.ERR_BadAwaitWithoutAsyncMethod, "await").WithArguments("System.Threading.Tasks.Task<int>").WithLocation(9, 9),
                 // (11,20): error CS0029: Cannot implicitly convert type 'int' to 'System.Threading.Tasks.Task<int>'
                 //             return 1;
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "1").WithArguments("int", "System.Threading.Tasks.Task<int>").WithLocation(11, 20)
@@ -621,13 +609,13 @@ class C
                 // (6,9): error CS0518: Predefined type 'System.IDisposable' is not defined or imported
                 //         using (new C())
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "using").WithArguments("System.IDisposable").WithLocation(6, 9),
-                // (6,16): error CS1674: 'C': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (6,16): error CS1674: 'C': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
                 //         using (new C())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "new C()").WithArguments("C").WithLocation(6, 16),
                 // (9,9): error CS0518: Predefined type 'System.IDisposable' is not defined or imported
                 //         using (var x = new C())
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "using").WithArguments("System.IDisposable").WithLocation(9, 9),
-                // (9,16): error CS1674: 'C': type used in a using statement must be implicitly convertible to 'System.IDisposable'
+                // (9,16): error CS1674: 'C': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
                 //         using (var x = new C())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "var x = new C()").WithArguments("C").WithLocation(9, 16)
                 );
@@ -925,6 +913,33 @@ class C : System.IDisposable
                 //         await using (new C())
                 Diagnostic(ErrorCode.ERR_NoConvToIAsyncDispWrongAsync, "new C()").WithArguments("C").WithLocation(6, 22)
                 );
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        public void TestWithDynamicDeclaration_ExplicitInterfaceImplementation()
+        {
+            string source = @"
+class C : System.IAsyncDisposable
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        await using (dynamic x = new C())
+        {
+            System.Console.Write(""body "");
+        }
+        System.Console.Write(""end "");
+        return 1;
+    }
+    System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()
+    {
+        System.Console.Write(""DisposeAsync "");
+        return new System.Threading.Tasks.ValueTask(System.Threading.Tasks.Task.CompletedTask);
+    }
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(source + s_interfaces, options: TestOptions.DebugExe, references: new[] { CSharpRef });
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "body DisposeAsync end");
         }
 
         [ConditionalFact(typeof(WindowsDesktopOnly))]
@@ -1635,6 +1650,381 @@ public class D
 
             var another = new AwaitExpressionInfo(new AwaitableInfo(getAwaiter1, isCompleted1, getResult1));
             Assert.True(first.GetHashCode() == another.GetHashCode());
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_ExtensionMethod()
+        {
+            string source = @"
+public class C
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        await using (var x = new C())
+        {
+        }
+
+        return 1;
+    }
+}
+public static class Extensions
+{
+    public static System.Threading.Tasks.ValueTask DisposeAsync(this C c)
+        => throw null;
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (6,22): warning CS0280: 'C' does not implement the 'disposable' pattern. 'Extensions.DisposeAsync(C)' has the wrong signature.
+                //         await using (var x = new C())
+                Diagnostic(ErrorCode.WRN_PatternBadSignature, "var x = new C()").WithArguments("C", "disposable", "Extensions.DisposeAsync(C)").WithLocation(6, 22),
+                // (6,22): error CS8410: 'C': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.
+                //         await using (var x = new C())
+                Diagnostic(ErrorCode.ERR_NoConvToIAsyncDisp, "var x = new C()").WithArguments("C").WithLocation(6, 22)
+                );
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_Expression_ExtensionMethod()
+        {
+            string source = @"
+public class C
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        await using (new C())
+        {
+        }
+
+        return 1;
+    }
+}
+public static class Extensions
+{
+    public static System.Threading.Tasks.ValueTask DisposeAsync(this C c)
+        => throw null;
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (6,22): warning CS0280: 'C' does not implement the 'disposable' pattern. 'Extensions.DisposeAsync(C)' has the wrong signature.
+                //         await using (new C())
+                Diagnostic(ErrorCode.WRN_PatternBadSignature, "new C()").WithArguments("C", "disposable", "Extensions.DisposeAsync(C)").WithLocation(6, 22),
+                // (6,22): error CS8410: 'C': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.
+                //         await using (new C())
+                Diagnostic(ErrorCode.ERR_NoConvToIAsyncDisp, "new C()").WithArguments("C").WithLocation(6, 22)
+                );
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_Expression_InstanceMethod()
+        {
+            string source = @"
+public class C
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        await using (new C())
+        {
+            System.Console.Write(""using "");
+        }
+
+        System.Console.Write(""return"");
+        return 1;
+    }
+    public async System.Threading.Tasks.ValueTask DisposeAsync()
+    {
+        System.Console.Write($""dispose_start "");
+        await System.Threading.Tasks.Task.Yield();
+        System.Console.Write($""dispose_end "");
+    }
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_InstanceMethod()
+        {
+            string source = @"
+public class C
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        await using (var x = new C())
+        {
+            System.Console.Write(""using "");
+        }
+
+        System.Console.Write(""return"");
+        return 1;
+    }
+    public async System.Threading.Tasks.ValueTask DisposeAsync()
+    {
+        System.Console.Write($""dispose_start "");
+        await System.Threading.Tasks.Task.Yield();
+        System.Console.Write($""dispose_end "");
+    }
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_InterfacePreferredOverInstanceMethod()
+        {
+            string source = @"
+public class C : System.IAsyncDisposable
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        await using (var x = new C())
+        {
+            System.Console.Write(""using "");
+        }
+
+        System.Console.Write(""return"");
+        return 1;
+    }
+    async System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()
+    {
+        System.Console.Write($""dispose_start "");
+        await System.Threading.Tasks.Task.Yield();
+        System.Console.Write($""dispose_end "");
+    }
+    public System.Threading.Tasks.ValueTask DisposeAsync()
+        => throw null;
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_InstanceMethod_OptionalParameter()
+        {
+            string source = @"
+public class C
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        await using (var x = new C())
+        {
+            System.Console.Write(""using "");
+        }
+
+        System.Console.Write(""return"");
+        return 1;
+    }
+    public async System.Threading.Tasks.ValueTask DisposeAsync(int i = 0)
+    {
+        System.Console.Write($""dispose_start "");
+        await System.Threading.Tasks.Task.Yield();
+        System.Console.Write($""dispose_end "");
+    }
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_InstanceMethod_ParamsParameter()
+        {
+            string source = @"
+public class C
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        await using (var x = new C())
+        {
+            System.Console.Write(""using "");
+        }
+
+        System.Console.Write(""return"");
+        return 1;
+    }
+    public async System.Threading.Tasks.ValueTask DisposeAsync(params int[] x)
+    {
+        System.Console.Write($""dispose_start "");
+        await System.Threading.Tasks.Task.Yield();
+        System.Console.Write($""dispose_end "");
+    }
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_InstanceMethod_ReturningVoid()
+        {
+            string source = @"
+public class C
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        await using (var x = new C())
+        {
+        }
+
+        return 1;
+    }
+    public void DisposeAsync()
+    {
+    }
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces });
+            comp.VerifyDiagnostics(
+                // (6,22): error CS4008: Cannot await 'void'
+                //         await using (var x = new C())
+                Diagnostic(ErrorCode.ERR_BadAwaitArgVoidCall, "var x = new C()").WithLocation(6, 22)
+                );
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_InstanceMethod_ReturningInt()
+        {
+            string source = @"
+public class C
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        await using (var x = new C())
+        {
+        }
+
+        return 1;
+    }
+    public int DisposeAsync()
+        => throw null;
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces });
+            comp.VerifyDiagnostics(
+                // (6,22): error CS1061: 'int' does not contain a definition for 'GetAwaiter' and no accessible extension method 'GetAwaiter' accepting a first argument of type 'int' could be found (are you missing a using directive or an assembly reference?)
+                //         await using (var x = new C())
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "var x = new C()").WithArguments("int", "GetAwaiter").WithLocation(6, 22)
+                );
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_InstanceMethod_Inaccessible()
+        {
+            string source = @"
+public class D
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        await using (var x = new C())
+        {
+        }
+
+        return 1;
+    }
+}
+public class C
+{
+    private System.Threading.Tasks.ValueTask DisposeAsync()
+        => throw null;
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces });
+            comp.VerifyDiagnostics(
+                // (6,22): error CS0122: 'C.DisposeAsync()' is inaccessible due to its protection level
+                //         await using (var x = new C())
+                Diagnostic(ErrorCode.ERR_BadAccess, "var x = new C()").WithArguments("C.DisposeAsync()").WithLocation(6, 22),
+                // (6,22): error CS8410: 'C': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method.
+                //         await using (var x = new C())
+                Diagnostic(ErrorCode.ERR_NoConvToIAsyncDisp, "var x = new C()").WithArguments("C").WithLocation(6, 22)
+                );
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_InstanceMethod_UsingDeclaration()
+        {
+            string source = @"
+public class C
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        {
+            await using var x = new C();
+            System.Console.Write(""using "");
+        }
+        System.Console.Write(""return"");
+        return 1;
+    }
+    public async System.Threading.Tasks.ValueTask DisposeAsync()
+    {
+        System.Console.Write($""dispose_start "");
+        await System.Threading.Tasks.Task.Yield();
+        System.Console.Write($""dispose_end "");
+    }
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return");
+        }
+
+        [ConditionalFact(typeof(WindowsDesktopOnly))]
+        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
+        public void TestPatternBasedDisposal_Awaitable()
+        {
+            string source = @"
+public struct C
+{
+    public static async System.Threading.Tasks.Task<int> Main()
+    {
+        {
+            await using var x = new C();
+            System.Console.Write(""using "");
+        }
+        System.Console.Write(""return"");
+        return 1;
+    }
+    public Awaitable DisposeAsync()
+    {
+        System.Console.Write($""dispose_start "");
+        System.Console.Write($""dispose_end "");
+        return new Awaitable();
+    }
+}
+
+public class Awaitable
+{
+    public Awaiter GetAwaiter() { return new Awaiter(); }
+}
+public class Awaiter : System.Runtime.CompilerServices.INotifyCompletion
+{
+    public bool IsCompleted { get { return true; } }
+    public bool GetResult() { return true; }
+    public void OnCompleted(System.Action continuation) { }
+}
+";
+            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
@@ -2088,37 +2088,6 @@ public struct C
 
         [ConditionalFact(typeof(WindowsDesktopOnly))]
         [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
-        public void TestPatternBasedDisposal_ReturnsTaskOfBool()
-        {
-            string source = @"
-public struct C
-{
-    public static async System.Threading.Tasks.Task<int> Main()
-    {
-        {
-            await using var x = new C();
-            System.Console.Write(""using "");
-        }
-        System.Console.Write(""return"");
-        return 1;
-    }
-    public async System.Threading.Tasks.Task<bool> DisposeAsync()
-    {
-        System.Console.Write($""dispose_start "");
-        await System.Threading.Tasks.Task.Yield();
-        System.Console.Write($""dispose_end "");
-        return true;
-    }
-}
-";
-            // it's okay to await `Task<bool>` even if we don't care about the result
-            var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces }, options: TestOptions.DebugExe);
-            comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return");
-        }
-
-        [ConditionalFact(typeof(WindowsDesktopOnly))]
-        [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
         public void TestPatternBasedDisposal_ReturnsTaskOfInt()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
@@ -1520,6 +1520,46 @@ static class DisposeExtension
         }
 
         [Fact]
+        public void TestForEachPatternDisposableRefStructWithTwoExtensionMethods()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.Write(x);
+        }
+    }
+}
+
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+ref struct DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+}
+
+static class DisposeExtension1
+{
+    public static void Dispose(this DisposableEnumerator de) => throw null;
+}
+static class DisposeExtension2
+{
+    public static void Dispose(this DisposableEnumerator de) => throw null;
+}
+";
+            // extension methods do not contribute to disposal
+            CompileAndVerify(source, expectedOutput: @"123");
+        }
+
+        [Fact]
         public void TestForEachPatternDisposableRefStructWithExtensionMethodAndDefaultArguments()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
@@ -1493,7 +1493,7 @@ class C
     {
         foreach (var x in new Enumerable1())
         {
-            System.Console.WriteLine(x);
+            System.Console.Write(x);
         }
     }
 }
@@ -1512,17 +1512,11 @@ ref struct DisposableEnumerator
 
 static class DisposeExtension
 {
-    public static void Dispose(this DisposableEnumerator de) { System.Console.WriteLine(""Done with DisposableEnumerator""); } 
+    public static void Dispose(this DisposableEnumerator de) => throw null;
 }
-
 ";
-
-
-            var compilation = CompileAndVerify(source, expectedOutput: @"
-1
-2
-3
-Done with DisposableEnumerator");
+            // extension methods do not contribute to disposal
+            CompileAndVerify(source, expectedOutput: @"123");
         }
 
         [Fact]
@@ -1535,7 +1529,7 @@ class C
     {
         foreach (var x in new Enumerable1())
         {
-            System.Console.WriteLine(x);
+            System.Console.Write(x);
         }
     }
 }
@@ -1554,17 +1548,11 @@ ref struct DisposableEnumerator
 
 static class DisposeExtension
 {
-    public static void Dispose(this DisposableEnumerator de, int arg = 4) { System.Console.WriteLine($""Done with DisposableEnumerator. arg was {arg}""); } 
+    public static void Dispose(this DisposableEnumerator de, int arg = 4) => throw null;
 }
-
 ";
-
-
-            var compilation = CompileAndVerify(source, expectedOutput: @"
-1
-2
-3
-Done with DisposableEnumerator. arg was 4");
+            // extension methods do not contribute to disposal
+            CompileAndVerify(source, expectedOutput: @"123");
         }
 
         [Fact]
@@ -1577,7 +1565,7 @@ class C
     {
         foreach (var x in new Enumerable1())
         {
-            System.Console.WriteLine(x);
+            System.Console.Write(x);
         }
     }
 }
@@ -1596,17 +1584,11 @@ ref struct DisposableEnumerator
 
 static class DisposeExtension
 {
-    public static void Dispose(this DisposableEnumerator de, params object[] args) { System.Console.WriteLine($""Done with DisposableEnumerator. Args was {args}, length {args.Length}""); } 
+    public static void Dispose(this DisposableEnumerator de, params object[] args) => throw null;
 }
-
 ";
-
-
-            var compilation = CompileAndVerify(source, expectedOutput: @"
-1
-2
-3
-Done with DisposableEnumerator. Args was System.Object[], length 0");
+            // extension methods do not contribute to disposal
+            CompileAndVerify(source, expectedOutput: @"123");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingDeclarationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingDeclarationTests.cs
@@ -812,27 +812,12 @@ This object has been disposed by IDisposable.Dispose().";
         }
     }";
 
-            var output = @"Disposed; ";
-            CompileAndVerify(source, expectedOutput: output).VerifyIL("Program.Main", @"
-{
-  // Code size       18 (0x12)
-  .maxstack  1
-  .locals init (S1 V_0) //s1
-  IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    ""S1""
-  .try
-  {
-    IL_0008:  leave.s    IL_0011
-  }
-  finally
-  {
-    IL_000a:  ldloc.0
-    IL_000b:  call       ""void C2.Dispose(S1)""
-    IL_0010:  endfinally
-  }
-  IL_0011:  ret
-}
-");
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (17,13): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //             using S1 s1 = new S1();
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "using S1 s1 = new S1();").WithArguments("S1").WithLocation(17, 13)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
@@ -1,9 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp.UnitTests.Emit;
-using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1125,7 +1121,6 @@ class C2
         public void UsingPatternExtensionMethodTest()
         {
             var source = @"
-using System;
 ref struct S1
 {
 }
@@ -1134,7 +1129,6 @@ static class C2
 {
     public static void Dispose(this S1 s1) 
     {
-        Console.WriteLine(""C2.Dispose(S1)"");
     }
 }
 
@@ -1147,26 +1141,15 @@ class C3
         }
     }
 }";
-            CompileAndVerify(source, expectedOutput: "C2.Dispose(S1)").VerifyIL("C3.Main()", @"
-{
-  // Code size       18 (0x12)
-  .maxstack  1
-  .locals init (S1 V_0) //s
-  IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    ""S1""
-  .try
-  {
-    IL_0008:  leave.s    IL_0011
-  }
-  finally
-  {
-    IL_000a:  ldloc.0
-    IL_000b:  call       ""void C2.Dispose(S1)""
-    IL_0010:  endfinally
-  }
-  IL_0011:  ret
-}
-");
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (17,16): warning CS0280: 'S1' does not implement the 'disposable' pattern. 'C2.Dispose(S1)' has the wrong signature or is an extension.
+                //         using (S1 s = new S1())
+                Diagnostic(ErrorCode.WRN_PatternBadSignature, "S1 s = new S1()").WithArguments("S1", "disposable", "C2.Dispose(S1)").WithLocation(17, 16),
+                // (17,16): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable'.
+                //         using (S1 s = new S1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(17, 16)
+                );
         }
 
         [Fact]
@@ -1231,7 +1214,7 @@ ref struct S1
 
 static class C2 
 {
-    internal static void Dispose(this S1 s1, int a = 1) { System.Console.WriteLine($""Dispose default param {a}""); }
+    internal static void Dispose(this S1 s1, int a = 1) { }
 }
 
 class C3
@@ -1243,7 +1226,15 @@ class C3
        }
     }
 }";
-            CompileAndVerify(source, expectedOutput: "Dispose default param 1");
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (15,15): warning CS0280: 'S1' does not implement the 'disposable' pattern. 'C2.Dispose(S1, int)' has the wrong signature or is an extension.
+                //        using (S1 s = new S1())
+                Diagnostic(ErrorCode.WRN_PatternBadSignature, "S1 s = new S1()").WithArguments("S1", "disposable", "C2.Dispose(S1, int)").WithLocation(15, 15),
+                // (15,15): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable'.
+                //        using (S1 s = new S1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(15, 15)
+                );
         }
 
         [Fact]
@@ -1256,7 +1247,7 @@ ref struct S1
 
 static class C2 
 {
-    internal static void Dispose(this S1 s1, params int[] args) { System.Console.WriteLine($""Dispose params {args.Length}""); }
+    internal static void Dispose(this S1 s1, params int[] args) { }
 }
 
 class C3
@@ -1268,7 +1259,15 @@ class C3
        }
     }
 }";
-            CompileAndVerify(source, expectedOutput: "Dispose params 0");
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (15,15): warning CS0280: 'S1' does not implement the 'disposable' pattern. 'C2.Dispose(S1, params int[])' has the wrong signature or is an extension.
+                //        using (S1 s = new S1())
+                Diagnostic(ErrorCode.WRN_PatternBadSignature, "S1 s = new S1()").WithArguments("S1", "disposable", "C2.Dispose(S1, params int[])").WithLocation(15, 15),
+                // (15,15): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable'.
+                //        using (S1 s = new S1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(15, 15)
+                );
         }
 
         // The object could be created outside the "using" statement 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
@@ -1143,9 +1143,6 @@ class C3
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (17,16): warning CS0280: 'S1' does not implement the 'disposable' pattern. 'C2.Dispose(S1)' has the wrong signature or is an extension.
-                //         using (S1 s = new S1())
-                Diagnostic(ErrorCode.WRN_PatternBadSignature, "S1 s = new S1()").WithArguments("S1", "disposable", "C2.Dispose(S1)").WithLocation(17, 16),
                 // (17,16): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable'.
                 //         using (S1 s = new S1())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(17, 16)
@@ -1228,9 +1225,6 @@ class C3
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (15,15): warning CS0280: 'S1' does not implement the 'disposable' pattern. 'C2.Dispose(S1, int)' has the wrong signature or is an extension.
-                //        using (S1 s = new S1())
-                Diagnostic(ErrorCode.WRN_PatternBadSignature, "S1 s = new S1()").WithArguments("S1", "disposable", "C2.Dispose(S1, int)").WithLocation(15, 15),
                 // (15,15): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable'.
                 //        using (S1 s = new S1())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(15, 15)
@@ -1261,9 +1255,6 @@ class C3
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (15,15): warning CS0280: 'S1' does not implement the 'disposable' pattern. 'C2.Dispose(S1, params int[])' has the wrong signature or is an extension.
-                //        using (S1 s = new S1())
-                Diagnostic(ErrorCode.WRN_PatternBadSignature, "S1 s = new S1()").WithArguments("S1", "disposable", "C2.Dispose(S1, params int[])").WithLocation(15, 15),
                 // (15,15): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable'.
                 //        using (S1 s = new S1())
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(15, 15)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
@@ -38,7 +38,6 @@ class C
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "MissingType").WithArguments("MissingType"));
         }
 
-
         [Fact]
         public void TestErrorNullLiteralCollection()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -439,6 +439,9 @@ class C4
         }
     }
 }";
+            // Extension methods should just be ignored, rather than rejected after-the-fact. So there should be no error about ambiguities
+            // Tracked by https://github.com/dotnet/roslyn/issues/32767
+
             CreateCompilation(source).VerifyDiagnostics(
                 // (20,16): error CS0121: The call is ambiguous between the following methods or properties: 'C2.Dispose(S1)' and 'C3.Dispose(S1)'
                 //         using (S1 c = new S1())
@@ -673,6 +676,9 @@ class C4
        }
     }
 }";
+            // Extension methods should just be ignored, rather than rejected after-the-fact. So there should be no error about ambiguities
+            // Tracked by https://github.com/dotnet/roslyn/issues/32767
+
             CreateCompilation(source).VerifyDiagnostics(
                 // (21,15): error CS0121: The call is ambiguous between the following methods or properties: 'C2.Dispose(S1, int)' and 'C3.Dispose(S1, int)'
                 //        using (S1 s = new S1())

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -338,7 +338,14 @@ class C3
         using (s1b) { }
     }
 }";
-            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics(
+                // (15,16): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //         using (S1 s = new S1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(15, 16),
+                // (19,16): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //         using (s1b) { }
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "s1b").WithArguments("S1").WithLocation(19, 16)
+                );
         }
 
         [Fact]
@@ -366,7 +373,14 @@ class C3
         using (s1b) { }
     }
 }";
-            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics(
+                // (16,16): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //         using (S1 s = new S1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(16, 16),
+                // (20,16): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //         using (s1b) { }
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "s1b").WithArguments("S1").WithLocation(20, 16)
+                );
         }
 
         [Fact]
@@ -445,7 +459,7 @@ ref struct S1
 
 namespace N1
 {
-    static class C2 
+    static class C2
     {
         public static void Dispose(this S1 s1) { }
     }
@@ -453,7 +467,7 @@ namespace N1
 
 namespace N2
 {
-    static class C3 
+    static class C3
     {
         public static void Dispose(this S1 s1) { }
     }
@@ -461,7 +475,7 @@ namespace N2
 
 namespace N3
 {
-    static class C4 
+    static class C4
     {
         public static int Dispose(this S1 s1) { return 0; }
     }
@@ -474,7 +488,7 @@ namespace N4
     {
         static void M()
         {
-            using (S1 s = new S1()) // error 1: no extension in scope
+            using (S1 s = new S1()) // error 1
             {
             }
         }
@@ -487,7 +501,7 @@ namespace N4
     {
         static void M2()
         {
-            using (S1 s = new S1()) // success: resolve against C2.Dispose
+            using (S1 s = new S1()) // error 2
             {
             }
         }
@@ -500,7 +514,7 @@ namespace N4
     {
         static void M3()
         {
-            using (S1 s = new S1()) // error 2: C4.Dispose does not match pattern
+            using (S1 s = new S1()) // error 3
             {
             }
         }
@@ -514,7 +528,7 @@ namespace N4
     {
         static void M4()
         {
-            using (S1 s = new S1())  // error 3: C2.Dispose and C4.Dispose are ambiguous
+            using (S1 s = new S1())  // error 4
             {
             }
         }
@@ -529,7 +543,7 @@ namespace N4
         {
             static void M5()
             {
-                using (S1 s = new S1())  // error 4: C4.Dispose does not match pattern
+                using (S1 s = new S1())  // error 5
                 {
                 }
             }
@@ -542,36 +556,39 @@ namespace N4
             {
                 static void M6()
                 {
-                    using (S1 s = new S1())  // success: resolve against C2.Dispose
-                    { 
+                    using (S1 s = new S1())  // error 6
+                    {
                     }
                 }
             }
         }
     }
 }";
+            // Extension methods should just be ignored, rather than rejected after-the-fact. So there should be no error about ambiguities
+            // Tracked by https://github.com/dotnet/roslyn/issues/32767
+
             CreateCompilation(source).VerifyDiagnostics(
-                // (37,20): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable'.
-                //             using (S1 s = new S1()) // error 1: no extension in scope
+                // (37,20): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //             using (S1 s = new S1()) // error 1
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(37, 20),
-                // (63,20): warning CS0280: 'S1' does not implement the 'disposable' pattern. 'C4.Dispose(S1)' has the wrong signature.
-                //             using (S1 s = new S1()) // error 2: C4.Dispose does not match pattern
-                Diagnostic(ErrorCode.WRN_PatternBadSignature, "S1 s = new S1()").WithArguments("S1", "disposable", "N3.C4.Dispose(S1)").WithLocation(63, 20),
-                // (63,20): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable'.
-                //             using (S1 s = new S1()) // error 2: C4.Dispose does not match pattern
+                // (50,20): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //             using (S1 s = new S1()) // error 2
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(50, 20),
+                // (63,20): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //             using (S1 s = new S1()) // error 3
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(63, 20),
                 // (77,20): error CS0121: The call is ambiguous between the following methods or properties: 'N1.C2.Dispose(S1)' and 'N3.C4.Dispose(S1)'
-                //             using (S1 s = new S1())  // error 3: C2.Dispose and C4.Dispose are ambiguous
+                //             using (S1 s = new S1())  // error 4
                 Diagnostic(ErrorCode.ERR_AmbigCall, "S1 s = new S1()").WithArguments("N1.C2.Dispose(S1)", "N3.C4.Dispose(S1)").WithLocation(77, 20),
-                // (77,20): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable'.
-                //             using (S1 s = new S1())  // error 3: C2.Dispose and C4.Dispose are ambiguous
+                // (77,20): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //             using (S1 s = new S1())  // error 4
                 Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(77, 20),
-                // (92,24): warning CS0280: 'S1' does not implement the 'disposable' pattern. 'C4.Dispose(S1)' has the wrong signature.
-                //                 using (S1 s = new S1())  // error 4: C4.Dispose does not match pattern
-                Diagnostic(ErrorCode.WRN_PatternBadSignature, "S1 s = new S1()").WithArguments("S1", "disposable", "N3.C4.Dispose(S1)").WithLocation(92, 24),
-                // (92,24): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable'.
-                //                 using (S1 s = new S1())  // error 4: C4.Dispose does not match pattern
-                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(92, 24)
+                // (92,24): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //                 using (S1 s = new S1())  // error 5
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(92, 24),
+                // (105,28): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //                     using (S1 s = new S1())  // error 6
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(105, 28)
                 );
         }
 
@@ -612,7 +629,20 @@ class C4
         using (s2b) { }
     }
 }";
-            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics(
+                // (22,16): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //         using (S1 s = new S1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(22, 16),
+                // (26,16): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //         using (s1b) { }
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "s1b").WithArguments("S1").WithLocation(26, 16),
+                // (28,16): error CS1674: 'S2': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //         using (S2 s = new S2())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S2 s = new S2()").WithArguments("S2").WithLocation(28, 16),
+                // (32,16): error CS1674: 'S2': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //         using (s2b) { }
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "s2b").WithArguments("S2").WithLocation(32, 16)
+                );
         }
 
         [Fact]
@@ -677,7 +707,14 @@ class C3
        using (s1b) { }
     }
 }";
-            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics(
+                // (15,15): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //        using (S1 s = new S1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(15, 15),
+                // (19,15): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //        using (s1b) { }
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "s1b").WithArguments("S1").WithLocation(19, 15)
+                );
         }
 
         [Fact]
@@ -739,7 +776,11 @@ class C3
        }
     }
 }";
-            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics(
+                // (16,15): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //        using (S1 s = new S1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(16, 15)
+                );
         }
 
         [Fact]
@@ -766,7 +807,14 @@ class C3
        using (s1b) { }
     }
 }";
-            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source).VerifyDiagnostics(
+                // (15,15): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //        using (S1 s = new S1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(15, 15),
+                // (19,15): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //        using (s1b) { }
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "s1b").WithArguments("S1").WithLocation(19, 15)
+                );
         }
 
         [Fact]
@@ -791,7 +839,11 @@ class C2
        }
     }
 }";
-            var compilation = CreateCompilation(source).VerifyDiagnostics();
+            var compilation = CreateCompilation(source).VerifyDiagnostics(
+                // (15,15): error CS1674: 'S1': type used in a using statement must be implicitly convertible to 'System.IDisposable' or implement a suitable 'Dispose' method.
+                //        using (S1 s = new S1())
+                Diagnostic(ErrorCode.ERR_NoConvToIDisp, "S1 s = new S1()").WithArguments("S1").WithLocation(15, 15)
+                );
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/32316 (async using and foreach should allow pattern-based disposal)
Fixes https://github.com/dotnet/roslyn/issues/32722 (fix diagnostic message)