### PR TITLE
Fix dev div insertion files unsigning

### DIFF
--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -9,6 +9,7 @@
 
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GroupItemsBy" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.Unsign" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.JoinItems" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask TaskName="Roslyn.Tools.ReplacePackageParts" AssemblyFile="$(_NuGetRepackAssembly)" />
 
@@ -34,8 +35,16 @@
 
   <!-- 
     List of dependencies that are expected to be inserted into VS by Roslyn Insertion Tool.
-    OptimizeAssemblies is a list of relative paths within the package of the implementation assemblies that are deployed to VS installation and should get IBC data embedded.
-    Note - optimizing Authenticode-signed 3rd party libraries would invalidate their signature.
+    
+    Metadata:
+      - OptimizeAssemblies
+        List of relative paths within the package of the implementation assemblies that should get IBC data embedded.
+        Each of these assemblies is expected to be trained and have IBC data available.
+        Note - optimizing Authenticode-signed 3rd party libraries invalidates their signature.
+           
+      - UnsignAssemblies
+        List of relative paths within the package of the implementation assemblies that need to be re-signed 
+        This target only unsigns them, SignTool signs them as with other unsigned files.
   -->
   <ItemGroup>
     <ExpectedDependency Include="Humanizer.Core"/>
@@ -43,8 +52,8 @@
     <ExpectedDependency Include="Microsoft.DiaSymReader"/>
     <ExpectedDependency Include="Microsoft.CodeAnalysis.Elfie"/>
     <ExpectedDependency Include="System.Buffers" />
-    <ExpectedDependency Include="System.Collections.Immutable" OptimizeAssemblies="lib/netstandard2.0/System.Collections.Immutable.dll;lib/netstandard1.0/System.Collections.Immutable.dll" />
-    <ExpectedDependency Include="System.Reflection.Metadata" OptimizeAssemblies="lib/netstandard2.0/System.Reflection.Metadata.dll;lib/netstandard1.1/System.Reflection.Metadata.dll" />
+    <ExpectedDependency Include="System.Collections.Immutable" OptimizeAssemblies="lib/netstandard2.0/System.Collections.Immutable.dll" UnsignAssemblies="lib/netstandard1.3/System.Collections.Immutable.dll" />
+    <ExpectedDependency Include="System.Reflection.Metadata" OptimizeAssemblies="lib/netstandard2.0/System.Reflection.Metadata.dll" UnsignAssemblies="lib/netstandard1.1/System.Reflection.Metadata.dll" />
     <ExpectedDependency Include="System.Memory"/>
     <ExpectedDependency Include="System.Runtime.CompilerServices.Unsafe" OptimizeAssemblies="lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll" />
     <ExpectedDependency Include="System.Text.Encoding.CodePages" OptimizeAssemblies="lib/netstandard2.0/System.Text.Encoding.CodePages.dll" />
@@ -120,41 +129,53 @@
     <Error Text="Unexpected dependencies found -- update ExpectedDependency list: @(_RemainingDependency)" Condition="'@(_RemainingDependency)' != ''"/>
     <Error Text="Missing dependencies expected to be inserted -- update ExpectedDependency list: @(_UninsertedExpectedDependency)" Condition="'@(_UninsertedExpectedDependency)' != ''"/>
 
-    <!-- 
-      We need to calculate a full path of the corresponding optimized assembly for each relative path listed in ExpectedDependency.OptimizeAssemblies.
-      First we split the list in OptimizeAssemblies, then prepend the directory path, group them back to _AssembliesFullPathsGrouped and finally join back to ExpectedDependency item group.
+    <!--
+      For each relative path listed in OptimizeAssemblies and UnsignAssemblies metadata
+      we need to calculate a full path of the corresponding optimized/unsigned assembly.
+      First we split the list in OptimizeAssemblies/UnsignedAssemblies, prepend the directory path to each relative path, 
+      group the full paths and finally inner-join the items back to ExpectedDependency item group.
     -->
     <ItemGroup>
