### PR TITLE
Fix up support for changing rule set files through the Solution Explorer 

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/AnalyzersTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -70,6 +71,29 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
                 project.SetOptions($"/ruleset:{ruleSetFile.Path}");
                 var ca1012DiagnosticOption = environment.Workspace.CurrentSolution.Projects.Single().CompilationOptions.SpecificDiagnosticOptions["CA1012"];
                 Assert.Equal(expected: ReportDiagnostic.Error, actual: ca1012DiagnosticOption);
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void RuleSet_PathCanBeFound()
+        {
+            using (var ruleSetFile = new DisposableFile())
+            using (var environment = new TestEnvironment())
+            {
+                ProjectId projectId;
+
+                using (var project = CSharpHelpers.CreateCSharpCPSProject(environment, "Test"))
+                {
+                    project.SetOptions($"/ruleset:{ruleSetFile.Path}");
+
+                    projectId = project.Id;
+
+                    Assert.Equal(ruleSetFile.Path, environment.Workspace.TryGetRuleSetPathForProject(projectId));
+                }
+
+                // Ensure it's still not available after we disposed the project
+                Assert.Null(environment.Workspace.TryGetRuleSetPathForProject(projectId));
             }
         }
     }

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/AnalyzersTests.cs
@@ -65,6 +65,23 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
             }
         }
 
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void RuleSet_CanBeFetchedFromWorkspace()
+        {
+            using (var ruleSetFile = new DisposableFile())
+            using (var environment = new TestEnvironment())
+            {
+                var project = CSharpHelpers.CreateCSharpProject(environment, "Test");
+
+                ((IAnalyzerHost)project).SetRuleSetFile(ruleSetFile.Path);
+
+                var projectId = environment.Workspace.CurrentSolution.ProjectIds.Single();
+                Assert.Equal(ruleSetFile.Path, environment.Workspace.TryGetRuleSetPathForProject(projectId));
+            }
+        }
+
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void RuleSet_ProjectSettingOverridesGeneralOption()

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -2,20 +2,14 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
-using Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -26,10 +20,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
     using Workspace = Microsoft.CodeAnalysis.Workspace;
 
-    // NOTE: Microsoft.VisualStudio.LanguageServices.TypeScript.TypeScriptProject derives from AbstractProject.
-#pragma warning disable CS0618 // IVisualStudioHostProject is obsolete
+    [Obsolete("This is a compatibility shim for TypeScript and Live Unit Testing; please do not use it.")]
     internal abstract partial class AbstractProject : ForegroundThreadAffinitizedObject, IVisualStudioHostProject
-#pragma warning restore CS0618 // IVisualStudioHostProject is obsolete
     {
         internal const string ProjectGuidPropertyName = "ProjectGuid";
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -107,8 +107,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return VisualStudioProject.OutputFilePath;
         }
 
-        public IReferenceCountedDisposable<IRuleSetFile> RuleSetFile { get; private set; }
-
         protected IVsReportExternalErrors ExternalErrorReporter { get; }
 
         internal HostDiagnosticUpdateSource HostDiagnosticUpdateSource { get; }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -78,6 +78,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                     ProjectGuid = GetProjectIDGuid(hierarchy),
                 });
 
