### PR TITLE
Avoid unnecessary thread-local variables

### DIFF
--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
@@ -188,33 +188,20 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         private List<T> AddOperations<T>(List<SyntaxNode> nodes, Action<List<T>, SyntaxNode> addOperations, CancellationToken cancellationToken)
         {
-            using (var localOperations = new ThreadLocal<List<T>>(() => new List<T>(), trackAllValues: true))
-            using (var localList = new ThreadLocal<List<T>>(() => new List<T>(), trackAllValues: false))
+            var operations = new List<T>();
+            var list = new List<T>();
+
+            foreach (var n in nodes)
             {
-                // find out which executor we want to use.
-                foreach (var n in nodes)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
+                addOperations(list, n);
 
-                    var list = localList.Value;
-                    addOperations(list, n);
-
-                    foreach (var element in list)
-                    {
-                        if (element != null)
-                        {
-                            localOperations.Value.Add(element);
-                        }
-                    }
-
-                    list.Clear();
-                }
-
-                var operations = new List<T>(localOperations.Values.Sum(v => v.Count));
-                operations.AddRange(localOperations.Values.SelectMany(v => v));
-
-                return operations;
+                list.RemoveAll(item => item == null);
+                operations.AddRange(list);
+                list.Clear();
             }
+
+            return operations;
         }
 
         private TokenPairWithOperations[] CreateTokenOperation(


### PR DESCRIPTION
This unnecessary use of `ThreadLocal<T>` was showing up in formatter performance traces. The improvement is small, but the code is also simpler when normal local variables are used.