-      <_AssembliesSplit Include="%(ExpectedDependency.OptimizeAssemblies)" DependencyName="%(ExpectedDependency.Identity)" />
-      <_AssembliesFullPaths Include="%(_AssembliesSplit.DependencyName)" OptimizeAssembliesFullPaths="$(_OptimizedDependenciesDir)%(_AssembliesSplit.DependencyName)\%(_AssembliesSplit.Identity)" />
+      <_OptimizeAssembliesSplit Include="%(ExpectedDependency.OptimizeAssemblies)" DependencyName="%(ExpectedDependency.Identity)" Condition="'$(ApplyPartialNgenOptimization)' == 'true'" />
+      <_UnsignAssembliesSplit Include="%(ExpectedDependency.UnsignAssemblies)" DependencyName="%(ExpectedDependency.Identity)"/>
+      
+      <_DependenciesWithFullPaths Include="@(_Dependency->'%(Identity)')" Exclude="@(_OptimizeAssembliesSplit->'%(DependencyName)');@(_UnsignAssembliesSplit->'%(DependencyName)')"/>
+      <_DependenciesWithFullPaths Include="%(_OptimizeAssembliesSplit.DependencyName)" OptimizeAssembliesFullPaths="$(_OptimizedDependenciesDir)%(_OptimizeAssembliesSplit.DependencyName)\%(_OptimizeAssembliesSplit.Identity)" />
+      <_DependenciesWithFullPaths Include="%(_UnsignAssembliesSplit.DependencyName)" UnsignAssembliesFullPaths="$(_OptimizedDependenciesDir)%(_UnsignAssembliesSplit.DependencyName)\%(_UnsignAssembliesSplit.Identity)" />
     </ItemGroup>
 
-    <Microsoft.DotNet.Arcade.Sdk.GroupItemsBy Items="@(_AssembliesFullPaths)" GroupMetadata="OptimizeAssembliesFullPaths">
-      <Output TaskParameter="GroupedItems" ItemName="_AssembliesFullPathsGrouped" />
+    <Microsoft.DotNet.Arcade.Sdk.GroupItemsBy Items="@(_DependenciesWithFullPaths)" GroupMetadata="OptimizeAssembliesFullPaths;UnsignAssembliesFullPaths">
+      <Output TaskParameter="GroupedItems" ItemName="_DependenciesWithFullPathsGrouped" />
     </Microsoft.DotNet.Arcade.Sdk.GroupItemsBy>
 
-    <JoinItems Left="@(ExpectedDependency)" LeftMetadata="*" Right="@(_AssembliesFullPathsGrouped)" RightMetadata="OptimizeAssembliesFullPaths">
+    <JoinItems Left="@(ExpectedDependency)" LeftMetadata="*" Right="@(_DependenciesWithFullPathsGrouped)" RightMetadata="OptimizeAssembliesFullPaths;UnsignAssembliesFullPaths">
       <Output TaskParameter="JoinResult" ItemName="_ExpectedDependencyWithFullPaths" />
     </JoinItems>
 
     <!--
-      Join metadata specified in ExpectedMetadata into the item group of actual dependencies, which has extra metadata we need.
+      Join metadata specified in _Dependency and ExpectedMetadata groups.
     -->
     <JoinItems Left="@(_Dependency)" LeftMetadata="*" Right="@(_ExpectedDependencyWithFullPaths)" RightMetadata="*">
       <Output TaskParameter="JoinResult" ItemName="_DependencyWithExpectedMetadata" />
     </JoinItems>
 
     <ItemGroup>
-      <_DependencyWithExpectedMetadata>
-        <_UnpackDir>$(_OptimizedDependenciesDir)%(_DependencyWithExpectedMetadata.Identity)\</_UnpackDir>
-      </_DependencyWithExpectedMetadata>
+      <!-- Input to ApplyOptimizations target: assembly paths to apply optimization data to. -->
+      <OptimizeAssembly Include="%(_DependencyWithExpectedMetadata.OptimizeAssembliesFullPaths)" />
 
-      <_DependencyWithOptimizationData Include="@(_DependencyWithExpectedMetadata)" 
-                                       Condition="'%(_DependencyWithExpectedMetadata.OptimizeAssemblies)' != '' and '$(ApplyPartialNgenOptimization)' == 'true'" />
+      <!-- Assemblies in the unpacked packages that we want to unsign, but are not geting optimization data -->
+      <_UnsignAssembly Include="%(_DependencyWithExpectedMetadata.UnsignAssembliesFullPaths)" />
 
