### PR TITLE
Update usages of the source file name when copying a banner to a new file.

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddFileBanner/AddFileBannerTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddFileBanner/AddFileBannerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.AddFileBanner;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddFileBanner

--- a/src/EditorFeatures/CSharpTest/AddFileBanner/AddFileBannerTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddFileBanner/AddFileBannerTests.cs
@@ -253,5 +253,60 @@ class Program2
     </Project>
 </Workspace>");
         }
+
+        [WorkItem(32792, "https://github.com/dotnet/roslyn/issues/32792")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddFileBanner)]
+        public async Task TestUpdateFileNameInComment2()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""Goo.cs"">[||]using System;
+
+class Program1
+{
+    static void Main()
+    {
+    }
+}
+        </Document>
+        <Document FilePath=""Bar.cs"">/* This is the banner in Bar.cs
+ It goes over multiple lines.  This line has Baz.cs
+ The last line includes Bar.cs */
+
+class Program2
+{
+}
+        </Document>
+    </Project>
+</Workspace>",
+@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""Goo.cs"">/* This is the banner in Goo.cs
+ It goes over multiple lines.  This line has Baz.cs
+ The last line includes Goo.cs */
+
+using System;
+
+class Program1
+{
+    static void Main()
+    {
+    }
+}
+        </Document>
+        <Document FilePath=""Bar.cs"">/* This is the banner in Bar.cs
+ It goes over multiple lines.  This line has Baz.cs
+ The last line includes Bar.cs */
+
+class Program2
+{
+}
+        </Document>
+    </Project>
+</Workspace>");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/AddFileBanner/AddFileBannerTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddFileBanner/AddFileBannerTests.cs
@@ -198,6 +198,7 @@ class Program2
 </Workspace>");
         }
 
+        [WorkItem(32792, "https://github.com/dotnet/roslyn/issues/32792")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddFileBanner)]
         public async Task TestUpdateFileNameInComment()
         {

--- a/src/EditorFeatures/CSharpTest/AddFileBanner/AddFileBannerTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddFileBanner/AddFileBannerTests.cs
@@ -197,5 +197,59 @@ class Program2
     </Project>
 </Workspace>");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddFileBanner)]
+        public async Task TestUpdateFileNameInComment()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""Goo.cs"">[||]using System;
+
+class Program1
+{
+    static void Main()
+    {
+    }
+}
+        </Document>
+        <Document FilePath=""Bar.cs"">// This is the banner in Bar.cs
+// It goes over multiple lines.  This line has Baz.cs
+// The last line includes Bar.cs
+
+class Program2
+{
+}
+        </Document>
+    </Project>
+</Workspace>",
+@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""Goo.cs"">// This is the banner in Goo.cs
+// It goes over multiple lines.  This line has Baz.cs
+// The last line includes Goo.cs
+
+using System;
+
+class Program1
+{
+    static void Main()
+    {
+    }
+}
+        </Document>
+        <Document FilePath=""Bar.cs"">// This is the banner in Bar.cs
+// It goes over multiple lines.  This line has Baz.cs
+// The last line includes Bar.cs
+
+class Program2
+{
+}
+        </Document>
+    </Project>
+</Workspace>");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/AddFileBanner/AddFileBannerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AddFileBanner/AddFileBannerTests.vb
@@ -114,9 +114,9 @@ class Program1
     end sub
 end class
         </Document>
-        <Document FilePath=""Bar.vb"">' This is the banner in Bar.cs
-' It goes over multiple lines.  This line has Baz.cs
-' The last line includes Bar.cs
+        <Document FilePath=""Bar.vb"">' This is the banner in Bar.vb
+' It goes over multiple lines.  This line has Baz.vb
+' The last line includes Bar.vb
 
 class Program2
 end class
@@ -126,9 +126,9 @@ end class
 "
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document FilePath=""Goo.vb"">' This is the banner in Goo.cs
-' It goes over multiple lines.  This line has Baz.cs
-' The last line includes Goo.cs
+        <Document FilePath=""Goo.vb"">' This is the banner in Goo.vb
+' It goes over multiple lines.  This line has Baz.vb
+' The last line includes Goo.vb
 
 Imports System
 
@@ -137,9 +137,9 @@ class Program1
     end sub
 end class
         </Document>
-        <Document FilePath=""Bar.vb"">' This is the banner in Bar.cs
-' It goes over multiple lines.  This line has Baz.cs
-' The last line includes Bar.cs
+        <Document FilePath=""Bar.vb"">' This is the banner in Bar.vb
+' It goes over multiple lines.  This line has Baz.vb
+' The last line includes Bar.vb
 
 class Program2
 end class

--- a/src/EditorFeatures/VisualBasicTest/AddFileBanner/AddFileBannerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AddFileBanner/AddFileBannerTests.vb
@@ -100,6 +100,7 @@ end class
 </Workspace>")
         End Function
 
+        <WorkItem(32792, "https://github.com/dotnet/roslyn/issues/32792")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddFileBanner)>
         Public Async Function TestUpdateFileNameInComment() As Task
             Await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/VisualBasicTest/AddFileBanner/AddFileBannerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AddFileBanner/AddFileBannerTests.vb
@@ -101,6 +101,53 @@ end class
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddFileBanner)>
+        Public Async Function TestUpdateFileNameInComment() As Task
+            Await TestInRegularAndScriptAsync(
+"
+<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""Goo.vb"">[||]Imports System
+
+class Program1
+    sub Main()
+    end sub
+end class
+        </Document>
+        <Document FilePath=""Bar.vb"">' This is the banner in Bar.cs
+' It goes over multiple lines.  This line has Baz.cs
+' The last line includes Bar.cs
+
+class Program2
+end class
+        </Document>
+    </Project>
+</Workspace>",
+"
+<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""Goo.vb"">' This is the banner in Goo.cs
+' It goes over multiple lines.  This line has Baz.cs
+' The last line includes Goo.cs
+
+Imports System
+
+class Program1
+    sub Main()
+    end sub
+end class
+        </Document>
+        <Document FilePath=""Bar.vb"">' This is the banner in Bar.cs
+' It goes over multiple lines.  This line has Baz.cs
+' The last line includes Bar.cs
+
+class Program2
+end class
+        </Document>
+    </Project>
+</Workspace>")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddFileBanner)>
         Public Async Function TestMissingWhenAlreadyThere() As Task
             Await TestMissingAsync(
 "

--- a/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerCodeRefactoringProvider.cs
@@ -12,5 +12,17 @@ namespace Microsoft.CodeAnalysis.CSharp.AddFileBanner
     {
         protected override bool IsCommentStartCharacter(char ch)
             => ch == '/';
+
+        protected override SyntaxTrivia CreateTrivia(SyntaxTrivia trivia, string text)
+        {
+            switch (trivia.Kind())
+            {
+                case SyntaxKind.SingleLineCommentTrivia:
+                case SyntaxKind.MultiLineCommentTrivia:
+                    return SyntaxFactory.Comment(text);
+            }
+
+            return trivia;
+        }
     }
 }

--- a/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerCodeRefactoringProvider.vb
@@ -13,5 +13,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddFileBanner
         Protected Overrides Function IsCommentStartCharacter(ch As Char) As Boolean
             Return ch = "'"c
         End Function
+
+        Protected Overrides Function CreateTrivia(trivia As SyntaxTrivia, text As String) As SyntaxTrivia
+            Return If(trivia.Kind() = SyntaxKind.CommentTrivia,
+                      SyntaxFactory.CommentTrivia(text),
+                      trivia)
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/32792