### PR TITLE
Avoid touching files that didn't actually change

### DIFF
--- a/src/Tools/dotnet-format/CodeFormatter.cs
+++ b/src/Tools/dotnet-format/CodeFormatter.cs
@@ -159,6 +159,13 @@ namespace Microsoft.CodeAnalysis.Tools.CodeFormatter
                     }
 
                     var formattedDocument = await Formatter.FormatAsync(document, documentOptions, cancellationToken).ConfigureAwait(false);
+                    var formattedSourceText = await formattedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                    if (formattedSourceText.ContentEquals(await document.GetTextAsync(cancellationToken).ConfigureAwait(false)))
+                    {
+                        // Avoid touching files that didn't actually change
+                        return null;
+                    }
+
                     return await formattedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
                 }, cancellationToken);
 

--- a/src/Tools/dotnet-format/CodeFormatter.cs
+++ b/src/Tools/dotnet-format/CodeFormatter.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Tools.CodeFormatter
                         return null;
                     }
 
-                    return await formattedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                     return formattedSourceText;
                 }, cancellationToken);
 
                 formattedDocuments.Add((documentId, formatTask));


### PR DESCRIPTION
Substantially improves the performance of **dotnet-format** when a solution is mostly already formatted.