### PR TITLE
Add Newtonsoft.Json dependency to dotnet-format

### DIFF
--- a/src/Tools/dotnet-format/dotnet-format.csproj
+++ b/src/Tools/dotnet-format/dotnet-format.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="$(MicrosoftVisualStudioCodingConventionsVersion)" Publish="true" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes failure to resolve NuGet SDKs.