### PR TITLE
Bail on null type information in GenerateDeconstructMethodCodeFixProvider

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateDeconstructMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateDeconstructMethodTests.cs
@@ -296,5 +296,24 @@ class D
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestDeconstructionAssignment_InvalidDeclaration()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System.Collections.Generic;
+
+class C
+{
+    void Method()
+    {
+        var stuff = new Dictionary<string, string>();
+        foreach ((key, value) in [|stuff|]) // Invalid variable declarator syntax
+        {
+        }
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateDeconstructMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateDeconstructMethodTests.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateDeconstructMethod;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateDeconstructMethod
@@ -297,6 +298,7 @@ class D
 }");
         }
 
+        [WorkItem(32510, "https://github.com/dotnet/roslyn/issues/32510")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public async Task TestDeconstructionAssignment_InvalidDeclaration()
         {

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateDeconstructMethodCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateDeconstructMethodCodeFixProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateDeconstructMethod
                     throw ExceptionUtilities.Unreachable;
             }
 
-            if (type.Kind != SymbolKind.NamedType)
+            if (type == null || type.Kind != SymbolKind.NamedType)
             {
                 return;
             }

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateDeconstructMethodCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateDeconstructMethodCodeFixProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateDeconstructMethod
                     throw ExceptionUtilities.Unreachable;
             }
 
-            if (type == null || type.Kind != SymbolKind.NamedType)
+            if (type?.Kind != SymbolKind.NamedType)
             {
                 return;
             }


### PR DESCRIPTION
It's possible that a valid foreach statement has an invalid variable declaration syntax, which can result in no type information on calling `GetForEachStatementInfo`

Fixes #32510 