### PR TITLE
Display compiler generated members in raw view.

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ResultsViewTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ResultsViewTests.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.Utilities;
-using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 using BindingFlags = System.Reflection.BindingFlags;
 
@@ -813,6 +814,131 @@ class C
                     EvalResult("_2", "\"2\"", "object {string}", "o._2", DkmEvaluationResultFlags.RawString, editableValue: "\"2\""),
                     EvalResult("_3", "\"3\"", "System.Collections.IEnumerable {string}", "o._3", DkmEvaluationResultFlags.RawString, editableValue: "\"3\""),
                     EvalResult("_4", "\"4\"", "System.Collections.Generic.IEnumerable<char> {string}", "o._4", DkmEvaluationResultFlags.RawString, editableValue: "\"4\""));
+            }
+        }
+
+        [Fact]
+        public void AsyncStateMachine()
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    static void Main() => Async(1).Wait();
+
+    static async Task Async(int parameter)
+    {
+        int i = 42;
+        await Task.FromResult(1);
+        Console.WriteLine(i + parameter);
+    }
+}
+";
+            var assembly = GetAssembly(source);
+            var assemblies = ReflectionUtilities.GetMscorlibAndSystemCore(typeof(Task).Assembly, assembly);
+            using (ReflectionUtilities.LoadAssemblies(assemblies))
+            {
+                var runtime = new DkmClrRuntimeInstance(assemblies);
+                var stateMachineType = assembly.GetType("C").GetNestedTypes(BindingFlags.NonPublic).Single();
+
+                var value = CreateDkmClrValue(
+                    value: stateMachineType.Instantiate(),
+                    type: runtime.GetType((TypeImpl)stateMachineType));
+
+                // Raw view
+
+                var evalResult = FormatResult("sm", value, inspectionContext: CreateDkmInspectionContext(DkmEvaluationFlags.ShowValueRaw));
+
+                Verify(evalResult,
+                    EvalResult("sm", "{C.<Async>d__1}", "C.<Async>d__1", "sm, raw", DkmEvaluationResultFlags.Expandable));
+
+                var children = GetChildren(evalResult);
+                Verify(children,
+                    EvalResult("<>1__state", "0", "int", null, DkmEvaluationResultFlags.None),
+                    EvalResult("<>t__builder", "{System.Runtime.CompilerServices.AsyncTaskMethodBuilder}", "System.Runtime.CompilerServices.AsyncTaskMethodBuilder", null, DkmEvaluationResultFlags.Expandable),
+                    EvalResult("<>u__1", "{System.Runtime.CompilerServices.TaskAwaiter<int>}", "System.Runtime.CompilerServices.TaskAwaiter<int>", null, DkmEvaluationResultFlags.Expandable),
+                    EvalResult("<i>5__2", "0", "int", null, DkmEvaluationResultFlags.None),
+                    EvalResult("parameter", "0", "int", "sm.parameter", DkmEvaluationResultFlags.None));
+
+                // Regular view
+
+                evalResult = FormatResult("sm", value, inspectionContext: CreateDkmInspectionContext(DkmEvaluationFlags.None));
+
+                Verify(evalResult,
+                    EvalResult("sm", "{C.<Async>d__1}", "C.<Async>d__1", "sm", DkmEvaluationResultFlags.Expandable));
+
+                children = GetChildren(evalResult);
+                Verify(children,
+                    EvalResult("parameter", "0", "int", "sm.parameter", DkmEvaluationResultFlags.None));
+            }
+        }
+
+        [Fact]
+        public void IteratorStateMachine()
+        {
+            var source = @"
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+class C
+{
+    static void Main() => Iter(1).ToArray();
+
+    static IEnumerable<int> Iter(int parameter)
+    {
+        int i = 42;
+        yield return 1;
+        Console.WriteLine(i + parameter);
+    }
+}
+";
+            var assembly = GetAssembly(source);
+            var assemblies = ReflectionUtilities.GetMscorlibAndSystemCore(typeof(Task).Assembly, assembly);
+            using (ReflectionUtilities.LoadAssemblies(assemblies))
+            {
+                var runtime = new DkmClrRuntimeInstance(assemblies);
+                var stateMachineType = assembly.GetType("C").GetNestedTypes(BindingFlags.NonPublic).Single();
+
+                var value = CreateDkmClrValue(
+                    value: stateMachineType.Instantiate(1),
+                    type: runtime.GetType((TypeImpl)stateMachineType));
+
+                // Raw view
+
+                var evalResult = FormatResult("sm", value, inspectionContext: CreateDkmInspectionContext(DkmEvaluationFlags.ShowValueRaw));
+
+                Verify(evalResult,
+                    EvalResult("sm", "{C.<Iter>d__1}", "C.<Iter>d__1", "sm, raw", DkmEvaluationResultFlags.Expandable));
+
+                var children = GetChildren(evalResult);
+                Verify(children,
+                    EvalResult("<>1__state", "1", "int", null, DkmEvaluationResultFlags.None),
+                    EvalResult("<>2__current", "0", "int", null, DkmEvaluationResultFlags.None),
+                    EvalResult("<>3__parameter", "0", "int", null, DkmEvaluationResultFlags.None),
+                    EvalResult("<>l__initialThreadId", UnspecifiedValue, "int", null, DkmEvaluationResultFlags.None),
+                    EvalResult("<i>5__2", "0", "int", null, DkmEvaluationResultFlags.None),
+                    EvalResult("System.Collections.Generic.IEnumerator<int>.Current", "0", "int", "((System.Collections.Generic.IEnumerator<int>)sm).Current", DkmEvaluationResultFlags.ReadOnly),
+                    EvalResult("System.Collections.IEnumerator.Current", "0", "object {int}", "((System.Collections.IEnumerator)sm).Current", DkmEvaluationResultFlags.ReadOnly),
+                    EvalResult("parameter", "0", "int", "sm.parameter", DkmEvaluationResultFlags.None),
+                    EvalResult("Results View", "Expanding the Results View will enumerate the IEnumerable", "", "sm, raw, results", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly));
+
+                // Regular view
+
+                evalResult = FormatResult("sm", value, inspectionContext: CreateDkmInspectionContext(DkmEvaluationFlags.None));
+
+                Verify(evalResult,
+                    EvalResult("sm", "{C.<Iter>d__1}", "C.<Iter>d__1", "sm", DkmEvaluationResultFlags.Expandable));
+
+                children = GetChildren(evalResult);
+                Verify(children,
+                    EvalResult("System.Collections.Generic.IEnumerator<int>.Current", "0", "int", "((System.Collections.Generic.IEnumerator<int>)sm).Current", DkmEvaluationResultFlags.ReadOnly),
+                    EvalResult("System.Collections.IEnumerator.Current", "0", "object {int}", "((System.Collections.IEnumerator)sm).Current", DkmEvaluationResultFlags.ReadOnly),
+                    EvalResult("parameter", "0", "int", "sm.parameter", DkmEvaluationResultFlags.None),
+                    EvalResult("Results View", "Expanding the Results View will enumerate the IEnumerable", "", "sm, results", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly));
             }
         }
 

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             var expansions = ArrayBuilder<Expansion>.GetInstance();
 
