### PR TITLE
Preserve Extern modifier when running code cleanup

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -171,6 +171,31 @@ class Program
                 (CodeCleanupOptions.AddAccessibilityModifiers, enabled: true));
         }
 
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
+        public Task RetainExternModifier()
+        {
+            var code = @"class Program
+{
+    void Method()
+    {
+        static extern int a;
+    }
+}
+";
+            var expected = @"internal class Program
+{
+    private void Method()
+    {
+        static private extern int a;
+    }
+}
+";
+            return AssertCodeCleanupResult(expected, code,
+                (CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, enabled: true),
+                (CodeCleanupOptions.AddAccessibilityModifiers, enabled: true));
+        }
+
         protected static async Task AssertCodeCleanupResult(string expected, string code, params (PerLanguageOption<bool> option, bool enabled)[] options)
         {
             var exportProvider = ExportProviderCache

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -1825,6 +1825,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 list = list.Add(SyntaxFactory.Token(SyntaxKind.RefKeyword));
             }
 
+            if (modifiers.IsExtern)
+            {
+                list = list.Add(SyntaxFactory.Token(SyntaxKind.ExternKeyword));
+            }
             return list;
         }
 
@@ -1926,6 +1930,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
                     case SyntaxKind.RefKeyword:
                         modifiers = modifiers | DeclarationModifiers.Ref;
+                        break;
+
+                    case SyntaxKind.ExternKeyword:
+                        modifiers = modifiers | DeclarationModifiers.Extern;
                         break;
                 }
             }

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -26,7 +26,8 @@ namespace Microsoft.CodeAnalysis.Editing
             bool isWithEvents = false,
             bool isPartial = false,
             bool isAsync = false,
-            bool isWriteOnly = false)
+            bool isWriteOnly = false,
+            bool isExtern = false)
             : this(
                   (isStatic ? Modifiers.Static : Modifiers.None) |
                   (isAbstract ? Modifiers.Abstract : Modifiers.None) |
@@ -39,7 +40,8 @@ namespace Microsoft.CodeAnalysis.Editing
                   (isConst ? Modifiers.Const : Modifiers.None) |
                   (isWithEvents ? Modifiers.WithEvents : Modifiers.None) |
                   (isPartial ? Modifiers.Partial : Modifiers.None) |
-                  (isAsync ? Modifiers.Async : Modifiers.None))
+                  (isAsync ? Modifiers.Async : Modifiers.None) |
+                  (isExtern ? Modifiers.Extern : Modifiers.None))
         {
         }
 
@@ -83,6 +85,8 @@ namespace Microsoft.CodeAnalysis.Editing
         public bool IsPartial => (_modifiers & Modifiers.Partial) != 0;
 
         public bool IsAsync => (_modifiers & Modifiers.Async) != 0;
+
+        public bool IsExtern => (_modifiers & Modifiers.Extern) != 0;
 
         public bool IsWriteOnly => (_modifiers & Modifiers.WriteOnly) != 0;
 
@@ -176,6 +180,7 @@ namespace Microsoft.CodeAnalysis.Editing
             Async = 0x0800,
             WriteOnly = 0x1000,
             Ref = 0x2000,
+            Extern = 0x4000
         }
 
         public static DeclarationModifiers None => default;
@@ -193,6 +198,7 @@ namespace Microsoft.CodeAnalysis.Editing
         public static DeclarationModifiers Partial => new DeclarationModifiers(Modifiers.Partial);
         public static DeclarationModifiers Async => new DeclarationModifiers(Modifiers.Async);
         public static DeclarationModifiers WriteOnly => new DeclarationModifiers(Modifiers.WriteOnly);
+        public static DeclarationModifiers Extern => new DeclarationModifiers(Modifiers.Extern);
         public static DeclarationModifiers Ref => new DeclarationModifiers(Modifiers.Ref);
 
         public static DeclarationModifiers operator |(DeclarationModifiers left, DeclarationModifiers right)

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.CodeAnalysis.Editing.DeclarationModifiers.IsExtern.get -> bool
 Microsoft.CodeAnalysis.Solution.WithProjectDocumentsOrder(Microsoft.CodeAnalysis.ProjectId projectId, System.Collections.Immutable.ImmutableList<Microsoft.CodeAnalysis.DocumentId> documentIds) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> void
 Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.DocumentId documentId, bool isSolutionClosing) -> void
@@ -34,6 +35,7 @@ Microsoft.CodeAnalysis.Workspace.OnOutputRefFilePathChanged(Microsoft.CodeAnalys
 override Microsoft.CodeAnalysis.FileTextLoader.LoadTextAndVersionAsync(Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.DocumentId documentId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.TextAndVersion>
 override Microsoft.CodeAnalysis.Options.OptionKey.ToString() -> string
 static Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.AdditiveTypeNames.get -> System.Collections.Immutable.ImmutableArray<string>
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Extern.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindSourceDeclarationsWithPatternAsync(Microsoft.CodeAnalysis.Project project, string pattern, Microsoft.CodeAnalysis.SymbolFilter filter, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ISymbol>>
 static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindSourceDeclarationsWithPatternAsync(Microsoft.CodeAnalysis.Project project, string pattern, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ISymbol>>
 static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindSourceDeclarationsWithPatternAsync(Microsoft.CodeAnalysis.Solution solution, string pattern, Microsoft.CodeAnalysis.SymbolFilter filter, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ISymbol>>


### PR DESCRIPTION
Fixes #29561 

outstanding issues:

- [ ] Fix the formatting of the line after the field declaration

- [ ] Add tests for other modifiers

