### PR TITLE
make solution crawler to handle removed document as high priority.

### DIFF
--- a/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
@@ -18,7 +18,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 ImmutableHashSet.Create<string>(
                                     PredefinedInvocationReasons.DocumentRemoved,
                                     PredefinedInvocationReasons.SyntaxChanged,
-                                    PredefinedInvocationReasons.SemanticChanged));
+                                    PredefinedInvocationReasons.SemanticChanged,
+                                    PredefinedInvocationReasons.HighPriority));
 
         public static readonly InvocationReasons ProjectParseOptionChanged =
             new InvocationReasons(


### PR DESCRIPTION
this will make clean up to happen faster. this is following existing pattern of remove things faster and show up things slower pattern we have been using on squiggles.

impact on user expierence will be like errors from error list or todo comments on todo list goes away faster when document is removed or project is removed from solution.

mitigating https://github.com/dotnet/roslyn/issues/30577