### PR TITLE
Improve method that finds an expression's parent lambda to introduce a local into

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -2479,10 +2479,10 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<int, Func<int, int>> f = x =>
+        Func<int, Func<int, int>> f = x => y =>
         {
             var {|Rename:v|} = x + 1;
-            return y => v;
+            return v;
         };
     }
 }",
@@ -2539,8 +2539,11 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<int, int> {|Rename:p|} = y => y + 1;
-        Func<int, Func<int, int>> f = x => p;
+        Func<int, Func<int, int>> f = x =>
+        {
+            Func<int, int> {|Rename:p|} = y => y + 1;
+            return p;
+        };
     }
 }");
         }
@@ -4377,11 +4380,11 @@ class TestClass
     @"using System;
 class TestClass
 {
-    Func<int, int> Y()
+    Func<int, int> Y() => f =>
     {
         const int {|Rename:V|} = 9;
-        return f => f * V;
-    }
+        return f * V;
+    };
 }";
 
             await TestInRegularAndScriptAsync(code, expected, index: 2);
@@ -4431,11 +4434,11 @@ class TestClass
     @"using System;
 class TestClass
 {
-    Func<int, int> Y()
+    Func<int, int> Y() => (f) =>
     {
         const int {|Rename:V|} = 9;
-        return (f) => f * V;
-    }
+        return f * V;
+    };
 }";
 
             await TestInRegularAndScriptAsync(code, expected, index: 2);

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -3337,6 +3337,41 @@ class T
             await TestInRegularAndScriptAsync(code, expected, index: 2);
         }
 
+        [WorkItem(31012, "https://github.com/dotnet/roslyn/issues/31012")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestIntroduceLocalInArgumentList()
+        {
+            var code =
+                @"using System;
+public interface IResolver { int Resolve(); }
+public class Test
+{
+    private void register(Func<IResolver, object> a) { }
+    private void test(Func<int, object> factory)
+        => register(x => factory(
+            [|x.Resolve()|]
+        ));
+}";
+
+            var expected =
+                @"using System;
+public interface IResolver { int Resolve(); }
+public class Test
+{
+    private void register(Func<IResolver, object> a) { }
+    private void test(Func<int, object> factory)
+        => register(x =>
+        {
+            int {|Rename:arg|} = x.Resolve();
+            return factory(
+     arg
+ );
+        });
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, index: 0);
+        }
+
         [WorkItem(24807, "https://github.com/dotnet/roslyn/issues/24807")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public async Task TestIntroduceLocalInExpressionBodiedVoidMethod()

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
                     return (LambdaExpressionSyntax)current.Parent;
                 }
 
-                current = current.Parent as ExpressionSyntax;
+                current = current.Parent?.FirstAncestorOrSelf<ExpressionSyntax>();
             }
 
             return null;


### PR DESCRIPTION
This is a fix for issue https://github.com/dotnet/roslyn/issues/31012.

Consider the expression `x.Resolve()` on line 8 of the following piece of code:
```cs
using System;
public interface IResolver { int Resolve(); }
public class Test
{
    private void register(Func<IResolver, object> a) { }
    private void test(Func<int, object> factory)
        => register(x => factory(
            x.Resolve() // <== this one
        ));
}
```
When we want to introduce a local for it, we enter a method called `GetParentLambda` which, starting with the expression `x.Resolve()`, looks along its parent chain in order to find the lambda that begins with `x =>` on line 7. But it doesn't find it, because the parent of `x.Resolve()` is an `ArgumentSyntax` and not an `ExpressionSyntax`, which causes it to stop looking.

The fix that I am proposing here changes the algorithm in such a way that it skips over the `ArgumentSyntax` and the `ArgumentListSyntax`, so that it finds the lambda that it's looking for.