### PR TITLE
Allow ForEach to For when there are comments 

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertForEachToFor/ConvertForEachToForTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertForEachToFor/ConvertForEachToForTests.cs
@@ -360,7 +360,7 @@ class Test
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertForEachToFor)]
-        public async Task CommentNotSupported()
+        public async Task TestCommentsInTheMiddleOfParentheses()
         {
             var text = @"
 class Test
@@ -372,11 +372,21 @@ class Test
     }
 }
 ";
-            await TestMissingInRegularAndScriptAsync(text);
+            var expected = @"
+class Test
+{
+    void Method()
+    {
+        var array = new int[] { 1, 3, 4 };
+        for (int {|Rename:i|} = 0; i < array.Length; i++) ;
+    }
+}
+";
+            await TestInRegularAndScriptAsync(text, expected);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertForEachToFor)]
-        public async Task CommentNotSupported2()
+        public async Task TestCommentsAtBeginningOfParentheses()
         {
             var text = @"
 class Test
@@ -388,11 +398,21 @@ class Test
     }
 }
 ";
-            await TestMissingInRegularAndScriptAsync(text);
+            var expected = @"
+class Test
+{
+    void Method()
+    {
+        var array = new int[] { 1, 3, 4 };
+        for (int {|Rename:i|} = 0; i < array.Length; i++) ;
+    }
+}
+";
+            await TestInRegularAndScriptAsync(text, expected);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertForEachToFor)]
-        public async Task CommentNotSupported3()
+        public async Task TestCommentsAtTheEndOfParentheses()
         {
             var text = @"
 class Test
@@ -404,7 +424,17 @@ class Test
     }
 }
 ";
-            await TestMissingInRegularAndScriptAsync(text);
+            var expected = @"
+class Test
+{
+    void Method()
+    {
+        var array = new int[] { 1, 3, 4 };
+        for (int {|Rename:i|} = 0; i < array.Length; i++) ;
+    }
+}
+";
+            await TestInRegularAndScriptAsync(text, expected);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertForEachToFor)]

--- a/src/EditorFeatures/VisualBasicTest/ConvertForEachToFor/ConvertForEachToForTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertForEachToFor/ConvertForEachToForTests.vb
@@ -228,7 +228,7 @@ End Class
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertForEachToFor)>
-        Public Async Function CommentNotSupported() As Task
+        Public Async Function TestCommentsLiveBetweenForEachAndArrayDeclaration() As Task
             Dim initial = "
 Class Test
     Sub Method()
@@ -239,8 +239,16 @@ Class Test
     End Sub
 End Class
 "
-
-            Await TestMissingInRegularAndScriptAsync(initial)
+            Dim Expected = "
+Class Test
+    Sub Method()
+        Dim {|Rename:array|} = New Integer() {1, 2, 3}
+        For {|Rename:i|} = 0 To array.Length - 1
+        Next
+    End Sub
+End Class
+"
+            Await TestInRegularAndScriptAsync(initial, Expected)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertForEachToFor)>

--- a/src/Features/CSharp/Portable/ConvertForEachToFor/CSharpConvertForEachToForCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertForEachToFor/CSharpConvertForEachToForCodeRefactoringProvider.cs
@@ -5,12 +5,10 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.ConvertForEachToFor;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -36,24 +34,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertForEachToFor
             if (!scope.IntersectsWith(selection))
             {
                 return null;
-            }
-
-            // check whether there is any comments between foreach and ) tokens
-            // if they do, we don't support conversion.
-            foreach (var trivia in foreachStatement.DescendantTrivia(n => n == foreachStatement || scope.Contains(n.FullSpan)))
-            {
-                if (trivia.Span.End <= scope.Start ||
-                    scope.End <= trivia.Span.Start)
-                {
-                    continue;
-                }
-
-                if (trivia.Kind() != SyntaxKind.WhitespaceTrivia &&
-                    trivia.Kind() != SyntaxKind.EndOfLineTrivia)
-                {
-                    // we don't know what to do with these comments
-                    return null;
-                }
             }
 
             return foreachStatement;

--- a/src/Features/VisualBasic/Portable/ConvertForEachToFor/VisualBasicConvertForEachToForCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ConvertForEachToFor/VisualBasicConvertForEachToForCodeRefactoringProvider.vb
@@ -33,22 +33,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertForEachToFor
                 Return Nothing
             End If
 
-            ' check whether there Is any comments or line continuation within foreach statement
-            ' if they do, we don't support conversion.
-            For Each trivia In forEachBlock.ForEachStatement.DescendantTrivia()
-                If trivia.Span.End <= scope.Start OrElse
-                   scope.End <= trivia.Span.Start Then
-                    Continue For
-                End If
-
-                If trivia.Kind() <> SyntaxKind.WhitespaceTrivia AndAlso
-                   trivia.Kind() <> SyntaxKind.EndOfLineTrivia AndAlso
-                   trivia.Kind() <> SyntaxKind.LineContinuationTrivia Then
-                    ' we don't know what to do with these
-                    Return Nothing
-                End If
-            Next
-
             Return forEachBlock
         End Function
 


### PR DESCRIPTION
Related: [issue](26571)

Remove the check for comments for both VB and C# so the refactoring will be provided.
Change the corresponding tests.


