### PR TITLE
Tweak bail out approach from unused member analyzer for struct layout types

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -2085,6 +2085,26 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(32727, "https://github.com/dotnet/roslyn/issues/32727")]
+        public async Task NestedStructLayoutTypeWithReference()
+        {
+            await TestDiagnosticMissingAsync(
+@"using System.Runtime.InteropServices;
+
+class Program
+{
+    private const int [|MAX_PATH|] = 260;
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ProcessEntry32
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = MAX_PATH)]
+        public string szExeFile;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         public async Task FixAllFields_Document()
         {
             await TestInRegularAndScriptAsync(

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -154,13 +154,6 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 Action<ISymbol, ValueUsageInfo> onSymbolUsageFound = OnSymbolUsage;
                 compilationStartContext.RegisterSymbolStartAction(symbolStartContext =>
                 {
-                    if (symbolStartContext.Symbol.GetAttributes().Any(a => a.AttributeClass == _structLayoutAttributeType))
-                    {
-                        // Bail out for types with 'StructLayoutAttribute' as the ordering of the members is critical,
-                        // and removal of unused members might break semantics.
-                        return;
-                    }
-
                     var hasInvalidOrDynamicOperation = false;
                     symbolStartContext.RegisterOperationAction(AnalyzeMemberReferenceOperation, OperationKind.FieldReference, OperationKind.MethodReference, OperationKind.PropertyReference, OperationKind.EventReference);
                     symbolStartContext.RegisterOperationAction(AnalyzeFieldInitializer, OperationKind.FieldInitializer);
@@ -348,6 +341,13 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 //  2. Dynamic operations, where we do not know the exact member being referenced at compile time.
                 if (hasInvalidOrDynamicOperation)
                 {
+                    return;
+                }
+
+                if (symbolEndContext.Symbol.GetAttributes().Any(a => a.AttributeClass == _structLayoutAttributeType))
+                {
+                    // Bail out for types with 'StructLayoutAttribute' as the ordering of the members is critical,
+                    // and removal of unused members might break semantics.
                     return;
                 }
 


### PR DESCRIPTION
Current implementation bailed out in symbol start action, which caused both analysis and reporting to be skipped in a type with StructLayout attribute. New implementation bails out in symbol end action, so we only skip reporting not analysis.

Fixes #32727