### PR TITLE
Generate top-level nullability rewriter.

### DIFF
--- a/eng/generate-compiler-code.ps1
+++ b/eng/generate-compiler-code.ps1
@@ -127,7 +127,7 @@ try {
     $csharpTestDir = Join-Path $RepoRoot "src\Compilers\CSharp\Test\Syntax"
     $basicDir = Join-Path $RepoRoot "src\Compilers\VisualBasic\Portable"
     $basicTestDir = Join-Path $RepoRoot "src\Compilers\VisualBasic\Test\Syntax"
-    $generationTempDir = Join-Path $TempDir "Generated"
+    $generationTempDir = Join-Path $RepoRoot "artifacts\log\$configuration\Generated"
 
     Run-Language "CSharp" "cs" $csharpDir $csharpTestDir $csharpSyntaxGenerator $csharpErrorFactsGenerator
     Run-Language "VB" "vb" $basicDir $basicTestDir $basicSyntaxGenerator $basicErrorFactsGenerator

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -48,6 +48,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
         }
+
+        public new NullableAnnotation TopLevelNullability
+        {
+            get => base.TopLevelNullability;
+            set => base.TopLevelNullability = value;
+        }
     }
 
     internal partial class BoundPassByCopy

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -49,14 +49,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public Nullability TopLevelNullability
+        public new Nullability TopLevelNullability
         {
-            get => base.TopLevelNullableAnnotation.ConvertToPublicNullability(this.Type);
-        }
-
-        public void SetTopLevelNullableAnnotation(NullableAnnotation annotation)
-        {
-            base.TopLevelNullableAnnotation = annotation;
+            get => base.TopLevelNullability;
+            set => base.TopLevelNullability = value;
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -49,10 +49,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public new NullableAnnotation TopLevelNullability
+        public Nullability TopLevelNullability
         {
-            get => base.TopLevelNullability;
-            set => base.TopLevelNullability = value;
+            get => base.TopLevelNullableAnnotation.ConvertToPublicNullability(this.Type);
+        }
+
+        public void SetTopLevelNullableAnnotation(NullableAnnotation annotation)
+        {
+            base.TopLevelNullableAnnotation = annotation;
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -156,10 +156,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Top level nullability for the node. This should not be used by flow analysis: it
-        /// is lossy, and loses the distinction between NotAnnotated and NotNullable.
+        /// Top level nullability for the node. This should not be used by flow analysis.
         /// </summary>
-        protected NullableAnnotation TopLevelNullableAnnotation
+        protected Nullability TopLevelNullability
         {
             get
             {
@@ -169,16 +168,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 switch (_attributes & BoundNodeAttributes.TopLevelNullabilityMask)
                 {
                     case BoundNodeAttributes.TopLevelNullable:
-                        return NullableAnnotation.Nullable;
+                        return Nullability.MayBeNull;
 
                     case BoundNodeAttributes.TopLevelNonNullable:
-                        return NullableAnnotation.NotNullable;
+                        return Nullability.NotNull;
 
                     case BoundNodeAttributes.TopLevelUnknown:
-                        return NullableAnnotation.Unknown;
+                        return Nullability.Unknown;
 
                     case BoundNodeAttributes.TopLevelNullableUnset:
-                        return NullableAnnotation.NotComputed;
+                        return Nullability.NotComputed;
 
                     default:
                         throw ExceptionUtilities.UnexpectedValue(_attributes);
@@ -190,21 +189,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert((_attributes & BoundNodeAttributes.WasTopLevelNullabilityChecked) == 0,
                     "bound node nullability should not be set after reading it");
 #endif
-                // PROTOTYPE(nullable-api): Will likely need to handle generics specially in this conversion
                 _attributes &= ~BoundNodeAttributes.TopLevelNullabilityMask;
                 switch (value)
                 {
-                    case NullableAnnotation.Annotated:
-                    case NullableAnnotation.Nullable:
+                    case Nullability.MayBeNull:
                         _attributes |= BoundNodeAttributes.TopLevelNullable;
                         break;
 
-                    case NullableAnnotation.NotAnnotated:
-                    case NullableAnnotation.NotNullable:
+                    case Nullability.NotNull:
                         _attributes |= BoundNodeAttributes.TopLevelNonNullable;
                         break;
 
-                    case NullableAnnotation.Unknown:
+                    case Nullability.Unknown:
                         _attributes |= BoundNodeAttributes.TopLevelUnknown;
                         break;
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -20,20 +20,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         [Flags()]
         private enum BoundNodeAttributes : byte
         {
-            HasErrors = 0b0001,
-            CompilerGenerated = 0b0010,
-            TopLevelNullableUnset = 0b0000,
-            TopLevelNullable = 0b0100,
-            TopLevelNonNullable = 0b1000,
-            TopLevelUnknown = 0b1100,
-            TopLevelNullabilityMask = 0b1100,
+            HasErrors = 1 << 0,
+            CompilerGenerated = 1 << 1,
+            TopLevelNullableUnset = 0,
+            TopLevelNullable = 1 << 2,
+            TopLevelNonNullable = 1 << 3,
+            TopLevelUnknown = TopLevelNullable | TopLevelNonNullable,
+            TopLevelNullabilityMask = TopLevelUnknown,
 #if DEBUG
             /// <summary>
             /// Captures the fact that consumers of the node already checked the state of the WasCompilerGenerated bit.
             /// Allows to assert on attempts to set WasCompilerGenerated bit after that.
             /// </summary>
-            WasCompilerGeneratedIsChecked = 0b010000,
-            WasTopLevelNullabilityChecked = 0b100000
+            WasCompilerGeneratedIsChecked = 1 << 4,
+            WasTopLevelNullabilityChecked = 1 << 5,
 #endif
         }
 
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Top level nullability for the node. This should not be used by flow analysis: it
         /// is lossy, and loses the distinction between NotAnnotated and NotNullable.
         /// </summary>
-        protected NullableAnnotation TopLevelNullability
+        protected NullableAnnotation TopLevelNullableAnnotation
         {
             get
             {
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert((_attributes & BoundNodeAttributes.WasTopLevelNullabilityChecked) == 0,
                     "bound node nullability should not be set after reading it");
 #endif
-                // TODO: Will likely need to handle generics specially in this conversion
+                // PROTOTYPE(nullable-api): Will likely need to handle generics specially in this conversion
                 _attributes &= ~BoundNodeAttributes.TopLevelNullabilityMask;
                 switch (value)
                 {

--- a/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal sealed partial class NullabilityRewriter : BoundTreeRewriter
+    {
+        protected override BoundExpression VisitExpressionWithoutStackGuard(BoundExpression node)
+        {
+            return (BoundExpression)Visit(node);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -11409,7 +11409,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundDeconstructValuePlaceholder updatedNode = node.Update(node.ValEscape, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -11422,7 +11422,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundTupleOperandPlaceholder updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -11435,7 +11435,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundAwaitableValuePlaceholder updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -11448,7 +11448,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundDup updatedNode = node.Update(node.RefKind, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -11461,7 +11461,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11479,7 +11479,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ResultKind, node.Symbols, childBoundNodes, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11497,7 +11497,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.AliasOpt, node.InferredType, boundContainingTypeOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11515,7 +11515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundTypeOrValueExpression updatedNode = node.Update(node.Data, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -11528,7 +11528,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundNamespaceExpression updatedNode = node.Update(node.NamespaceSymbol, node.AliasOpt);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -11541,7 +11541,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11559,7 +11559,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11577,7 +11577,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.OperatorKind, operand, node.MethodOpt, node.OperandConversion, node.ResultConversion, node.ResultKind, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11595,7 +11595,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, node.IsManaged, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11613,7 +11613,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11632,7 +11632,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, index, node.Checked, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11650,7 +11650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, node.GetTypeFromHandle, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11668,7 +11668,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11686,7 +11686,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11704,7 +11704,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, node.MethodOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11723,7 +11723,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(leftOperand, rightOperand, node.MethodOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11742,7 +11742,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.OperatorKind, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, left, right, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11763,7 +11763,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(left, right, convertedLeft, convertedRight, node.OperatorKind, node.Operators, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11782,7 +11782,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.OperatorKind, node.LogicalOperator, node.TrueOperator, node.FalseOperator, node.ResultKind, left, right, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11801,7 +11801,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Operator, left, right, node.LeftConversion, node.FinalConversion, node.ResultKind, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11820,7 +11820,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(left, right, node.IsRef, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11839,7 +11839,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(left, right, node.IsUsed, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11858,7 +11858,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(leftOperand, rightOperand, node.LeftConversion, node.OperatorResultKind, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11877,7 +11877,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(leftOperand, rightOperand, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11897,7 +11897,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.IsRef, condition, consequence, alternative, node.ConstantValueOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11916,7 +11916,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, indices, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11934,7 +11934,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11952,7 +11952,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, node.AwaitableInfo, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11970,7 +11970,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(sourceType, node.GetTypeFromHandle, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11988,7 +11988,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundMethodDefIndex updatedNode = node.Update(node.Method, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12001,7 +12001,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundMaximumMethodDefIndex updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12014,7 +12014,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundInstrumentationPayloadRoot updatedNode = node.Update(node.AnalysisKind, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12027,7 +12027,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundModuleVersionId updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12040,7 +12040,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundModuleVersionIdString updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12053,7 +12053,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundSourceDocumentIndex updatedNode = node.Update(node.Document, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12066,7 +12066,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundMethodInfo updatedNode = node.Update(node.Method, node.GetMethodFromHandle, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12079,7 +12079,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundFieldInfo updatedNode = node.Update(node.Field, node.GetFieldFromHandle, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12092,7 +12092,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundDefaultExpression updatedNode = node.Update(node.ConstantValueOpt, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12106,7 +12106,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, targetType, node.Conversion, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12125,7 +12125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, targetType, node.Conversion, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12143,7 +12143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(sourceType, node.ConstantValueOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12161,7 +12161,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, node.ConversionGroupOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12179,7 +12179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundArgList updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12192,7 +12192,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(arguments, node.ArgumentRefKindsOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12210,7 +12210,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ElementPointerType, node.ElementPointerTypeConversion, expression, node.GetPinnableOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12228,7 +12228,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundLiteral updatedNode = node.Update(node.ConstantValueOpt, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12241,7 +12241,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundThisReference updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12254,7 +12254,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundPreviousSubmissionReference updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12267,7 +12267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundHostObjectMemberReference updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12280,7 +12280,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundBaseReference updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12293,7 +12293,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundLocal updatedNode = node.Update(node.LocalSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12306,7 +12306,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundPseudoVariable updatedNode = node.Update(node.LocalSymbol, node.EmitExpressions, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12319,7 +12319,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.RangeVariableSymbol, value, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12337,7 +12337,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundParameter updatedNode = node.Update(node.ParameterSymbol, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12350,7 +12350,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundLabel updatedNode = node.Update(node.Label, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12365,7 +12365,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12383,7 +12383,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12402,7 +12402,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Locals, sideEffects, value, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12421,7 +12421,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Locals, sideEffects, value, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12439,7 +12439,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiver, node.TypeArgumentsOpt, node.Name, node.Invoked, node.Indexed, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12458,7 +12458,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableMethods, expression, arguments, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12477,7 +12477,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiver, accessExpression, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12497,7 +12497,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiver, node.HasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12515,7 +12515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundConditionalReceiver updatedNode = node.Update(node.Id, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12529,7 +12529,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(valueTypeReceiver, referenceTypeReceiver, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12547,7 +12547,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, node.Methods, node.LookupSymbolOpt, node.LookupError, node.Flags, receiverOpt, node.ResultKind);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12565,7 +12565,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Properties, receiverOpt, node.ResultKind);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12584,7 +12584,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.BinderOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12603,7 +12603,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Event, node.IsAddition, node.IsDynamic, receiverOpt, argument, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12622,7 +12622,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Constructor, constructorArguments, node.ConstructorArgumentNamesOpt, namedArguments, node.ResultKind, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12641,7 +12641,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Constructor, node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12659,7 +12659,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ArgumentNamesOpt, node.InferredNamesOpt, arguments, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12677,7 +12677,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.NaturalTypeOpt, arguments, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12696,7 +12696,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, node.ApplicableMethods, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12714,7 +12714,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.GuidString, initializerExpressionOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12732,7 +12732,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(initializers, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12750,7 +12750,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.MemberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, node.ReceiverType, node.BinderOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12768,7 +12768,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundDynamicObjectInitializerMember updatedNode = node.Update(node.MemberName, node.ReceiverType, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12781,7 +12781,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(initializers, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12800,7 +12800,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.AddMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12819,7 +12819,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ApplicableMethods, expression, arguments, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12837,7 +12837,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundImplicitReceiver updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12851,7 +12851,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Constructor, arguments, declarations, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12869,7 +12869,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundAnonymousPropertyDeclaration updatedNode = node.Update(node.Property, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12882,7 +12882,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(initializerExpressionOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12900,7 +12900,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(argument, node.MethodOpt, node.IsExtensionMethod, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12919,7 +12919,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(bounds, initializerOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12937,7 +12937,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(initializers);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12956,7 +12956,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ElementType, count, initializerOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12975,7 +12975,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ElementType, count, initializerOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12993,7 +12993,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, node.FieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13011,7 +13011,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundHoistedFieldAccess updatedNode = node.Update(node.FieldSymbol, type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -13024,7 +13024,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, node.PropertySymbol, node.ResultKind, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13042,7 +13042,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, node.EventSymbol, node.IsUsableAsField, node.ResultKind, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13061,7 +13061,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, node.Indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13080,7 +13080,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableIndexers, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13099,7 +13099,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(unboundLambda, node.Symbol, body, node.Diagnostics, node.Binder, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13117,7 +13117,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             UnboundLambda updatedNode = node.Update(node.Data);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -13130,7 +13130,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(value, node.DefinedSymbol, node.Binder, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13148,7 +13148,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(argument, node.ConstantValueOpt, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13166,7 +13166,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(parts, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13186,7 +13186,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(value, alignment, format, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13206,7 +13206,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, pattern, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13224,7 +13224,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundDiscardExpression updatedNode = node.Update(type);
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -13237,7 +13237,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13255,7 +13255,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.VariableSymbol, receiverOpt);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13273,7 +13273,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.VariableSymbol, receiverOpt);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13291,7 +13291,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             OutDeconstructVarPendingInference updatedNode = node.Update();
-            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -13304,7 +13304,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, node.NullableAnnotation, type);
-                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
+                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -11409,7 +11409,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundDeconstructValuePlaceholder updatedNode = node.Update(node.ValEscape, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -11422,7 +11422,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundTupleOperandPlaceholder updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -11435,7 +11435,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundAwaitableValuePlaceholder updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -11448,7 +11448,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundDup updatedNode = node.Update(node.RefKind, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -11461,7 +11461,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11479,7 +11479,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ResultKind, node.Symbols, childBoundNodes, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11497,7 +11497,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.AliasOpt, node.InferredType, boundContainingTypeOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11515,7 +11515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundTypeOrValueExpression updatedNode = node.Update(node.Data, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -11528,7 +11528,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundNamespaceExpression updatedNode = node.Update(node.NamespaceSymbol, node.AliasOpt);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -11541,7 +11541,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11559,7 +11559,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11577,7 +11577,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.OperatorKind, operand, node.MethodOpt, node.OperandConversion, node.ResultConversion, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11595,7 +11595,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, node.IsManaged, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11613,7 +11613,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11632,7 +11632,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, index, node.Checked, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11650,7 +11650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, node.GetTypeFromHandle, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11668,7 +11668,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11686,7 +11686,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11704,7 +11704,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, node.MethodOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11723,7 +11723,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(leftOperand, rightOperand, node.MethodOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11742,7 +11742,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.OperatorKind, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, left, right, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11763,7 +11763,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(left, right, convertedLeft, convertedRight, node.OperatorKind, node.Operators, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11782,7 +11782,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.OperatorKind, node.LogicalOperator, node.TrueOperator, node.FalseOperator, node.ResultKind, left, right, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11801,7 +11801,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Operator, left, right, node.LeftConversion, node.FinalConversion, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11820,7 +11820,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(left, right, node.IsRef, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11839,7 +11839,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(left, right, node.IsUsed, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11858,7 +11858,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(leftOperand, rightOperand, node.LeftConversion, node.OperatorResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11877,7 +11877,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(leftOperand, rightOperand, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11897,7 +11897,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.IsRef, condition, consequence, alternative, node.ConstantValueOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11916,7 +11916,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, indices, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11934,7 +11934,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11952,7 +11952,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, node.AwaitableInfo, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11970,7 +11970,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(sourceType, node.GetTypeFromHandle, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -11988,7 +11988,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundMethodDefIndex updatedNode = node.Update(node.Method, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12001,7 +12001,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundMaximumMethodDefIndex updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12014,7 +12014,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundInstrumentationPayloadRoot updatedNode = node.Update(node.AnalysisKind, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12027,7 +12027,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundModuleVersionId updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12040,7 +12040,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundModuleVersionIdString updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12053,7 +12053,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundSourceDocumentIndex updatedNode = node.Update(node.Document, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12066,7 +12066,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundMethodInfo updatedNode = node.Update(node.Method, node.GetMethodFromHandle, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12079,7 +12079,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundFieldInfo updatedNode = node.Update(node.Field, node.GetFieldFromHandle, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12092,7 +12092,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundDefaultExpression updatedNode = node.Update(node.ConstantValueOpt, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12106,7 +12106,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, targetType, node.Conversion, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12125,7 +12125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, targetType, node.Conversion, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12143,7 +12143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(sourceType, node.ConstantValueOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12161,7 +12161,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, node.ConversionGroupOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12179,7 +12179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundArgList updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12192,7 +12192,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(arguments, node.ArgumentRefKindsOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12210,7 +12210,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ElementPointerType, node.ElementPointerTypeConversion, expression, node.GetPinnableOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12228,7 +12228,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundLiteral updatedNode = node.Update(node.ConstantValueOpt, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12241,7 +12241,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundThisReference updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12254,7 +12254,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundPreviousSubmissionReference updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12267,7 +12267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundHostObjectMemberReference updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12280,7 +12280,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundBaseReference updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12293,7 +12293,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundLocal updatedNode = node.Update(node.LocalSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12306,7 +12306,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundPseudoVariable updatedNode = node.Update(node.LocalSymbol, node.EmitExpressions, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12319,7 +12319,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.RangeVariableSymbol, value, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12337,7 +12337,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundParameter updatedNode = node.Update(node.ParameterSymbol, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12350,7 +12350,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundLabel updatedNode = node.Update(node.Label, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12365,7 +12365,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12383,7 +12383,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12402,7 +12402,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Locals, sideEffects, value, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12421,7 +12421,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Locals, sideEffects, value, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12439,7 +12439,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiver, node.TypeArgumentsOpt, node.Name, node.Invoked, node.Indexed, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12458,7 +12458,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableMethods, expression, arguments, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12477,7 +12477,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiver, accessExpression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12497,7 +12497,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiver, node.HasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12515,7 +12515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundConditionalReceiver updatedNode = node.Update(node.Id, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12529,7 +12529,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(valueTypeReceiver, referenceTypeReceiver, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12547,7 +12547,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, node.Methods, node.LookupSymbolOpt, node.LookupError, node.Flags, receiverOpt, node.ResultKind);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12565,7 +12565,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Properties, receiverOpt, node.ResultKind);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12584,7 +12584,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.BinderOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12603,7 +12603,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Event, node.IsAddition, node.IsDynamic, receiverOpt, argument, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12622,7 +12622,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Constructor, constructorArguments, node.ConstructorArgumentNamesOpt, namedArguments, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12641,7 +12641,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Constructor, node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12659,7 +12659,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ArgumentNamesOpt, node.InferredNamesOpt, arguments, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12677,7 +12677,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.NaturalTypeOpt, arguments, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12696,7 +12696,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, node.ApplicableMethods, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12714,7 +12714,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.GuidString, initializerExpressionOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12732,7 +12732,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(initializers, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12750,7 +12750,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.MemberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, node.ReceiverType, node.BinderOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12768,7 +12768,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundDynamicObjectInitializerMember updatedNode = node.Update(node.MemberName, node.ReceiverType, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12781,7 +12781,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(initializers, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12800,7 +12800,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.AddMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12819,7 +12819,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ApplicableMethods, expression, arguments, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12837,7 +12837,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundImplicitReceiver updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12851,7 +12851,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Constructor, arguments, declarations, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12869,7 +12869,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundAnonymousPropertyDeclaration updatedNode = node.Update(node.Property, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -12882,7 +12882,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(initializerExpressionOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12900,7 +12900,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(argument, node.MethodOpt, node.IsExtensionMethod, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12919,7 +12919,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(bounds, initializerOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12937,7 +12937,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(initializers);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12956,7 +12956,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ElementType, count, initializerOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12975,7 +12975,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.ElementType, count, initializerOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -12993,7 +12993,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, node.FieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13011,7 +13011,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundHoistedFieldAccess updatedNode = node.Update(node.FieldSymbol, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -13024,7 +13024,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, node.PropertySymbol, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13042,7 +13042,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, node.EventSymbol, node.IsUsableAsField, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13061,7 +13061,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, node.Indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13080,7 +13080,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(receiverOpt, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableIndexers, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13099,7 +13099,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(unboundLambda, node.Symbol, body, node.Diagnostics, node.Binder, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13117,7 +13117,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             UnboundLambda updatedNode = node.Update(node.Data);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -13130,7 +13130,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(value, node.DefinedSymbol, node.Binder, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13148,7 +13148,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(argument, node.ConstantValueOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13166,7 +13166,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(parts, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13186,7 +13186,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(value, alignment, format, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13206,7 +13206,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, pattern, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13224,7 +13224,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundDiscardExpression updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -13237,7 +13237,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13255,7 +13255,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.VariableSymbol, receiverOpt);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13273,7 +13273,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.VariableSymbol, receiverOpt);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {
@@ -13291,7 +13291,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             OutDeconstructVarPendingInference updatedNode = node.Update();
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+            updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             return updatedNode;
         }
 
@@ -13304,7 +13304,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(expression, node.NullableAnnotation, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation;
+                updatedNode.SetTopLevelNullableAnnotation(_topLevelNullabilities[node].NullableAnnotation);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -10358,13 +10358,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitBadExpression(BoundBadExpression node)
         {
-            ImmutableArray<BoundExpression> childBoundNodes = (ImmutableArray<BoundExpression>)this.VisitList(node.ChildBoundNodes);
+            ImmutableArray<BoundExpression> childBoundNodes = this.VisitList(node.ChildBoundNodes);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.ResultKind, node.Symbols, childBoundNodes, type);
         }
         public override BoundNode VisitBadStatement(BoundBadStatement node)
         {
-            ImmutableArray<BoundNode> childBoundNodes = (ImmutableArray<BoundNode>)this.VisitList(node.ChildBoundNodes);
+            ImmutableArray<BoundNode> childBoundNodes = this.VisitList(node.ChildBoundNodes);
             return node.Update(childBoundNodes);
         }
         public override BoundNode VisitExtractedFinallyBlock(BoundExtractedFinallyBlock node)
@@ -10525,7 +10525,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitArrayAccess(BoundArrayAccess node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            ImmutableArray<BoundExpression> indices = (ImmutableArray<BoundExpression>)this.VisitList(node.Indices);
+            ImmutableArray<BoundExpression> indices = this.VisitList(node.Indices);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(expression, indices, type);
         }
@@ -10625,7 +10625,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitArgListOperator(BoundArgListOperator node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(arguments, node.ArgumentRefKindsOpt, type);
         }
@@ -10648,12 +10648,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitBlock(BoundBlock node)
         {
-            ImmutableArray<BoundStatement> statements = (ImmutableArray<BoundStatement>)this.VisitList(node.Statements);
+            ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
             return node.Update(node.Locals, node.LocalFunctions, statements);
         }
         public override BoundNode VisitScope(BoundScope node)
         {
-            ImmutableArray<BoundStatement> statements = (ImmutableArray<BoundStatement>)this.VisitList(node.Statements);
+            ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
             return node.Update(node.Locals, statements);
         }
         public override BoundNode VisitStateMachineScope(BoundStateMachineScope node)
@@ -10665,17 +10665,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundTypeExpression declaredType = (BoundTypeExpression)this.Visit(node.DeclaredType);
             BoundExpression initializerOpt = (BoundExpression)this.Visit(node.InitializerOpt);
-            ImmutableArray<BoundExpression> argumentsOpt = (ImmutableArray<BoundExpression>)this.VisitList(node.ArgumentsOpt);
+            ImmutableArray<BoundExpression> argumentsOpt = this.VisitList(node.ArgumentsOpt);
             return node.Update(node.LocalSymbol, declaredType, initializerOpt, argumentsOpt);
         }
         public override BoundNode VisitMultipleLocalDeclarations(BoundMultipleLocalDeclarations node)
         {
-            ImmutableArray<BoundLocalDeclaration> localDeclarations = (ImmutableArray<BoundLocalDeclaration>)this.VisitList(node.LocalDeclarations);
+            ImmutableArray<BoundLocalDeclaration> localDeclarations = this.VisitList(node.LocalDeclarations);
             return node.Update(localDeclarations);
         }
         public override BoundNode VisitUsingLocalDeclarations(BoundUsingLocalDeclarations node)
         {
-            ImmutableArray<BoundLocalDeclaration> localDeclarations = (ImmutableArray<BoundLocalDeclaration>)this.VisitList(node.LocalDeclarations);
+            ImmutableArray<BoundLocalDeclaration> localDeclarations = this.VisitList(node.LocalDeclarations);
             return node.Update(node.DisposeMethodOpt, node.IDisposableConversion, node.AwaitOpt, localDeclarations);
         }
         public override BoundNode VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
@@ -10723,7 +10723,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            ImmutableArray<BoundSwitchSection> switchSections = (ImmutableArray<BoundSwitchSection>)this.VisitList(node.SwitchSections);
+            ImmutableArray<BoundSwitchSection> switchSections = this.VisitList(node.SwitchSections);
             BoundDecisionDag decisionDag = node.DecisionDag;
             BoundSwitchLabel defaultLabel = (BoundSwitchLabel)this.Visit(node.DefaultLabel);
             return node.Update(expression, node.InnerLocals, node.InnerLocalFunctions, switchSections, decisionDag, defaultLabel, node.BreakLabel);
@@ -10797,7 +10797,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitTryStatement(BoundTryStatement node)
         {
             BoundBlock tryBlock = (BoundBlock)this.Visit(node.TryBlock);
-            ImmutableArray<BoundCatchBlock> catchBlocks = (ImmutableArray<BoundCatchBlock>)this.VisitList(node.CatchBlocks);
+            ImmutableArray<BoundCatchBlock> catchBlocks = this.VisitList(node.CatchBlocks);
             BoundBlock finallyBlockOpt = (BoundBlock)this.Visit(node.FinallyBlockOpt);
             return node.Update(tryBlock, catchBlocks, finallyBlockOpt, node.FinallyLabelOpt, node.PreferFaultHandler);
         }
@@ -10877,7 +10877,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitStatementList(BoundStatementList node)
         {
-            ImmutableArray<BoundStatement> statements = (ImmutableArray<BoundStatement>)this.VisitList(node.Statements);
+            ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
             return node.Update(statements);
         }
         public override BoundNode VisitConditionalGoto(BoundConditionalGoto node)
@@ -10888,7 +10888,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitSwitchExpression(BoundSwitchExpression node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            ImmutableArray<BoundSwitchExpressionArm> switchArms = (ImmutableArray<BoundSwitchExpressionArm>)this.VisitList(node.SwitchArms);
+            ImmutableArray<BoundSwitchExpressionArm> switchArms = this.VisitList(node.SwitchArms);
             BoundDecisionDag decisionDag = node.DecisionDag;
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, type);
@@ -10983,8 +10983,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitSwitchSection(BoundSwitchSection node)
         {
-            ImmutableArray<BoundSwitchLabel> switchLabels = (ImmutableArray<BoundSwitchLabel>)this.VisitList(node.SwitchLabels);
-            ImmutableArray<BoundStatement> statements = (ImmutableArray<BoundStatement>)this.VisitList(node.Statements);
+            ImmutableArray<BoundSwitchLabel> switchLabels = this.VisitList(node.SwitchLabels);
+            ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
             return node.Update(node.Locals, switchLabels, statements);
         }
         public override BoundNode VisitSwitchLabel(BoundSwitchLabel node)
@@ -11001,14 +11001,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitSequence(BoundSequence node)
         {
-            ImmutableArray<BoundExpression> sideEffects = (ImmutableArray<BoundExpression>)this.VisitList(node.SideEffects);
+            ImmutableArray<BoundExpression> sideEffects = this.VisitList(node.SideEffects);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.Locals, sideEffects, value, type);
         }
         public override BoundNode VisitSpillSequence(BoundSpillSequence node)
         {
-            ImmutableArray<BoundStatement> sideEffects = (ImmutableArray<BoundStatement>)this.VisitList(node.SideEffects);
+            ImmutableArray<BoundStatement> sideEffects = this.VisitList(node.SideEffects);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.Locals, sideEffects, value, type);
@@ -11022,7 +11022,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDynamicInvocation(BoundDynamicInvocation node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableMethods, expression, arguments, type);
         }
@@ -11068,7 +11068,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitCall(BoundCall node)
         {
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(receiverOpt, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.BinderOpt, type);
         }
@@ -11081,34 +11081,34 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitAttribute(BoundAttribute node)
         {
-            ImmutableArray<BoundExpression> constructorArguments = (ImmutableArray<BoundExpression>)this.VisitList(node.ConstructorArguments);
-            ImmutableArray<BoundExpression> namedArguments = (ImmutableArray<BoundExpression>)this.VisitList(node.NamedArguments);
+            ImmutableArray<BoundExpression> constructorArguments = this.VisitList(node.ConstructorArguments);
+            ImmutableArray<BoundExpression> namedArguments = this.VisitList(node.NamedArguments);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.Constructor, constructorArguments, node.ConstructorArgumentNamesOpt, namedArguments, node.ResultKind, type);
         }
         public override BoundNode VisitObjectCreationExpression(BoundObjectCreationExpression node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerExpressionBase initializerExpressionOpt = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpressionOpt);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.Constructor, node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, type);
         }
         public override BoundNode VisitTupleLiteral(BoundTupleLiteral node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.ArgumentNamesOpt, node.InferredNamesOpt, arguments, type);
         }
         public override BoundNode VisitConvertedTupleLiteral(BoundConvertedTupleLiteral node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol naturalTypeOpt = this.VisitType(node.NaturalTypeOpt);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(naturalTypeOpt, arguments, type);
         }
         public override BoundNode VisitDynamicObjectCreationExpression(BoundDynamicObjectCreationExpression node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerExpressionBase initializerExpressionOpt = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpressionOpt);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, node.ApplicableMethods, type);
@@ -11121,13 +11121,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitObjectInitializerExpression(BoundObjectInitializerExpression node)
         {
-            ImmutableArray<BoundExpression> initializers = (ImmutableArray<BoundExpression>)this.VisitList(node.Initializers);
+            ImmutableArray<BoundExpression> initializers = this.VisitList(node.Initializers);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(initializers, type);
         }
         public override BoundNode VisitObjectInitializerMember(BoundObjectInitializerMember node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol receiverType = this.VisitType(node.ReceiverType);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.MemberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, receiverType, node.BinderOpt, type);
@@ -11140,13 +11140,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitCollectionInitializerExpression(BoundCollectionInitializerExpression node)
         {
-            ImmutableArray<BoundExpression> initializers = (ImmutableArray<BoundExpression>)this.VisitList(node.Initializers);
+            ImmutableArray<BoundExpression> initializers = this.VisitList(node.Initializers);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(initializers, type);
         }
         public override BoundNode VisitCollectionElementInitializer(BoundCollectionElementInitializer node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundExpression implicitReceiverOpt = (BoundExpression)this.Visit(node.ImplicitReceiverOpt);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.AddMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, type);
@@ -11154,7 +11154,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDynamicCollectionElementInitializer(BoundDynamicCollectionElementInitializer node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.ApplicableMethods, expression, arguments, type);
         }
@@ -11165,8 +11165,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitAnonymousObjectCreationExpression(BoundAnonymousObjectCreationExpression node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
-            ImmutableArray<BoundAnonymousPropertyDeclaration> declarations = (ImmutableArray<BoundAnonymousPropertyDeclaration>)this.VisitList(node.Declarations);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
+            ImmutableArray<BoundAnonymousPropertyDeclaration> declarations = this.VisitList(node.Declarations);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(node.Constructor, arguments, declarations, type);
         }
@@ -11189,14 +11189,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitArrayCreation(BoundArrayCreation node)
         {
-            ImmutableArray<BoundExpression> bounds = (ImmutableArray<BoundExpression>)this.VisitList(node.Bounds);
+            ImmutableArray<BoundExpression> bounds = this.VisitList(node.Bounds);
             BoundArrayInitialization initializerOpt = (BoundArrayInitialization)this.Visit(node.InitializerOpt);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(bounds, initializerOpt, type);
         }
         public override BoundNode VisitArrayInitialization(BoundArrayInitialization node)
         {
-            ImmutableArray<BoundExpression> initializers = (ImmutableArray<BoundExpression>)this.VisitList(node.Initializers);
+            ImmutableArray<BoundExpression> initializers = this.VisitList(node.Initializers);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(initializers);
         }
@@ -11242,14 +11242,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitIndexerAccess(BoundIndexerAccess node)
         {
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(receiverOpt, node.Indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, type);
         }
         public override BoundNode VisitDynamicIndexerAccess(BoundDynamicIndexerAccess node)
         {
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(receiverOpt, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableIndexers, type);
         }
@@ -11273,7 +11273,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitTypeOrInstanceInitializers(BoundTypeOrInstanceInitializers node)
         {
-            ImmutableArray<BoundStatement> statements = (ImmutableArray<BoundStatement>)this.VisitList(node.Statements);
+            ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
             return node.Update(statements);
         }
         public override BoundNode VisitNameOfOperator(BoundNameOfOperator node)
@@ -11284,7 +11284,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode VisitInterpolatedString(BoundInterpolatedString node)
         {
-            ImmutableArray<BoundExpression> parts = (ImmutableArray<BoundExpression>)this.VisitList(node.Parts);
+            ImmutableArray<BoundExpression> parts = this.VisitList(node.Parts);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(parts, type);
         }
@@ -11325,15 +11325,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitRecursivePattern(BoundRecursivePattern node)
         {
             BoundTypeExpression declaredType = (BoundTypeExpression)this.Visit(node.DeclaredType);
-            ImmutableArray<BoundSubpattern> deconstruction = (ImmutableArray<BoundSubpattern>)this.VisitList(node.Deconstruction);
-            ImmutableArray<BoundSubpattern> properties = (ImmutableArray<BoundSubpattern>)this.VisitList(node.Properties);
+            ImmutableArray<BoundSubpattern> deconstruction = this.VisitList(node.Deconstruction);
+            ImmutableArray<BoundSubpattern> properties = this.VisitList(node.Properties);
             BoundExpression variableAccess = (BoundExpression)this.Visit(node.VariableAccess);
             TypeSymbol inputType = this.VisitType(node.InputType);
             return node.Update(declaredType, node.DeconstructMethod, deconstruction, properties, node.Variable, variableAccess, inputType);
         }
         public override BoundNode VisitITuplePattern(BoundITuplePattern node)
         {
-            ImmutableArray<BoundSubpattern> subpatterns = (ImmutableArray<BoundSubpattern>)this.VisitList(node.Subpatterns);
+            ImmutableArray<BoundSubpattern> subpatterns = this.VisitList(node.Subpatterns);
             TypeSymbol inputType = this.VisitType(node.InputType);
             return node.Update(node.GetLengthMethod, node.GetItemMethod, subpatterns, inputType);
         }
@@ -11393,58 +11393,58 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class NullabilityRewriter : BoundTreeRewriter
     {
-        private readonly ImmutableDictionary<BoundExpression, TypeSymbolWithAnnotations> _topLevelNullabilities;
+        private readonly ImmutableDictionary<BoundExpression, TypeSymbolWithAnnotations> _updatedNullabilities;
 
-        public NullabilityRewriter(ImmutableDictionary<BoundExpression, TypeSymbolWithAnnotations> topLevelNullabilities)
+        public NullabilityRewriter(ImmutableDictionary<BoundExpression, TypeSymbolWithAnnotations> updatedNullabilities)
         {
-            _topLevelNullabilities = topLevelNullabilities;
+            _updatedNullabilities = updatedNullabilities;
         }
 
         public override BoundNode VisitDeconstructValuePlaceholder(BoundDeconstructValuePlaceholder node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundDeconstructValuePlaceholder updatedNode = node.Update(node.ValEscape, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundDeconstructValuePlaceholder updatedNode = node.Update(node.ValEscape, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitTupleOperandPlaceholder(BoundTupleOperandPlaceholder node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundTupleOperandPlaceholder updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundTupleOperandPlaceholder updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitAwaitableValuePlaceholder(BoundAwaitableValuePlaceholder node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundAwaitableValuePlaceholder updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundAwaitableValuePlaceholder updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitDup(BoundDup node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundDup updatedNode = node.Update(node.RefKind, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundDup updatedNode = node.Update(node.RefKind, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -11453,10 +11453,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundPassByCopy updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(expression, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11467,13 +11467,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitBadExpression(BoundBadExpression node)
         {
-            ImmutableArray<BoundExpression> childBoundNodes = (ImmutableArray<BoundExpression>)this.VisitList(node.ChildBoundNodes);
+            ImmutableArray<BoundExpression> childBoundNodes = this.VisitList(node.ChildBoundNodes);
             BoundBadExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.ResultKind, node.Symbols, childBoundNodes, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ResultKind, node.Symbols, childBoundNodes, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11487,10 +11487,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundTypeExpression boundContainingTypeOpt = (BoundTypeExpression)this.Visit(node.BoundContainingTypeOpt);
             BoundTypeExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.AliasOpt, node.InferredType, boundContainingTypeOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.AliasOpt, node.InferredType, boundContainingTypeOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11501,25 +11501,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitTypeOrValueExpression(BoundTypeOrValueExpression node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundTypeOrValueExpression updatedNode = node.Update(node.Data, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundTypeOrValueExpression updatedNode = node.Update(node.Data, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitNamespaceExpression(BoundNamespaceExpression node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
             BoundNamespaceExpression updatedNode = node.Update(node.NamespaceSymbol, node.AliasOpt);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -11528,10 +11528,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundUnaryOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11545,10 +11545,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundSuppressNullableWarningExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(expression, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11562,10 +11562,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundIncrementOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.OperatorKind, operand, node.MethodOpt, node.OperandConversion, node.ResultConversion, node.ResultKind, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, node.MethodOpt, node.OperandConversion, node.ResultConversion, node.ResultKind, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11579,10 +11579,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundAddressOfOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(operand, node.IsManaged, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, node.IsManaged, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11596,10 +11596,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundPointerIndirectionOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(operand, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11614,10 +11614,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression index = (BoundExpression)this.Visit(node.Index);
             BoundPointerElementAccess updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(expression, index, node.Checked, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, index, node.Checked, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11631,10 +11631,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundRefTypeOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(operand, node.GetTypeFromHandle, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, node.GetTypeFromHandle, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11648,10 +11648,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundMakeRefOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(operand, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11665,10 +11665,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundRefValueOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(operand, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11682,10 +11682,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundFromEndIndexExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(operand, node.MethodOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, node.MethodOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11700,10 +11700,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rightOperand = (BoundExpression)this.Visit(node.RightOperand);
             BoundRangeExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(leftOperand, rightOperand, node.MethodOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(leftOperand, rightOperand, node.MethodOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11718,10 +11718,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             BoundBinaryOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.OperatorKind, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, left, right, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.OperatorKind, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, left, right, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11738,10 +11738,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression convertedRight = node.ConvertedRight;
             BoundTupleBinaryOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(left, right, convertedLeft, convertedRight, node.OperatorKind, node.Operators, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(left, right, convertedLeft, convertedRight, node.OperatorKind, node.Operators, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11756,10 +11756,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             BoundUserDefinedConditionalLogicalOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.OperatorKind, node.LogicalOperator, node.TrueOperator, node.FalseOperator, node.ResultKind, left, right, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.OperatorKind, node.LogicalOperator, node.TrueOperator, node.FalseOperator, node.ResultKind, left, right, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11774,10 +11774,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             BoundCompoundAssignmentOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.Operator, left, right, node.LeftConversion, node.FinalConversion, node.ResultKind, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Operator, left, right, node.LeftConversion, node.FinalConversion, node.ResultKind, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11792,10 +11792,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             BoundAssignmentOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(left, right, node.IsRef, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(left, right, node.IsRef, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11810,10 +11810,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundConversion right = (BoundConversion)this.Visit(node.Right);
             BoundDeconstructionAssignmentOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(left, right, node.IsUsed, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(left, right, node.IsUsed, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11828,10 +11828,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rightOperand = (BoundExpression)this.Visit(node.RightOperand);
             BoundNullCoalescingOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(leftOperand, rightOperand, node.LeftConversion, node.OperatorResultKind, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(leftOperand, rightOperand, node.LeftConversion, node.OperatorResultKind, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11846,10 +11846,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rightOperand = (BoundExpression)this.Visit(node.RightOperand);
             BoundNullCoalescingAssignmentOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(leftOperand, rightOperand, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(leftOperand, rightOperand, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11865,10 +11865,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression alternative = (BoundExpression)this.Visit(node.Alternative);
             BoundConditionalOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.IsRef, condition, consequence, alternative, node.ConstantValueOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.IsRef, condition, consequence, alternative, node.ConstantValueOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11880,13 +11880,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitArrayAccess(BoundArrayAccess node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            ImmutableArray<BoundExpression> indices = (ImmutableArray<BoundExpression>)this.VisitList(node.Indices);
+            ImmutableArray<BoundExpression> indices = this.VisitList(node.Indices);
             BoundArrayAccess updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(expression, indices, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, indices, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11900,10 +11900,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundArrayLength updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(expression, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11917,10 +11917,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundAwaitExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(expression, node.AwaitableInfo, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, node.AwaitableInfo, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11934,10 +11934,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundTypeExpression sourceType = (BoundTypeExpression)this.Visit(node.SourceType);
             BoundTypeOfOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(sourceType, node.GetTypeFromHandle, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(sourceType, node.GetTypeFromHandle, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11948,109 +11948,109 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitMethodDefIndex(BoundMethodDefIndex node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundMethodDefIndex updatedNode = node.Update(node.Method, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundMethodDefIndex updatedNode = node.Update(node.Method, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitMaximumMethodDefIndex(BoundMaximumMethodDefIndex node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundMaximumMethodDefIndex updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundMaximumMethodDefIndex updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitInstrumentationPayloadRoot(BoundInstrumentationPayloadRoot node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundInstrumentationPayloadRoot updatedNode = node.Update(node.AnalysisKind, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundInstrumentationPayloadRoot updatedNode = node.Update(node.AnalysisKind, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitModuleVersionId(BoundModuleVersionId node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundModuleVersionId updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundModuleVersionId updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitModuleVersionIdString(BoundModuleVersionIdString node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundModuleVersionIdString updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundModuleVersionIdString updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitSourceDocumentIndex(BoundSourceDocumentIndex node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundSourceDocumentIndex updatedNode = node.Update(node.Document, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundSourceDocumentIndex updatedNode = node.Update(node.Document, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitMethodInfo(BoundMethodInfo node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundMethodInfo updatedNode = node.Update(node.Method, node.GetMethodFromHandle, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundMethodInfo updatedNode = node.Update(node.Method, node.GetMethodFromHandle, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitFieldInfo(BoundFieldInfo node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundFieldInfo updatedNode = node.Update(node.Field, node.GetFieldFromHandle, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundFieldInfo updatedNode = node.Update(node.Field, node.GetFieldFromHandle, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitDefaultExpression(BoundDefaultExpression node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundDefaultExpression updatedNode = node.Update(node.ConstantValueOpt, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundDefaultExpression updatedNode = node.Update(node.ConstantValueOpt, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12060,10 +12060,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundTypeExpression targetType = (BoundTypeExpression)this.Visit(node.TargetType);
             BoundIsOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(operand, targetType, node.Conversion, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, targetType, node.Conversion, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12078,10 +12078,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundTypeExpression targetType = (BoundTypeExpression)this.Visit(node.TargetType);
             BoundAsOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(operand, targetType, node.Conversion, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, targetType, node.Conversion, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12095,10 +12095,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundTypeExpression sourceType = (BoundTypeExpression)this.Visit(node.SourceType);
             BoundSizeOfOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(sourceType, node.ConstantValueOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(sourceType, node.ConstantValueOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12112,10 +12112,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundConversion updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, node.ConversionGroupOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, node.ConversionGroupOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12126,25 +12126,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitArgList(BoundArgList node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundArgList updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundArgList updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitArgListOperator(BoundArgListOperator node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundArgListOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(arguments, node.ArgumentRefKindsOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(arguments, node.ArgumentRefKindsOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12158,10 +12158,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundFixedLocalCollectionInitializer updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.ElementPointerType, node.ElementPointerTypeConversion, expression, node.GetPinnableOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ElementPointerType, node.ElementPointerTypeConversion, expression, node.GetPinnableOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12172,85 +12172,85 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitLiteral(BoundLiteral node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundLiteral updatedNode = node.Update(node.ConstantValueOpt, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundLiteral updatedNode = node.Update(node.ConstantValueOpt, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitThisReference(BoundThisReference node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundThisReference updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundThisReference updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitPreviousSubmissionReference(BoundPreviousSubmissionReference node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundPreviousSubmissionReference updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundPreviousSubmissionReference updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitHostObjectMemberReference(BoundHostObjectMemberReference node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundHostObjectMemberReference updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundHostObjectMemberReference updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitBaseReference(BoundBaseReference node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundBaseReference updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundBaseReference updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitLocal(BoundLocal node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundLocal updatedNode = node.Update(node.LocalSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundLocal updatedNode = node.Update(node.LocalSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitPseudoVariable(BoundPseudoVariable node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundPseudoVariable updatedNode = node.Update(node.LocalSymbol, node.EmitExpressions, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundPseudoVariable updatedNode = node.Update(node.LocalSymbol, node.EmitExpressions, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12259,10 +12259,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundRangeVariable updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.RangeVariableSymbol, value, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.RangeVariableSymbol, value, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12273,39 +12273,39 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitParameter(BoundParameter node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundParameter updatedNode = node.Update(node.ParameterSymbol, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundParameter updatedNode = node.Update(node.ParameterSymbol, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitLabel(BoundLabel node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundLabel updatedNode = node.Update(node.Label, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundLabel updatedNode = node.Update(node.Label, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitSwitchExpression(BoundSwitchExpression node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            ImmutableArray<BoundSwitchExpressionArm> switchArms = (ImmutableArray<BoundSwitchExpressionArm>)this.VisitList(node.SwitchArms);
+            ImmutableArray<BoundSwitchExpressionArm> switchArms = this.VisitList(node.SwitchArms);
             BoundDecisionDag decisionDag = node.DecisionDag;
             BoundSwitchExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12319,10 +12319,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundSequencePointExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(expression, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12333,14 +12333,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitSequence(BoundSequence node)
         {
-            ImmutableArray<BoundExpression> sideEffects = (ImmutableArray<BoundExpression>)this.VisitList(node.SideEffects);
+            ImmutableArray<BoundExpression> sideEffects = this.VisitList(node.SideEffects);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundSequence updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.Locals, sideEffects, value, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Locals, sideEffects, value, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12351,14 +12351,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitSpillSequence(BoundSpillSequence node)
         {
-            ImmutableArray<BoundStatement> sideEffects = (ImmutableArray<BoundStatement>)this.VisitList(node.SideEffects);
+            ImmutableArray<BoundStatement> sideEffects = this.VisitList(node.SideEffects);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundSpillSequence updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.Locals, sideEffects, value, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Locals, sideEffects, value, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12372,10 +12372,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
             BoundDynamicMemberAccess updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(receiver, node.TypeArgumentsOpt, node.Name, node.Invoked, node.Indexed, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiver, node.TypeArgumentsOpt, node.Name, node.Invoked, node.Indexed, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12387,13 +12387,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDynamicInvocation(BoundDynamicInvocation node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundDynamicInvocation updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableMethods, expression, arguments, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableMethods, expression, arguments, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12408,10 +12408,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression accessExpression = (BoundExpression)this.Visit(node.AccessExpression);
             BoundConditionalAccess updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(receiver, accessExpression, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiver, accessExpression, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12427,10 +12427,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression whenNullOpt = (BoundExpression)this.Visit(node.WhenNullOpt);
             BoundLoweredConditionalAccess updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(receiver, node.HasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiver, node.HasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12441,13 +12441,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitConditionalReceiver(BoundConditionalReceiver node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundConditionalReceiver updatedNode = node.Update(node.Id, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundConditionalReceiver updatedNode = node.Update(node.Id, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12457,10 +12457,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression referenceTypeReceiver = (BoundExpression)this.Visit(node.ReferenceTypeReceiver);
             BoundComplexConditionalReceiver updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(valueTypeReceiver, referenceTypeReceiver, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(valueTypeReceiver, referenceTypeReceiver, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12474,10 +12474,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             BoundMethodGroup updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, node.Methods, node.LookupSymbolOpt, node.LookupError, node.Flags, receiverOpt, node.ResultKind);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12491,10 +12491,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             BoundPropertyGroup updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 updatedNode = node.Update(node.Properties, receiverOpt, node.ResultKind);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12506,13 +12506,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitCall(BoundCall node)
         {
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundCall updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(receiverOpt, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.BinderOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.BinderOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12527,10 +12527,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             BoundEventAssignmentOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.Event, node.IsAddition, node.IsDynamic, receiverOpt, argument, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Event, node.IsAddition, node.IsDynamic, receiverOpt, argument, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12541,14 +12541,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitAttribute(BoundAttribute node)
         {
-            ImmutableArray<BoundExpression> constructorArguments = (ImmutableArray<BoundExpression>)this.VisitList(node.ConstructorArguments);
-            ImmutableArray<BoundExpression> namedArguments = (ImmutableArray<BoundExpression>)this.VisitList(node.NamedArguments);
+            ImmutableArray<BoundExpression> constructorArguments = this.VisitList(node.ConstructorArguments);
+            ImmutableArray<BoundExpression> namedArguments = this.VisitList(node.NamedArguments);
             BoundAttribute updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.Constructor, constructorArguments, node.ConstructorArgumentNamesOpt, namedArguments, node.ResultKind, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Constructor, constructorArguments, node.ConstructorArgumentNamesOpt, namedArguments, node.ResultKind, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12559,14 +12559,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitObjectCreationExpression(BoundObjectCreationExpression node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerExpressionBase initializerExpressionOpt = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpressionOpt);
             BoundObjectCreationExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.Constructor, node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Constructor, node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12577,13 +12577,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitTupleLiteral(BoundTupleLiteral node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundTupleLiteral updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.ArgumentNamesOpt, node.InferredNamesOpt, arguments, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ArgumentNamesOpt, node.InferredNamesOpt, arguments, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12594,13 +12594,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitConvertedTupleLiteral(BoundConvertedTupleLiteral node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundConvertedTupleLiteral updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.NaturalTypeOpt, arguments, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.NaturalTypeOpt, arguments, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12611,14 +12611,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitDynamicObjectCreationExpression(BoundDynamicObjectCreationExpression node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerExpressionBase initializerExpressionOpt = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpressionOpt);
             BoundDynamicObjectCreationExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, node.ApplicableMethods, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, node.ApplicableMethods, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12632,10 +12632,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundObjectInitializerExpressionBase initializerExpressionOpt = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpressionOpt);
             BoundNoPiaObjectCreationExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.GuidString, initializerExpressionOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.GuidString, initializerExpressionOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12646,13 +12646,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitObjectInitializerExpression(BoundObjectInitializerExpression node)
         {
-            ImmutableArray<BoundExpression> initializers = (ImmutableArray<BoundExpression>)this.VisitList(node.Initializers);
+            ImmutableArray<BoundExpression> initializers = this.VisitList(node.Initializers);
             BoundObjectInitializerExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(initializers, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(initializers, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12663,13 +12663,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitObjectInitializerMember(BoundObjectInitializerMember node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerMember updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.MemberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, node.ReceiverType, node.BinderOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.MemberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, node.ReceiverType, node.BinderOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12680,25 +12680,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitDynamicObjectInitializerMember(BoundDynamicObjectInitializerMember node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundDynamicObjectInitializerMember updatedNode = node.Update(node.MemberName, node.ReceiverType, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundDynamicObjectInitializerMember updatedNode = node.Update(node.MemberName, node.ReceiverType, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitCollectionInitializerExpression(BoundCollectionInitializerExpression node)
         {
-            ImmutableArray<BoundExpression> initializers = (ImmutableArray<BoundExpression>)this.VisitList(node.Initializers);
+            ImmutableArray<BoundExpression> initializers = this.VisitList(node.Initializers);
             BoundCollectionInitializerExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(initializers, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(initializers, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12709,14 +12709,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitCollectionElementInitializer(BoundCollectionElementInitializer node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundExpression implicitReceiverOpt = (BoundExpression)this.Visit(node.ImplicitReceiverOpt);
             BoundCollectionElementInitializer updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.AddMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.AddMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12728,13 +12728,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDynamicCollectionElementInitializer(BoundDynamicCollectionElementInitializer node)
         {
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundDynamicCollectionElementInitializer updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.ApplicableMethods, expression, arguments, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ApplicableMethods, expression, arguments, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12745,26 +12745,26 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitImplicitReceiver(BoundImplicitReceiver node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundImplicitReceiver updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundImplicitReceiver updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitAnonymousObjectCreationExpression(BoundAnonymousObjectCreationExpression node)
         {
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
-            ImmutableArray<BoundAnonymousPropertyDeclaration> declarations = (ImmutableArray<BoundAnonymousPropertyDeclaration>)this.VisitList(node.Declarations);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
+            ImmutableArray<BoundAnonymousPropertyDeclaration> declarations = this.VisitList(node.Declarations);
             BoundAnonymousObjectCreationExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.Constructor, arguments, declarations, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Constructor, arguments, declarations, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12775,13 +12775,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitAnonymousPropertyDeclaration(BoundAnonymousPropertyDeclaration node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundAnonymousPropertyDeclaration updatedNode = node.Update(node.Property, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundAnonymousPropertyDeclaration updatedNode = node.Update(node.Property, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12790,10 +12790,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundObjectInitializerExpressionBase initializerExpressionOpt = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpressionOpt);
             BoundNewT updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(initializerExpressionOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(initializerExpressionOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12807,10 +12807,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             BoundDelegateCreationExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(argument, node.MethodOpt, node.IsExtensionMethod, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(argument, node.MethodOpt, node.IsExtensionMethod, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12821,14 +12821,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitArrayCreation(BoundArrayCreation node)
         {
-            ImmutableArray<BoundExpression> bounds = (ImmutableArray<BoundExpression>)this.VisitList(node.Bounds);
+            ImmutableArray<BoundExpression> bounds = this.VisitList(node.Bounds);
             BoundArrayInitialization initializerOpt = (BoundArrayInitialization)this.Visit(node.InitializerOpt);
             BoundArrayCreation updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(bounds, initializerOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(bounds, initializerOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12839,13 +12839,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitArrayInitialization(BoundArrayInitialization node)
         {
-            ImmutableArray<BoundExpression> initializers = (ImmutableArray<BoundExpression>)this.VisitList(node.Initializers);
+            ImmutableArray<BoundExpression> initializers = this.VisitList(node.Initializers);
             BoundArrayInitialization updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 updatedNode = node.Update(initializers);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12860,10 +12860,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundArrayInitialization initializerOpt = (BoundArrayInitialization)this.Visit(node.InitializerOpt);
             BoundStackAllocArrayCreation updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.ElementType, count, initializerOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ElementType, count, initializerOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12878,10 +12878,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundArrayInitialization initializerOpt = (BoundArrayInitialization)this.Visit(node.InitializerOpt);
             BoundConvertedStackAllocExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(node.ElementType, count, initializerOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ElementType, count, initializerOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12895,10 +12895,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             BoundFieldAccess updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(receiverOpt, node.FieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, node.FieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12909,13 +12909,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitHoistedFieldAccess(BoundHoistedFieldAccess node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundHoistedFieldAccess updatedNode = node.Update(node.FieldSymbol, twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundHoistedFieldAccess updatedNode = node.Update(node.FieldSymbol, type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12924,10 +12924,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             BoundPropertyAccess updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(receiverOpt, node.PropertySymbol, node.ResultKind, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, node.PropertySymbol, node.ResultKind, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12941,10 +12941,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             BoundEventAccess updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(receiverOpt, node.EventSymbol, node.IsUsableAsField, node.ResultKind, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, node.EventSymbol, node.IsUsableAsField, node.ResultKind, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12956,13 +12956,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitIndexerAccess(BoundIndexerAccess node)
         {
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundIndexerAccess updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(receiverOpt, node.Indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, node.Indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12974,13 +12974,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDynamicIndexerAccess(BoundDynamicIndexerAccess node)
         {
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
-            ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundDynamicIndexerAccess updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(receiverOpt, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableIndexers, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableIndexers, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12995,10 +12995,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundBlock body = (BoundBlock)this.Visit(node.Body);
             BoundLambda updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(unboundLambda, node.Symbol, body, node.Diagnostics, node.Binder, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(unboundLambda, node.Symbol, body, node.Diagnostics, node.Binder, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13009,13 +13009,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitUnboundLambda(UnboundLambda node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
             UnboundLambda updatedNode = node.Update(node.Data);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -13024,10 +13024,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundQueryClause updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(value, node.DefinedSymbol, node.Binder, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(value, node.DefinedSymbol, node.Binder, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13041,10 +13041,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             BoundNameOfOperator updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(argument, node.ConstantValueOpt, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(argument, node.ConstantValueOpt, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13055,13 +13055,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitInterpolatedString(BoundInterpolatedString node)
         {
-            ImmutableArray<BoundExpression> parts = (ImmutableArray<BoundExpression>)this.VisitList(node.Parts);
+            ImmutableArray<BoundExpression> parts = this.VisitList(node.Parts);
             BoundInterpolatedString updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(parts, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(parts, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13077,10 +13077,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundLiteral format = (BoundLiteral)this.Visit(node.Format);
             BoundStringInsert updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(value, alignment, format, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(value, alignment, format, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13096,10 +13096,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundDecisionDag decisionDag = node.DecisionDag;
             BoundIsPatternExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(expression, pattern, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, pattern, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13110,13 +13110,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitDiscardExpression(BoundDiscardExpression node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
-            BoundDiscardExpression updatedNode = node.Update(twsa.TypeSymbol);
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundDiscardExpression updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -13125,10 +13125,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundThrowExpression updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(expression, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13142,10 +13142,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             OutVariablePendingInference updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 updatedNode = node.Update(node.VariableSymbol, receiverOpt);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13159,10 +13159,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             DeconstructionVariablePendingInference updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 updatedNode = node.Update(node.VariableSymbol, receiverOpt);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13173,13 +13173,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitOutDeconstructVarPendingInference(OutDeconstructVarPendingInference node)
         {
-            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
                 return node;
             }
 
             OutDeconstructVarPendingInference updatedNode = node.Update();
-            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -13188,10 +13188,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundExpressionWithNullability updatedNode;
 
-            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
+            if (_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
             {
-                updatedNode = node.Update(expression, node.NullableAnnotation, twsa.TypeSymbol);
-                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, node.NullableAnnotation, type.TypeSymbol);
+                updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -11436,6 +11436,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return updatedNode;
         }
 
+        public override BoundNode VisitDisposableValuePlaceholder(BoundDisposableValuePlaceholder node)
+        {
+            if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))
+            {
+                return node;
+            }
+
+            BoundDisposableValuePlaceholder updatedNode = node.Update(type.TypeSymbol);
+            updatedNode.TopLevelNullability = type.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            return updatedNode;
+        }
+
         public override BoundNode VisitDup(BoundDup node)
         {
             if (!_updatedNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations type))

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -11402,53 +11402,49 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitDeconstructValuePlaceholder(BoundDeconstructValuePlaceholder node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundDeconstructValuePlaceholder updatedNode = node.Update(node.ValEscape, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundDeconstructValuePlaceholder updatedNode = node.Update(node.ValEscape, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitTupleOperandPlaceholder(BoundTupleOperandPlaceholder node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundTupleOperandPlaceholder updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundTupleOperandPlaceholder updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitAwaitableValuePlaceholder(BoundAwaitableValuePlaceholder node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundAwaitableValuePlaceholder updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundAwaitableValuePlaceholder updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitDup(BoundDup node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundDup updatedNode = node.Update(node.RefKind, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundDup updatedNode = node.Update(node.RefKind, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -11457,11 +11453,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundPassByCopy updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(expression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11475,11 +11470,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> childBoundNodes = (ImmutableArray<BoundExpression>)this.VisitList(node.ChildBoundNodes);
             BoundBadExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.ResultKind, node.Symbols, childBoundNodes, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ResultKind, node.Symbols, childBoundNodes, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11493,11 +11487,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundTypeExpression boundContainingTypeOpt = (BoundTypeExpression)this.Visit(node.BoundContainingTypeOpt);
             BoundTypeExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.AliasOpt, node.InferredType, boundContainingTypeOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.AliasOpt, node.InferredType, boundContainingTypeOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11508,27 +11501,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitTypeOrValueExpression(BoundTypeOrValueExpression node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundTypeOrValueExpression updatedNode = node.Update(node.Data, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundTypeOrValueExpression updatedNode = node.Update(node.Data, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitNamespaceExpression(BoundNamespaceExpression node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             BoundNamespaceExpression updatedNode = node.Update(node.NamespaceSymbol, node.AliasOpt);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -11537,11 +11528,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundUnaryOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11555,11 +11545,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundSuppressNullableWarningExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(expression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11573,11 +11562,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundIncrementOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.OperatorKind, operand, node.MethodOpt, node.OperandConversion, node.ResultConversion, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, node.MethodOpt, node.OperandConversion, node.ResultConversion, node.ResultKind, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11591,11 +11579,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundAddressOfOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(operand, node.IsManaged, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, node.IsManaged, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11609,11 +11596,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundPointerIndirectionOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(operand, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11628,11 +11614,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression index = (BoundExpression)this.Visit(node.Index);
             BoundPointerElementAccess updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(expression, index, node.Checked, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, index, node.Checked, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11646,11 +11631,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundRefTypeOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(operand, node.GetTypeFromHandle, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, node.GetTypeFromHandle, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11664,11 +11648,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundMakeRefOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(operand, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11682,11 +11665,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundRefValueOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(operand, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11700,11 +11682,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundFromEndIndexExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(operand, node.MethodOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, node.MethodOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11719,11 +11700,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rightOperand = (BoundExpression)this.Visit(node.RightOperand);
             BoundRangeExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(leftOperand, rightOperand, node.MethodOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(leftOperand, rightOperand, node.MethodOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11738,11 +11718,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             BoundBinaryOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.OperatorKind, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, left, right, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.OperatorKind, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, left, right, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11759,11 +11738,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression convertedRight = node.ConvertedRight;
             BoundTupleBinaryOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(left, right, convertedLeft, convertedRight, node.OperatorKind, node.Operators, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(left, right, convertedLeft, convertedRight, node.OperatorKind, node.Operators, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11778,11 +11756,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             BoundUserDefinedConditionalLogicalOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.OperatorKind, node.LogicalOperator, node.TrueOperator, node.FalseOperator, node.ResultKind, left, right, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.OperatorKind, node.LogicalOperator, node.TrueOperator, node.FalseOperator, node.ResultKind, left, right, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11797,11 +11774,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             BoundCompoundAssignmentOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.Operator, left, right, node.LeftConversion, node.FinalConversion, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Operator, left, right, node.LeftConversion, node.FinalConversion, node.ResultKind, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11816,11 +11792,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             BoundAssignmentOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(left, right, node.IsRef, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(left, right, node.IsRef, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11835,11 +11810,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundConversion right = (BoundConversion)this.Visit(node.Right);
             BoundDeconstructionAssignmentOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(left, right, node.IsUsed, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(left, right, node.IsUsed, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11854,11 +11828,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rightOperand = (BoundExpression)this.Visit(node.RightOperand);
             BoundNullCoalescingOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(leftOperand, rightOperand, node.LeftConversion, node.OperatorResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(leftOperand, rightOperand, node.LeftConversion, node.OperatorResultKind, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11873,11 +11846,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rightOperand = (BoundExpression)this.Visit(node.RightOperand);
             BoundNullCoalescingAssignmentOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(leftOperand, rightOperand, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(leftOperand, rightOperand, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11893,11 +11865,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression alternative = (BoundExpression)this.Visit(node.Alternative);
             BoundConditionalOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.IsRef, condition, consequence, alternative, node.ConstantValueOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.IsRef, condition, consequence, alternative, node.ConstantValueOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11912,11 +11883,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> indices = (ImmutableArray<BoundExpression>)this.VisitList(node.Indices);
             BoundArrayAccess updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(expression, indices, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, indices, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11930,11 +11900,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundArrayLength updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(expression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11948,11 +11917,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundAwaitExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(expression, node.AwaitableInfo, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, node.AwaitableInfo, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11966,11 +11934,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundTypeExpression sourceType = (BoundTypeExpression)this.Visit(node.SourceType);
             BoundTypeOfOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(sourceType, node.GetTypeFromHandle, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(sourceType, node.GetTypeFromHandle, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -11981,118 +11948,109 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitMethodDefIndex(BoundMethodDefIndex node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundMethodDefIndex updatedNode = node.Update(node.Method, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundMethodDefIndex updatedNode = node.Update(node.Method, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitMaximumMethodDefIndex(BoundMaximumMethodDefIndex node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundMaximumMethodDefIndex updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundMaximumMethodDefIndex updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitInstrumentationPayloadRoot(BoundInstrumentationPayloadRoot node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundInstrumentationPayloadRoot updatedNode = node.Update(node.AnalysisKind, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundInstrumentationPayloadRoot updatedNode = node.Update(node.AnalysisKind, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitModuleVersionId(BoundModuleVersionId node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundModuleVersionId updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundModuleVersionId updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitModuleVersionIdString(BoundModuleVersionIdString node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundModuleVersionIdString updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundModuleVersionIdString updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitSourceDocumentIndex(BoundSourceDocumentIndex node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundSourceDocumentIndex updatedNode = node.Update(node.Document, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundSourceDocumentIndex updatedNode = node.Update(node.Document, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitMethodInfo(BoundMethodInfo node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundMethodInfo updatedNode = node.Update(node.Method, node.GetMethodFromHandle, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundMethodInfo updatedNode = node.Update(node.Method, node.GetMethodFromHandle, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitFieldInfo(BoundFieldInfo node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundFieldInfo updatedNode = node.Update(node.Field, node.GetFieldFromHandle, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundFieldInfo updatedNode = node.Update(node.Field, node.GetFieldFromHandle, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitDefaultExpression(BoundDefaultExpression node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundDefaultExpression updatedNode = node.Update(node.ConstantValueOpt, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundDefaultExpression updatedNode = node.Update(node.ConstantValueOpt, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12102,11 +12060,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundTypeExpression targetType = (BoundTypeExpression)this.Visit(node.TargetType);
             BoundIsOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(operand, targetType, node.Conversion, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, targetType, node.Conversion, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12121,11 +12078,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundTypeExpression targetType = (BoundTypeExpression)this.Visit(node.TargetType);
             BoundAsOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(operand, targetType, node.Conversion, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, targetType, node.Conversion, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12139,11 +12095,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundTypeExpression sourceType = (BoundTypeExpression)this.Visit(node.SourceType);
             BoundSizeOfOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(sourceType, node.ConstantValueOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(sourceType, node.ConstantValueOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12157,11 +12112,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundConversion updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, node.ConversionGroupOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(operand, node.Conversion, node.IsBaseConversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, node.ConversionGroupOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12172,14 +12126,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitArgList(BoundArgList node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundArgList updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundArgList updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12188,11 +12141,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
             BoundArgListOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(arguments, node.ArgumentRefKindsOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(arguments, node.ArgumentRefKindsOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12206,11 +12158,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundFixedLocalCollectionInitializer updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.ElementPointerType, node.ElementPointerTypeConversion, expression, node.GetPinnableOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ElementPointerType, node.ElementPointerTypeConversion, expression, node.GetPinnableOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12221,92 +12172,85 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitLiteral(BoundLiteral node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundLiteral updatedNode = node.Update(node.ConstantValueOpt, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundLiteral updatedNode = node.Update(node.ConstantValueOpt, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitThisReference(BoundThisReference node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundThisReference updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundThisReference updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitPreviousSubmissionReference(BoundPreviousSubmissionReference node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundPreviousSubmissionReference updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundPreviousSubmissionReference updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitHostObjectMemberReference(BoundHostObjectMemberReference node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundHostObjectMemberReference updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundHostObjectMemberReference updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitBaseReference(BoundBaseReference node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundBaseReference updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundBaseReference updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitLocal(BoundLocal node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundLocal updatedNode = node.Update(node.LocalSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundLocal updatedNode = node.Update(node.LocalSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitPseudoVariable(BoundPseudoVariable node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundPseudoVariable updatedNode = node.Update(node.LocalSymbol, node.EmitExpressions, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundPseudoVariable updatedNode = node.Update(node.LocalSymbol, node.EmitExpressions, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12315,11 +12259,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundRangeVariable updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.RangeVariableSymbol, value, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.RangeVariableSymbol, value, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12330,27 +12273,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitParameter(BoundParameter node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundParameter updatedNode = node.Update(node.ParameterSymbol, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundParameter updatedNode = node.Update(node.ParameterSymbol, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
         public override BoundNode VisitLabel(BoundLabel node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundLabel updatedNode = node.Update(node.Label, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundLabel updatedNode = node.Update(node.Label, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12361,11 +12302,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundDecisionDag decisionDag = node.DecisionDag;
             BoundSwitchExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12379,11 +12319,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundSequencePointExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(expression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12398,11 +12337,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundSequence updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.Locals, sideEffects, value, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Locals, sideEffects, value, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12417,11 +12355,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundSpillSequence updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.Locals, sideEffects, value, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Locals, sideEffects, value, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12435,11 +12372,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
             BoundDynamicMemberAccess updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(receiver, node.TypeArgumentsOpt, node.Name, node.Invoked, node.Indexed, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiver, node.TypeArgumentsOpt, node.Name, node.Invoked, node.Indexed, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12454,11 +12390,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
             BoundDynamicInvocation updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableMethods, expression, arguments, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableMethods, expression, arguments, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12473,11 +12408,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression accessExpression = (BoundExpression)this.Visit(node.AccessExpression);
             BoundConditionalAccess updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(receiver, accessExpression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiver, accessExpression, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12493,11 +12427,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression whenNullOpt = (BoundExpression)this.Visit(node.WhenNullOpt);
             BoundLoweredConditionalAccess updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(receiver, node.HasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiver, node.HasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12508,14 +12441,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitConditionalReceiver(BoundConditionalReceiver node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundConditionalReceiver updatedNode = node.Update(node.Id, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundConditionalReceiver updatedNode = node.Update(node.Id, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12525,11 +12457,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression referenceTypeReceiver = (BoundExpression)this.Visit(node.ReferenceTypeReceiver);
             BoundComplexConditionalReceiver updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(valueTypeReceiver, referenceTypeReceiver, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(valueTypeReceiver, referenceTypeReceiver, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12543,11 +12474,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             BoundMethodGroup updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, node.Methods, node.LookupSymbolOpt, node.LookupError, node.Flags, receiverOpt, node.ResultKind);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12561,11 +12491,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             BoundPropertyGroup updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.Properties, receiverOpt, node.ResultKind);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12580,11 +12509,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
             BoundCall updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(receiverOpt, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.BinderOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.BinderOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12599,11 +12527,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             BoundEventAssignmentOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.Event, node.IsAddition, node.IsDynamic, receiverOpt, argument, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Event, node.IsAddition, node.IsDynamic, receiverOpt, argument, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12618,11 +12545,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> namedArguments = (ImmutableArray<BoundExpression>)this.VisitList(node.NamedArguments);
             BoundAttribute updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.Constructor, constructorArguments, node.ConstructorArgumentNamesOpt, namedArguments, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Constructor, constructorArguments, node.ConstructorArgumentNamesOpt, namedArguments, node.ResultKind, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12637,11 +12563,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundObjectInitializerExpressionBase initializerExpressionOpt = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpressionOpt);
             BoundObjectCreationExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.Constructor, node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Constructor, node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12655,11 +12580,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
             BoundTupleLiteral updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.ArgumentNamesOpt, node.InferredNamesOpt, arguments, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ArgumentNamesOpt, node.InferredNamesOpt, arguments, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12673,11 +12597,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
             BoundConvertedTupleLiteral updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.NaturalTypeOpt, arguments, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.NaturalTypeOpt, arguments, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12692,11 +12615,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundObjectInitializerExpressionBase initializerExpressionOpt = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpressionOpt);
             BoundDynamicObjectCreationExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, node.ApplicableMethods, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, node.ApplicableMethods, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12710,11 +12632,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundObjectInitializerExpressionBase initializerExpressionOpt = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpressionOpt);
             BoundNoPiaObjectCreationExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.GuidString, initializerExpressionOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.GuidString, initializerExpressionOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12728,11 +12649,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> initializers = (ImmutableArray<BoundExpression>)this.VisitList(node.Initializers);
             BoundObjectInitializerExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(initializers, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(initializers, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12746,11 +12666,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
             BoundObjectInitializerMember updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.MemberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, node.ReceiverType, node.BinderOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.MemberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, node.ReceiverType, node.BinderOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12761,14 +12680,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitDynamicObjectInitializerMember(BoundDynamicObjectInitializerMember node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundDynamicObjectInitializerMember updatedNode = node.Update(node.MemberName, node.ReceiverType, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundDynamicObjectInitializerMember updatedNode = node.Update(node.MemberName, node.ReceiverType, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12777,11 +12695,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> initializers = (ImmutableArray<BoundExpression>)this.VisitList(node.Initializers);
             BoundCollectionInitializerExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(initializers, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(initializers, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12796,11 +12713,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression implicitReceiverOpt = (BoundExpression)this.Visit(node.ImplicitReceiverOpt);
             BoundCollectionElementInitializer updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.AddMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.AddMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12815,11 +12731,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
             BoundDynamicCollectionElementInitializer updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.ApplicableMethods, expression, arguments, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ApplicableMethods, expression, arguments, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12830,14 +12745,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitImplicitReceiver(BoundImplicitReceiver node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundImplicitReceiver updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundImplicitReceiver updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12847,11 +12761,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundAnonymousPropertyDeclaration> declarations = (ImmutableArray<BoundAnonymousPropertyDeclaration>)this.VisitList(node.Declarations);
             BoundAnonymousObjectCreationExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.Constructor, arguments, declarations, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.Constructor, arguments, declarations, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12862,14 +12775,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitAnonymousPropertyDeclaration(BoundAnonymousPropertyDeclaration node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundAnonymousPropertyDeclaration updatedNode = node.Update(node.Property, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundAnonymousPropertyDeclaration updatedNode = node.Update(node.Property, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -12878,11 +12790,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundObjectInitializerExpressionBase initializerExpressionOpt = (BoundObjectInitializerExpressionBase)this.Visit(node.InitializerExpressionOpt);
             BoundNewT updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(initializerExpressionOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(initializerExpressionOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12896,11 +12807,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             BoundDelegateCreationExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(argument, node.MethodOpt, node.IsExtensionMethod, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(argument, node.MethodOpt, node.IsExtensionMethod, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12915,11 +12825,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundArrayInitialization initializerOpt = (BoundArrayInitialization)this.Visit(node.InitializerOpt);
             BoundArrayCreation updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(bounds, initializerOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(bounds, initializerOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12933,11 +12842,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> initializers = (ImmutableArray<BoundExpression>)this.VisitList(node.Initializers);
             BoundArrayInitialization updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(initializers);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12952,11 +12860,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundArrayInitialization initializerOpt = (BoundArrayInitialization)this.Visit(node.InitializerOpt);
             BoundStackAllocArrayCreation updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.ElementType, count, initializerOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ElementType, count, initializerOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12971,11 +12878,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundArrayInitialization initializerOpt = (BoundArrayInitialization)this.Visit(node.InitializerOpt);
             BoundConvertedStackAllocExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(node.ElementType, count, initializerOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(node.ElementType, count, initializerOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -12989,11 +12895,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             BoundFieldAccess updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(receiverOpt, node.FieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, node.FieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13004,14 +12909,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitHoistedFieldAccess(BoundHoistedFieldAccess node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundHoistedFieldAccess updatedNode = node.Update(node.FieldSymbol, type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundHoistedFieldAccess updatedNode = node.Update(node.FieldSymbol, twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -13020,11 +12924,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             BoundPropertyAccess updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(receiverOpt, node.PropertySymbol, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, node.PropertySymbol, node.ResultKind, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13038,11 +12941,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             BoundEventAccess updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(receiverOpt, node.EventSymbol, node.IsUsableAsField, node.ResultKind, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, node.EventSymbol, node.IsUsableAsField, node.ResultKind, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13057,11 +12959,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
             BoundIndexerAccess updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(receiverOpt, node.Indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, node.Indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13076,11 +12977,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> arguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
             BoundDynamicIndexerAccess updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(receiverOpt, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableIndexers, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(receiverOpt, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.ApplicableIndexers, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13095,11 +12995,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundBlock body = (BoundBlock)this.Visit(node.Body);
             BoundLambda updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(unboundLambda, node.Symbol, body, node.Diagnostics, node.Binder, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(unboundLambda, node.Symbol, body, node.Diagnostics, node.Binder, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13110,14 +13009,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitUnboundLambda(UnboundLambda node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             UnboundLambda updatedNode = node.Update(node.Data);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -13126,11 +13024,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundQueryClause updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(value, node.DefinedSymbol, node.Binder, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(value, node.DefinedSymbol, node.Binder, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13144,11 +13041,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             BoundNameOfOperator updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(argument, node.ConstantValueOpt, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(argument, node.ConstantValueOpt, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13162,11 +13058,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> parts = (ImmutableArray<BoundExpression>)this.VisitList(node.Parts);
             BoundInterpolatedString updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(parts, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(parts, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13182,11 +13077,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundLiteral format = (BoundLiteral)this.Visit(node.Format);
             BoundStringInsert updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(value, alignment, format, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(value, alignment, format, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13202,11 +13096,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundDecisionDag decisionDag = node.DecisionDag;
             BoundIsPatternExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(expression, pattern, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, pattern, decisionDag, node.WhenTrueLabel, node.WhenFalseLabel, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13217,14 +13110,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitDiscardExpression(BoundDiscardExpression node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-            BoundDiscardExpression updatedNode = node.Update(type);
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            BoundDiscardExpression updatedNode = node.Update(twsa.TypeSymbol);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -13233,11 +13125,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundThrowExpression updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(expression, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13251,11 +13142,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             OutVariablePendingInference updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.VariableSymbol, receiverOpt);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13269,11 +13159,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
             DeconstructionVariablePendingInference updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
                 updatedNode = node.Update(node.VariableSymbol, receiverOpt);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {
@@ -13284,14 +13173,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitOutDeconstructVarPendingInference(OutDeconstructVarPendingInference node)
         {
-            if (!_topLevelNullabilities.ContainsKey(node))
+            if (!_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
                 return node;
             }
 
-            TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
             OutDeconstructVarPendingInference updatedNode = node.Update();
-            updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+            updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             return updatedNode;
         }
 
@@ -13300,11 +13188,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundExpressionWithNullability updatedNode;
 
-            if (_topLevelNullabilities.ContainsKey(node))
+            if (_topLevelNullabilities.TryGetValue(node, out TypeSymbolWithAnnotations twsa))
             {
-                TypeSymbol type = _topLevelNullabilities[node].TypeSymbol;
-                updatedNode = node.Update(expression, node.NullableAnnotation, type);
-                updatedNode.TopLevelNullability = _topLevelNullabilities[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
+                updatedNode = node.Update(expression, node.NullableAnnotation, twsa.TypeSymbol);
+                updatedNode.TopLevelNullability = twsa.NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -18,7 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         Annotated,    // Type is annotated - string?, T? where T : class; and for int?, T? where T : struct.
         NotNullable,  // Explicitly set by flow analysis
         Nullable,     // Explicitly set by flow analysis
-        NotComputed,  // Used for the public API only
     }
 
     internal static class NullableAnnotationExtensions
@@ -104,7 +103,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public static NullableAnnotation JoinForFlowAnalysisBranches<T>(this NullableAnnotation selfAnnotation, NullableAnnotation otherAnnotation, T type, Func<T, bool> isPossiblyNullableReferenceTypeTypeParameter)
         {
-            Debug.Assert(selfAnnotation != NullableAnnotation.NotComputed && otherAnnotation != NullableAnnotation.NotComputed);
             if (selfAnnotation == otherAnnotation)
             {
                 return selfAnnotation;
@@ -309,9 +307,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 case NullableAnnotation.Unknown:
                     return Nullability.Unknown;
-
-                case NullableAnnotation.NotComputed:
-                    return Nullability.NotComputed;
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(annotation);

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -2,6 +2,12 @@
 Microsoft.CodeAnalysis.IFieldSymbol.IsFixedSizeBuffer.get -> bool
 Microsoft.CodeAnalysis.ITypeSymbol.IsRefLikeType.get -> bool
 Microsoft.CodeAnalysis.ITypeSymbol.IsUnmanagedType.get -> bool
+Microsoft.CodeAnalysis.Nullability
+Microsoft.CodeAnalysis.Nullability.MayBeNull = 4 -> Microsoft.CodeAnalysis.Nullability
+Microsoft.CodeAnalysis.Nullability.NotApplicable = 0 -> Microsoft.CodeAnalysis.Nullability
+Microsoft.CodeAnalysis.Nullability.NotComputed = 1 -> Microsoft.CodeAnalysis.Nullability
+Microsoft.CodeAnalysis.Nullability.NotNull = 3 -> Microsoft.CodeAnalysis.Nullability
+Microsoft.CodeAnalysis.Nullability.Unknown = 2 -> Microsoft.CodeAnalysis.Nullability
 Microsoft.CodeAnalysis.OperationKind.Binary = 32 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.ConstructorBody = 89 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.DiscardPattern = 104 -> Microsoft.CodeAnalysis.OperationKind

--- a/src/Compilers/Core/Portable/Symbols/Nullability.cs
+++ b/src/Compilers/Core/Portable/Symbols/Nullability.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis
+{
+    public enum Nullability
+    {
+        NotApplicable,
+        NotComputed,
+        Unknown,
+        NotNull,
+        MayBeNull
+    }
+}

--- a/src/Compilers/Core/Portable/Symbols/Nullability.cs
+++ b/src/Compilers/Core/Portable/Symbols/Nullability.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.CodeAnalysis
 {
+    // PROTOTYPE(nullable-api): Doc comment
     public enum Nullability
     {
         NotApplicable,

--- a/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
@@ -11560,147 +11560,147 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend MustInherit Partial Class BoundTreeWalker
         Inherits BoundTreeVisitor
 
-        Public Overrides Function VisitTypeArguments(node as BoundTypeArguments) As BoundNode
+        Public Overrides Function VisitTypeArguments(node As BoundTypeArguments) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitOmittedArgument(node as BoundOmittedArgument) As BoundNode
+        Public Overrides Function VisitOmittedArgument(node As BoundOmittedArgument) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLValueToRValueWrapper(node as BoundLValueToRValueWrapper) As BoundNode
+        Public Overrides Function VisitLValueToRValueWrapper(node As BoundLValueToRValueWrapper) As BoundNode
             Me.Visit(node.UnderlyingLValue)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitWithLValueExpressionPlaceholder(node as BoundWithLValueExpressionPlaceholder) As BoundNode
+        Public Overrides Function VisitWithLValueExpressionPlaceholder(node As BoundWithLValueExpressionPlaceholder) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitWithRValueExpressionPlaceholder(node as BoundWithRValueExpressionPlaceholder) As BoundNode
+        Public Overrides Function VisitWithRValueExpressionPlaceholder(node As BoundWithRValueExpressionPlaceholder) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitRValuePlaceholder(node as BoundRValuePlaceholder) As BoundNode
+        Public Overrides Function VisitRValuePlaceholder(node As BoundRValuePlaceholder) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLValuePlaceholder(node as BoundLValuePlaceholder) As BoundNode
+        Public Overrides Function VisitLValuePlaceholder(node As BoundLValuePlaceholder) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitDup(node as BoundDup) As BoundNode
+        Public Overrides Function VisitDup(node As BoundDup) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitBadExpression(node as BoundBadExpression) As BoundNode
+        Public Overrides Function VisitBadExpression(node As BoundBadExpression) As BoundNode
             Me.VisitList(node.ChildBoundNodes)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitBadStatement(node as BoundBadStatement) As BoundNode
+        Public Overrides Function VisitBadStatement(node As BoundBadStatement) As BoundNode
             Me.VisitList(node.ChildBoundNodes)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitParenthesized(node as BoundParenthesized) As BoundNode
+        Public Overrides Function VisitParenthesized(node As BoundParenthesized) As BoundNode
             Me.Visit(node.Expression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitBadVariable(node as BoundBadVariable) As BoundNode
+        Public Overrides Function VisitBadVariable(node As BoundBadVariable) As BoundNode
             Me.Visit(node.Expression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitArrayAccess(node as BoundArrayAccess) As BoundNode
+        Public Overrides Function VisitArrayAccess(node As BoundArrayAccess) As BoundNode
             Me.Visit(node.Expression)
             Me.VisitList(node.Indices)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitArrayLength(node as BoundArrayLength) As BoundNode
+        Public Overrides Function VisitArrayLength(node As BoundArrayLength) As BoundNode
             Me.Visit(node.Expression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitGetType(node as BoundGetType) As BoundNode
+        Public Overrides Function VisitGetType(node As BoundGetType) As BoundNode
             Me.Visit(node.SourceType)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitFieldInfo(node as BoundFieldInfo) As BoundNode
+        Public Overrides Function VisitFieldInfo(node As BoundFieldInfo) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitMethodInfo(node as BoundMethodInfo) As BoundNode
+        Public Overrides Function VisitMethodInfo(node As BoundMethodInfo) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitTypeExpression(node as BoundTypeExpression) As BoundNode
+        Public Overrides Function VisitTypeExpression(node As BoundTypeExpression) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitTypeOrValueExpression(node as BoundTypeOrValueExpression) As BoundNode
+        Public Overrides Function VisitTypeOrValueExpression(node As BoundTypeOrValueExpression) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitNamespaceExpression(node as BoundNamespaceExpression) As BoundNode
+        Public Overrides Function VisitNamespaceExpression(node As BoundNamespaceExpression) As BoundNode
             Me.Visit(node.UnevaluatedReceiverOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitMethodDefIndex(node as BoundMethodDefIndex) As BoundNode
+        Public Overrides Function VisitMethodDefIndex(node As BoundMethodDefIndex) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitMaximumMethodDefIndex(node as BoundMaximumMethodDefIndex) As BoundNode
+        Public Overrides Function VisitMaximumMethodDefIndex(node As BoundMaximumMethodDefIndex) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitInstrumentationPayloadRoot(node as BoundInstrumentationPayloadRoot) As BoundNode
+        Public Overrides Function VisitInstrumentationPayloadRoot(node As BoundInstrumentationPayloadRoot) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitModuleVersionId(node as BoundModuleVersionId) As BoundNode
+        Public Overrides Function VisitModuleVersionId(node As BoundModuleVersionId) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitModuleVersionIdString(node as BoundModuleVersionIdString) As BoundNode
+        Public Overrides Function VisitModuleVersionIdString(node As BoundModuleVersionIdString) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitSourceDocumentIndex(node as BoundSourceDocumentIndex) As BoundNode
+        Public Overrides Function VisitSourceDocumentIndex(node As BoundSourceDocumentIndex) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitUnaryOperator(node as BoundUnaryOperator) As BoundNode
+        Public Overrides Function VisitUnaryOperator(node As BoundUnaryOperator) As BoundNode
             Me.Visit(node.Operand)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitUserDefinedUnaryOperator(node as BoundUserDefinedUnaryOperator) As BoundNode
+        Public Overrides Function VisitUserDefinedUnaryOperator(node As BoundUserDefinedUnaryOperator) As BoundNode
             Me.Visit(node.UnderlyingExpression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitNullableIsTrueOperator(node as BoundNullableIsTrueOperator) As BoundNode
+        Public Overrides Function VisitNullableIsTrueOperator(node As BoundNullableIsTrueOperator) As BoundNode
             Me.Visit(node.Operand)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitBinaryOperator(node as BoundBinaryOperator) As BoundNode
+        Public Overrides Function VisitBinaryOperator(node As BoundBinaryOperator) As BoundNode
             Me.Visit(node.Left)
             Me.Visit(node.Right)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitUserDefinedBinaryOperator(node as BoundUserDefinedBinaryOperator) As BoundNode
+        Public Overrides Function VisitUserDefinedBinaryOperator(node As BoundUserDefinedBinaryOperator) As BoundNode
             Me.Visit(node.UnderlyingExpression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitUserDefinedShortCircuitingOperator(node as BoundUserDefinedShortCircuitingOperator) As BoundNode
+        Public Overrides Function VisitUserDefinedShortCircuitingOperator(node As BoundUserDefinedShortCircuitingOperator) As BoundNode
             Me.Visit(node.LeftOperand)
             Me.Visit(node.LeftOperandPlaceholder)
             Me.Visit(node.LeftTest)
@@ -11708,362 +11708,362 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Public Overrides Function VisitCompoundAssignmentTargetPlaceholder(node as BoundCompoundAssignmentTargetPlaceholder) As BoundNode
+        Public Overrides Function VisitCompoundAssignmentTargetPlaceholder(node As BoundCompoundAssignmentTargetPlaceholder) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitAssignmentOperator(node as BoundAssignmentOperator) As BoundNode
+        Public Overrides Function VisitAssignmentOperator(node As BoundAssignmentOperator) As BoundNode
             Me.Visit(node.Left)
             Me.Visit(node.LeftOnTheRightOpt)
             Me.Visit(node.Right)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitReferenceAssignment(node as BoundReferenceAssignment) As BoundNode
+        Public Overrides Function VisitReferenceAssignment(node As BoundReferenceAssignment) As BoundNode
             Me.Visit(node.ByRefLocal)
             Me.Visit(node.LValue)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitAddressOfOperator(node as BoundAddressOfOperator) As BoundNode
+        Public Overrides Function VisitAddressOfOperator(node As BoundAddressOfOperator) As BoundNode
             Me.Visit(node.MethodGroup)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitTernaryConditionalExpression(node as BoundTernaryConditionalExpression) As BoundNode
+        Public Overrides Function VisitTernaryConditionalExpression(node As BoundTernaryConditionalExpression) As BoundNode
             Me.Visit(node.Condition)
             Me.Visit(node.WhenTrue)
             Me.Visit(node.WhenFalse)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitBinaryConditionalExpression(node as BoundBinaryConditionalExpression) As BoundNode
+        Public Overrides Function VisitBinaryConditionalExpression(node As BoundBinaryConditionalExpression) As BoundNode
             Me.Visit(node.TestExpression)
             Me.Visit(node.ElseExpression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitConversion(node as BoundConversion) As BoundNode
+        Public Overrides Function VisitConversion(node As BoundConversion) As BoundNode
             Me.Visit(node.Operand)
             Me.Visit(node.ExtendedInfoOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitRelaxationLambda(node as BoundRelaxationLambda) As BoundNode
+        Public Overrides Function VisitRelaxationLambda(node As BoundRelaxationLambda) As BoundNode
             Me.Visit(node.Lambda)
             Me.Visit(node.ReceiverPlaceholderOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitConvertedTupleElements(node as BoundConvertedTupleElements) As BoundNode
+        Public Overrides Function VisitConvertedTupleElements(node As BoundConvertedTupleElements) As BoundNode
             Me.VisitList(node.ElementPlaceholders)
             Me.VisitList(node.ConvertedElements)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitUserDefinedConversion(node as BoundUserDefinedConversion) As BoundNode
+        Public Overrides Function VisitUserDefinedConversion(node As BoundUserDefinedConversion) As BoundNode
             Me.Visit(node.UnderlyingExpression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitDirectCast(node as BoundDirectCast) As BoundNode
+        Public Overrides Function VisitDirectCast(node As BoundDirectCast) As BoundNode
             Me.Visit(node.Operand)
             Me.Visit(node.RelaxationLambdaOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitTryCast(node as BoundTryCast) As BoundNode
+        Public Overrides Function VisitTryCast(node As BoundTryCast) As BoundNode
             Me.Visit(node.Operand)
             Me.Visit(node.RelaxationLambdaOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitTypeOf(node as BoundTypeOf) As BoundNode
+        Public Overrides Function VisitTypeOf(node As BoundTypeOf) As BoundNode
             Me.Visit(node.Operand)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitSequencePoint(node as BoundSequencePoint) As BoundNode
+        Public Overrides Function VisitSequencePoint(node As BoundSequencePoint) As BoundNode
             Me.Visit(node.StatementOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitSequencePointExpression(node as BoundSequencePointExpression) As BoundNode
+        Public Overrides Function VisitSequencePointExpression(node As BoundSequencePointExpression) As BoundNode
             Me.Visit(node.Expression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitSequencePointWithSpan(node as BoundSequencePointWithSpan) As BoundNode
+        Public Overrides Function VisitSequencePointWithSpan(node As BoundSequencePointWithSpan) As BoundNode
             Me.Visit(node.StatementOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitNoOpStatement(node as BoundNoOpStatement) As BoundNode
+        Public Overrides Function VisitNoOpStatement(node As BoundNoOpStatement) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitMethodGroup(node as BoundMethodGroup) As BoundNode
+        Public Overrides Function VisitMethodGroup(node As BoundMethodGroup) As BoundNode
             Me.Visit(node.TypeArgumentsOpt)
             Me.Visit(node.ReceiverOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitPropertyGroup(node as BoundPropertyGroup) As BoundNode
+        Public Overrides Function VisitPropertyGroup(node As BoundPropertyGroup) As BoundNode
             Me.Visit(node.ReceiverOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitReturnStatement(node as BoundReturnStatement) As BoundNode
+        Public Overrides Function VisitReturnStatement(node As BoundReturnStatement) As BoundNode
             Me.Visit(node.ExpressionOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitYieldStatement(node as BoundYieldStatement) As BoundNode
+        Public Overrides Function VisitYieldStatement(node As BoundYieldStatement) As BoundNode
             Me.Visit(node.Expression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitThrowStatement(node as BoundThrowStatement) As BoundNode
+        Public Overrides Function VisitThrowStatement(node As BoundThrowStatement) As BoundNode
             Me.Visit(node.ExpressionOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitRedimStatement(node as BoundRedimStatement) As BoundNode
+        Public Overrides Function VisitRedimStatement(node As BoundRedimStatement) As BoundNode
             Me.VisitList(node.Clauses)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitRedimClause(node as BoundRedimClause) As BoundNode
+        Public Overrides Function VisitRedimClause(node As BoundRedimClause) As BoundNode
             Me.Visit(node.Operand)
             Me.VisitList(node.Indices)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitEraseStatement(node as BoundEraseStatement) As BoundNode
+        Public Overrides Function VisitEraseStatement(node As BoundEraseStatement) As BoundNode
             Me.VisitList(node.Clauses)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitCall(node as BoundCall) As BoundNode
+        Public Overrides Function VisitCall(node As BoundCall) As BoundNode
             Me.Visit(node.ReceiverOpt)
             Me.VisitList(node.Arguments)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitAttribute(node as BoundAttribute) As BoundNode
+        Public Overrides Function VisitAttribute(node As BoundAttribute) As BoundNode
             Me.VisitList(node.ConstructorArguments)
             Me.VisitList(node.NamedArguments)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLateMemberAccess(node as BoundLateMemberAccess) As BoundNode
+        Public Overrides Function VisitLateMemberAccess(node As BoundLateMemberAccess) As BoundNode
             Me.Visit(node.ReceiverOpt)
             Me.Visit(node.TypeArgumentsOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLateInvocation(node as BoundLateInvocation) As BoundNode
+        Public Overrides Function VisitLateInvocation(node As BoundLateInvocation) As BoundNode
             Me.Visit(node.Member)
             Me.VisitList(node.ArgumentsOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLateAddressOfOperator(node as BoundLateAddressOfOperator) As BoundNode
+        Public Overrides Function VisitLateAddressOfOperator(node As BoundLateAddressOfOperator) As BoundNode
             Me.Visit(node.MemberAccess)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitTupleLiteral(node as BoundTupleLiteral) As BoundNode
+        Public Overrides Function VisitTupleLiteral(node As BoundTupleLiteral) As BoundNode
             Me.VisitList(node.Arguments)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitConvertedTupleLiteral(node as BoundConvertedTupleLiteral) As BoundNode
+        Public Overrides Function VisitConvertedTupleLiteral(node As BoundConvertedTupleLiteral) As BoundNode
             Me.VisitList(node.Arguments)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitObjectCreationExpression(node as BoundObjectCreationExpression) As BoundNode
+        Public Overrides Function VisitObjectCreationExpression(node As BoundObjectCreationExpression) As BoundNode
             Me.VisitList(node.Arguments)
             Me.Visit(node.InitializerOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitNoPiaObjectCreationExpression(node as BoundNoPiaObjectCreationExpression) As BoundNode
+        Public Overrides Function VisitNoPiaObjectCreationExpression(node As BoundNoPiaObjectCreationExpression) As BoundNode
             Me.Visit(node.InitializerOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitAnonymousTypeCreationExpression(node as BoundAnonymousTypeCreationExpression) As BoundNode
+        Public Overrides Function VisitAnonymousTypeCreationExpression(node As BoundAnonymousTypeCreationExpression) As BoundNode
             Me.VisitList(node.Declarations)
             Me.VisitList(node.Arguments)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitAnonymousTypePropertyAccess(node as BoundAnonymousTypePropertyAccess) As BoundNode
+        Public Overrides Function VisitAnonymousTypePropertyAccess(node As BoundAnonymousTypePropertyAccess) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitAnonymousTypeFieldInitializer(node as BoundAnonymousTypeFieldInitializer) As BoundNode
+        Public Overrides Function VisitAnonymousTypeFieldInitializer(node As BoundAnonymousTypeFieldInitializer) As BoundNode
             Me.Visit(node.Value)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitObjectInitializerExpression(node as BoundObjectInitializerExpression) As BoundNode
+        Public Overrides Function VisitObjectInitializerExpression(node As BoundObjectInitializerExpression) As BoundNode
             Me.Visit(node.PlaceholderOpt)
             Me.VisitList(node.Initializers)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitCollectionInitializerExpression(node as BoundCollectionInitializerExpression) As BoundNode
+        Public Overrides Function VisitCollectionInitializerExpression(node As BoundCollectionInitializerExpression) As BoundNode
             Me.Visit(node.PlaceholderOpt)
             Me.VisitList(node.Initializers)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitNewT(node as BoundNewT) As BoundNode
+        Public Overrides Function VisitNewT(node As BoundNewT) As BoundNode
             Me.Visit(node.InitializerOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitDelegateCreationExpression(node as BoundDelegateCreationExpression) As BoundNode
+        Public Overrides Function VisitDelegateCreationExpression(node As BoundDelegateCreationExpression) As BoundNode
             Me.Visit(node.ReceiverOpt)
             Me.Visit(node.RelaxationLambdaOpt)
             Me.Visit(node.RelaxationReceiverPlaceholderOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitArrayCreation(node as BoundArrayCreation) As BoundNode
+        Public Overrides Function VisitArrayCreation(node As BoundArrayCreation) As BoundNode
             Me.VisitList(node.Bounds)
             Me.Visit(node.InitializerOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitArrayLiteral(node as BoundArrayLiteral) As BoundNode
+        Public Overrides Function VisitArrayLiteral(node As BoundArrayLiteral) As BoundNode
             Me.VisitList(node.Bounds)
             Me.Visit(node.Initializer)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitArrayInitialization(node as BoundArrayInitialization) As BoundNode
+        Public Overrides Function VisitArrayInitialization(node As BoundArrayInitialization) As BoundNode
             Me.VisitList(node.Initializers)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitFieldAccess(node as BoundFieldAccess) As BoundNode
+        Public Overrides Function VisitFieldAccess(node As BoundFieldAccess) As BoundNode
             Me.Visit(node.ReceiverOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitPropertyAccess(node as BoundPropertyAccess) As BoundNode
+        Public Overrides Function VisitPropertyAccess(node As BoundPropertyAccess) As BoundNode
             Me.Visit(node.ReceiverOpt)
             Me.VisitList(node.Arguments)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitEventAccess(node as BoundEventAccess) As BoundNode
+        Public Overrides Function VisitEventAccess(node As BoundEventAccess) As BoundNode
             Me.Visit(node.ReceiverOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitBlock(node as BoundBlock) As BoundNode
+        Public Overrides Function VisitBlock(node As BoundBlock) As BoundNode
             Me.VisitList(node.Statements)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitStateMachineScope(node as BoundStateMachineScope) As BoundNode
+        Public Overrides Function VisitStateMachineScope(node As BoundStateMachineScope) As BoundNode
             Me.Visit(node.Statement)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLocalDeclaration(node as BoundLocalDeclaration) As BoundNode
+        Public Overrides Function VisitLocalDeclaration(node As BoundLocalDeclaration) As BoundNode
             Me.Visit(node.DeclarationInitializerOpt)
             Me.Visit(node.IdentifierInitializerOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitAsNewLocalDeclarations(node as BoundAsNewLocalDeclarations) As BoundNode
+        Public Overrides Function VisitAsNewLocalDeclarations(node As BoundAsNewLocalDeclarations) As BoundNode
             Me.VisitList(node.LocalDeclarations)
             Me.Visit(node.Initializer)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitDimStatement(node as BoundDimStatement) As BoundNode
+        Public Overrides Function VisitDimStatement(node As BoundDimStatement) As BoundNode
             Me.VisitList(node.LocalDeclarations)
             Me.Visit(node.InitializerOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitInitializer(node as BoundInitializer) As BoundNode
+        Public Overrides Function VisitInitializer(node As BoundInitializer) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitFieldInitializer(node as BoundFieldInitializer) As BoundNode
+        Public Overrides Function VisitFieldInitializer(node As BoundFieldInitializer) As BoundNode
             Me.Visit(node.MemberAccessExpressionOpt)
             Me.Visit(node.InitialValue)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitPropertyInitializer(node as BoundPropertyInitializer) As BoundNode
+        Public Overrides Function VisitPropertyInitializer(node As BoundPropertyInitializer) As BoundNode
             Me.Visit(node.MemberAccessExpressionOpt)
             Me.Visit(node.InitialValue)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitParameterEqualsValue(node as BoundParameterEqualsValue) As BoundNode
+        Public Overrides Function VisitParameterEqualsValue(node As BoundParameterEqualsValue) As BoundNode
             Me.Visit(node.Value)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitGlobalStatementInitializer(node as BoundGlobalStatementInitializer) As BoundNode
+        Public Overrides Function VisitGlobalStatementInitializer(node As BoundGlobalStatementInitializer) As BoundNode
             Me.Visit(node.Statement)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitSequence(node as BoundSequence) As BoundNode
+        Public Overrides Function VisitSequence(node As BoundSequence) As BoundNode
             Me.VisitList(node.SideEffects)
             Me.Visit(node.ValueOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitExpressionStatement(node as BoundExpressionStatement) As BoundNode
+        Public Overrides Function VisitExpressionStatement(node As BoundExpressionStatement) As BoundNode
             Me.Visit(node.Expression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitIfStatement(node as BoundIfStatement) As BoundNode
+        Public Overrides Function VisitIfStatement(node As BoundIfStatement) As BoundNode
             Me.Visit(node.Condition)
             Me.Visit(node.Consequence)
             Me.Visit(node.AlternativeOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitSelectStatement(node as BoundSelectStatement) As BoundNode
+        Public Overrides Function VisitSelectStatement(node As BoundSelectStatement) As BoundNode
             Me.Visit(node.ExpressionStatement)
             Me.Visit(node.ExprPlaceholderOpt)
             Me.VisitList(node.CaseBlocks)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitCaseBlock(node as BoundCaseBlock) As BoundNode
+        Public Overrides Function VisitCaseBlock(node As BoundCaseBlock) As BoundNode
             Me.Visit(node.CaseStatement)
             Me.Visit(node.Body)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitCaseStatement(node as BoundCaseStatement) As BoundNode
+        Public Overrides Function VisitCaseStatement(node As BoundCaseStatement) As BoundNode
             Me.VisitList(node.CaseClauses)
             Me.Visit(node.ConditionOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitSimpleCaseClause(node as BoundSimpleCaseClause) As BoundNode
+        Public Overrides Function VisitSimpleCaseClause(node As BoundSimpleCaseClause) As BoundNode
             Me.Visit(node.ValueOpt)
             Me.Visit(node.ConditionOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitRangeCaseClause(node as BoundRangeCaseClause) As BoundNode
+        Public Overrides Function VisitRangeCaseClause(node As BoundRangeCaseClause) As BoundNode
             Me.Visit(node.LowerBoundOpt)
             Me.Visit(node.UpperBoundOpt)
             Me.Visit(node.LowerBoundConditionOpt)
@@ -12071,26 +12071,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Public Overrides Function VisitRelationalCaseClause(node as BoundRelationalCaseClause) As BoundNode
+        Public Overrides Function VisitRelationalCaseClause(node As BoundRelationalCaseClause) As BoundNode
             Me.Visit(node.ValueOpt)
             Me.Visit(node.ConditionOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitDoLoopStatement(node as BoundDoLoopStatement) As BoundNode
+        Public Overrides Function VisitDoLoopStatement(node As BoundDoLoopStatement) As BoundNode
             Me.Visit(node.TopConditionOpt)
             Me.Visit(node.BottomConditionOpt)
             Me.Visit(node.Body)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitWhileStatement(node as BoundWhileStatement) As BoundNode
+        Public Overrides Function VisitWhileStatement(node As BoundWhileStatement) As BoundNode
             Me.Visit(node.Condition)
             Me.Visit(node.Body)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitForToUserDefinedOperators(node as BoundForToUserDefinedOperators) As BoundNode
+        Public Overrides Function VisitForToUserDefinedOperators(node As BoundForToUserDefinedOperators) As BoundNode
             Me.Visit(node.LeftOperandPlaceholder)
             Me.Visit(node.RightOperandPlaceholder)
             Me.Visit(node.Addition)
@@ -12100,7 +12100,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Public Overrides Function VisitForToStatement(node as BoundForToStatement) As BoundNode
+        Public Overrides Function VisitForToStatement(node As BoundForToStatement) As BoundNode
             Me.Visit(node.InitialValue)
             Me.Visit(node.LimitValue)
             Me.Visit(node.StepValue)
@@ -12111,7 +12111,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Public Overrides Function VisitForEachStatement(node as BoundForEachStatement) As BoundNode
+        Public Overrides Function VisitForEachStatement(node As BoundForEachStatement) As BoundNode
             Me.Visit(node.Collection)
             Me.Visit(node.ControlVariable)
             Me.Visit(node.Body)
@@ -12119,22 +12119,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Public Overrides Function VisitExitStatement(node as BoundExitStatement) As BoundNode
+        Public Overrides Function VisitExitStatement(node As BoundExitStatement) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitContinueStatement(node as BoundContinueStatement) As BoundNode
+        Public Overrides Function VisitContinueStatement(node As BoundContinueStatement) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitTryStatement(node as BoundTryStatement) As BoundNode
+        Public Overrides Function VisitTryStatement(node As BoundTryStatement) As BoundNode
             Me.Visit(node.TryBlock)
             Me.VisitList(node.CatchBlocks)
             Me.Visit(node.FinallyBlockOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitCatchBlock(node as BoundCatchBlock) As BoundNode
+        Public Overrides Function VisitCatchBlock(node As BoundCatchBlock) As BoundNode
             Me.Visit(node.ExceptionSourceOpt)
             Me.Visit(node.ErrorLineNumberOpt)
             Me.Visit(node.ExceptionFilterOpt)
@@ -12142,51 +12142,51 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLiteral(node as BoundLiteral) As BoundNode
+        Public Overrides Function VisitLiteral(node As BoundLiteral) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitMeReference(node as BoundMeReference) As BoundNode
+        Public Overrides Function VisitMeReference(node As BoundMeReference) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitValueTypeMeReference(node as BoundValueTypeMeReference) As BoundNode
+        Public Overrides Function VisitValueTypeMeReference(node As BoundValueTypeMeReference) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitMyBaseReference(node as BoundMyBaseReference) As BoundNode
+        Public Overrides Function VisitMyBaseReference(node As BoundMyBaseReference) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitMyClassReference(node as BoundMyClassReference) As BoundNode
+        Public Overrides Function VisitMyClassReference(node As BoundMyClassReference) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitPreviousSubmissionReference(node as BoundPreviousSubmissionReference) As BoundNode
+        Public Overrides Function VisitPreviousSubmissionReference(node As BoundPreviousSubmissionReference) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitHostObjectMemberReference(node as BoundHostObjectMemberReference) As BoundNode
+        Public Overrides Function VisitHostObjectMemberReference(node As BoundHostObjectMemberReference) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLocal(node as BoundLocal) As BoundNode
+        Public Overrides Function VisitLocal(node As BoundLocal) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitPseudoVariable(node as BoundPseudoVariable) As BoundNode
+        Public Overrides Function VisitPseudoVariable(node As BoundPseudoVariable) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitParameter(node as BoundParameter) As BoundNode
+        Public Overrides Function VisitParameter(node As BoundParameter) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitByRefArgumentPlaceholder(node as BoundByRefArgumentPlaceholder) As BoundNode
+        Public Overrides Function VisitByRefArgumentPlaceholder(node As BoundByRefArgumentPlaceholder) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitByRefArgumentWithCopyBack(node as BoundByRefArgumentWithCopyBack) As BoundNode
+        Public Overrides Function VisitByRefArgumentWithCopyBack(node As BoundByRefArgumentWithCopyBack) As BoundNode
             Me.Visit(node.OriginalArgument)
             Me.Visit(node.InConversion)
             Me.Visit(node.InPlaceholder)
@@ -12195,229 +12195,229 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLateBoundArgumentSupportingAssignmentWithCapture(node as BoundLateBoundArgumentSupportingAssignmentWithCapture) As BoundNode
+        Public Overrides Function VisitLateBoundArgumentSupportingAssignmentWithCapture(node As BoundLateBoundArgumentSupportingAssignmentWithCapture) As BoundNode
             Me.Visit(node.OriginalArgument)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLabelStatement(node as BoundLabelStatement) As BoundNode
+        Public Overrides Function VisitLabelStatement(node As BoundLabelStatement) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLabel(node as BoundLabel) As BoundNode
+        Public Overrides Function VisitLabel(node As BoundLabel) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitGotoStatement(node as BoundGotoStatement) As BoundNode
+        Public Overrides Function VisitGotoStatement(node As BoundGotoStatement) As BoundNode
             Me.Visit(node.LabelExpressionOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitStatementList(node as BoundStatementList) As BoundNode
+        Public Overrides Function VisitStatementList(node As BoundStatementList) As BoundNode
             Me.VisitList(node.Statements)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitConditionalGoto(node as BoundConditionalGoto) As BoundNode
+        Public Overrides Function VisitConditionalGoto(node As BoundConditionalGoto) As BoundNode
             Me.Visit(node.Condition)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitWithStatement(node as BoundWithStatement) As BoundNode
+        Public Overrides Function VisitWithStatement(node As BoundWithStatement) As BoundNode
             Me.Visit(node.OriginalExpression)
             Me.Visit(node.Body)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitUnboundLambda(node as UnboundLambda) As BoundNode
+        Public Overrides Function VisitUnboundLambda(node As UnboundLambda) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLambda(node as BoundLambda) As BoundNode
+        Public Overrides Function VisitLambda(node As BoundLambda) As BoundNode
             Me.Visit(node.Body)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitQueryExpression(node as BoundQueryExpression) As BoundNode
+        Public Overrides Function VisitQueryExpression(node As BoundQueryExpression) As BoundNode
             Me.Visit(node.LastOperator)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitQuerySource(node as BoundQuerySource) As BoundNode
+        Public Overrides Function VisitQuerySource(node As BoundQuerySource) As BoundNode
             Me.Visit(node.Expression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitToQueryableCollectionConversion(node as BoundToQueryableCollectionConversion) As BoundNode
+        Public Overrides Function VisitToQueryableCollectionConversion(node As BoundToQueryableCollectionConversion) As BoundNode
             Me.Visit(node.ConversionCall)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitQueryableSource(node as BoundQueryableSource) As BoundNode
+        Public Overrides Function VisitQueryableSource(node As BoundQueryableSource) As BoundNode
             Me.Visit(node.Source)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitQueryClause(node as BoundQueryClause) As BoundNode
+        Public Overrides Function VisitQueryClause(node As BoundQueryClause) As BoundNode
             Me.Visit(node.UnderlyingExpression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitOrdering(node as BoundOrdering) As BoundNode
+        Public Overrides Function VisitOrdering(node As BoundOrdering) As BoundNode
             Me.Visit(node.UnderlyingExpression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitQueryLambda(node as BoundQueryLambda) As BoundNode
+        Public Overrides Function VisitQueryLambda(node As BoundQueryLambda) As BoundNode
             Me.Visit(node.Expression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitRangeVariableAssignment(node as BoundRangeVariableAssignment) As BoundNode
+        Public Overrides Function VisitRangeVariableAssignment(node As BoundRangeVariableAssignment) As BoundNode
             Me.Visit(node.Value)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitGroupTypeInferenceLambda(node as GroupTypeInferenceLambda) As BoundNode
+        Public Overrides Function VisitGroupTypeInferenceLambda(node As GroupTypeInferenceLambda) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitAggregateClause(node as BoundAggregateClause) As BoundNode
+        Public Overrides Function VisitAggregateClause(node As BoundAggregateClause) As BoundNode
             Me.Visit(node.CapturedGroupOpt)
             Me.Visit(node.GroupPlaceholderOpt)
             Me.Visit(node.UnderlyingExpression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitGroupAggregation(node as BoundGroupAggregation) As BoundNode
+        Public Overrides Function VisitGroupAggregation(node As BoundGroupAggregation) As BoundNode
             Me.Visit(node.Group)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitRangeVariable(node as BoundRangeVariable) As BoundNode
+        Public Overrides Function VisitRangeVariable(node As BoundRangeVariable) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitAddHandlerStatement(node as BoundAddHandlerStatement) As BoundNode
+        Public Overrides Function VisitAddHandlerStatement(node As BoundAddHandlerStatement) As BoundNode
             Me.Visit(node.EventAccess)
             Me.Visit(node.Handler)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitRemoveHandlerStatement(node as BoundRemoveHandlerStatement) As BoundNode
+        Public Overrides Function VisitRemoveHandlerStatement(node As BoundRemoveHandlerStatement) As BoundNode
             Me.Visit(node.EventAccess)
             Me.Visit(node.Handler)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitRaiseEventStatement(node as BoundRaiseEventStatement) As BoundNode
+        Public Overrides Function VisitRaiseEventStatement(node As BoundRaiseEventStatement) As BoundNode
             Me.Visit(node.EventInvocation)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitUsingStatement(node as BoundUsingStatement) As BoundNode
+        Public Overrides Function VisitUsingStatement(node As BoundUsingStatement) As BoundNode
             Me.VisitList(node.ResourceList)
             Me.Visit(node.ResourceExpressionOpt)
             Me.Visit(node.Body)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitSyncLockStatement(node as BoundSyncLockStatement) As BoundNode
+        Public Overrides Function VisitSyncLockStatement(node As BoundSyncLockStatement) As BoundNode
             Me.Visit(node.LockExpression)
             Me.Visit(node.Body)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitXmlName(node as BoundXmlName) As BoundNode
+        Public Overrides Function VisitXmlName(node As BoundXmlName) As BoundNode
             Me.Visit(node.XmlNamespace)
             Me.Visit(node.LocalName)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitXmlNamespace(node as BoundXmlNamespace) As BoundNode
+        Public Overrides Function VisitXmlNamespace(node As BoundXmlNamespace) As BoundNode
             Me.Visit(node.XmlNamespace)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitXmlDocument(node as BoundXmlDocument) As BoundNode
+        Public Overrides Function VisitXmlDocument(node As BoundXmlDocument) As BoundNode
             Me.Visit(node.Declaration)
             Me.VisitList(node.ChildNodes)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitXmlDeclaration(node as BoundXmlDeclaration) As BoundNode
+        Public Overrides Function VisitXmlDeclaration(node As BoundXmlDeclaration) As BoundNode
             Me.Visit(node.Version)
             Me.Visit(node.Encoding)
             Me.Visit(node.Standalone)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitXmlProcessingInstruction(node as BoundXmlProcessingInstruction) As BoundNode
+        Public Overrides Function VisitXmlProcessingInstruction(node As BoundXmlProcessingInstruction) As BoundNode
             Me.Visit(node.Target)
             Me.Visit(node.Data)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitXmlComment(node as BoundXmlComment) As BoundNode
+        Public Overrides Function VisitXmlComment(node As BoundXmlComment) As BoundNode
             Me.Visit(node.Value)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitXmlAttribute(node as BoundXmlAttribute) As BoundNode
+        Public Overrides Function VisitXmlAttribute(node As BoundXmlAttribute) As BoundNode
             Me.Visit(node.Name)
             Me.Visit(node.Value)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitXmlElement(node as BoundXmlElement) As BoundNode
+        Public Overrides Function VisitXmlElement(node As BoundXmlElement) As BoundNode
             Me.Visit(node.Argument)
             Me.VisitList(node.ChildNodes)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitXmlMemberAccess(node as BoundXmlMemberAccess) As BoundNode
+        Public Overrides Function VisitXmlMemberAccess(node As BoundXmlMemberAccess) As BoundNode
             Me.Visit(node.MemberAccess)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitXmlEmbeddedExpression(node as BoundXmlEmbeddedExpression) As BoundNode
+        Public Overrides Function VisitXmlEmbeddedExpression(node As BoundXmlEmbeddedExpression) As BoundNode
             Me.Visit(node.Expression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitXmlCData(node as BoundXmlCData) As BoundNode
+        Public Overrides Function VisitXmlCData(node As BoundXmlCData) As BoundNode
             Me.Visit(node.Value)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitResumeStatement(node as BoundResumeStatement) As BoundNode
+        Public Overrides Function VisitResumeStatement(node As BoundResumeStatement) As BoundNode
             Me.Visit(node.LabelExpressionOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitOnErrorStatement(node as BoundOnErrorStatement) As BoundNode
+        Public Overrides Function VisitOnErrorStatement(node As BoundOnErrorStatement) As BoundNode
             Me.Visit(node.LabelExpressionOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitUnstructuredExceptionHandlingStatement(node as BoundUnstructuredExceptionHandlingStatement) As BoundNode
+        Public Overrides Function VisitUnstructuredExceptionHandlingStatement(node As BoundUnstructuredExceptionHandlingStatement) As BoundNode
             Me.Visit(node.Body)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitUnstructuredExceptionHandlingCatchFilter(node as BoundUnstructuredExceptionHandlingCatchFilter) As BoundNode
+        Public Overrides Function VisitUnstructuredExceptionHandlingCatchFilter(node As BoundUnstructuredExceptionHandlingCatchFilter) As BoundNode
             Me.Visit(node.ActiveHandlerLocal)
             Me.Visit(node.ResumeTargetLocal)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitUnstructuredExceptionOnErrorSwitch(node as BoundUnstructuredExceptionOnErrorSwitch) As BoundNode
+        Public Overrides Function VisitUnstructuredExceptionOnErrorSwitch(node As BoundUnstructuredExceptionOnErrorSwitch) As BoundNode
             Me.Visit(node.Value)
             Me.VisitList(node.Jumps)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitUnstructuredExceptionResumeSwitch(node as BoundUnstructuredExceptionResumeSwitch) As BoundNode
+        Public Overrides Function VisitUnstructuredExceptionResumeSwitch(node As BoundUnstructuredExceptionResumeSwitch) As BoundNode
             Me.Visit(node.ResumeTargetTemporary)
             Me.Visit(node.ResumeLabel)
             Me.Visit(node.ResumeNextLabel)
@@ -12425,7 +12425,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Public Overrides Function VisitAwaitOperator(node as BoundAwaitOperator) As BoundNode
+        Public Overrides Function VisitAwaitOperator(node As BoundAwaitOperator) As BoundNode
             Me.Visit(node.Operand)
             Me.Visit(node.AwaitableInstancePlaceholder)
             Me.Visit(node.GetAwaiter)
@@ -12435,21 +12435,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Public Overrides Function VisitSpillSequence(node as BoundSpillSequence) As BoundNode
+        Public Overrides Function VisitSpillSequence(node As BoundSpillSequence) As BoundNode
             Me.VisitList(node.Statements)
             Me.Visit(node.ValueOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitStopStatement(node as BoundStopStatement) As BoundNode
+        Public Overrides Function VisitStopStatement(node As BoundStopStatement) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitEndStatement(node as BoundEndStatement) As BoundNode
+        Public Overrides Function VisitEndStatement(node As BoundEndStatement) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitMidResult(node as BoundMidResult) As BoundNode
+        Public Overrides Function VisitMidResult(node As BoundMidResult) As BoundNode
             Me.Visit(node.Original)
             Me.Visit(node.Start)
             Me.Visit(node.LengthOpt)
@@ -12457,46 +12457,46 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Public Overrides Function VisitConditionalAccess(node as BoundConditionalAccess) As BoundNode
+        Public Overrides Function VisitConditionalAccess(node As BoundConditionalAccess) As BoundNode
             Me.Visit(node.Receiver)
             Me.Visit(node.Placeholder)
             Me.Visit(node.AccessExpression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitConditionalAccessReceiverPlaceholder(node as BoundConditionalAccessReceiverPlaceholder) As BoundNode
+        Public Overrides Function VisitConditionalAccessReceiverPlaceholder(node As BoundConditionalAccessReceiverPlaceholder) As BoundNode
             Return Nothing
         End Function
 
-        Public Overrides Function VisitLoweredConditionalAccess(node as BoundLoweredConditionalAccess) As BoundNode
+        Public Overrides Function VisitLoweredConditionalAccess(node As BoundLoweredConditionalAccess) As BoundNode
             Me.Visit(node.ReceiverOrCondition)
             Me.Visit(node.WhenNotNull)
             Me.Visit(node.WhenNullOpt)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitComplexConditionalAccessReceiver(node as BoundComplexConditionalAccessReceiver) As BoundNode
+        Public Overrides Function VisitComplexConditionalAccessReceiver(node As BoundComplexConditionalAccessReceiver) As BoundNode
             Me.Visit(node.ValueTypeReceiver)
             Me.Visit(node.ReferenceTypeReceiver)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitNameOfOperator(node as BoundNameOfOperator) As BoundNode
+        Public Overrides Function VisitNameOfOperator(node As BoundNameOfOperator) As BoundNode
             Me.Visit(node.Argument)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitTypeAsValueExpression(node as BoundTypeAsValueExpression) As BoundNode
+        Public Overrides Function VisitTypeAsValueExpression(node As BoundTypeAsValueExpression) As BoundNode
             Me.Visit(node.Expression)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitInterpolatedStringExpression(node as BoundInterpolatedStringExpression) As BoundNode
+        Public Overrides Function VisitInterpolatedStringExpression(node As BoundInterpolatedStringExpression) As BoundNode
             Me.VisitList(node.Contents)
             Return Nothing
         End Function
 
-        Public Overrides Function VisitInterpolation(node as BoundInterpolation) As BoundNode
+        Public Overrides Function VisitInterpolation(node As BoundInterpolation) As BoundNode
             Me.Visit(node.Expression)
             Me.Visit(node.AlignmentOpt)
             Me.Visit(node.FormatStringOpt)

--- a/src/Tools/Source/CompilerGeneratorTools/.editorconfig
+++ b/src/Tools/Source/CompilerGeneratorTools/.editorconfig
@@ -1,0 +1,10 @@
+# Project-specific settings:
+[*.{cs,vb}]
+# Local functions are camelCase
+dotnet_naming_style.local_function_style.capitalization = camel_case
+
+# CSharp code style settings:
+[*.cs]
+csharp_style_var_for_built_in_types = false:none
+csharp_style_var_when_type_is_apparent = true:none
+csharp_style_var_elsewhere = false:none

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -1528,7 +1528,7 @@ namespace BoundTreeGenerator
 
                             void writeNullabilityUpdate()
                             {
-                                WriteLine($"updatedNode.SetTopLevelNullableAnnotation({topLevelNullabilities}[node].NullableAnnotation);");
+                                WriteLine($"updatedNode.TopLevelNullability = {topLevelNullabilities}[node].NullableAnnotation.ConvertToPublicNullability(updatedNode.Type);");
                             }
                         }
                         Unbrace();

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -1084,7 +1084,7 @@ namespace BoundTreeGenerator
                     {
                         WriteLine("Case BoundKind.{0}: ", FixKeyword(StripBound(node.Name)));
                         Indent();
-                        WriteLine(GetVisitFunctionDeclaration(node.Name, isOverride: false));
+                        WriteLine("Return Visit{0}(CType(node, {1}), arg)", StripBound(node.Name), node.Name);
                         Outdent();
                     }
                     Outdent();
@@ -1483,39 +1483,39 @@ namespace BoundTreeGenerator
                             {
                                 WriteLine($"{node.Name} updatedNode;");
                                 Blank();
-                                WriteNullabilityCheck(inverted: false);
+                                writeNullabilityCheck(inverted: false);
                                 Brace();
-                                WriteTypeSymbolRetreival();
-                                WriteUpdate(decl: false, updatedType: true);
-                                WriteNullabilityUpdate();
+                                writeTypeSymbolRetrieval();
+                                writeUpdate(decl: false, updatedType: true);
+                                writeNullabilityUpdate();
                                 Unbrace();
                                 WriteLine("else");
                                 Brace();
-                                WriteUpdate(decl: false, updatedType: false);
+                                writeUpdate(decl: false, updatedType: false);
                                 Unbrace();
                                 WriteLine("return updatedNode;");
                             }
                             else
                             {
-                                WriteNullabilityCheck(inverted: true);
+                                writeNullabilityCheck(inverted: true);
                                 Brace();
                                 WriteLine("return node;");
                                 Unbrace();
                                 Blank();
-                                WriteTypeSymbolRetreival();
-                                WriteUpdate(decl: true, updatedType: true);
-                                WriteNullabilityUpdate();
+                                writeTypeSymbolRetrieval();
+                                writeUpdate(decl: true, updatedType: true);
+                                writeNullabilityUpdate();
                                 WriteLine("return updatedNode;");
                             }
                             Unbrace();
 
-                            void WriteNullabilityCheck(bool inverted) =>
+                            void writeNullabilityCheck(bool inverted) =>
                                 WriteLine($"if ({(inverted ? "!" : "")}{topLevelNullabilities}.ContainsKey(node))");
 
-                            void WriteTypeSymbolRetreival() =>
+                            void writeTypeSymbolRetrieval() =>
                                 WriteLine($"TypeSymbol type = {topLevelNullabilities}[node].TypeSymbol;");
 
-                            void WriteUpdate(bool decl, bool updatedType)
+                            void writeUpdate(bool decl, bool updatedType)
                             {
                                 Write($"{(decl ? $"{node.Name} " : "")}updatedNode = node.Update");
                                 ParenList(
@@ -1526,9 +1526,9 @@ namespace BoundTreeGenerator
                                 WriteLine(";");
                             }
 
-                            void WriteNullabilityUpdate()
+                            void writeNullabilityUpdate()
                             {
-                                WriteLine($"updatedNode.TopLevelNullability = {topLevelNullabilities}[node].NullableAnnotation;");
+                                WriteLine($"updatedNode.SetTopLevelNullableAnnotation({topLevelNullabilities}[node].NullableAnnotation);");
                             }
                         }
                         Unbrace();

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -173,6 +173,7 @@ namespace BoundTreeGenerator
             WriteVisitor();
             WriteWalker();
             WriteRewriter();
+            WriteNullabilityRewriter();
             WriteTreeDumperNodeProducer();
             WriteEndNamespace();
         }
@@ -1083,7 +1084,7 @@ namespace BoundTreeGenerator
                     {
                         WriteLine("Case BoundKind.{0}: ", FixKeyword(StripBound(node.Name)));
                         Indent();
-                        WriteLine("Return Visit{0}(CType(node, {1}), arg)", StripBound(node.Name), node.Name);
+                        WriteLine(GetVisitFunctionDeclaration(node.Name, isOverride: false));
                         Outdent();
                     }
                     Outdent();
@@ -1143,7 +1144,7 @@ namespace BoundTreeGenerator
                     Indent();
                     foreach (var node in _tree.Types.OfType<Node>())
                     {
-                        WriteLine("Public Overridable Function Visit{0}(node As {1}) As BoundNode", StripBound(node.Name), node.Name);
+                        WriteLine(GetVisitFunctionDeclaration(node.Name, isOverride: false));
                         Indent();
                         WriteLine("Return Me.DefaultVisit(node)");
                         Outdent();
@@ -1169,7 +1170,7 @@ namespace BoundTreeGenerator
                     Brace();
                     foreach (var node in _tree.Types.OfType<Node>())
                     {
-                        WriteLine("public override BoundNode Visit{0}({1} node)", StripBound(node.Name), node.Name);
+                        WriteLine(GetVisitFunctionDeclaration(node.Name, isOverride: true));
                         Brace();
                         foreach (Field field in AllFields(node).Where(f => IsDerivedOrListOfDerived("BoundNode", f.Type) && !SkipInVisitor(f)))
                         {
@@ -1192,7 +1193,7 @@ namespace BoundTreeGenerator
 
                     foreach (var node in _tree.Types.OfType<Node>())
                     {
-                        WriteLine("Public Overrides Function Visit{0}(node as {1}) As BoundNode", StripBound(node.Name), node.Name);
+                        WriteLine(GetVisitFunctionDeclaration(node.Name, isOverride: true));
                         Indent();
                         foreach (Field field in AllFields(node).Where(f => IsDerivedOrListOfDerived("BoundNode", f.Type) && !SkipInVisitor(f)))
                             WriteLine("Me.Visit{1}(node.{0})", field.Name, IsNodeList(field.Type) ? "List" : "");
@@ -1346,7 +1347,7 @@ namespace BoundTreeGenerator
                         Brace();
                         foreach (var node in _tree.Types.OfType<Node>())
                         {
-                            WriteLine("public override BoundNode Visit{0}({1} node)", StripBound(node.Name), node.Name);
+                            WriteLine(GetVisitFunctionDeclaration(node.Name, isOverride: true));
                             Brace();
                             bool hadField = false;
                             foreach (Field field in AllNodeOrNodeListFields(node))
@@ -1392,7 +1393,7 @@ namespace BoundTreeGenerator
                         Blank();
                         foreach (var node in _tree.Types.OfType<Node>())
                         {
-                            WriteLine("Public Overrides Function Visit{0}(node As {1}) As BoundNode", StripBound(node.Name), node.Name);
+                            WriteLine(GetVisitFunctionDeclaration(node.Name, isOverride: true));
                             Indent();
 
                             bool hadField = false;
@@ -1430,6 +1431,107 @@ namespace BoundTreeGenerator
                         }
                         Outdent();
                         WriteLine("End Class");
+                        break;
+                    }
+
+                default:
+                    throw new ArgumentException("Unexpected target language", nameof(_targetLang));
+            }
+        }
+
+        private void WriteNullabilityRewriter()
+        {
+            switch (_targetLang)
+            {
+                case TargetLanguage.VB:
+                    break;
+
+                case TargetLanguage.CSharp:
+                    {
+                        Blank();
+                        WriteLine("internal sealed partial class NullabilityRewriter : BoundTreeRewriter");
+                        Brace();
+
+                        var topLevelNullabilities = "_topLevelNullabilities";
+                        WriteLine($"private readonly ImmutableDictionary<BoundExpression, TypeSymbolWithAnnotations> {topLevelNullabilities};");
+
+                        Blank();
+                        WriteLine("public NullabilityRewriter(ImmutableDictionary<BoundExpression, TypeSymbolWithAnnotations> topLevelNullabilities)");
+                        Brace();
+                        WriteLine($"{topLevelNullabilities} = topLevelNullabilities;");
+                        Unbrace();
+
+                        foreach (var node in _tree.Types.OfType<Node>().Where(n => IsDerivedType("BoundExpression", n.Name)))
+                        {
+                            Blank();
+                            WriteLine(GetVisitFunctionDeclaration(node.Name, isOverride: true));
+                            Brace();
+                            bool hadField = false;
+                            foreach (Field field in AllNodeOrNodeListFields(node))
+                            {
+                                hadField = true;
+                                if (SkipInVisitor(field))
+                                {
+                                    WriteLine($"{field.Type} {ToCamelCase(field.Name)} = node.{field.Name};");
+                                }
+                                else
+                                {
+                                    WriteLine($"{field.Type} {ToCamelCase(field.Name)} = ({field.Type})this.Visit{(IsNodeList(field.Type) ? "List" : "")}(node.{field.Name});");
+                                }
+                            }
+                            if (hadField)
+                            {
+                                WriteLine($"{node.Name} updatedNode;");
+                                Blank();
+                                WriteNullabilityCheck(inverted: false);
+                                Brace();
+                                WriteTypeSymbolRetreival();
+                                WriteUpdate(decl: false, updatedType: true);
+                                WriteNullabilityUpdate();
+                                Unbrace();
+                                WriteLine("else");
+                                Brace();
+                                WriteUpdate(decl: false, updatedType: false);
+                                Unbrace();
+                                WriteLine("return updatedNode;");
+                            }
+                            else
+                            {
+                                WriteNullabilityCheck(inverted: true);
+                                Brace();
+                                WriteLine("return node;");
+                                Unbrace();
+                                Blank();
+                                WriteTypeSymbolRetreival();
+                                WriteUpdate(decl: true, updatedType: true);
+                                WriteNullabilityUpdate();
+                                WriteLine("return updatedNode;");
+                            }
+                            Unbrace();
+
+                            void WriteNullabilityCheck(bool inverted) =>
+                                WriteLine($"if ({(inverted ? "!" : "")}{topLevelNullabilities}.ContainsKey(node))");
+
+                            void WriteTypeSymbolRetreival() =>
+                                WriteLine($"TypeSymbol type = {topLevelNullabilities}[node].TypeSymbol;");
+
+                            void WriteUpdate(bool decl, bool updatedType)
+                            {
+                                Write($"{(decl ? $"{node.Name} " : "")}updatedNode = node.Update");
+                                ParenList(
+                                    AllSpecifiableFields(node),
+                                    field => IsDerivedOrListOfDerived("BoundNode", field.Type) || (updatedType && field.Name == "Type")
+                                                ? ToCamelCase(field.Name)
+                                                : string.Format("node.{0}", field.Name));
+                                WriteLine(";");
+                            }
+
+                            void WriteNullabilityUpdate()
+                            {
+                                WriteLine($"updatedNode.TopLevelNullability = {topLevelNullabilities}[node].NullableAnnotation;");
+                            }
+                        }
+                        Unbrace();
                         break;
                     }
 
@@ -1632,6 +1734,21 @@ namespace BoundTreeGenerator
 
                 case TargetLanguage.VB:
                     return name.IsVBKeyword();
+
+                default:
+                    throw new ArgumentException("Unexpected target language", nameof(_targetLang));
+            }
+        }
+
+        private string GetVisitFunctionDeclaration(string nodeName, bool isOverride)
+        {
+            switch (_targetLang)
+            {
+                case TargetLanguage.CSharp:
+                    return $"public {(isOverride ? "override" : "virtual")} BoundNode Visit{StripBound(nodeName)}({nodeName} node)";
+
+                case TargetLanguage.VB:
+                    return $"Public {(isOverride ? "Overrides" : "Overridable")} Function Visit{StripBound(nodeName)}(node As {nodeName}) As BoundNode";
 
                 default:
                     throw new ArgumentException("Unexpected target language", nameof(_targetLang));


### PR DESCRIPTION
Generate a rewriter that will set the top-level nullability bits on `BoundExpression` given a map of expressions to TSWA.