### PR TITLE
Readonly members syntax and symbol API

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -368,6 +368,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return (_modifiers & DeclarationModifiers.Virtual) != 0; }
         }
 
+        internal bool IsReadOnly
+        {
+            get { return (_modifiers & DeclarationModifiers.ReadOnly) != 0; }
+        }
+
         public sealed override Accessibility DeclaredAccessibility
         {
             get { return ModifierUtils.EffectiveAccessibility(_modifiers); }
@@ -435,6 +440,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            if (this.ContainingType.IsStructType())
+            {
+                allowedModifiers |= DeclarationModifiers.ReadOnly;
+            }
+
             if (!isInterface)
             {
                 allowedModifiers |= DeclarationModifiers.Extern;
@@ -467,6 +477,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 // A static member '{0}' cannot be marked as override, virtual, or abstract
                 diagnostics.Add(ErrorCode.ERR_StaticNotVirtual, location, this);
+            }
+            else if (IsStatic && IsReadOnly)
+            {
+                // The modifier '{0}' is not valid for this item
+                diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.ReadOnlyKeyword));
             }
             else if (IsOverride && (IsNew || IsVirtual))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -478,7 +478,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // A static member '{0}' cannot be marked as override, virtual, or abstract
                 diagnostics.Add(ErrorCode.ERR_StaticNotVirtual, location, this);
             }
-            else if (IsStatic && IsReadOnly)
+            else if (IsReadOnly && (IsStatic || HasAssociatedField))
             {
                 // The modifier '{0}' is not valid for this item
                 diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.ReadOnlyKeyword));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -509,6 +509,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal bool IsReadOnly
+        {
+            get
+            {
+                return (this.DeclarationModifiers & DeclarationModifiers.ReadOnly) != 0;
+            }
+        }
+
         internal sealed override Cci.CallingConvention CallingConvention
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -772,6 +772,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 allowedModifiers |= DeclarationModifiers.Extern | DeclarationModifiers.Async;
             }
 
+            if (ContainingType.IsStructType())
+            {
+                allowedModifiers |= DeclarationModifiers.ReadOnly;
+            }
+
             var mods = ModifierUtils.MakeAndCheckNontypeMemberModifiers(modifiers, defaultAccess, allowedModifiers, location, diagnostics, out modifierErrors);
 
             this.CheckUnsafeModifier(mods, diagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -938,6 +938,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // The modifier '{0}' is not valid for this item
                 diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.VirtualKeyword));
             }
+            else if (IsStatic && IsReadOnly)
+            {
+                // The modifier '{0}' is not valid for this item
+                diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.ReadOnlyKeyword));
+            }
             else if (IsAbstract && !ContainingType.IsAbstract && (ContainingType.TypeKind == TypeKind.Class || ContainingType.TypeKind == TypeKind.Submission))
             {
                 // '{0}' is abstract but it is contained in non-abstract class '{1}'

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -410,7 +410,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             const DeclarationModifiers defaultAccess = DeclarationModifiers.None;
 
             // Check that the set of modifiers is allowed
-            const DeclarationModifiers allowedModifiers = DeclarationModifiers.AccessibilityMask;
+            DeclarationModifiers allowedModifiers = DeclarationModifiers.AccessibilityMask;
+            if (this.ContainingType.IsStructType())
+            {
+                allowedModifiers |= DeclarationModifiers.ReadOnly;
+            }
+
             var mods = ModifierUtils.MakeAndCheckNontypeMemberModifiers(syntax.Modifiers, defaultAccess, allowedModifiers, location, diagnostics, out modifierErrors);
 
             // For interface, check there are no accessibility modifiers.
@@ -450,6 +455,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (ContainingType.IsSealed && localAccessibility.HasProtected() && !this.IsOverride)
             {
                 diagnostics.Add(AccessCheck.GetProtectedMemberInSealedTypeError(ContainingType), location, this);
+            }
+            else if (IsStatic && IsReadOnly)
+            {
+                // The modifier '{0}' is not valid for this item
+                diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.ReadOnlyKeyword));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // Check that the set of modifiers is allowed
             DeclarationModifiers allowedModifiers = DeclarationModifiers.AccessibilityMask;
