### PR TITLE
Ensure we refresh the project output path when the obj path changes

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSInputSet.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSInputSet.cs
@@ -51,6 +51,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             {
                 VisualStudioProject.AssemblyName = Path.GetFileNameWithoutExtension(filename);
             }
+
+            RefreshBinOutputPath();
         }
 
         public void SetOutputFileType(OutputFileType fileType)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             VisualStudioProject.RemoveSourceFile(filename);
         }
 
-        private void RefreshBinOutputPath()
+        protected void RefreshBinOutputPath()
         {
             var storage = Hierarchy as IVsBuildPropertyStorage;
             if (storage == null)

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -317,6 +317,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                 VisualStudioProject.AssemblyName = Path.GetFileNameWithoutExtension(pCompilerOptions.wszExeName)
             End If
 
+            RefreshBinOutputPath()
+
             _runtimeLibraries = VisualStudioProjectOptionsProcessor.GetRuntimeLibraries(_compilerHost)
 
             If Not _runtimeLibraries.SequenceEqual(oldRuntimeLibraries, StringComparer.Ordinal) Then


### PR DESCRIPTION
For legacy projects, we would update our bin path whenever the obj path was updated as a heuristic. We lost that as a part of my rewrite as a simple oversight; this restores that back.

Fixes https://github.com/dotnet/roslyn/issues/32711

<details><summary>Ask Mode template</summary>

### Customer scenario

If you switch between Debug/Release, the path in a Roslyn API isn't updated. This API is used by many things, like Live Unit Testing, which causes things to get out of sync and you may see duplicate or missing tests.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/32711
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/763897

### Workarounds, if any

Don't switch configurations, but there's no alternative if you need to do that.

### Risk

Low.

### Performance impact

There's a small impact because we're querying the project system for additional information. We were doing this in Dev15 so it's not a regression from our previous major release.

### Is this a regression from a previous update?

This was broken in Dev16.0 Preview 1.

### Root cause analysis

We don't have any unit tests that cover this particular area. Creating tests are particularly complicated because there's a lot of mocks that are required. We're actively looking to deprecate this legacy code in future Dev16 updates.

### How was the bug found?

Internal testing.
</details>