-            // Expand members. TODO: Ideally, this would be done lazily.
+            // Expand members. TODO: Ideally, this would be done lazily (https://github.com/dotnet/roslyn/issues/32800)
             // From the members, collect the fields and properties,
             // separated into static and instance members.
             var staticMembers = ArrayBuilder<MemberAndDeclarationInfo>.GetInstance();

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -58,25 +58,21 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             var expansions = ArrayBuilder<Expansion>.GetInstance();
 
+            // Expand members. TODO: Ideally, this would be done lazily.
             // From the members, collect the fields and properties,
             // separated into static and instance members.
             var staticMembers = ArrayBuilder<MemberAndDeclarationInfo>.GetInstance();
             var instanceMembers = ArrayBuilder<MemberAndDeclarationInfo>.GetInstance();
             var appDomain = value.Type.AppDomain;
 
-            // Expand members. (Ideally, this should be done lazily.)
             var allMembers = ArrayBuilder<MemberAndDeclarationInfo>.GetInstance();
             var includeInherited = (flags & ExpansionFlags.IncludeBaseMembers) == ExpansionFlags.IncludeBaseMembers;
             var hideNonPublic = (inspectionContext.EvaluationFlags & DkmEvaluationFlags.HideNonPublicMembers) == DkmEvaluationFlags.HideNonPublicMembers;
