### PR TITLE
Issue 32399 Fix removable cast suggestion on GetType in VB

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
@@ -1363,7 +1363,7 @@ End Module
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
-        Public Async Function TestDontRemoveNecessaryPredefinedCastWithGetType() As Task
+        Public Async Function TestDontRemoveNecessaryStringPredefinedCastWithGetType() As Task
             Dim markup =
 <File>
 Module Program
@@ -1378,7 +1378,37 @@ End Module
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
-        Public Async Function TestDontRemoveNecessaryCTypeCastWithGetType() As Task
+        Public Async Function TestDontRemoveNecessaryWideningPredefinedCastWithGetType() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = [|CLng(a).GetType()|]
+    End Sub
+End Module
+</File>
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestDontRemoveNecessaryNarrowingPredefinedCastWithGetType() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = [|CByte(a).GetType()|]
+    End Sub
+End Module
+</File>
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestDontRemoveNecessaryStringCTypeCastWithGetType() As Task
             Dim markup =
 <File>
 Module Program
@@ -1389,6 +1419,174 @@ Module Program
 End Module
 </File>
             Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestDontRemoveNecessaryWideningCTypeCastWithGetType() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = [|CType(a, Long).GetType()|]
+    End Sub
+End Module
+</File>
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestDontRemoveNecessaryNarrowingCTypeCastWithGetType() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = [|CType(a, Byte).GetType()|]
+    End Sub
+End Module
+</File>
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestDontRemoveNecessaryUserDefinedCTypeCastWithGetType() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = [|CType(a, WeirdInt).GetType()|]
+    End Sub
+
+    Public Class WeirdInt
+        Private val As Integer
+        Public Sub New(ByVal b As Integer)
+            Me.val = b
+        End Sub
+        Public Shared Widening Operator CType(ByVal d As WeirdInt) As Integer
+            Return d.val
+        End Operator
+        Public Shared Narrowing Operator CType(ByVal i As Integer) As WeirdInt
+            Return New WeirdInt(i)
+        End Operator
+    End Class
+End Module
+</File>
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestRemoveUnnecessaryCTypeCastWithGetType() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = [|CType(a, Object).GetType()|]
+    End Sub
+End Module
+</File>
+            Dim expected =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = a.GetType()
+    End Sub
+End Module
+</File>
+            Await TestAsync(markup, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestRemoveUnnecessaryInheritedCTypeCastWithGetType() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a As BaseClass
+        a = New DerivedClass()
+        Dim b = [|CType(a, BaseClass).GetType()|]
+    End Sub
+
+    Public Class BaseClass
+    End Class
+
+    Public Class DerivedClass : Inherits BaseClass
+    End Class
+End Module
+</File>
+            Dim expected =
+<File>
+Module Program
+    Sub Main()
+        Dim a As BaseClass
+        a = New DerivedClass()
+        Dim b = a.GetType()
+    End Sub
+
+    Public Class BaseClass
+    End Class
+
+    Public Class DerivedClass : Inherits BaseClass
+    End Class
+End Module
+</File>
+            Await TestAsync(markup, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestRemoveUnnecessaryDirectCastWithGetType() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = [|DirectCast(a, Object).GetType()|]
+    End Sub
+End Module
+</File>
+            Dim expected =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = a.GetType()
+    End Sub
+End Module
+</File>
+            Await TestAsync(markup, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestRemoveUnnecessaryTryCastWithGetType() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = [|TryCast(a, Object).GetType()|]
+    End Sub
+End Module
+</File>
+            Dim expected =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = a.GetType()
+    End Sub
+End Module
+</File>
+            Await TestAsync(markup, expected)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
@@ -1362,6 +1362,51 @@ End Module
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestDontRemoveNecessaryPredefinedCastWithGetType() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = [|CStr(a).GetType()|]
+    End Sub
+End Module
+</File>
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestDontRemoveNecessaryCTypeCastWithGetType() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = [|CType(a, String).GetType()|]
+    End Sub
+End Module
+</File>
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
+        <WorkItem(32399, "https://github.com/dotnet/roslyn/issues/32399")>
+        Public Async Function TestDontRemoveNecessaryPredefinedCastWithToString() As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main()
+        Dim a = 2
+        Dim b = [|CStr(a).ToString()|]
+    End Sub
+End Module
+</File>
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)>
         <WorkItem(30617, "https://github.com/dotnet/roslyn/issues/30617")>
         Public Async Function TestDontRemoveNecessaryPredefinedCastInWithStatement() As Task
             Dim markup =

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -536,7 +536,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 var originalExpressionSymbol = this.OriginalSemanticModel.GetSymbolInfo(currentOriginalNode).Symbol;
                 var replacedExpressionSymbol = this.SpeculativeSemanticModel.GetSymbolInfo(currentReplacedNode).Symbol;
 
-                if (IsExpressionSymbolSystemObjectMethod(originalExpressionSymbol) && IsExpressionSymbolSystemObjectMethod(replacedExpressionSymbol))
+                if (IsSymbolSystemObjectInstanceMethod(originalExpressionSymbol) && IsSymbolSystemObjectInstanceMethod(replacedExpressionSymbol))
                 {
                     var previousOriginalType = this.OriginalSemanticModel.GetTypeInfo(previousOriginalNode).Type;
                     var previousReplacedType = this.SpeculativeSemanticModel.GetTypeInfo(previousReplacedNode).Type;
@@ -551,7 +551,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// <summary>
         /// Determines if the symbol is a non-overridable, non static method on System.Object (e.g. GetType)
         /// </summary>
-        private bool IsExpressionSymbolSystemObjectMethod(ISymbol symbol)
+        private bool IsSymbolSystemObjectInstanceMethod(ISymbol symbol)
         {
             return symbol != null
                 && symbol.IsKind(SymbolKind.Method)

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -554,7 +554,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// <summary>
         /// Determines if the symbol is a non-overridable, non static method on System.Object (e.g. GetType)
         /// </summary>
-        private bool IsSymbolSystemObjectInstanceMethod(ISymbol symbol)
+        private static bool IsSymbolSystemObjectInstanceMethod(ISymbol symbol)
         {
             return symbol != null
                 && symbol.IsKind(SymbolKind.Method)

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -476,7 +476,6 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 // If replacing the node will result in a change in overload resolution, we won't remove it.
                 var originalExpression = (TExpressionSyntax)currentOriginalNode;
                 var newExpression = (TExpressionSyntax)currentReplacedNode;
-
                 if (ReplacementBreaksExpression(originalExpression, newExpression))
                 {
                     return true;

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -527,7 +527,8 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         }
 
         /// <summary>
-        /// Determine if removing the cast could cause the semantics of System.Object method call.
+        /// Determine if removing the cast could cause the semantics of System.Object method call to change.
+        /// E.g. Dim b = CStr(1).GetType() is necessary, but the GetType method symbol info resolves to the same with or without the cast.
         /// </summary>
         private bool ReplacementBreaksSystemObjectMethodResolution(SyntaxNode currentOriginalNode, SyntaxNode currentReplacedNode, SyntaxNode previousOriginalNode, SyntaxNode previousReplacedNode)
         {

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -540,8 +540,10 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 {
                     var previousOriginalType = this.OriginalSemanticModel.GetTypeInfo(previousOriginalNode).Type;
                     var previousReplacedType = this.SpeculativeSemanticModel.GetTypeInfo(previousReplacedNode).Type;
-
-                    return !Equals(previousOriginalType, previousReplacedType);
+                    if (previousReplacedType != null && previousOriginalType != null)
+                    {
+                        return !previousReplacedType.InheritsFromOrEquals(previousOriginalType);
+                    }
                 }
             }
 

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -670,6 +670,10 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             var symbol = originalSymbolInfo.Symbol;
             var newSymbol = newSymbolInfo.Symbol;
 
+            var originalTypeInfo = _semanticModel.GetTypeInfo(expression);
+            //_semanticModel.Get
+            //var newTypeInfo = this.SpeculativeSemanticModel.GetTypeInfo(newExpression);
+
             if (SymbolInfosAreCompatible(originalSymbolInfo, newSymbolInfo))
             {
                 // Original and new symbols for the invocation expression are compatible.

--- a/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
@@ -384,7 +384,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
                 Dim newWithStatement = DirectCast(currentReplacedNode, WithStatementSyntax)
 
                 Return ReplacementBreaksWithStatement(originalWithStatement, newWithStatement)
-
             Else
                 Dim originalCollectionRangeVariableSyntax = TryCast(currentOriginalNode, CollectionRangeVariableSyntax)
                 If originalCollectionRangeVariableSyntax IsNot Nothing Then
@@ -423,15 +422,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
                 End If
             End If
 
-            Return False
-        End Function
-
-        Private Function ReplacementBreaksGetTypeResolution(originalExpression As ExpressionSyntax, replacedExpression As ExpressionSyntax) As Boolean
-            Dim originalExpressionSymbolInfo = Me.OriginalSemanticModel.GetSymbolInfo(originalExpression)
-            Dim replacedExpressionSymbolInfo = Me.SpeculativeSemanticModel.GetSymbolInfo(replacedExpression)
-
-            Dim originalExpressionTypeInfo = Me.OriginalSemanticModel.GetTypeInfo(originalExpression)
-            Dim replacedExpressionTypeInfo = Me.SpeculativeSemanticModel.GetTypeInfo(replacedExpression)
             Return False
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
@@ -384,6 +384,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
                 Dim newWithStatement = DirectCast(currentReplacedNode, WithStatementSyntax)
 
                 Return ReplacementBreaksWithStatement(originalWithStatement, newWithStatement)
+
             Else
                 Dim originalCollectionRangeVariableSyntax = TryCast(currentOriginalNode, CollectionRangeVariableSyntax)
                 If originalCollectionRangeVariableSyntax IsNot Nothing Then
@@ -422,6 +423,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
                 End If
             End If
 
+            Return False
+        End Function
+
+        Private Function ReplacementBreaksGetTypeResolution(originalExpression As ExpressionSyntax, replacedExpression As ExpressionSyntax) As Boolean
+            Dim originalExpressionSymbolInfo = Me.OriginalSemanticModel.GetSymbolInfo(originalExpression)
+            Dim replacedExpressionSymbolInfo = Me.SpeculativeSemanticModel.GetSymbolInfo(replacedExpression)
+
+            Dim originalExpressionTypeInfo = Me.OriginalSemanticModel.GetTypeInfo(originalExpression)
+            Dim replacedExpressionTypeInfo = Me.SpeculativeSemanticModel.GetTypeInfo(replacedExpression)
             Return False
         End Function
 


### PR DESCRIPTION
See https://github.com/dotnet/roslyn/issues/32399

In VB there are a few predefined casting operators that allow conversions from certain types of expressions to another type (e.g. CStr accepts numerics, dates, booleans).  

When using GetType on the resultant object, the cast is marked as unnecessary as the symbol in both the regular and speculative tree resolves to System.Object.GetType().  This causes the symbols to be marked as compatible, and so the cast is removed.  In the case of other methods like ToString the symbols resolve differently (e.g. System.Int32.ToString() vs System.String.ToString()).  

My best guess at resolving this is then that cast should not be removed when the symbol is a non-overridable (non-static) method of System.Object.  User defined casts go through a different route in the analyzer and are not affected.
