### PR TITLE
Move MSBuild installation directory to Current

### DIFF
--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
@@ -65,7 +65,7 @@
         <Path Condition="'%(CompilerArtifact._OptimizeAssembly)' != ''">%(CompilerArtifact._OptimizeAssembly)</Path>
         <NGenArchitectureString Condition="'%(CompilerArtifact.NgenArchitecture)' != ''"> vs.file.ngenArchitecture=%(CompilerArtifact.NgenArchitecture)</NGenArchitectureString>
         <NGenPriorityString Condition="'%(CompilerArtifact.NGenPriority)' != ''"> vs.file.ngenPriority=%(CompilerArtifact.NGenPriority)</NGenPriorityString>
-        <NGenApplicationString Condition="'%(CompilerArtifact.NGenApplication)' != ''"> vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\Roslyn\%(CompilerArtifact.NGenApplication)"</NGenApplicationString>
+        <NGenApplicationString Condition="'%(CompilerArtifact.NGenApplication)' != ''"> vs.file.ngenApplication="[installDir]\MSBuild\Current\Bin\Roslyn\%(CompilerArtifact.NGenApplication)"</NGenApplicationString>
       </_File>
 
       <_FileEntries Include='file source="%(_File.Path)"%(_File.NGenArchitectureString)%(_File.NGenPriorityString)%(_File.NGenApplicationString)'/>
@@ -144,49 +144,49 @@ vs.dependencies
 vs.nonCriticalProcesses
   vs.nonCriticalProcess name="VBCSCompiler"
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn
+folder InstallDir:\MSBuild\Current\Bin\Roslyn
   @(_FileEntries, '%0d%0a  ')
 
 folder InstallDir:\Common7\Tools\vsdevcmd\ext
   file source="$(MSBuildProjectDirectory)\roslyn.bat"
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\cs
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\cs
   @(_CsSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\de
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\de
   @(_DeSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\es
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\es
   @(_EsSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\fr
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\fr
   @(_FrSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\it
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\it
   @(_ItSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ja
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\ja
   @(_JaSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ko
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\ko
   @(_KoSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\pl
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\pl
   @(_PlSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\pt-BR
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\pt-BR
   @(_PlSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ru
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\ru
   @(_RuSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\tr
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\tr
   @(_TrSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\zh-Hans
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\zh-Hans
   @(_zh-HansSatellite->'%(_FileEntries)', '%0d%0a  ')
 
-folder InstallDir:\MSBuild\15.0\Bin\Roslyn\zh-Hant
+folder InstallDir:\MSBuild\Current\Bin\Roslyn\zh-Hant
   @(_zh-HantSatellite->'%(_FileEntries)', '%0d%0a  ')
 ]]>
       </_Lines>

--- a/src/Setup/DevDivVsix/CompilersPackage/roslyn.bat
+++ b/src/Setup/DevDivVsix/CompilersPackage/roslyn.bat
@@ -6,7 +6,7 @@ if "%VSCMD_ARG_CLEAN_ENV%" NEQ "" goto :clean_env
 @REM ------------------------------------------------------------------------
 :start
 
-set "PATH=%VSINSTALLDIR%MSBuild\15.0\bin\Roslyn;%PATH%"
+set "PATH=%VSINSTALLDIR%MSBuild\Current\bin\Roslyn;%PATH%"
 
 goto :end
 


### PR DESCRIPTION
MSBuild has changed their installation versioning story. Components now
insert into a directory named Current instead of a directory name
matching the Visual Studio major version (i.e. 15.0). This changes
Roslyn to match the new design.

Note: this change must be inserted into VS in coordination with MSBuild.
Otherwise the insertion will fail.

https://github.com/Microsoft/msbuild/issues/4069
https://github.com/Microsoft/msbuild/issues/3778