### PR TITLE
Bail out on reporting unused parameter diagnostic for special paramet…

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1067,5 +1067,18 @@ internal sealed class CustomSerializingType : ISerializable
     }
 }");
         }
+
+        [WorkItem(32851, "https://github.com/dotnet/roslyn/issues/32851")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task Parameter_Unused_SpecialNames()
+        {
+            await TestDiagnosticMissingAsync(
+@"class C
+{
+    [|void M(int _, char _1, C _3)|]
+    {
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.vb
@@ -87,5 +87,15 @@ $"Public Class C
     End Sub
 End Class")
         End Function
+
+        <WorkItem(32851, "https://github.com/dotnet/roslyn/issues/32851")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)>
+        Public Async Function Parameter_Unused_SpecialNames() As Task
+            Await TestDiagnosticMissingAsync(
+$"Class C
+    [|Sub M(_0 As Integer, _1 As Char, _3 As C)|]
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -223,6 +223,19 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     return false;
                 }
 
+                // Ignore special parameter names for methods that need a specific signature.
+                // For example, methods used as a delegate in a different type or project.
+                // This also serves as a convenient way to suppress instances of unused parameter diagnostic
+                // without disabling the diagnostic completely.
+                // We ignore parameter names that start with an underscore and are optionally followed by an integer,
+                // such as '_', '_1', '_2', etc.
+                if (parameter.Name.StartsWith("_") &&
+                    (parameter.Name.Length == 1 ||
+                     uint.TryParse(parameter.Name.Substring(1), out _)))
+                {
+                    return false;
+                }
+
                 return true;
             }
         }


### PR DESCRIPTION
…er names

We ignore parameter names that start with an underscore and are optionally followed by an integer, such as `_`, `_1`, `_2`, etc.
This allows bailing out on unused parameters for methods that need a specific signature and are forced to have these parameters. This also serves as a convenient way to suppress instances of unused parameter diagnostic without disabling the diagnostic completely.

Fixes #32851
Fixes #32228