### PR TITLE
Require dev16 for integration testing

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -3,9 +3,7 @@ trigger:
 - master
 - master-vs-deps
 - dev16.0-preview2
-- dev16.0-preview2-vs-deps
 - dev16.0-preview3
-- dev16.0-preview3-vs-deps
 - dev16.1-preview1
 - dev16.1-preview1-vs-deps
 
@@ -16,9 +14,7 @@ pr:
 - features/*
 - demos/*
 - dev16.0-preview2
-- dev16.0-preview2-vs-deps
 - dev16.0-preview3
-- dev16.0-preview3-vs-deps
 - dev16.1-preview1
 - dev16.1-preview1-vs-deps
 

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "tools": {
     "dotnet": "2.1.401",
     "vs": {
-      "version": "15.8"
+      "version": "16.0"
     },
     "xcopy-msbuild": "15.9.0-alpha"
   },

--- a/src/VisualStudio/IntegrationTest/TestUtilities/App.config
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/App.config
@@ -10,7 +10,7 @@
   <userSettings>
     <Microsoft.VisualStudio.IntegrationTest.Utilities.Settings>
       <setting name="VsProductVersion" serializeAs="String">
-        <value>15</value>
+        <value>16</value>
       </setting>
       <setting name="VsRootSuffix" serializeAs="String">
         <value>RoslynDev</value>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Settings.Designer.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.0.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("15")]
+        [global::System.Configuration.DefaultSettingValueAttribute("16")]
         public string VsProductVersion {
             get {
                 return ((string)(this["VsProductVersion"]));

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Settings.settings
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Settings.settings
@@ -3,7 +3,7 @@
   <Profiles />
   <Settings>
     <Setting Name="VsProductVersion" Type="System.String" Scope="User">
-      <Value Profile="(Default)">15</Value>
+      <Value Profile="(Default)">16</Value>
     </Setting>
     <Setting Name="VsRootSuffix" Type="System.String" Scope="User">
       <Value Profile="(Default)">RoslynDev</Value>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -39,9 +39,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         {
             var majorVsProductVersion = VsProductVersion.Split('.')[0];
 
-            if (int.Parse(majorVsProductVersion) < 15)
+            if (int.Parse(majorVsProductVersion) < 16)
             {
-                throw new PlatformNotSupportedException("The Visual Studio Integration Test Framework is only supported on Visual Studio 15.0 and later.");
+                throw new PlatformNotSupportedException("The Visual Studio Integration Test Framework is only supported on Visual Studio 16.0 and later.");
             }
         }
 


### PR DESCRIPTION
The vs-deps branches have dependencies on Visual Studio 2019 that cannot be fulfilled on Visual Studio 2017. This change updates these branches to require Visual Studio 2019 for integration testing.