### PR TITLE
Issue 26640 Fix unnecessary cast warning in conditional expressions when required.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -2013,21 +2013,70 @@ class Program
 
         [WorkItem(26640, "https://github.com/dotnet/roslyn/issues/26640")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
-        public async Task DontRemoveNumericCastInObjectCast()
+        public async Task DontRemoveNumericImplicitConstantCastInObjectCast()
         {
-
+            //return b ? [|(byte)1 : (byte)0|];
+            //return [|(byte)1|];
+            /*int tr = 1;
+            int fr = 0;
+            return [|b ? (byte)tr : (byte)fr|];
+             */
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
-    public object M1(bool b)
-        {
-            return b ? [|(byte)1 : (byte)0|];
+    object M1(bool b)
+    {
+        return [|b ? (byte)1 : (byte)0|];
+    }
+}");
         }
 
-        public byte M2()
+        [WorkItem(26640, "https://github.com/dotnet/roslyn/issues/26640")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveNumericImplicitNumericCastInObjectCast()
         {
-            return (byte) M1(true);
+            await TestMissingInRegularAndScriptAsync(
+@"class C
+{
+    object M1(bool b)
+    {
+        return [|b ? 1 : (double)0|];
+    }
+}");
         }
+
+        [WorkItem(26640, "https://github.com/dotnet/roslyn/issues/26640")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveNumericImplicitCharCastWithSameReturnTypeInObjectCast()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class C
+{
+    object M1(bool b)
+    {
+        return [|b ? '1' : (uint)'0'|];
+    }
+}");
+        }
+
+        [WorkItem(26640, "https://github.com/dotnet/roslyn/issues/26640")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task RemoveUnnecessaryNumericCastToSameTypeInConditionalExpression()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    object M1(bool b)
+    {
+        return [|b ? (int)1 : 0|];
+    }
+}",
+@"class C
+{
+    object M1(bool b)
+    {
+        return b ? 1 : 0;
+    }
 }");
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -2011,6 +2011,26 @@ class Program
 }");
         }
 
+        [WorkItem(26640, "https://github.com/dotnet/roslyn/issues/26640")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveNumericCastInObjectCast()
+        {
+
+            await TestMissingInRegularAndScriptAsync(
+@"class C
+{
+    public object M1(bool b)
+        {
+            return b ? (byte)1 : (byte)0;
+        }
+
+        public byte M2()
+        {
+            return (byte) M1(true);
+        }
+}");
+        }
+
         [WorkItem(545894, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545894")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public async Task DontRemoveNecessaryCastInAttribute()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -2027,6 +2027,27 @@ class Program
 
         [WorkItem(26640, "https://github.com/dotnet/roslyn/issues/26640")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task RemoveCastToDoubleFromIntWithTwoInConditionalExpression()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    object M1(bool b)
+    {
+        return [|b ? (double)1 : (double)0|];
+    }
+}",
+@"class C
+{
+    object M1(bool b)
+    {
+        return b ? 1 : (double)0;
+    }
+}");
+        }
+
+        [WorkItem(26640, "https://github.com/dotnet/roslyn/issues/26640")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public async Task DontRemoveCastToDoubleFromIntInConditionalExpression()
         {
             await TestMissingInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -2013,14 +2013,8 @@ class Program
 
         [WorkItem(26640, "https://github.com/dotnet/roslyn/issues/26640")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
-        public async Task DontRemoveNumericImplicitConstantCastInObjectCast()
+        public async Task DontRemoveCastToByteFromIntInConditionalExpression()
         {
-            //return b ? [|(byte)1 : (byte)0|];
-            //return [|(byte)1|];
-            /*int tr = 1;
-            int fr = 0;
-            return [|b ? (byte)tr : (byte)fr|];
-             */
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {
@@ -2033,7 +2027,7 @@ class Program
 
         [WorkItem(26640, "https://github.com/dotnet/roslyn/issues/26640")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
-        public async Task DontRemoveNumericImplicitNumericCastInObjectCast()
+        public async Task DontRemoveCastToDoubleFromIntInConditionalExpression()
         {
             await TestMissingInRegularAndScriptAsync(
 @"class C
@@ -2047,7 +2041,7 @@ class Program
 
         [WorkItem(26640, "https://github.com/dotnet/roslyn/issues/26640")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
-        public async Task DontRemoveNumericImplicitCharCastWithSameReturnTypeInObjectCast()
+        public async Task DontRemoveCastToUIntFromCharInConditionalExpression()
         {
             await TestMissingInRegularAndScriptAsync(
 @"class C

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -2021,7 +2021,7 @@ class Program
 {
     public object M1(bool b)
         {
-            return b ? (byte)1 : (byte)0;
+            return b ? [|(byte)1 : (byte)0|];
         }
 
         public byte M2()

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         {
             var originalParamType = this.OriginalSemanticModel.GetDeclaredSymbol(originalParam).Type;
             var replacedParamType = this.SpeculativeSemanticModel.GetDeclaredSymbol(replacedParam).Type;
-            return originalParamType == replacedParamType;
+            return Equals(originalParamType, replacedParamType);
         }
 
         private bool ReplacementChangesSemanticsForNodes(
@@ -405,7 +405,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 var originalCaseType = this.OriginalSemanticModel.GetTypeInfo(previousOriginalNode, this.CancellationToken).Type;
                 var newCaseType = this.SpeculativeSemanticModel.GetTypeInfo(previousReplacedNode, this.CancellationToken).Type;
 
-                if (originalCaseType == newCaseType)
+                if (Equals(originalCaseType, newCaseType))
                     return false;
 
                 var oldSwitchStatement = (SwitchStatementSyntax)originalCaseSwitchLabel.Parent.Parent;
@@ -501,7 +501,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         private bool ReplacementBreaksBoxingInConditionalExpression(TypeInfo originalExpressionTypeInfo, TypeInfo newExpressionTypeInfo, ExpressionSyntax previousOriginalNode, ExpressionSyntax previousReplacedNode)
         {
             // If the resultant types are different and it is boxing to the converted type then semantics could be changing.
-            if (originalExpressionTypeInfo.Type != newExpressionTypeInfo.Type)
+            if (!Equals(originalExpressionTypeInfo.Type, newExpressionTypeInfo.Type))
             {
                 var originalConvertedTypeConversion = this.OriginalSemanticModel.ClassifyConversion(previousOriginalNode, originalExpressionTypeInfo.ConvertedType);
                 var newExpressionConvertedTypeConversion = this.SpeculativeSemanticModel.ClassifyConversion(previousReplacedNode, newExpressionTypeInfo.ConvertedType);

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -497,6 +497,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
         /// <summary>
         /// Checks if the conversion might change the resultant boxed type.
+        /// Similar boxing checks are performed elsewhere, but in this case we need to perform the check on the entire conditional expression.
+        /// This will make sure the resultant cast is proper for the type of the conditional expression.
         /// </summary>
         private bool ReplacementBreaksBoxingInConditionalExpression(TypeInfo originalExpressionTypeInfo, TypeInfo newExpressionTypeInfo, ExpressionSyntax previousOriginalNode, ExpressionSyntax previousReplacedNode)
         {

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -362,8 +362,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                         newOtherPartOfConditional = newExpression.WhenTrue;
                     }
 
-                    var originalExpressionType = this.OriginalSemanticModel.GetTypeInfo(originalExpression, this.CancellationToken).Type;
-                    var newExpressionType = this.SpeculativeSemanticModel.GetTypeInfo(newExpression, this.CancellationToken).Type;
+                    var originalExpressionTypeInfo = this.OriginalSemanticModel.GetTypeInfo(originalExpression, this.CancellationToken);
+                    var newExpressionTypeInfo = this.SpeculativeSemanticModel.GetTypeInfo(newExpression, this.CancellationToken);
+
+                    var originalExpressionType = originalExpressionTypeInfo.Type;
+                    var newExpressionType = newExpressionTypeInfo.Type;
 
                     if (originalExpressionType == null || newExpressionType == null)
                     {
@@ -377,6 +380,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
                     // If this changes a boxing operation in one of the branches, we assume that semantics will change.
                     if (originalConversion.IsBoxing != newConversion.IsBoxing)
+                    {
+                        return true;
+                    }
+
+                    if (ReplacementBreaksBoxingInConditionalExpression(originalExpressionTypeInfo, newExpressionTypeInfo, (ExpressionSyntax)previousOriginalNode, (ExpressionSyntax)previousReplacedNode))
                     {
                         return true;
                     }
@@ -482,6 +490,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             else if (currentOriginalNode.Kind() == SyntaxKind.DefaultExpression)
             {
                 return !TypesAreCompatible((ExpressionSyntax)currentOriginalNode, (ExpressionSyntax)currentReplacedNode);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the conversion might change the resultant boxed type.
+        /// </summary>
+        private bool ReplacementBreaksBoxingInConditionalExpression(TypeInfo originalExpressionTypeInfo, TypeInfo newExpressionTypeInfo, ExpressionSyntax previousOriginalNode, ExpressionSyntax previousReplacedNode)
+        {
+            // If the resultant types are different and it is boxing to the converted type then semantics could be changing.
+            if (originalExpressionTypeInfo.Type != newExpressionTypeInfo.Type)
+            {
+                var originalConvertedTypeConversion = this.OriginalSemanticModel.ClassifyConversion(previousOriginalNode, originalExpressionTypeInfo.ConvertedType);
+                var newExpressionConvertedTypeConversion = this.SpeculativeSemanticModel.ClassifyConversion(previousReplacedNode, newExpressionTypeInfo.ConvertedType);
+
+                if (originalConvertedTypeConversion.IsBoxing && newExpressionConvertedTypeConversion.IsBoxing)
+                {
+                    return true;
+                }
             }
 
             return false;


### PR DESCRIPTION
For https://github.com/dotnet/roslyn/issues/26640

This makes the check for semantic changes look at the boxing result for the conditional expression - if it is boxed, the types being boxed should be the same in the original and speculated.  I'm not sure if this logic is correct, there might be case where this should not apply but I haven't thought of one.