### PR TITLE
made VS not to crash when servicehub couldn't locate our servicehub s…

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.Connections.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.Connections.cs
@@ -122,13 +122,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     await Task.Delay(retry_delayInMS, cancellationToken).ConfigureAwait(false);
                 }
 
-                // crash right away to get better dump. otherwise, we will get dump from async exception
-                // which most likely lost all valuable data
-                FatalError.ReportUnlessCanceled(lastException);
-                GC.KeepAlive(lastException);
+                RemoteHostCrashInfoBar.ShowInfoBar(workspace);
 
-                // unreachable
-                throw ExceptionUtilities.Unreachable;
+                // raise soft crash exception rather than doing hard crash.
+                // we had enough feedback from users not to crash VS on servicehub failure
+                throw new SoftCrashException("RequestServiceAsync Failed", lastException, cancellationToken);
             }
 
             #region code related to make diagnosis easier later


### PR DESCRIPTION
…ervices.

when it happens we will show the info bar and proceed. this is not error recovery but not forcing users to restart VS right away by crashing VS. now a user will have time to do what they want and then restart VS

this is what user will be when this happens
![image](https://user-images.githubusercontent.com/1333179/51745506-e358c500-2057-11e9-932d-e46b439293fc.png)

this mitigate this issue - https://github.com/dotnet/roslyn/issues/26308