-      <_DependencyWithoutOptimizationData Include="@(_DependencyWithExpectedMetadata)" Exclude="@(_DependencyWithOptimizationData)"/>
+      <!-- Packages that contain optimized assembly or assembly we want to re-sign. -->
+      <_PackageToRepack Include="%(_DependencyWithExpectedMetadata._NuGetPackageDir)%(_DependencyWithExpectedMetadata._NuGetPackageFileName)"
+                        UnpackDir="$(_OptimizedDependenciesDir)%(_DependencyWithExpectedMetadata.Identity)\"
+                        Parts="%(_DependencyWithExpectedMetadata.OptimizeAssemblies);%(_DependencyWithExpectedMetadata.UnsignAssemblies)"
+                        ReplacementFiles="%(_DependencyWithExpectedMetadata.OptimizeAssembliesFullPaths);%(_DependencyWithExpectedMetadata.UnsignAssembliesFullPaths)"
+                        Condition="'%(_DependencyWithExpectedMetadata.OptimizeAssembliesFullPaths)' != '' or '%(_DependencyWithExpectedMetadata.UnsignAssembliesFullPaths)' != ''"/>
 
-      <OptimizeAssembly Include="%(_DependencyWithOptimizationData.OptimizeAssembliesFullPaths)" />
+      <!-- Packages that we insert without modifications -->
+      <_PackageToCopy Include="%(_DependencyWithExpectedMetadata._NuGetPackageDir)%(_DependencyWithExpectedMetadata._NuGetPackageFileName)"
+                      Exclude="@(_PackageToRepack)"/>
     </ItemGroup>
   </Target>
 
@@ -176,37 +197,37 @@
   </Target>
 
   <!-- 
-    Unpack dependent packages to a temp folder where optimization data will be applied.
+    Unpack dependent packages to a temp folder.
   -->
-  <Target Name="_UnpackOptimizedDependencies" Condition="'@(_DependencyWithOptimizationData)' != ''">
-    <MakeDir Directories="@(_DependencyWithOptimizationData->'%(_UnpackDir)')"/>
-
-    <Unzip SourceFiles="%(_DependencyWithOptimizationData._NuGetPackageDir)%(_DependencyWithOptimizationData._NuGetPackageFileName)" 
-           DestinationFolder="%(_DependencyWithOptimizationData._UnpackDir)" />
+  <Target Name="_UnpackDependencies" Condition="'@(_PackageToRepack)' != ''">
+    <MakeDir Directories="@(_PackageToRepack->'%(DestinationFolder)')"/>
+    <Unzip SourceFiles="@(_PackageToRepack)" DestinationFolder="%(_PackageToRepack.UnpackDir)" />
   </Target>
-
+  
   <!--
     Copy NuGet packages to be inserted into VS by the insertion tool.
   -->
   <Target Name="_CopyPackagesToInsert"
           AfterTargets="Build"
           Condition="'$(Configuration)' == 'Release' and '$(ContinuousIntegrationBuild)' == 'true'"
-          DependsOnTargets="_CalculateDependenciesToInsert;_UnpackOptimizedDependencies;ApplyOptimizations">
+          DependsOnTargets="_CalculateDependenciesToInsert;_UnpackDependencies;ApplyOptimizations">
 
     <MakeDir Directories="$(DevDivPackagesDir)"/>
 
+    <!-- Unsign assemblies that need to be unsigned but not optimized. -->
+    <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_UnsignAssembly.Identity)" />
+    
     <!-- Repack optimized dependencies -->
-    <Roslyn.Tools.ReplacePackageParts SourcePackage="%(_DependencyWithOptimizationData._NuGetPackageDir)%(_DependencyWithOptimizationData._NuGetPackageFileName)"
+    <Roslyn.Tools.ReplacePackageParts SourcePackage="%(_PackageToRepack.Identity)"
                                       DestinationFolder="$(DevDivPackagesDir)"
                                       NewVersionSuffix="$(_OptimizedNuGetPackageVersionSuffix)"
