### PR TITLE
Avoid a lambda allocation when accessing a cache in a hotpath.

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -163,7 +163,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return GetMetadataChecksumSlow(solution, reference, cancellationToken);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static Checksum GetMetadataChecksumSlow(Solution solution, PortableExecutableReference reference, CancellationToken cancellationToken)
         {
             return ChecksumCache.GetOrCreate(reference, _ =>

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
@@ -157,6 +158,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return cached;
             }
 
+            return GetMetadataChecksumSlow(solution, reference, cancellationToken);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/33131")]
+        private static Checksum GetMetadataChecksumSlow(Solution solution, PortableExecutableReference reference, CancellationToken cancellationToken)
+        {
             return ChecksumCache.GetOrCreate(reference, _ =>
             {
                 var serializer = solution.Workspace.Services.GetService<ISerializerService>();

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -147,6 +147,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
         }
 
+        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/33131", AllowCaptures = false)]
         public static Checksum GetMetadataChecksum(
             Solution solution, PortableExecutableReference reference, CancellationToken cancellationToken)
         {
@@ -158,6 +159,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return cached;
             }
 
+            // Break things up to the fast path above and this slow path were we allocate a closure.
             return GetMetadataChecksumSlow(solution, reference, cancellationToken);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -151,6 +151,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             // We can reuse the index for any given reference as long as it hasn't changed.
             // So our checksum is just the checksum for the PEReference itself.
+            // First see if the value is already in the cache, to avoid an allocation if possible.
+            if (ChecksumCache.TryGetValue(reference, out var cached))
+            {
+                return cached;
+            }
+
             return ChecksumCache.GetOrCreate(reference, _ =>
             {
                 var serializer = solution.Workspace.Services.GetService<ISerializerService>();

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -164,7 +164,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/33131")]
         private static Checksum GetMetadataChecksumSlow(Solution solution, PortableExecutableReference reference, CancellationToken cancellationToken)
         {
             return ChecksumCache.GetOrCreate(reference, _ =>

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return cached;
             }
 
-            // Break things up to the fast path above and this slow path were we allocate a closure.
+            // Break things up to the fast path above and this slow path where we allocate a closure.
             return GetMetadataChecksumSlow(solution, reference, cancellationToken);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -277,6 +277,20 @@ namespace Microsoft.CodeAnalysis.Serialization
             return (IReadOnlyList<T>)s_cache.GetValue(unorderedList, orderedListGetter);
         }
 
+        public static bool TryGetValue(object value, out Checksum checksum)
+        {
+            // same key should always return same checksum
+            if (!s_cache.TryGetValue(value, out var result))
+            {
+                checksum = default;
+                return false;
+            }
+
+            checksum = (Checksum)result;
+            return true;
+        }
+
+
         public static Checksum GetOrCreate(object value, ConditionalWeakTable<object, object>.CreateValueCallback checksumCreator)
         {
             // same key should always return same checksum


### PR DESCRIPTION
Mitigation for https://github.com/dotnet/roslyn/issues/33131