### PR TITLE
Account for both parts of partial methods while computing dependent s…

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -175,13 +175,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                 memberSet.Add(member);
 
                                 // Ensure that we include symbols for both parts of partial methods.
-                                if (member is IMethodSymbol method)
+                                if (member is IMethodSymbol method &&
+                                    !(method.PartialImplementationPart is null))
                                 {
-                                    var otherPartOfPartialOpt = method.PartialDefinitionPart ?? method.PartialImplementationPart;
-                                    if (otherPartOfPartialOpt != null)
-                                    {
-                                        memberSet.Add(otherPartOfPartialOpt);
-                                    }
+                                    memberSet.Add(method.PartialImplementationPart);
                                 }
                             }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -173,6 +173,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                             {
                                 memberSet = memberSet ?? new HashSet<ISymbol>();
                                 memberSet.Add(member);
+
+                                // Ensure that we include symbols for both parts of partial methods.
+                                if (member is IMethodSymbol method)
+                                {
+                                    var otherPartOfPartialOpt = method.PartialDefinitionPart ?? method.PartialImplementationPart;
+                                    if (otherPartOfPartialOpt != null)
+                                    {
+                                        memberSet.Add(otherPartOfPartialOpt);
+                                    }
+                                }
                             }
 
                             if (member.Kind != symbol.Kind &&

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -2242,5 +2242,34 @@ static class MyClass3
     </Project>
 </Workspace>");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(32702, "https://github.com/dotnet/roslyn/issues/32702")]
+        public async Task UsedExtensionMethod_ReferencedFromPartialMethod()
+        {
+            await TestDiagnosticMissingAsync(
+@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+static partial class B
+{
+    static partial void PartialMethod(A a);
+}
+        </Document>
+        <Document>
+static partial class B
+{
+    static partial void PartialMethod()
+    {
+        UsedMethod();
+    }
+
+    private static void [|UsedMethod|]() { }
+}
+        </Document>
+    </Project>
+</Workspace>");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -2254,7 +2254,7 @@ static class MyClass3
         <Document>
 static partial class B
 {
-    static partial void PartialMethod(A a);
+    static partial void PartialMethod();
 }
         </Document>
         <Document>


### PR DESCRIPTION
…ymbols for symbol end action

We invoke symbol end actions for named type symbols after symbol callbacks have been made for all its member symbols. However, we did not account for both parts of partial methods, which means we would end up with a symbol end callback for a named type prior to the partial implementation part being analyzed. This caused the remove unused member analyzer in IDE to incorrectly flag private members referenced in partial methods.

Fixes #32702