-                                      Parts="%(_DependencyWithOptimizationData.OptimizeAssemblies)"
-                                      ReplacementFiles="%(_DependencyWithOptimizationData.OptimizeAssembliesFullPaths)"
-                                      Condition="'@(_DependencyWithOptimizationData)' != ''">
+                                      Parts="%(_PackageToRepack.Parts)"
+                                      ReplacementFiles="%(_PackageToRepack.ReplacementFiles)">
       <Output TaskParameter="NewPackage" ItemName="FileWrites" />
     </Roslyn.Tools.ReplacePackageParts>
 
     <!-- Copy unoptimized dependencies -->
-    <Copy SourceFiles="@(_DependencyWithoutOptimizationData->'%(_NuGetPackageDir)%(_NuGetPackageFileName)')" DestinationFolder="$(DevDivPackagesDir)">
+    <Copy SourceFiles="@(_PackageToCopy)" DestinationFolder="$(DevDivPackagesDir)">
       <Output TaskParameter="CopiedFiles" ItemName="FileWrites"/>
     </Copy>
   </Target>

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -35,13 +35,13 @@
 
   <!-- 
     List of dependencies that are expected to be inserted into VS by Roslyn Insertion Tool.
-    
+
     Metadata:
       - OptimizeAssemblies
         List of relative paths within the package of the implementation assemblies that should get IBC data embedded.
         Each of these assemblies is expected to be trained and have IBC data available.
         Note - optimizing Authenticode-signed 3rd party libraries invalidates their signature.
-           
+
       - UnsignAssemblies
         List of relative paths within the package of the implementation assemblies that need to be re-signed 
         This target only unsigns them, SignTool signs them as with other unsigned files.
@@ -52,7 +52,7 @@
     <ExpectedDependency Include="Microsoft.DiaSymReader"/>
     <ExpectedDependency Include="Microsoft.CodeAnalysis.Elfie"/>
     <ExpectedDependency Include="System.Buffers" />
-    <ExpectedDependency Include="System.Collections.Immutable" OptimizeAssemblies="lib/netstandard2.0/System.Collections.Immutable.dll" UnsignAssemblies="lib/netstandard1.3/System.Collections.Immutable.dll" />
+    <ExpectedDependency Include="System.Collections.Immutable" OptimizeAssemblies="lib/netstandard2.0/System.Collections.Immutable.dll" UnsignAssemblies="lib/netstandard1.0/System.Collections.Immutable.dll" />
     <ExpectedDependency Include="System.Reflection.Metadata" OptimizeAssemblies="lib/netstandard2.0/System.Reflection.Metadata.dll" UnsignAssemblies="lib/netstandard1.1/System.Reflection.Metadata.dll" />
     <ExpectedDependency Include="System.Memory"/>
     <ExpectedDependency Include="System.Runtime.CompilerServices.Unsafe" OptimizeAssemblies="lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll" />
@@ -138,7 +138,7 @@
     <ItemGroup>
       <_OptimizeAssembliesSplit Include="%(ExpectedDependency.OptimizeAssemblies)" DependencyName="%(ExpectedDependency.Identity)" Condition="'$(ApplyPartialNgenOptimization)' == 'true'" />
       <_UnsignAssembliesSplit Include="%(ExpectedDependency.UnsignAssemblies)" DependencyName="%(ExpectedDependency.Identity)"/>
-      
+
       <_DependenciesWithFullPaths Include="@(_Dependency->'%(Identity)')" Exclude="@(_OptimizeAssembliesSplit->'%(DependencyName)');@(_UnsignAssembliesSplit->'%(DependencyName)')"/>
       <_DependenciesWithFullPaths Include="%(_OptimizeAssembliesSplit.DependencyName)" OptimizeAssembliesFullPaths="$(_OptimizedDependenciesDir)%(_OptimizeAssembliesSplit.DependencyName)\%(_OptimizeAssembliesSplit.Identity)" />
       <_DependenciesWithFullPaths Include="%(_UnsignAssembliesSplit.DependencyName)" UnsignAssembliesFullPaths="$(_OptimizedDependenciesDir)%(_UnsignAssembliesSplit.DependencyName)\%(_UnsignAssembliesSplit.Identity)" />