-            if (this.ContainingType.IsStructType())
+            if (this.ContainingType.IsStructType() && !_property.HasReadOnlyModifier)
             {
                 allowedModifiers |= DeclarationModifiers.ReadOnly;
             }
@@ -456,7 +456,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 diagnostics.Add(AccessCheck.GetProtectedMemberInSealedTypeError(ContainingType), location, this);
             }
-            else if (IsStatic && IsReadOnly)
+            else if (IsStatic && IsReadOnly && !_property.HasReadOnlyModifier)
             {
                 // The modifier '{0}' is not valid for this item
                 diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.ReadOnlyKeyword));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -114,6 +114,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ? propertySyntax.ExpressionBody
                 : ((IndexerDeclarationSyntax)syntax).ExpressionBody;
             bool hasExpressionBody = arrowExpression != null;
+
+            if (!hasExpressionBody && HasReadOnlyModifier)
+            {
+                diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.ReadOnlyKeyword));
+            }
+
             bool hasInitializer = !isIndexer && propertySyntax.Initializer != null;
 
             bool notRegularProperty = (!IsAbstract && !IsExtern && !isIndexer && hasAccessorList);
@@ -627,6 +633,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return (_modifiers & DeclarationModifiers.New) != 0; }
         }
 
+        private bool HasReadOnlyModifier
+        {
+            get { return (_modifiers & DeclarationModifiers.ReadOnly) != 0; }
+        }
+
         public override MethodSymbol GetMethod
         {
             get { return _getMethod; }
@@ -811,6 +822,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         allowedModifiers |= DeclarationModifiers.Static;
                     }
                 }
+            }
+
+            if (ContainingType.IsStructType())
+            {
+                allowedModifiers |= DeclarationModifiers.ReadOnly;
             }
 
             if (!isInterface)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -627,6 +627,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return (_modifiers & DeclarationModifiers.New) != 0; }
         }
 
+        internal bool HasReadOnlyModifier => (_modifiers & DeclarationModifiers.ReadOnly) != 0;
+
         public override MethodSymbol GetMethod
         {
             get { return _getMethod; }
@@ -894,6 +896,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 // A static member '{0}' cannot be marked as override, virtual, or abstract
                 diagnostics.Add(ErrorCode.ERR_StaticNotVirtual, location, this);
+            }
+            else if (IsStatic && HasReadOnlyModifier)
+            {
+                // The modifier '{0}' is not valid for this item
+                diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.ReadOnlyKeyword));
             }
             else if (IsOverride && (IsNew || IsVirtual))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -115,11 +115,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 : ((IndexerDeclarationSyntax)syntax).ExpressionBody;
             bool hasExpressionBody = arrowExpression != null;
 
-            if (!hasExpressionBody && HasReadOnlyModifier)
-            {
-                diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.ReadOnlyKeyword));
-            }
-
             bool hasInitializer = !isIndexer && propertySyntax.Initializer != null;
 
             bool notRegularProperty = (!IsAbstract && !IsExtern && !isIndexer && hasAccessorList);
@@ -631,11 +626,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal bool IsNew
         {
             get { return (_modifiers & DeclarationModifiers.New) != 0; }
-        }
-
-        private bool HasReadOnlyModifier
-        {
-            get { return (_modifiers & DeclarationModifiers.ReadOnly) != 0; }
         }
 
         public override MethodSymbol GetMethod

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -114,7 +114,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ? propertySyntax.ExpressionBody
                 : ((IndexerDeclarationSyntax)syntax).ExpressionBody;
             bool hasExpressionBody = arrowExpression != null;
-
             bool hasInitializer = !isIndexer && propertySyntax.Initializer != null;
 
             bool notRegularProperty = (!IsAbstract && !IsExtern && !isIndexer && hasAccessorList);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -584,7 +584,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         public sealed override bool IsValueType => GetIsValueType(ConsList<TypeParameterSymbol>.Empty);
