### PR TITLE
Handle string concat with no string literals in ConvertToInterpolatedString

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
@@ -709,5 +709,26 @@ public class C
     }
 }");
         }
+
+        [WorkItem(32864, "https://github.com/dotnet/roslyn/issues/32864")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestConcatenationWithNoStringLiterals()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        var v = 1 [||]+ (""string"");
+    }
+}",
+@"public class C
+{
+    void M()
+    {
+        var v = $""{1}{(""string"")}"";
+    }
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
                 var firstStringToken = stringLiterals[0].GetFirstToken();
                 isVerbatimStringLiteral = syntaxFacts.IsVerbatimStringLiteral(firstStringToken);
                 if (stringLiterals.Any(
-                    lit => isVerbatimStringLiteral != syntaxFacts.IsVerbatimStringLiteral(lit.GetFirstToken())))
+                        lit => isVerbatimStringLiteral != syntaxFacts.IsVerbatimStringLiteral(lit.GetFirstToken())))
                 {
                     return;
                 }

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -60,25 +61,32 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
             var pieces = new List<SyntaxNode>();
             CollectPiecesDown(syntaxFacts, pieces, top, semanticModel, cancellationToken);
 
+            var stringLiterals = pieces.Where(syntaxFacts.IsStringLiteralExpression).ToImmutableArray();
+
             // If the entire expression is just concatenated strings, then don't offer to
             // make an interpolated string.  The user likely manually split this for
             // readability.
-            if (pieces.All(syntaxFacts.IsStringLiteralExpression))
+            if (stringLiterals.Length == pieces.Count)
             {
                 return;
             }
 
-            // Make sure that all the string tokens we're concatenating are the same type
-            // of string literal.  i.e. if we have an expression like: @" "" " + " \r\n "
-            // then we don't merge this.  We don't want to be munging different types of
-            // escape sequences in these strings, so we only support combining the string
-            // tokens if they're all the same type.
-            var firstStringToken = pieces.First(syntaxFacts.IsStringLiteralExpression).GetFirstToken();
-            var isVerbatimStringLiteral = syntaxFacts.IsVerbatimStringLiteral(firstStringToken);
-            if (pieces.Where(syntaxFacts.IsStringLiteralExpression).Any(
-                    lit => isVerbatimStringLiteral != syntaxFacts.IsVerbatimStringLiteral(lit.GetFirstToken())))
+            var isVerbatimStringLiteral = false;
+            if (stringLiterals.Length > 0)
             {
-                return;
+
+                // Make sure that all the string tokens we're concatenating are the same type
+                // of string literal.  i.e. if we have an expression like: @" "" " + " \r\n "
+                // then we don't merge this.  We don't want to be munging different types of
+                // escape sequences in these strings, so we only support combining the string
+                // tokens if they're all the same type.
+                var firstStringToken = stringLiterals[0].GetFirstToken();
+                isVerbatimStringLiteral = syntaxFacts.IsVerbatimStringLiteral(firstStringToken);
+                if (stringLiterals.Any(
+                    lit => isVerbatimStringLiteral != syntaxFacts.IsVerbatimStringLiteral(lit.GetFirstToken())))
+                {
+                    return;
+                }
             }
 
             var interpolatedString = CreateInterpolatedString(document, isVerbatimStringLiteral, pieces);


### PR DESCRIPTION
Fix #32864.

I have considered a few different options based on this particular scenario, e.g. 
```cs
var x = 1 + ("string");
```

1. Provide refactoring to convert it to 
```cs
var x = $"{1}{("string")}";
```

2. Provide refactoring that first removes unnecessary parentheses
```cs
var x = $"{1}string";
```

3. Don't offer to "convert to interpolated string". User must explicitly remove unnecessary parentheses first.

Option 1 is the simplest and most flexible (users might want the paren?). But once "convert to interpolated string" is selected first and then "remove paren", there's no way to flatten it to `${1}string` automatically.

Option 2 and 3 would avoid this problem by limiting the action user can take.

I ended up choosing Option 1 because (1) it's a very small change, with no behavior change to the refactoring, and (2) "flatten interpolated string" seems like a useful refactoring/codefix to have :)

@dotnet/roslyn-ide @CyrusNajmabadi 
