### PR TITLE
Fix indentation of wrapped expressions

### DIFF
--- a/src/EditorFeatures/CSharp/Wrapping/BinaryExpression/CSharpBinaryExpressionWrapper.cs
+++ b/src/EditorFeatures/CSharp/Wrapping/BinaryExpression/CSharpBinaryExpressionWrapper.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation;
 using Microsoft.CodeAnalysis.Editor.Wrapping.BinaryExpression;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.Wrapping.BinaryExpression
@@ -12,6 +13,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Wrapping.BinaryExpression
             : base(CSharpSyntaxFactsService.Instance, CSharpPrecedenceService.Instance)
         {
         }
+
+        protected override IBlankLineIndentationService GetIndentationService()
+            => new CSharpIndentationService();
 
         protected override SyntaxTriviaList GetNewLineBeforeOperatorTrivia(SyntaxTriviaList newLine)
             => newLine;

--- a/src/EditorFeatures/CSharpTest/Wrapping/BinaryWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/BinaryWrappingTests.cs
@@ -450,8 +450,8 @@ BeginningOfLine,
 @"class C {
     void Goo() {
         var v = a &&
-                b &&
-                c;
+            b &&
+            c;
     }
 }");
         }
@@ -465,8 +465,8 @@ BeginningOfLine,
 }",
 @"class C {
     bool v = a &&
-             b &&
-             c;
+        b &&
+        c;
 }");
         }
 
@@ -482,9 +482,9 @@ BeginningOfLine,
 @"class C {
     void Bar() {
         var goo = ""now"" +
-                  ""is"" +
-                  ""the"" +
-                  ""time"";
+            ""is"" +
+            ""the"" +
+            ""time"";
     }
 }");
         }
@@ -501,9 +501,9 @@ BeginningOfLine,
 @"class C {
     void Bar() {
         var goo = ""now""
-                  + ""is""
-                  + ""the""
-                  + ""time"";
+            + ""is""
+            + ""the""
+            + ""time"";
     }
 }");
         }

--- a/src/EditorFeatures/Core/Wrapping/AbstractWrapper.cs
+++ b/src/EditorFeatures/Core/Wrapping/AbstractWrapper.cs
@@ -21,6 +21,8 @@ namespace Microsoft.CodeAnalysis.Editor.Wrapping
     /// </summary>
     internal abstract partial class AbstractSyntaxWrapper : ISyntaxWrapper
     {
+        protected abstract IBlankLineIndentationService GetIndentationService();
+
         public abstract Task<ICodeActionComputer> TryCreateComputerAsync(Document document, int position, SyntaxNode node, CancellationToken cancellationToken);
 
         protected static async Task<bool> ContainsUnformattableContentAsync(

--- a/src/EditorFeatures/Core/Wrapping/SeparatedSyntaxList/AbstractSeparatedSyntaxListWrapper.cs
+++ b/src/EditorFeatures/Core/Wrapping/SeparatedSyntaxList/AbstractSeparatedSyntaxListWrapper.cs
@@ -30,8 +30,6 @@ namespace Microsoft.CodeAnalysis.Editor.Wrapping.SeparatedSyntaxList
 
         protected abstract string Wrap_every_item { get; }
 
-        protected abstract IBlankLineIndentationService GetIndentationService();
-
         protected abstract TListSyntax TryGetApplicableList(SyntaxNode node);
         protected abstract SeparatedSyntaxList<TListItemSyntax> GetListItems(TListSyntax listSyntax);
         protected abstract bool PositionIsApplicable(

--- a/src/EditorFeatures/VisualBasic/Wrapping/BinaryExpression/VisualBasicBinaryExpressionWrapper.vb
+++ b/src/EditorFeatures/VisualBasic/Wrapping/BinaryExpression/VisualBasicBinaryExpressionWrapper.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
 Imports Microsoft.CodeAnalysis.Editor.Wrapping.BinaryExpression
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -10,6 +11,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Wrapping.BinaryExpression
         Public Sub New()
             MyBase.New(VisualBasicSyntaxFactsService.Instance, VisualBasicPrecedenceService.Instance)
         End Sub
+
+        Protected Overrides Function GetIndentationService() As IBlankLineIndentationService
+            Return New VisualBasicIndentationService()
+        End Function
 
         Protected Overrides Function GetNewLineBeforeOperatorTrivia(newLine As SyntaxTriviaList) As SyntaxTriviaList
             Return newLine.InsertRange(0, {SyntaxFactory.WhitespaceTrivia(" "), SyntaxFactory.LineContinuationTrivia("_")})

--- a/src/EditorFeatures/VisualBasicTest/Wrapping/BinaryWrappingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Wrapping/BinaryWrappingTests.vb
@@ -427,8 +427,8 @@ end class",
 "class C
     sub Goo()
         dim v = a andalso
-                b andalso
-                c
+            b andalso
+            c
     end sub
 end class")
         End Function
@@ -441,8 +441,8 @@ end class")
 end class",
 "class C
     dim v = a andalso
-            b andalso
-            c
+        b andalso
+        c
 end class")
         End Function
 
@@ -457,9 +457,9 @@ end class",
 "class C
     sub Bar()
         dim goo = ""now"" &
-                  ""is"" &
-                  ""the"" &
-                  ""time""
+            ""is"" &
+            ""the"" &
+            ""time""
     end sub
 end class")
         End Function
@@ -475,9 +475,9 @@ end class",
 "class C
     sub Bar()
         dim goo = ""now"" _
-                  & ""is"" _
-                  & ""the"" _
-                  & ""time""
+            & ""is"" _
+            & ""the"" _
+            & ""time""
     end sub
 end class")
         End Function


### PR DESCRIPTION
The previous implementation did not use the standard indentation service to determine the proper indentation level. The code is updated to use the indentation reported by the indentation service.