-        
+
         internal sealed override ManagedKind ManagedKind
         {
             get

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -265,7 +265,10 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics();
-            comp.GetMember<NamedTypeSymbol>("S").GetMember<MethodSymbol>("M"); // TODO: MethodSymbol.IsReadOnly
+
+            var method = (SourceMemberMethodSymbol)comp.GetMember<NamedTypeSymbol>("S").GetMember<MethodSymbol>("M");
+            // PROTOTYPE: add `public abstract bool IsReadOnly` to MethodSymbol and implement in subtypes?
+            Assert.True(method.IsReadOnly);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -332,6 +332,29 @@ public struct S
         }
 
         [Fact]
+        public void ReadOnlyClassProperty()
+        {
+            var csharp = @"
+public class C
+{
+    public int i;
+    public int P
+    {
+        readonly get
+        {
+            return i;
+        }
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (7,18): error CS0106: The modifier 'readonly' is not valid for this item
+                //         readonly get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("readonly").WithLocation(7, 18));
+        }
+
+        [Fact]
         public void ReadOnlyStructStaticProperty()
         {
             var csharp = @"
@@ -366,9 +389,40 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (5,32): error CS0106: The modifier 'readonly' is not valid for this item
+                // (5,37): error CS0106: The modifier 'readonly' is not valid for this item
                 //     public static readonly int P => i;
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "P").WithArguments("readonly").WithLocation(5, 32));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "i").WithArguments("readonly").WithLocation(5, 37));
+        }
+
+        [Fact]
+        public void ReadOnlyStructExpressionProperty()
+        {
+            var csharp = @"
+public struct S
+{
+    public int i;
+    public readonly int P => i;
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void ReadOnlyStructBlockProperty()
+        {
+            var csharp = @"
+public struct S
+{
+    public int i;
+    public readonly int P { get { return i; } }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (5,25): error CS0106: The modifier 'readonly' is not valid for this item
+                //     public readonly int P { get { return i; } }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "P").WithArguments("readonly").WithLocation(5, 25));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -290,5 +290,25 @@ public class C
                 //     public readonly int M()
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "M").WithArguments("readonly").WithLocation(5, 25));
         }
+
+        [Fact]
+        public void ReadOnlyStructStaticMethod()
+        {
+            var csharp = @"
+public struct S
+{
+    public static int i;
+    public static readonly int M()
+    {
+        return i;
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (5,32): error CS0106: The modifier 'readonly' is not valid for this item
+                //     public static readonly int M()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M").WithArguments("readonly").WithLocation(5, 32));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -389,9 +389,9 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (5,37): error CS0106: The modifier 'readonly' is not valid for this item
+                // (5,32): error CS0106: The modifier 'readonly' is not valid for this item
                 //     public static readonly int P => i;
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "i").WithArguments("readonly").WithLocation(5, 37));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "P").WithArguments("readonly").WithLocation(5, 32));
         }
 
         [Fact]
@@ -440,6 +440,22 @@ public struct S
         }
 
         [Fact]
+        public void ReadOnlyProperty_RedundantReadOnlyAccessor()
+        {
+            var csharp = @"
+public struct S
+{
+    public readonly int P { readonly get; }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (4,38): error CS0106: The modifier 'readonly' is not valid for this item
+                //     public readonly int P { readonly get; }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("readonly").WithLocation(4, 38));
+        }
+
+        [Fact]
         public void ReadOnlyStaticAutoProperty()
         {
             var csharp = @"
@@ -451,12 +467,9 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (4,37): error CS0106: The modifier 'readonly' is not valid for this item
+                // (4,32): error CS0106: The modifier 'readonly' is not valid for this item
                 //     public static readonly int P1 { get; set; }
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("readonly").WithLocation(4, 37),
-                // (4,42): error CS0106: The modifier 'readonly' is not valid for this item
-                //     public static readonly int P1 { get; set; }
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("readonly").WithLocation(4, 42),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "P1").WithArguments("readonly").WithLocation(4, 32),
                 // (5,37): error CS0106: The modifier 'readonly' is not valid for this item
                 //     public static int P2 { readonly get; }
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("readonly").WithLocation(5, 37));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -250,6 +250,8 @@ public class Program
                 );
         }
 
+        // PROTOTYPE: readonly members features should require C# 8.0 or greater
+
         [Fact]
         public void ReadOnlyStructMethod()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -514,5 +514,52 @@ public readonly delegate int Del();
                 // public readonly delegate int Del();
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "Del").WithArguments("readonly").WithLocation(2, 30));
         }
