### PR TITLE
Add type IL verifier helper

### DIFF
--- a/src/Test/Utilities/Portable/CompilationVerifier.cs
+++ b/src/Test/Utilities/Portable/CompilationVerifier.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Xml.Linq;
+using ICSharpCode.Decompiler.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit;
@@ -149,6 +150,37 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     }
                 }
             }
+        }
+
+        public void VerifyTypeIL(string typeName, string expected)
+        {
+            var output = new ICSharpCode.Decompiler.PlainTextOutput();
+            using (var testEnvironment = RuntimeEnvironmentFactory.Create(_dependencies))
+            {
+                string mainModuleFullName = Emit(testEnvironment, manifestResources: null, EmitOptions.Default);
+                IList<ModuleData> moduleData = testEnvironment.GetAllModuleData();
+                var mainModule = moduleData.Single(md => md.FullName == mainModuleFullName);
+                using (var moduleMetadata = ModuleMetadata.CreateFromImage(testEnvironment.GetMainImage()))
+                {
+                    var peFile = new PEFile(mainModuleFullName, moduleMetadata.Module.PEReaderOpt);
+                    var metadataReader = moduleMetadata.GetMetadataReader();
+
+                    bool found = false;
+                    foreach (var typeDefHandle in metadataReader.TypeDefinitions)
+                    {
+                        var typeDef = metadataReader.GetTypeDefinition(typeDefHandle);
+                        if (metadataReader.GetString(typeDef.Name) == typeName)
+                        {
+                            var disassembler = new ICSharpCode.Decompiler.Disassembler.ReflectionDisassembler(output, default);
+                            disassembler.DisassembleType(peFile, typeDefHandle);
+                            found = true;
+                            break;
+                        }
+                    }
+                    Assert.True(found, "Could not find type named " + typeName);
+                }
+            }
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(expected, output.ToString(), escapeQuotes: false);
         }
 
         public void Emit(string expectedOutput, int? expectedReturnCode, string[] args, IEnumerable<ResourceDescription> manifestResources, EmitOptions emitOptions, Verification peVerify, SignatureDescription[] expectedSignatures)


### PR DESCRIPTION
This adds a test helper that can be used to verify the IL for a whole type. It should be very helpful for tests that introduce new members into a type, like closure conversion and async/iterator rewriting.