### PR TITLE
Ignore InvalidOperationException from GetInstalledPackages

### DIFF
--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -502,6 +502,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                 // Nuget may throw an ArgumentException when there is something about the project 
                 // they do not like/support.
             }
+            catch (InvalidOperationException)
+            {
+                // NuGet throws an InvalidOperationException if details
+                // for the project fail to load. We don't need to report
+                // these, and can assume that this will work on a future
+                // project change
+            }
             catch (Exception e) when (FatalError.ReportWithoutCrash(e))
             {
             }

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -502,12 +502,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                 // Nuget may throw an ArgumentException when there is something about the project 
                 // they do not like/support.
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException e) when (e.StackTrace.Contains("NuGet.PackageManagement.VisualStudio.NetCorePackageReferenceProject.GetPackageSpecsAsync"))
             {
                 // NuGet throws an InvalidOperationException if details
                 // for the project fail to load. We don't need to report
                 // these, and can assume that this will work on a future
                 // project change
+                // This should be removed with https://github.com/dotnet/roslyn/issues/33187
             }
             catch (Exception e) when (FatalError.ReportWithoutCrash(e))
             {


### PR DESCRIPTION
The NFW from these aren't meaningful, and it's expected that eventually this will work. 

Current NFW reports are [here](https://features.vsdata.io/investigatefault?mt=MAC_ADDRESS_HASHES&et=FAULT&sd=2018-12-29&ed=2019-01-28&pn=vs&fn=ide/vbcs/nonfatalwatson&en=nonfatalwatson&fh=13e849c3-da74-b9b7-5ed0-817c663d2226&ex=devenv&ut=external)

Helps resolve part of #20101 