### PR TITLE
Simulate the C# 7 compiler's behavior on traditional switch statements with old language versions

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -993,7 +993,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // SPEC:    The governing type of a switch statement is established by the switch expression.
             // SPEC:    1) If the type of the switch expression is sbyte, byte, short, ushort, int, uint,
-            // SPEC:       long, ulong, bool, char, bool, string, or an enum-type, or if it is the nullable type
+            // SPEC:       long, ulong, bool, char, string, or an enum-type, or if it is the nullable type
             // SPEC:       corresponding to one of these types, then that is the governing type of the switch statement. 
             // SPEC:    2) Otherwise, exactly one user-defined implicit conversion must exist from the
             // SPEC:       type of the switch expression to one of the following possible governing types:

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -993,9 +993,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // SPEC:    The governing type of a switch statement is established by the switch expression.
             // SPEC:    1) If the type of the switch expression is sbyte, byte, short, ushort, int, uint,
-            // SPEC:       long, ulong, bool, char, string, or an enum-type, or if it is the nullable type
+            // SPEC:       long, ulong, bool, char, bool, string, or an enum-type, or if it is the nullable type
             // SPEC:       corresponding to one of these types, then that is the governing type of the switch statement. 
-            // SPEC:    2) Otherwise, exactly one user-defined implicit conversion (Â§6.4) must exist from the
+            // SPEC:    2) Otherwise, exactly one user-defined implicit conversion must exist from the
             // SPEC:       type of the switch expression to one of the following possible governing types:
             // SPEC:       sbyte, byte, short, ushort, int, uint, long, ulong, char, string, or, a nullable type
             // SPEC:       corresponding to one of those types

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -2685,6 +2685,72 @@ class SwitchTest
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "goo").WithArguments("goo").WithLocation(40, 27));
         }
 
+        [Fact, WorkItem(32806, "https://github.com/dotnet/roslyn/issues/32806")]
+        public void TraditionalSwitchIsIncomplete_01()
+        {
+            var text = @"
+class SwitchTest
+{
+    static int Main(string[] args)
+    {
+        bool? test = null;
+
+        switch (test)
+        {
+            case true:
+                return 1;
+            case false:
+                return 0;
+            case null:
+                return -1;
+        }
+    }
+}
+";
+            CreateCompilation(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
+                // (4,16): error CS0161: 'SwitchTest.Main(string[])': not all code paths return a value
+                //     static int Main(string[] args)
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "Main").WithArguments("SwitchTest.Main(string[])").WithLocation(4, 16)
+                );
+            CreateCompilation(text, parseOptions: TestOptions.Regular7_3).VerifyDiagnostics(
+                // (4,16): error CS0161: 'SwitchTest.Main(string[])': not all code paths return a value
+                //     static int Main(string[] args)
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "Main").WithArguments("SwitchTest.Main(string[])").WithLocation(4, 16)
+                );
+            CreateCompilation(text, parseOptions: TestOptions.Regular8).VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem(32806, "https://github.com/dotnet/roslyn/issues/32806")]
+        public void TraditionalSwitchIsIncomplete_02()
+        {
+            var text = @"
+class SwitchTest
+{
+    static int Main(string[] args)
+    {
+        bool? test = null;
+
+        switch (test)
+        {
+            case true when true:
+                return 1;
+            case false:
+                return 0;
+            case null:
+                return -1;
+        }
+    }
+}
+";
+            CreateCompilation(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
+                // (10,13): error CS8059: Feature 'pattern matching' is not available in C# 6. Please use language version 7.0 or greater.
+                //             case true when true:
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "case true when true:").WithArguments("pattern matching", "7.0").WithLocation(10, 13)
+                );
+            CreateCompilation(text, parseOptions: TestOptions.Regular7_3).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.Regular8).VerifyDiagnostics();
+        }
+
         #endregion
 
         #region regressions


### PR DESCRIPTION
Fixes #32806
This was a "forward compatibility" bug, where new compilers would accept code in old language versions that the older compilers would not have accepted.