### PR TITLE
Fix cast exception in AbstractProject.RemoveDocument

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -224,8 +224,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         [Obsolete("This is a compatibility shim for TypeScript; please do not use it.")]
         internal void RemoveDocument(IVisualStudioHostDocument document)
         {
-            var shimDocument = (DocumentProvider.ShimDocument)document;
-
             var containedDocument = ContainedDocument.TryGetContainedDocument(document.Id);
             if (containedDocument != null)
             {
@@ -234,6 +232,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
             else
             {
+                var shimDocument = (DocumentProvider.ShimDocument)document;
                 VisualStudioProject.RemoveSourceFile(shimDocument.FilePath);
             }
         }


### PR DESCRIPTION
AbstractProject.RemoveDocument was trying to support removing ContainedDocuments, but had a misplaced cast which negated the whole attempt.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/776782

<details><summary>Ask Mode template</summary>

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/776782

### Workarounds, if any

None.

### Risk

Zero: just moving a cast later. In the broken case, maybe there's a different bug lurking but it won't be worse than what we have. In the existing functioning cases, nothing changes.

### Performance impact

None.

### Is this a regression from a previous update?

Unsure. The buggy code was put into Preview 1; why we're seeing it now is unclear.

### Root cause analysis

It seems TypeScript has some timing-dependent code where _sometimes_ they try to remove a contained document with AbstractProject.RemoveDocument(). Clearly we tried handling that, but didn't do it correctly. As best I can remember, I might have hit this once in testing but couldn't figure out a repro myself; I "fixed" the code regardless but clearly didn't hit the repro scenario again to observe it was still broken.

### How was the bug found?

DDRITs.

</details>