+
+        [Fact]
+        public void ReadOnlyIndexer()
+        {
+            var csharp = @"
+public struct S1
+{
+    public readonly int this[int i]
+    {
+        get => 42;
+        set {}
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void ReadOnlyExpressionIndexer()
+        {
+            var csharp = @"
+public struct S1
+{
+    public readonly int this[int i] => 42;
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void ReadOnlyGetExpressionIndexer()
+        {
+            var csharp = @"
+public struct S1
+{
+    public int this[int i]
+    {
+        readonly get => 42;
+        readonly set {}
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -397,7 +397,6 @@ public struct S
         [Fact]
         public void ReadOnlyStructExpressionProperty()
         {
-            // TODO(rigibson): this syntax needs to change to `public int P readonly => i;`
             var csharp = @"
 public struct S
 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -265,6 +265,27 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics();
+            comp.GetMember<NamedTypeSymbol>("S").GetMember<MethodSymbol>("M"); // TODO: MethodSymbol.IsReadOnly
+        }
+
+        [Fact]
+        public void ReadOnlyClassMethod()
+        {
+            var csharp = @"
+public class C
+{
+    public int i;
+    public readonly int M()
+    {
+        return i;
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (5,25): error CS0106: The modifier 'readonly' is not valid for this item
+                //     public readonly int M()
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M").WithArguments("readonly").WithLocation(5, 25));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -440,6 +440,29 @@ public struct S
         }
 
         [Fact]
+        public void ReadOnlyStaticAutoProperty()
+        {
+            var csharp = @"
+public struct S
+{
+    public static readonly int P1 { get; set; }
+    public static int P2 { readonly get; }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (4,37): error CS0106: The modifier 'readonly' is not valid for this item
+                //     public static readonly int P1 { get; set; }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("readonly").WithLocation(4, 37),
+                // (4,42): error CS0106: The modifier 'readonly' is not valid for this item
+                //     public static readonly int P1 { get; set; }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("readonly").WithLocation(4, 42),
+                // (5,37): error CS0106: The modifier 'readonly' is not valid for this item
+                //     public static int P2 { readonly get; }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("readonly").WithLocation(5, 37));
+        }
+
+        [Fact]
         public void RefReturningReadOnlyMethod()
         {
             // PROTOTYPE: would be good to add some more mutation here
@@ -479,6 +502,25 @@ public struct S
                 // (4,21): error CS0106: The modifier 'readonly' is not valid for this item
                 //     public readonly S(int i) { }
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "S").WithArguments("readonly").WithLocation(4, 21));
+        }
+
+        [Fact]
+        public void ReadOnlyDestructor()
+        {
+            var csharp = @"
+public struct S
+{
+    readonly ~S() { }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (4,15): error CS0106: The modifier 'readonly' is not valid for this item
+                //     readonly ~S() { }
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "S").WithArguments("readonly").WithLocation(4, 15),
+                // (4,15): error CS0575: Only class types can contain destructors
+                //     readonly ~S() { }
+                Diagnostic(ErrorCode.ERR_OnlyClassesCanContainDestructors, "S").WithArguments("S.~S()").WithLocation(4, 15));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -310,5 +310,80 @@ public struct S
                 //     public static readonly int M()
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "M").WithArguments("readonly").WithLocation(5, 32));
         }
+
+        [Fact]
+        public void ReadOnlyStructProperty()
+        {
+            var csharp = @"
+public struct S
+{
+    public int i;
+    public int P
+    {
+        readonly get
+        {
+            return i;
+        }
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void ReadOnlyStructStaticProperty()
+        {
+            var csharp = @"
+public struct S
+{
+    public static int i;
+    public static int P
+    {
+        readonly get
+        {
+            return i;
+        }
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (7,18): error CS0106: The modifier 'readonly' is not valid for this item
+                //         readonly get
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("readonly").WithLocation(7, 18));
+        }
+
+        [Fact]
+        public void ReadOnlyStructStaticExpressionProperty()
+        {
+            var csharp = @"
+public struct S
+{
+    public static int i;
+    public static readonly int P => i;
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (5,32): error CS0106: The modifier 'readonly' is not valid for this item
+                //     public static readonly int P => i;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "P").WithArguments("readonly").WithLocation(5, 32));
+        }
+
+        [Fact]
+        public void ReadOnlyAutoProperty()
+        {
+            var csharp = @"
+public struct S
+{
+    public int P1 { readonly get; }
+    public int P2 { readonly get; set; }
+    public int P3 { readonly get; readonly set; } // PROTOTYPE: readonly set on an auto-property should give an error
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -249,5 +249,22 @@ public class Program
                 Diagnostic(ErrorCode.ERR_AssgReadonlyStatic2, "s.field").WithArguments("Program.s").WithLocation(8, 9)
                 );
         }
+
+        [Fact]
+        public void ReadOnlyStructMethod()
+        {
+            var csharp = @"
+public struct S
+{
+    public int i;
+    public readonly int M()
+    {
+        return i;
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -397,6 +397,7 @@ public struct S
         [Fact]
         public void ReadOnlyStructExpressionProperty()
         {
+            // TODO(rigibson): this syntax needs to change to `public int P readonly => i;`
             var csharp = @"
 public struct S
 {
@@ -434,6 +435,32 @@ public struct S
     public int P1 { readonly get; }
     public int P2 { readonly get; set; }
     public int P3 { readonly get; readonly set; } // PROTOTYPE: readonly set on an auto-property should give an error
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefReturningReadOnlyMethod()
+        {
+            // PROTOTYPE: would be good to add some more mutation here
+            // as well as expected diagnostics once that part of the feature is ready.
+            var csharp = @"
+public struct S
+{
+    private static int f1;
+    public readonly ref int M1() => ref f1;
+
+    private static readonly int f2;
+    public readonly ref readonly int M2() => ref f1;
+
+    private static readonly int f3;
+    public ref readonly int M3()
+    {
+        f1++;
+        return ref f3;
+    }
 }
 ";
             var comp = CreateCompilation(csharp);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -2777,6 +2777,56 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void TestReadOnlyRefReturning()
+        {
+            var text = "struct a { readonly ref readonly int M() { } }";
+            var file = this.ParseFile(text);
+
+            Assert.NotNull(file);
+            Assert.Equal(1, file.Members.Count);
+            Assert.Equal(text, file.ToString());
+            Assert.Equal(0, file.Errors().Length);
+
+            Assert.Equal(SyntaxKind.StructDeclaration, file.Members[0].Kind());
+            var structDecl = (TypeDeclarationSyntax)file.Members[0];
+            Assert.Equal(0, structDecl.AttributeLists.Count);
+            Assert.Equal(0, structDecl.Modifiers.Count);
+            Assert.NotNull(structDecl.Keyword);
+            Assert.Equal(SyntaxKind.StructKeyword, structDecl.Keyword.Kind());
+            Assert.NotNull(structDecl.Identifier);
+            Assert.Equal("a", structDecl.Identifier.ToString());
+            Assert.Null(structDecl.BaseList);
+            Assert.Equal(0, structDecl.ConstraintClauses.Count);
+            Assert.NotNull(structDecl.OpenBraceToken);
+            Assert.NotNull(structDecl.CloseBraceToken);
+
+            Assert.Equal(1, structDecl.Members.Count);
+
+            Assert.Equal(SyntaxKind.MethodDeclaration, structDecl.Members[0].Kind());
+            var ms = (MethodDeclarationSyntax)structDecl.Members[0];
+            Assert.Equal(0, ms.AttributeLists.Count);
+            Assert.Equal(1, ms.Modifiers.Count);
+            Assert.Equal(SyntaxKind.ReadOnlyKeyword, ms.Modifiers[0].Kind());
+            Assert.Equal(SyntaxKind.RefType, ms.ReturnType.Kind());
+            var rt = (RefTypeSyntax)ms.ReturnType;
+            Assert.Equal(SyntaxKind.RefKeyword, rt.RefKeyword.Kind());
+            Assert.Equal(SyntaxKind.ReadOnlyKeyword, rt.ReadOnlyKeyword.Kind());
+            Assert.Equal("int", rt.Type.ToString());
+            Assert.NotNull(ms.Identifier);
+            Assert.Equal("M", ms.Identifier.ToString());
+            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
+            Assert.Equal(0, ms.ParameterList.Parameters.Count);
+            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
+            Assert.Equal(0, ms.ConstraintClauses.Count);
+            Assert.NotNull(ms.Body);
+            Assert.NotEqual(SyntaxKind.None, ms.Body.OpenBraceToken.Kind());
+            Assert.NotEqual(SyntaxKind.None, ms.Body.CloseBraceToken.Kind());
+            Assert.Equal(SyntaxKind.None, ms.SemicolonToken.Kind());
+        }
+
+        [Fact]
         public void TestStructExpressionPropertyWithReadonly()
         {
             var text = "struct a { readonly int M => 42; }";

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -2730,6 +2730,134 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void TestStructMethodWithReadonly()
+        {
+            var text = "struct a { readonly void M() { } }";
+            var file = this.ParseFile(text);
+
+            Assert.NotNull(file);
+            Assert.Equal(1, file.Members.Count);
+            Assert.Equal(text, file.ToString());
+            Assert.Equal(0, file.Errors().Length);
+
+            Assert.Equal(SyntaxKind.StructDeclaration, file.Members[0].Kind());
+            var structDecl = (TypeDeclarationSyntax)file.Members[0];
+            Assert.Equal(0, structDecl.AttributeLists.Count);
+            Assert.Equal(0, structDecl.Modifiers.Count);
+            Assert.NotNull(structDecl.Keyword);
+            Assert.Equal(SyntaxKind.StructKeyword, structDecl.Keyword.Kind());
+            Assert.NotNull(structDecl.Identifier);
+            Assert.Equal("a", structDecl.Identifier.ToString());
+            Assert.Null(structDecl.BaseList);
+            Assert.Equal(0, structDecl.ConstraintClauses.Count);
+            Assert.NotNull(structDecl.OpenBraceToken);
+            Assert.NotNull(structDecl.CloseBraceToken);
+
+            Assert.Equal(1, structDecl.Members.Count);
+
+            Assert.Equal(SyntaxKind.MethodDeclaration, structDecl.Members[0].Kind());
+            var ms = (MethodDeclarationSyntax)structDecl.Members[0];
+            Assert.Equal(0, ms.AttributeLists.Count);
+            Assert.Equal(1, ms.Modifiers.Count);
+            Assert.Equal(SyntaxKind.ReadOnlyKeyword, ms.Modifiers[0].Kind());
+            Assert.NotNull(ms.ReturnType);
+            Assert.Equal("void", ms.ReturnType.ToString());
+            Assert.NotNull(ms.Identifier);
+            Assert.Equal("M", ms.Identifier.ToString());
+            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
+            Assert.Equal(0, ms.ParameterList.Parameters.Count);
+            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
+            Assert.Equal(0, ms.ConstraintClauses.Count);
+            Assert.NotNull(ms.Body);
+            Assert.NotEqual(SyntaxKind.None, ms.Body.OpenBraceToken.Kind());
+            Assert.NotEqual(SyntaxKind.None, ms.Body.CloseBraceToken.Kind());
+            Assert.Equal(SyntaxKind.None, ms.SemicolonToken.Kind());
+        }
+
+        [Fact]
+        public void TestStructExpressionPropertyWithReadonly()
+        {
+            var text = "struct a { readonly int M => 42; }";
+            var file = this.ParseFile(text);
+
+            Assert.NotNull(file);
+            Assert.Equal(1, file.Members.Count);
+            Assert.Equal(text, file.ToString());
+            Assert.Equal(0, file.Errors().Length);
+
+            Assert.Equal(SyntaxKind.StructDeclaration, file.Members[0].Kind());
+            var structDecl = (TypeDeclarationSyntax)file.Members[0];
+            Assert.Equal(0, structDecl.AttributeLists.Count);
+            Assert.Equal(0, structDecl.Modifiers.Count);
+            Assert.NotNull(structDecl.Keyword);
+            Assert.Equal(SyntaxKind.StructKeyword, structDecl.Keyword.Kind());
+            Assert.NotNull(structDecl.Identifier);
+            Assert.Equal("a", structDecl.Identifier.ToString());
+            Assert.Null(structDecl.BaseList);
+            Assert.Equal(0, structDecl.ConstraintClauses.Count);
+            Assert.NotNull(structDecl.OpenBraceToken);
+            Assert.NotNull(structDecl.CloseBraceToken);
+
+            Assert.Equal(1, structDecl.Members.Count);
+
+            Assert.Equal(SyntaxKind.PropertyDeclaration, structDecl.Members[0].Kind());
+            var propertySyntax = (PropertyDeclarationSyntax)structDecl.Members[0];
+            Assert.Equal(0, propertySyntax.AttributeLists.Count);
+            Assert.Equal(1, propertySyntax.Modifiers.Count);
+            Assert.Equal(SyntaxKind.ReadOnlyKeyword, propertySyntax.Modifiers[0].Kind());
+            Assert.NotNull(propertySyntax.Type);
+            Assert.Equal("int", propertySyntax.Type.ToString());
+            Assert.NotNull(propertySyntax.Identifier);
+            Assert.Equal("M", propertySyntax.Identifier.ToString());
+            Assert.NotNull(propertySyntax.ExpressionBody);
+            Assert.NotEqual(SyntaxKind.None, propertySyntax.ExpressionBody.ArrowToken.Kind());
+            Assert.NotNull(propertySyntax.ExpressionBody.Expression);
+            Assert.Equal(SyntaxKind.SemicolonToken, propertySyntax.SemicolonToken.Kind());
+        }
+
+        [Fact]
+        public void TestStructGetterPropertyWithReadonly()
+        {
+            var text = "struct a { int P { readonly get { return 42; } } }";
+            var file = this.ParseFile(text);
+
+            Assert.NotNull(file);
+            Assert.Equal(1, file.Members.Count);
+            Assert.Equal(text, file.ToString());
+            Assert.Equal(0, file.Errors().Length);
+
+            Assert.Equal(SyntaxKind.StructDeclaration, file.Members[0].Kind());
+            var structDecl = (TypeDeclarationSyntax)file.Members[0];
+            Assert.Equal(0, structDecl.AttributeLists.Count);
+            Assert.Equal(0, structDecl.Modifiers.Count);
+            Assert.NotNull(structDecl.Keyword);
+            Assert.Equal(SyntaxKind.StructKeyword, structDecl.Keyword.Kind());
+            Assert.NotNull(structDecl.Identifier);
+            Assert.Equal("a", structDecl.Identifier.ToString());
+            Assert.Null(structDecl.BaseList);
+            Assert.Equal(0, structDecl.ConstraintClauses.Count);
+            Assert.NotNull(structDecl.OpenBraceToken);
+            Assert.NotNull(structDecl.CloseBraceToken);
+
+            Assert.Equal(1, structDecl.Members.Count);
+
+            Assert.Equal(SyntaxKind.PropertyDeclaration, structDecl.Members[0].Kind());
+            var propertySyntax = (PropertyDeclarationSyntax)structDecl.Members[0];
+            Assert.Equal(0, propertySyntax.AttributeLists.Count);
+            Assert.Equal(0, propertySyntax.Modifiers.Count);
+            Assert.NotNull(propertySyntax.Type);
+            Assert.Equal("int", propertySyntax.Type.ToString());
+            Assert.NotNull(propertySyntax.Identifier);
+            Assert.Equal("P", propertySyntax.Identifier.ToString());
+            var accessors = propertySyntax.AccessorList.Accessors;
+            Assert.Equal(1, accessors.Count);
+            Assert.Equal(1, accessors[0].Modifiers.Count);
+            Assert.Equal(SyntaxKind.ReadOnlyKeyword, accessors[0].Modifiers[0].Kind());
+        }
+
+        [Fact]
         public void TestClassMethodWithParameter()
         {
             var text = "class a { b X(c d) { } }";


### PR DESCRIPTION
Modified syntax checks and added symbol API to support the readonly members feature. See dotnet/csharplang#1710.

I outlined how I think the entire development of this feature breaks down in #32911. Would also appreciate feedback on that.