### PR TITLE
Fix Formatting Warnings on Build

### DIFF
--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
@@ -73,9 +73,9 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
                     return (t.invocationOrCreation, additionalNodesToTrack.ToImmutableAndFree());
                 },
                 (_1, _2, _3) => true,
-                (semanticModel, currentRoot, t, currentNode) 
+                (semanticModel, currentRoot, t, currentNode)
                     => ReplaceIdentifierWithInlineDeclaration(
-                        options, semanticModel, currentRoot, t.declarator, 
+                        options, semanticModel, currentRoot, t.declarator,
                         t.identifier, t.invocationOrCreation, currentNode, declarationsToRemove),
                 cancellationToken).ConfigureAwait(false);
         }

--- a/src/Tools/dotnet-format/CodeFormatter.cs
+++ b/src/Tools/dotnet-format/CodeFormatter.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Tools.CodeFormatter
                         return null;
                     }
 
-                     return formattedSourceText;
+                    return formattedSourceText;
                 }, cancellationToken);
 
                 formattedDocuments.Add((documentId, formatTask));


### PR DESCRIPTION
This PR fixes the several format warnings that occur when building with .\Build.cmd