### PR TITLE
Fix rootnamespce property name we received from project-system

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/AdditionalPropertyNames.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/CPS/AdditionalPropertyNames.cs
@@ -7,6 +7,9 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
     /// </summary>
     internal static class AdditionalPropertyNames
     {
-        public const string RootNamespace = "rootnamespace";
+        // All supported properties can be found in dotnet/project-system repo
+        // https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
+
+        public const string RootNamespace = "RootNamespace";
     }
 }


### PR DESCRIPTION
This would light up sync namespace refactoring fro CPS projects.

@dotnet/roslyn-ide @jasonmalinowski 