@@ -203,7 +203,7 @@
     <MakeDir Directories="@(_PackageToRepack->'%(DestinationFolder)')"/>
     <Unzip SourceFiles="@(_PackageToRepack)" DestinationFolder="%(_PackageToRepack.UnpackDir)" />
   </Target>
-  
+
   <!--
     Copy NuGet packages to be inserted into VS by the insertion tool.
   -->
@@ -216,7 +216,7 @@
 
     <!-- Unsign assemblies that need to be unsigned but not optimized. -->
     <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_UnsignAssembly.Identity)" />
-    
+
     <!-- Repack optimized dependencies -->
     <Roslyn.Tools.ReplacePackageParts SourcePackage="%(_PackageToRepack.Identity)"
                                       DestinationFolder="$(DevDivPackagesDir)"

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -136,7 +136,11 @@
       group the full paths and finally inner-join the items back to ExpectedDependency item group.
     -->
     <ItemGroup>
-      <_OptimizeAssembliesSplit Include="%(ExpectedDependency.OptimizeAssemblies)" DependencyName="%(ExpectedDependency.Identity)" Condition="'$(ApplyPartialNgenOptimization)' == 'true'" />
+      <ExpectedDependency>
+        <_EffectiveOptimizeAssemblies Condition="'$(ApplyPartialNgenOptimization)' == 'true'">%(ExpectedDependency.OptimizeAssemblies)</_EffectiveOptimizeAssemblies>
+      </ExpectedDependency>
+      
+      <_OptimizeAssembliesSplit Include="%(ExpectedDependency._EffectiveOptimizeAssemblies)" DependencyName="%(ExpectedDependency.Identity)" />
       <_UnsignAssembliesSplit Include="%(ExpectedDependency.UnsignAssemblies)" DependencyName="%(ExpectedDependency.Identity)"/>
 
       <_DependenciesWithFullPaths Include="@(_Dependency->'%(Identity)')" Exclude="@(_OptimizeAssembliesSplit->'%(DependencyName)');@(_UnsignAssembliesSplit->'%(DependencyName)')"/>
@@ -169,7 +173,7 @@
       <!-- Packages that contain optimized assembly or assembly we want to re-sign. -->
       <_PackageToRepack Include="%(_DependencyWithExpectedMetadata._NuGetPackageDir)%(_DependencyWithExpectedMetadata._NuGetPackageFileName)"
                         UnpackDir="$(_OptimizedDependenciesDir)%(_DependencyWithExpectedMetadata.Identity)\"
-                        Parts="%(_DependencyWithExpectedMetadata.OptimizeAssemblies);%(_DependencyWithExpectedMetadata.UnsignAssemblies)"
+                        Parts="%(_DependencyWithExpectedMetadata._EffectiveOptimizeAssemblies);%(_DependencyWithExpectedMetadata.UnsignAssemblies)"
                         ReplacementFiles="%(_DependencyWithExpectedMetadata.OptimizeAssembliesFullPaths);%(_DependencyWithExpectedMetadata.UnsignAssembliesFullPaths)"
                         Condition="'%(_DependencyWithExpectedMetadata.OptimizeAssembliesFullPaths)' != '' or '%(_DependencyWithExpectedMetadata.UnsignAssembliesFullPaths)' != ''"/>
 

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -200,8 +200,7 @@
     Unpack dependent packages to a temp folder.
   -->
   <Target Name="_UnpackDependencies" Condition="'@(_PackageToRepack)' != ''">
-    <MakeDir Directories="@(_PackageToRepack->'%(DestinationFolder)')"/>
-    <Unzip SourceFiles="@(_PackageToRepack)" DestinationFolder="%(_PackageToRepack.UnpackDir)" />
+    <Unzip SourceFiles="%(_PackageToRepack.Identity)" DestinationFolder="%(_PackageToRepack.UnpackDir)" />
   </Target>
 
   <!--


### PR DESCRIPTION
Corrects logic in DevDivInsertionFiles.csproj - separate assembly re-signing of libraries that we need to do to enable ResultProvider to run on Win10S from optimization data embedding. Previous thinking was that we can exploit optimization data embedding to force resigning with Win10S, but that does not work. We can only apply optimization data on assemblies we train against, and we don't train libraries loaded msvsmon process. 

Actually fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/755193.