### PR TITLE
don't retain fault result in task center if nuget info download failed.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/SymbolSearch/VisualStudioSymbolSearchService.ProgressService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/SymbolSearch/VisualStudioSymbolSearchService.ProgressService.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             var options = new TaskHandlerOptions
             {
                 Title = title,
-                ActionsAfterCompletion = CompletionActions.RetainOnFaulted
+                ActionsAfterCompletion = CompletionActions.None
             };
 
             return options;


### PR DESCRIPTION
to retain fault result in task center, we need to provide detail info UI so that user can click the fault task left in the task center, but right now we don't have one and we don't want to just show exception message in message box.

we could think of using RetainAndNotifyFault so that we show exception message in the task center tip, but that would be annoying since most likely it is info user didn't ask for or care.

we can add UI later if user ever ask for it. for now, taking simple approach of just removing it from task center once download is done in any way (success, cancelled, failed)

fixes https://github.com/dotnet/roslyn/issues/32944
closes #29694