### PR TITLE
Remove unneeded foreground check

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -167,8 +167,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
 
         protected void RemoveFile(string filename)
         {
-            AssertIsForeground();
-
             // We have tests that assert that XOML files should not get added; this was similar
             // behavior to how ASP.NET projects would add .aspx files even though we ultimately ignored
             // them. XOML support is planned to go away for Dev16, but for now leave the logic there.


### PR DESCRIPTION
We do not need to assert that we are on the foreground thread to remove a file in the legacy project. The CPS project does the same thing and it does not seem to require the foreground thread. This will help enable initialization of Roslyn on the background thread by the legacy project system.