### PR TITLE
Bail out for ref locals for unused value assignment analyzer

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -6042,5 +6042,44 @@ class C
     }
 }", optionName);
         }
+
+        [WorkItem(32855, "https://github.com/dotnet/roslyn/issues/32855")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task RefLocalInitialization(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Test
+{
+  int[] data = { 0 };
+
+  void Method()
+  {
+    ref int [|target|] = ref data[0];
+    target = 1;
+  }
+}", optionName);
+        }
+
+        [WorkItem(32855, "https://github.com/dotnet/roslyn/issues/32855")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task RefLocalAssignment(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class Test
+{
+  int[] data = { 0 };
+
+  int Method()
+  {
+    ref int target = ref data[0];
+    [|target|] = 1;
+    return data[0];
+  }
+}", optionName);
+        }
     }
 }

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -412,6 +412,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                         SymbolUsageResult resultFromFlowAnalysis,
                         out ImmutableDictionary<string, string> properties)
                     {
+                        Debug.Assert(!(symbol is ILocalSymbol local) || !local.IsRef);
+
                         properties = null;
 
                         // Bail out in following cases:

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
@@ -216,6 +216,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
 
             public override void VisitLocalReference(ILocalReferenceOperation operation)
             {
+                if (operation.Local.IsRef)
+                {
+                    // Bail out for ref locals.
+                    // We need points to analysis for analyzing writes to ref locals, which is currently not supported.
+                    return;
+                }
+
                 OnReferenceFound(operation.Local, operation);
             }
 


### PR DESCRIPTION
We need points to analysis for properly analyzing unused assignments to ref locals, which is currently not supported.
Fixes #32855