-            runtimeType.AppendTypeMembers(allMembers, predicate, declaredTypeAndInfo.Type, appDomain, includeInherited, hideNonPublic, isProxyType);
+            var includeCompilerGenerated = (inspectionContext.EvaluationFlags & DkmEvaluationFlags.ShowValueRaw) == DkmEvaluationFlags.ShowValueRaw;
+            runtimeType.AppendTypeMembers(allMembers, predicate, declaredTypeAndInfo.Type, appDomain, includeInherited, hideNonPublic, isProxyType, includeCompilerGenerated);
 
             foreach (var member in allMembers)
             {
-                var name = member.Name;
-                if (name.IsCompilerGenerated())
-                {
-                    continue;
-                }
                 if (member.IsStatic)
                 {
                     staticMembers.Add(member);

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/MemberInfo/EventInfoImpl.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/MemberInfo/EventInfoImpl.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         {
             get
             {
-                throw new NotImplementedException();
+                return Event.Name;
             }
         }
 

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
@@ -270,6 +270,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         private const DkmEvaluationResultCategory UnspecifiedCategory = (DkmEvaluationResultCategory)(-1);
         private const DkmEvaluationResultAccessType UnspecifiedAccessType = (DkmEvaluationResultAccessType)(-1);
+        public const string UnspecifiedValue = "<<unspecified value>>";
 
         internal static DkmEvaluationResult EvalResult(
             string name,
@@ -482,7 +483,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             if (expectedSuccess != null)
             {
                 var actualSuccess = (DkmSuccessEvaluationResult)actual;
-                Assert.Equal(expectedSuccess.Value, actualSuccess.Value);
+
+                Assert.NotEqual(UnspecifiedValue, actualSuccess.Value);
+                if (expectedSuccess.Value != UnspecifiedValue)
+                {
+                    Assert.Equal(expectedSuccess.Value, actualSuccess.Value);
+                }
+
                 Assert.Equal(expectedSuccess.Type, actualSuccess.Type);
                 Assert.Equal(expectedSuccess.Flags, actualSuccess.Flags);
                 if (expectedSuccess.Category != UnspecifiedCategory)
@@ -493,6 +500,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 {
                     Assert.Equal(expectedSuccess.Access, actualSuccess.Access);
                 }
+
                 Assert.Equal(expectedSuccess.EditableValue, actualSuccess.EditableValue);
                 Assert.True(
                     (expectedSuccess.CustomUIVisualizers == actualSuccess.CustomUIVisualizers) ||

--- a/src/Test/Utilities/Portable/Compilation/IRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Portable/Compilation/IRuntimeEnvironment.cs
@@ -250,7 +250,7 @@ namespace Roslyn.Test.Utilities
         {
             dumpDirectory = null;
 
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             foreach (var module in modules)
             {
                 // Limit the number of dumps to 10.  After 10 we're likely in a bad state and are 
@@ -289,23 +289,34 @@ namespace Roslyn.Test.Utilities
                     }
 
                     string pePath = Path.Combine(dumpDirectory, fileName + module.Kind.GetDefaultExtension());
-                    string pdbPath = (module.Pdb != null) ? pdbPath = Path.Combine(dumpDirectory, fileName + ".pdb") : null;
                     try
                     {
                         module.Image.WriteToFile(pePath);
-                        if (pdbPath != null)
+                    }
+                    catch (IOException e)
+                    {
+                        pePath = $"<unable to write file: '{pePath}' -- {e.Message}>";
+                    }
+
+                    string pdbPath;
+                    if (!module.Pdb.IsDefaultOrEmpty)
+                    {
+                        pdbPath = Path.Combine(dumpDirectory, fileName + ".pdb");
+
+                        try
                         {
                             module.Pdb.WriteToFile(pdbPath);
                         }
-                    }
-                    catch (IOException)
-                    {
-                        pePath = "<unable to write file>";
-                        if (pdbPath != null)
+                        catch (IOException e)
                         {
-                            pdbPath = "<unable to write file>";
+                            pdbPath = $"<unable to write file: '{pdbPath}' -- {e.Message}>";
                         }
                     }
+                    else
+                    {
+                        pdbPath = null;
+                    }
+
                     sb.Append("PE(" + module.Kind + "): ");
                     sb.AppendLine(pePath);
                     if (pdbPath != null)


### PR DESCRIPTION
The debugger has an option 
![image](https://user-images.githubusercontent.com/41759/51713097-c2f02280-1fe5-11e9-8e84-0de910ef5906.png)

which is also available via `raw` modifier (`<expr>, raw`). 

The meaning for managed objects right now is to disable using debugger visualizer attributes on the object instance. For example, an instance of `Dictionary<string,string>` is displayed like so:

![image](https://user-images.githubusercontent.com/41759/51713561-35adcd80-1fe7-11e9-90f5-ceed912570e7.png)

This change shows all compiler-generated members in this view.

An iterator looks like so:
![image](https://user-images.githubusercontent.com/41759/51713697-b7056000-1fe7-11e9-807a-4bb690e37177.png)

An async state machine like so:
![image](https://user-images.githubusercontent.com/41759/51717880-904f2580-1ff7-11e9-929f-fbfabdb84c0a.png)

Fixes https://github.com/dotnet/roslyn/issues/22428.
