### PR TITLE
Don't use an elastic CR/LF for separating using directives groups

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.CSharp.UseExpressionBody;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.CSharp;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Options;
@@ -85,6 +86,48 @@ class Program
             return AssertCodeCleanupResult(expected, code,
                 (CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, enabled: true),
                 (CodeCleanupOptions.SortImports, enabled: true),
+                (CodeCleanupOptions.ApplyImplicitExplicitTypePreferences, enabled: false),
+                (CodeCleanupOptions.AddAccessibilityModifiers, enabled: false));
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
+        public Task SortUsings_WithSeparateImportGroups()
+        {
+            var code = @"using System.Collections.Generic;
+using System;
+using Microsoft.CSharp;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var list = new List<int>();
+        Console.WriteLine(list.Count);
+        CSharpCodeProvider cSharpCodeProvider;
+    }
+}
+";
+
+            var expected = @"using System;
+using System.Collections.Generic;
+
+using Microsoft.CSharp;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var list = new List<int>();
+        Console.WriteLine(list.Count);
+        CSharpCodeProvider cSharpCodeProvider;
+    }
+}
+";
+            return AssertCodeCleanupResult(expected, code,
+                (CodeCleanupOptions.PerformAdditionalCodeCleanupDuringFormatting, enabled: true),
+                (CodeCleanupOptions.SortImports, enabled: true),
+                (GenerationOptions.SeparateImportDirectiveGroups, enabled: true),
                 (CodeCleanupOptions.ApplyImplicitExplicitTypePreferences, enabled: false),
                 (CodeCleanupOptions.AddAccessibilityModifiers, enabled: false));
         }

--- a/src/Workspaces/CSharp/Portable/Utilities/UsingsAndExternAliasesOrganizer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/UsingsAndExternAliasesOrganizer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 {
     internal static partial class UsingsAndExternAliasesOrganizer
     {
-        private static readonly SyntaxTrivia s_newLine = SyntaxFactory.ElasticCarriageReturnLineFeed;
+        private static readonly SyntaxTrivia s_newLine = SyntaxFactory.CarriageReturnLineFeed;
 
         public static void Organize(
             SyntaxList<ExternAliasDirectiveSyntax> externAliasList,


### PR DESCRIPTION
This fixes #28631. This is a bug that happens when you use the C# Code Cleanup, and you have "separating using directives groups" setting enabled (added in #21087). This setting is not honored because an elastic CR/LF is issued, and the Formatter will remove that via the `ElasticTriviaFormattingRule`.

/cc @CyrusNajmabadi 