### PR TITLE
Support running integration tests in VS 2019

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/StartPage_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/StartPage_InProc.cs
@@ -2,14 +2,19 @@
 
 using System;
 using Microsoft.VisualStudio.Shell.Interop;
+using vsStartUp = EnvDTE.vsStartUp;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 {
     internal class StartPage_InProc : InProcComponent
     {
         // Values come from Tools -> Options -> Environment -> Startup -> At startup
-        private const int ShowEmptyEnvironment = 4;
+        private const int ShowEmptyEnvironment = (int)vsStartUp.vsStartUpEmptyEnvironment;
         private const int ShowStartPage = 5;
+
+        // These values apply to Visual Studio 2019
+        private const int VS2019ShowStartWindow = 13;
+        private const int VS2019ShowEmptyEnvironment = 10;
 
         public static StartPage_InProc Create()
             => new StartPage_InProc();
@@ -19,7 +24,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             return InvokeOnUIThread(() =>
             {
                 var property = GetProperty();
-                return (int)property.Value == ShowStartPage;
+                if (new Version(property.DTE.Version).Major == 16)
+                {
+                    return (int)property.Value == VS2019ShowStartWindow;
+                }
+                else
+                {
+                    return (int)property.Value == ShowStartPage;
+                }
             });
         }
 
@@ -28,7 +40,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             InvokeOnUIThread(() =>
             {
                 var property = GetProperty();
-                property.Value = enabled ? ShowStartPage : ShowEmptyEnvironment;
+                if (new Version(property.DTE.Version).Major == 16)
+                {
+                    property.Value = enabled ? VS2019ShowStartWindow : VS2019ShowEmptyEnvironment;
+                }
+                else
+                {
+                    property.Value = enabled ? ShowStartPage : ShowEmptyEnvironment;
+                }
             });
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -163,7 +163,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 supportedPackageIds = ImmutableHashSet.CreateRange(instance.GetPackages().Select((supportedPackage) => supportedPackage.GetId()));
                 installationPath = instance.GetInstallationPath();
 
-                hostProcess = StartNewVisualStudioProcess(installationPath);
+                var instanceVersion = instance.GetInstallationVersion();
+                var majorVersion = int.Parse(instanceVersion.Substring(0, instanceVersion.IndexOf('.')));
+                hostProcess = StartNewVisualStudioProcess(installationPath, majorVersion);
 
                 var procDumpInfo = ProcDumpInfo.ReadFromEnvironment();
                 if (procDumpInfo != null)
@@ -248,14 +250,16 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             {
                 var isMatch = true;
                 {
-                    isMatch &= instance.GetInstallationVersion().StartsWith(VsProductVersion);
-
                     if (haveVsInstallDir)
                     {
                         var installationPath = instance.GetInstallationPath();
                         installationPath = Path.GetFullPath(installationPath);
                         installationPath = installationPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                         isMatch &= installationPath.Equals(vsInstallDir, StringComparison.OrdinalIgnoreCase);
+                    }
+                    else
+                    {
+                        isMatch &= instance.GetInstallationVersion().StartsWith(VsProductVersion);
                     }
                 }
                 return isMatch;
@@ -291,12 +295,19 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                                 "There were no instances of Visual Studio found that match the specified requirements.");
         }
 
-        private static Process StartNewVisualStudioProcess(string installationPath)
+        private static Process StartNewVisualStudioProcess(string installationPath, int majorVersion)
         {
             var vsExeFile = Path.Combine(installationPath, @"Common7\IDE\devenv.exe");
+            var vsRegEditExeFile = Path.Combine(installationPath, @"Common7\IDE\VsRegEdit.exe");
 
             if (_firstLaunch)
             {
+                if (majorVersion == 16)
+                {
+                    // Make sure the start window doesn't show on launch
+                    Process.Start(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU General OnEnvironmentStartup dword 10").WaitForExit();
+                }
+
                 // BUG: Currently building with /p:DeployExtension=true does not always cause the MEF cache to recompose...
                 //      So, run clearcache and updateconfiguration to workaround https://devdiv.visualstudio.com/DevDiv/_workitems?id=385351.
                 Process.Start(vsExeFile, $"/clearcache {VsLaunchArgs}").WaitForExit();


### PR DESCRIPTION
This change enables integration tests to be run from Test Explorer in Visual Studio 2019.