### PR TITLE
Work around bug in NamedPipeClientStream.ConnectAsync

### DIFF
--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                     // To avoid this, we first force ourselves to a background thread using Task.Run.
                     // This ensures that the Task created by ConnectAsync will run on the default
                     // TaskScheduler (i.e., on a threadpool thread) which was the intent all along.
-                    await Task.Run(async () => await pipeStream.ConnectAsync(timeoutMs, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
+                    await Task.Run(() => pipeStream.ConnectAsync(timeoutMs, cancellationToken)).ConfigureAwait(false);
                 }
                 catch (Exception e) when (e is IOException || e is TimeoutException)
                 {

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -336,7 +336,16 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 Log("Attempt to connect named pipe '{0}'", pipeName);
                 try
                 {
-                    await pipeStream.ConnectAsync(timeoutMs, cancellationToken).ConfigureAwait(false);
+                    // NamedPipeClientStream.ConnectAsync on the "full" framework has a bug where it
+                    // tries to move potentially expensive work (actually connecting to the pipe) to
+                    // a background thread with Task.Factory.StartNew. However, that call will merely
+                    // queue the work onto the TaskScheduler associated with the "current" Task which
+                    // does not guarantee it will be processed on a background thread and this could
+                    // lead to a hang.
+                    // To avoid this, we first force ourselves to a background thread using Task.Run.
+                    // This ensures that the Task created by ConnectAsync will run on the default
+                    // TaskScheduler (i.e., on a threadpool thread) which was the intent all along.
+                    await Task.Run(async () => await pipeStream.ConnectAsync(timeoutMs, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
                 }
                 catch (Exception e) when (e is IOException || e is TimeoutException)
                 {


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/764608.

`NamedPipeClientStream.ConnectAsync` attempts to be asynchronous by
moving the expensive work (actually connecting to the named pipe) off to
a background thread via `Task.Factory.StartNew(Action,
CancellationToken)`. However, this is the wrong overload to call, and in
some situations is guaranteed to _not_ schedule the new `Task` to a
background thread.

This overload will, by default, use whatever `TaskScheduler` is
associated with the "current" `Task`, if any, and only schedule the work
to at threadpool thread if there is no current `Task` or if that `Task`
is already associated with the threadpool `TaskScheduler`. If, on the
other hand, you're on the UI thread of a GUI application (like Visual
Studio) the new `Task` will also end up scheduled to the UI
thread--exactly the outcome we were trying to avoid.

Once this happens you can easily end up in a situation where a
subsequent blocking call (e.g. `Task.Wait(...)`) blocks the UI thread
while effectively waiting for that `Task` to complete... which it can't
do because the UI thread is blocked! Now you've got a single-threaded
deadlock and your UI hangs.

To work around this issue, here we first force ourselves to a
threadpool thread via `Task.Run` and _then_ call `ConnectAsync`. Thus
the `Task` created by `Task.Factory.StartNew` will also end up on a
threadpool thread.