+            ((VisualStudioWorkspaceImpl)Workspace).AddProjectRuleSetFileToInternalMaps(
+                VisualStudioProject,
+                () => VisualStudioProjectOptionsProcessor.EffectiveRuleSetFilePath);
+
             // Right now VB doesn't have the concept of "default namespace". But we conjure one in workspace 
             // by assigning the value of the project's root namespace to it. So various feature can choose to 
             // use it for their own purpose.

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
@@ -82,6 +82,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
+        /// <summary>
+        /// Returns the active path to the rule set file that is being used by this project, or null if there isn't a rule set file.
+        /// </summary>
+        public string EffectiveRuleSetFilePath => _ruleSetFile?.Target.Value.FilePath;
+
         private void ReparseCommandLine_NoLock()
         {
             var arguments = CommandLineParser.SplitCommandLineIntoArguments(_commandLine, removeHashComments: false);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
@@ -82,8 +82,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
-        public HostWorkspaceServices WorkspaceServices => _workspaceServices;
-
         private void ReparseCommandLine_NoLock()
         {
             var arguments = CommandLineParser.SplitCommandLineIntoArguments(_commandLine, removeHashComments: false);
@@ -114,7 +112,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var sourceSearchPaths = ImmutableArray<string>.Empty;
 
             var referenceResolver = new WorkspaceMetadataFileReferenceResolver(
-                    WorkspaceServices.GetRequiredService<IMetadataService>(),
+                    _workspaceServices.GetRequiredService<IMetadataService>(),
                     new RelativePathResolver(referenceSearchPaths, _commandLineArgumentsForCommandLine.BaseDirectory));
 
             var compilationOptions = _commandLineArgumentsForCommandLine.CompilationOptions

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -114,6 +114,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
+        [Obsolete("This is a compatibility shim for TypeScript and F#; please do not use it.")]
         internal bool TryGetProjectByBinPath(string filePath, out AbstractProject project)
         {
             var projectsWithBinPath = _workspace.CurrentSolution.Projects.Where(p => string.Equals(p.OutputFilePath, filePath, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -130,6 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
+        [Obsolete("This is a compatibility shim for TypeScript and F#; please do not use it.")]
         private sealed class StubProject : AbstractProject
         {
             private readonly ProjectId _id;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspace.cs
@@ -118,5 +118,7 @@ namespace Microsoft.VisualStudio.LanguageServices
         {
             return this.Services.GetService<IMetadataService>().GetReference(filePath, properties);
         }
+
+        internal abstract string TryGetRuleSetPathForProject(ProjectId projectId);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -246,6 +246,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
+        [Obsolete("This is a compatibility shim for Live Unit Testing; please do not use it.")]
         private sealed class StubProject : AbstractProject
         {
             private readonly string _outputPath;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -63,7 +63,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         private ImmutableDictionary<ProjectId, IVsHierarchy> _projectToHierarchyMap = ImmutableDictionary<ProjectId, IVsHierarchy>.Empty;
         private ImmutableDictionary<ProjectId, Guid> _projectToGuidMap = ImmutableDictionary<ProjectId, Guid>.Empty;
-        private Dictionary<string, List<VisualStudioProject>> _projectSystemNameToProjectsMap = new Dictionary<string, List<VisualStudioProject>>();
+
+        /// <summary>
+        /// A map to fetch the path to a rule set file for a project. This right now is only used to implement
+        /// <see cref="TryGetRuleSetPathForProject(ProjectId)"/> and any other use is extremely suspicious, since direct use of this is out of
+        /// sync with the Workspace if there is active batching happening.
+        /// </summary>
+        private readonly Dictionary<ProjectId, Func<string>> _projectToRuleSetFilePath = new Dictionary<ProjectId, Func<string>>();
+
+        private readonly Dictionary<string, List<VisualStudioProject>> _projectSystemNameToProjectsMap = new Dictionary<string, List<VisualStudioProject>>();
 
         /// <summary>
         /// A set of documents that were added by <see cref="VisualStudioProject.AddSourceTextContainer"/>, and aren't otherwise
@@ -133,6 +141,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _projectToHierarchyMap = _projectToHierarchyMap.Add(project.Id, hierarchy);
                 _projectToGuidMap = _projectToGuidMap.Add(project.Id, guid);
                 _projectSystemNameToProjectsMap.MultiAdd(projectSystemName, project);
+            }
+        }
+
+        internal void AddProjectRuleSetFileToInternalMaps(VisualStudioProject project, Func<string> ruleSetFilePathFunc)
+        {
+            lock (_gate)
+            {
+                _projectToRuleSetFilePath.Add(project.Id, ruleSetFilePathFunc);
             }
         }
 
@@ -211,6 +227,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
 
             return new StubProject(ProjectTracker, project, GetHierarchy(projectId), project.OutputFilePath);
+        }
+
+        // TODO: consider whether this should be going to the project system directly to get this path. This is only called on interactions from the
+        // Solution Explorer in the SolutionExplorerShim, where if we just could more directly get to the rule set file it'd simplify this.
+        internal override string TryGetRuleSetPathForProject(ProjectId projectId)
+        {
+            lock (_gate)
+            {
+                if (_projectToRuleSetFilePath.TryGetValue(projectId, out var ruleSetPathFunc))
+                {
+                    return ruleSetPathFunc();
+                }
+                else
+                {
+                    return null;
+                }
+            }
         }
 
         private sealed class StubProject : AbstractProject
@@ -1347,8 +1380,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     _projectReferenceInfoMap.Remove(projectId);
                 }
 
-                _projectToGuidMap = _projectToGuidMap.Remove(projectId);
                 _projectToHierarchyMap = _projectToHierarchyMap.Remove(projectId);
+                _projectToGuidMap = _projectToGuidMap.Remove(projectId);
+                _projectToRuleSetFilePath.Remove(projectId);
 
                 foreach (var (projectName, projects) in _projectSystemNameToProjectsMap)
                 {

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -66,6 +66,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             if (visualStudioWorkspace.Services.GetLanguageServices(visualStudioProject.Language).GetService<ICommandLineParserService>() != null)
             {
                 _visualStudioProjectOptionsProcessor = new VisualStudioProjectOptionsProcessor(_visualStudioProject, visualStudioWorkspace.Services);
+                _visualStudioWorkspace.AddProjectRuleSetFileToInternalMaps(
+                    visualStudioProject,
+                    () => _visualStudioProjectOptionsProcessor.EffectiveRuleSetFilePath);
             }
 
             // We don't have a SVsShellDebugger service in unit tests, in that case we can't implement ENC. We're OK

--- a/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.Designer.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SolutionExplorer {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SolutionExplorerShim {
@@ -120,15 +120,6 @@ namespace Microsoft.VisualStudio.LanguageServices.SolutionExplorer {
         internal static string Could_not_create_a_rule_set_for_project_0 {
             get {
                 return ResourceManager.GetString("Could_not_create_a_rule_set_for_project_0", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Could not find project {0}..
-        /// </summary>
-        internal static string Could_not_find_project_0 {
-            get {
-                return ResourceManager.GetString("Could_not_find_project_0", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.resx
+++ b/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.resx
@@ -135,9 +135,6 @@
   <data name="Diagnostic_Properties" xml:space="preserve">
     <value>Diagnostic Properties</value>
   </data>
-  <data name="Could_not_find_project_0" xml:space="preserve">
-    <value>Could not find project {0}.</value>
-  </data>
   <data name="No_rule_set_file_is_specified_or_the_file_does_not_exist" xml:space="preserve">
     <value>No rule set file is specified, or the file does not exist.</value>
   </data>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.cs.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.cs.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Diagnostické vlastnosti</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">Projekt {0} nebylo možné najít.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">Není zadaný žádný soubor sady pravidel nebo tento soubor neexistuje.</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.de.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.de.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Diagnoseeigenschaften</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">Das Projekt {0} wurde nicht gefunden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">Es wurde keine Regelsatzdatei angegeben, oder die Datei ist nicht vorhanden.</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.es.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.es.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Propiedades de diagnóstico</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">No se encuentra el proyecto {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">No se ha especificado ningún conjunto de reglas o el archivo no existe.</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.fr.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.fr.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Propriétés de diagnostic</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">Projet {0} introuvable.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">Aucun fichier d'ensemble de règles indiqué ou le fichier n'existe pas.</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.it.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.it.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Proprietà diagnostica</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">Il progetto {0} non è stato trovato.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">Il file del set di regole non è stato specificato oppure non esiste.</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.ja.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.ja.xlf
@@ -32,11 +32,6 @@
         <target state="translated">診断のプロパティ</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">プロジェクト {0} が見つかりませんでした。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">ルール セット ファイルが指定されていないか、ファイルが存在しません。</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.ko.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.ko.xlf
@@ -32,11 +32,6 @@
         <target state="translated">진단 속성</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">{0} 프로젝트를 찾을 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">규칙 설정 파일을 지정하지 않았거나 파일이 없습니다.</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.pl.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.pl.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Właściwości diagnostyczne</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">Nie można odnaleźć projektu {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">Nie określono pliku zestawu reguł lub plik nie istnieje.</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.pt-BR.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.pt-BR.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Propriedades de Diagnóstico</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">Não foi possível encontrar o projeto {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">Nenhum arquivo de conjunto de regras foi especificado ou o arquivo não existe.</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.ru.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.ru.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Свойства диагностики</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">Не удалось найти проект {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">Файл набора правил не задан или не существует.</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.tr.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.tr.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Tanılama Özellikleri</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">{0} projesi bulunamadı.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">Kural kümesi dosyası belirtilmedi veya dosya yok.</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.zh-Hans.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.zh-Hans.xlf
@@ -32,11 +32,6 @@
         <target state="translated">诊断属性</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">找不到项目 {0}。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">未指定任何规则集文件，或文件不存在。</target>

--- a/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.zh-Hant.xlf
+++ b/src/VisualStudio/Core/SolutionExplorerShim/xlf/SolutionExplorerShim.zh-Hant.xlf
@@ -32,11 +32,6 @@
         <target state="translated">診斷屬性</target>
         <note />
       </trans-unit>
-      <trans-unit id="Could_not_find_project_0">
-        <source>Could not find project {0}.</source>
-        <target state="translated">找不到專案 {0}。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="No_rule_set_file_is_specified_or_the_file_does_not_exist">
         <source>No rule set file is specified, or the file does not exist.</source>
         <target state="translated">未指定任何規則集檔案，或該檔案不存在。</target>

--- a/src/VisualStudio/TestUtilities2/CodeModel/Mocks/MockVisualStudioWorkspace.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/Mocks/MockVisualStudioWorkspace.vb
@@ -81,6 +81,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.Mocks
         Friend Function GetFileCodeModelComHandle(id As DocumentId) As ComHandle(Of EnvDTE80.FileCodeModel2, FileCodeModel)
             Return _fileCodeModels(id)
         End Function
+
+        Friend Overrides Function TryGetRuleSetPathForProject(projectId As ProjectId) As String
+            Throw New NotImplementedException()
+        End Function
     End Class
 
     Public Class MockInvisibleEditor


### PR DESCRIPTION
The AnalyzersCommandHandler was still trying to call GetHostProject to find the host project as a way to directly grab the rule set file to process that. That was deprecated but we hadn't fixed it up yet.

The fix is to re-thread through a way to get to the rule set. The "ownership" of a rule set file (if one exists for a project) is owned by the VisualStudioProjectOptionsProcessor, so we now need a way to jump to that directly from any project so another map is added to the VisualStudioWorkspaceImpl. That map is unfortunate -- the OptionsProcessor is really something that should be private to the project system itself and shouldn't be grabbable by any random code.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/779916
Completes task https://devdiv.visualstudio.com/DevDiv/_workitems/edit/698029

<details><summary>Ask Mode template</summary>

### Customer scenario

If you go to the Solution Explorer and expand the Analyzers node, you can browse the rules that are associated with the analyzers you reference. If you right click a rule, choose Set Severity, and choose an option, you get an error message instead of it working.

### Bugs this fixes

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/779916

### Workarounds, if any

Just edit the rule set file with the designer or manually.

### Risk

Low.

### Performance impact

None, nothing is really changing.

### Is this a regression from a previous update?

Yes, this was broken in Dev16.0 Preview 1.

### Root cause analysis

This was an incomplete refactoring that we had a TODO comment for but the tracking bug got misassigned. It was then caught in dogfooding and fixed. We've also figured out where the bug went and are cleaning those up.

### How was the bug found?

Internal dogfooding.

</details>