### PR TITLE
update mono-devel in dockerfile, and don't cache later commands

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -242,7 +242,7 @@ function BuildSolution {
 
     test=true
     test_runtime="/p:TestRuntime=Mono"
-    mono_path=`command -v mono`
+    mono_path="$scriptroot/InvokeMono.sh"
     mono_tool="/p:MonoTool=\"$mono_path\""
   elif [[ "$test_core_clr" == true ]]; then
     test=true

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -234,15 +234,17 @@ function BuildSolution {
   local test_runtime=""
   local mono_tool=""
   if [[ "$test_mono" == true ]]; then
+    
+    mono_path="$scriptroot/invoke-mono.sh"
     # Echo out the mono version to the comamnd line so it's visible in CI logs. It's not fixed
     # as we're using a feed vs. a hard coded package.
     if [[ "$ci" == true ]]; then
       mono --version
+      chmod +x "$mono_path"
     fi
 
     test=true
     test_runtime="/p:TestRuntime=Mono"
-    mono_path="$scriptroot/invoke-mono.sh"
     mono_tool="/p:MonoTool=\"$mono_path\""
   elif [[ "$test_core_clr" == true ]]; then
     test=true

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -242,7 +242,7 @@ function BuildSolution {
 
     test=true
     test_runtime="/p:TestRuntime=Mono"
-    mono_path="$scriptroot/InvokeMono.sh"
+    mono_path="$scriptroot/invoke-mono.sh"
     mono_tool="/p:MonoTool=\"$mono_path\""
   elif [[ "$test_core_clr" == true ]]; then
     test=true

--- a/eng/docker/Mono/Dockerfile
+++ b/eng/docker/Mono/Dockerfile
@@ -40,6 +40,12 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
     apt-get install -y mono-devel && \
     apt-get clean
 
+
+# Update previously installed mono-devel.
+# Cache bust ensures we'll always run the commands following regardless of docker cache status
+ARG CACHE_BUST=0
+RUN apt-get update && apt-get upgrade -y
+
 # Setup User to match Host User, and give superuser permissions
 ARG USER_ID=0
 RUN useradd -m code_executor -u ${USER_ID} -g sudo

--- a/eng/docker/mono.sh
+++ b/eng/docker/mono.sh
@@ -22,7 +22,7 @@ docker kill $CONTAINER_NAME || true
 
 # Build the docker container (will be fast if it is already built)
 echo "Building Docker Container using Dockerfile: $dockerfile"
-docker build --build-arg USER_ID=$(id -u) --build-arg CACHE_BUST=$(date +%s) -t $CONTAINER_TAG $dockerfile
+docker build --build-arg USER_ID=$(id -u) --build-arg CACHE_BUST=$(date +%s) --no-cache -t $CONTAINER_TAG $dockerfile
 
 # Run the build in the container
 echo "Launching build in Docker Container"

--- a/eng/docker/mono.sh
+++ b/eng/docker/mono.sh
@@ -22,7 +22,7 @@ docker kill $CONTAINER_NAME || true
 
 # Build the docker container (will be fast if it is already built)
 echo "Building Docker Container using Dockerfile: $dockerfile"
-docker build --build-arg USER_ID=$(id -u) -t $CONTAINER_TAG $dockerfile
+docker build --build-arg USER_ID=$(id -u) --build-arg CACHE_BUST=$(date +%s) -t $CONTAINER_TAG $dockerfile
 
 # Run the build in the container
 echo "Launching build in Docker Container"

--- a/eng/invoke-mono.sh
+++ b/eng/invoke-mono.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# invoke mono with debug flags
+mono --debug "$@"

--- a/eng/targets/XUnit.targets
+++ b/eng/targets/XUnit.targets
@@ -24,5 +24,4 @@
       </None>
     </ItemGroup>
   </Target>
-  
 </Project>

--- a/eng/targets/XUnit.targets
+++ b/eng/targets/XUnit.targets
@@ -24,4 +24,20 @@
       </None>
     </ItemGroup>
   </Target>
+
+  <!-- Add the debug flag to Mono -->
+  <Target Name="DebugMono" BeforeTargets="RunTests" Condition="'$(MonoTool)' != ''">
+
+    <!--
+        WORKAROUND:
+        Arcade's XUnit targets invokes the test runner (conceptually) as "$(MonoTool)" $(Args)
+        We need to hook into between the MonoTool and the Args.
+        This is achieved by quote abuse below. When MSBuild expands out the tool we'll end up closing the exe quotes,
+        adding our argument in, then having a second empty quoted argument before the real args. Hmmmmmm.
+    -->
+    <PropertyGroup>
+      <MonoTool>$(MonoTool)" --debug"</MonoTool>
+    </PropertyGroup>
+
+  </Target>
 </Project>

--- a/eng/targets/XUnit.targets
+++ b/eng/targets/XUnit.targets
@@ -24,20 +24,5 @@
       </None>
     </ItemGroup>
   </Target>
-
-  <!-- Add the debug flag to Mono -->
-  <Target Name="DebugMono" BeforeTargets="RunTests" Condition="'$(MonoTool)' != ''">
-
-    <!--
-        WORKAROUND:
-        Arcade's XUnit targets invokes the test runner (conceptually) as "$(MonoTool)" $(Args)
-        We need to hook into between the MonoTool and the Args.
-        This is achieved by quote abuse below. When MSBuild expands out the tool we'll end up closing the exe quotes,
-        adding our argument in, then having a second empty quoted argument before the real args. Hmmmmmm.
-    -->
-    <PropertyGroup>
-      <MonoTool>$(MonoTool)" --debug"</MonoTool>
-    </PropertyGroup>
-
-  </Target>
+  
 </Project>


### PR DESCRIPTION
This fixes a couple of related Mono CI things:

1. Pass --debug on the command line for future debugging:
    - We invoke xunit via arcade, which has limited extensibility points. I've hooked in a target with a bit of quote foo to enable it. It's not very pretty, I'll open a separate bug on Arcade to let us do this in the future more elegantly.

2. Docker compose caches layers, causing out of date mono builds:
    - We grab mono as part of the docker container build out. If the underlying machines hang around for a while, we'll never rebuild due to caching. 
    - This PR adds a dummy arg to the dockerfile that we pass in as current datetime; this allows us to cache up to that point, then always rebuild afterwards (see https://github.com/moby/moby/issues/1996)
    - We add a new apt-get update/upgrade pair after the dummy arg, so we'll always update mono to the latest regardless of caching, but its much quicker than always rebuilding from scratch 

3. A mono upgrade bug between 5.21 and 5.23 breaks `apt-get update`:
    - Sadly we hit this bug (https://github.com/mono/mono/issues/12316) upgrading between our cached images and latest
    - For now we need to rebuild docker images from scratch in order to flush out the earlier build from all of our build machines 
    - When all the machines in the pool have cycled through we can remove the `--no-cache` option and just do an incremental update (bullet 2). 
