### PR TITLE
[WIP] Add ISymbol.DeclaringSyntaxReferencesEnumerable

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -2177,6 +2177,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             get { throw new NotImplementedException(); }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { throw new NotImplementedException(); }
+        }
+
         internal override ConstantValue GetConstantValue(SyntaxNode node, LocalSymbol inProgress, DiagnosticBag diagnostics)
         {
             throw new NotImplementedException();

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.ObjectCreationPlaceholderLocal.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.ObjectCreationPlaceholderLocal.cs
@@ -68,6 +68,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+            {
+                get
+                {
+                    return SyntaxReferenceEnumerable.Empty;
+                }
+            }
+
             public override ImmutableArray<Location> Locations
             {
                 get

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineProperty.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/SynthesizedStateMachineProperty.cs
@@ -111,6 +111,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<SyntaxReference>.Empty; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { return SyntaxReferenceEnumerable.Empty; }
+        }
+
         public override Accessibility DeclaredAccessibility
         {
             get { return _getter.DeclaredAccessibility; }

--- a/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AliasSymbol.cs
@@ -159,6 +159,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(this, (symbol, index) => DeclaringSyntaxReferenceEnumerableMoveNextHelper<UsingDirectiveSyntax>(((AliasSymbol)symbol)._locations, index));
+            }
+        }
+
         public override bool IsExtern
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -253,6 +253,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+            {
+                get
+                {
+                    return new SyntaxReferenceEnumerable(this, (symbol, index) => DeclaringSyntaxReferenceEnumerableMoveNextHelper<AnonymousObjectCreationExpressionSyntax>(((AnonymousTypePublicSymbol)symbol).TypeDescriptor.Location, index));
+                }
+            }
+
             public override bool IsStatic
             {
                 get { return false; }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.FieldSymbol.cs
@@ -117,6 +117,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+            {
+                get
+                {
+                    return SyntaxReferenceEnumerable.Empty;
+                }
+            }
+
             public override Accessibility DeclaredAccessibility
             {
                 get { return Accessibility.Private; }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.PropertySymbol.cs
@@ -78,6 +78,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+            {
+                get
+                {
+                    return new SyntaxReferenceEnumerable(this, (symbol, index) => DeclaringSyntaxReferenceEnumerableMoveNextHelper<AnonymousObjectMemberDeclaratorSyntax>(((AnonymousTypePropertySymbol)symbol).Locations, index));
+                }
+            }
+
             public override bool IsStatic
             {
                 get { return false; }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
@@ -363,6 +363,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+            {
+                get
+                {
+                    return SyntaxReferenceEnumerable.Empty;
+                }
+            }
+
             public override bool IsStatic
             {
                 get { return false; }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
@@ -48,6 +48,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+            {
+                get
+                {
+                    return SyntaxReferenceEnumerable.Empty;
+                }
+            }
+
             public override int Ordinal
             {
                 get { return _ordinal; }

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -314,6 +314,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         internal override TResult Accept<TArgument, TResult>(CSharpSymbolVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             return visitor.VisitArrayType(this, argument);

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -283,6 +283,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         /// <summary>
         /// True if the assembly contains interactive code.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DiscardSymbol.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override Symbol ContainingSymbol => null;
         public override Accessibility DeclaredAccessibility => Accessibility.NotApplicable;
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable => SyntaxReferenceEnumerable.Empty;
         public override bool IsAbstract => false;
         public override bool IsExtern => false;
         public override bool IsImplicitlyDeclared => true;

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -81,6 +81,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => null;
 
         internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<TypeSymbol> basesBeingResolved)

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
@@ -94,6 +94,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override Symbol ContainingSymbol
         {
             get { return _containingType; }

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorPropertySymbol.cs
@@ -59,6 +59,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences { get { return ImmutableArray<SyntaxReference>.Empty; } }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable { get { return SyntaxReferenceEnumerable.Empty; } }
+
         public override Accessibility DeclaredAccessibility { get { return Accessibility.NotApplicable; } }
 
         public override bool IsStatic { get { return false; } }

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
@@ -111,6 +111,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+            {
+                get
+                {
+                    return SyntaxReferenceEnumerable.Empty;
+                }
+            }
+
             public override VarianceKind Variance
             {
                 get

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -256,6 +256,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         /// <summary>
         /// Returns the arity of this type, or the number of type parameters it takes.
         /// A non-generic type has zero arity.

--- a/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MergedNamespaceSymbol.cs
@@ -280,6 +280,45 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                if (_namespacesToMerge.Length == 0)
+                {
+                    return SyntaxReferenceEnumerable.Empty;
+                }
+                else if (_namespacesToMerge.Length == 1)
+                {
+                    return _namespacesToMerge[0].DeclaringSyntaxReferencesEnumerable;
+                }
+                else
+                {
+                    SyntaxReferenceEnumerator enumerator = default;
+                    return new SyntaxReferenceEnumerable(
+                        this,
+                        (symbol, index) =>
+                        {
+                            for (int namespaceIndex = index; namespaceIndex < _namespacesToMerge.Length;)
+                            {
+                                if (namespaceIndex >= 0 && enumerator.MoveNext())
+                                {
+                                    return (index, enumerator.Current);
+                                }
+
+                                namespaceIndex++;
+                                if (namespaceIndex < _namespacesToMerge.Length)
+                                {
+                                    enumerator = _namespacesToMerge[namespaceIndex].DeclaringSyntaxReferencesEnumerable.GetEnumerator();
+                                }
+                            }
+
+                            return default;
+                        });
+                }
+            }
+        }
+
         internal override void GetExtensionMethods(ArrayBuilder<MethodSymbol> methods, string name, int arity, LookupOptions options)
         {
             foreach (NamespaceSymbol namespaceSymbol in _namespacesToMerge)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -349,6 +349,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override ImmutableArray<CSharpAttributeData> GetAttributes()
         {
             if (_lazyCustomAttributes.IsDefault)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -378,6 +378,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override Accessibility DeclaredAccessibility
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -715,6 +715,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable => SyntaxReferenceEnumerable.Empty;
+
         public override ImmutableArray<CSharpAttributeData> GetAttributes()
         {
             if (!_packedFlags.IsCustomAttributesPopulated)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -1473,6 +1473,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override string Name
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
@@ -149,6 +149,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         /// <summary>
         /// Returns PEModuleSymbol containing the namespace.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -792,6 +792,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override ImmutableArray<CSharpAttributeData> GetAttributes()
         {
             if (_lazyCustomAttributes.IsDefault)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -532,6 +532,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override ImmutableArray<CSharpAttributeData> GetAttributes()
         {
             if (_lazyCustomAttributes.IsDefault)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -260,6 +260,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override bool HasConstructorConstraint
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/MissingNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingNamespaceSymbol.cs
@@ -106,6 +106,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override ImmutableArray<NamedTypeSymbol> GetTypeMembers()
         {
             return ImmutableArray<NamedTypeSymbol>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -197,6 +197,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         /// <summary>
         /// Returns an array of assembly identities for assemblies referenced by this module.
         /// Items at the same position from ReferencedAssemblies and from ReferencedAssemblySymbols 

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -193,6 +193,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         internal override TResult Accept<TArgument, TResult>(CSharpSymbolVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             return visitor.VisitPointerType(this, argument);

--- a/src/Compilers/CSharp/Portable/Symbols/PreprocessingSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PreprocessingSymbol.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     /// <summary>
     /// Represents a preprocessing conditional compilation symbol.
     /// </summary>
-    internal class PreprocessingSymbol : Symbol, IPreprocessingSymbol
+    internal sealed class PreprocessingSymbol : Symbol, IPreprocessingSymbol
     {
         private readonly string _name;
 
@@ -37,7 +36,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return GetDeclaringSyntaxReferenceHelper<CSharpSyntaxNode>(Locations);
+                return ImmutableArray<SyntaxReference>.Empty;
+            }
+        }
+
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/RangeVariableSymbol.cs
@@ -65,6 +65,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        if (index != -1)
+                        {
+                            return default;
+                        }
+
+                        SyntaxToken token = (SyntaxToken)((RangeVariableSymbol)symbol)._locations[0].SourceTree.GetRoot().FindToken(((RangeVariableSymbol)symbol)._locations[0].SourceSpan.Start);
+                        Debug.Assert(token.Kind() == SyntaxKind.IdentifierToken);
+                        CSharpSyntaxNode node = (CSharpSyntaxNode)token.Parent;
+                        Debug.Assert(node is QueryClauseSyntax || node is QueryContinuationSyntax || node is JoinIntoClauseSyntax);
+                        return (0, node.GetReference());
+                    });
+            }
+        }
+
         public override bool IsExtern
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -218,6 +218,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _reducedFrom.DeclaringSyntaxReferences; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { return _reducedFrom.DeclaringSyntaxReferencesEnumerable; }
+        }
+
         public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             return _reducedFrom.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.cs
@@ -162,6 +162,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return _underlyingNamespace.DeclaringSyntaxReferencesEnumerable;
+            }
+        }
+
         public override AssemblySymbol ContainingAssembly
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
@@ -111,6 +111,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences { get { throw ExceptionUtilities.Unreachable; } }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable { get { throw ExceptionUtilities.Unreachable; } }
+
         public override Accessibility DeclaredAccessibility { get { throw ExceptionUtilities.Unreachable; } }
 
         public override bool IsStatic { get { throw ExceptionUtilities.Unreachable; } }

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
@@ -79,6 +79,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences { get { throw ExceptionUtilities.Unreachable; } }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable { get { throw ExceptionUtilities.Unreachable; } }
+
         public override AssemblySymbol ContainingAssembly { get { throw ExceptionUtilities.Unreachable; } }
 
         internal override ModuleSymbol ContainingModule { get { throw ExceptionUtilities.Unreachable; } }

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyPropertySymbol.cs
@@ -69,6 +69,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences { get { throw ExceptionUtilities.Unreachable; } }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable { get { throw ExceptionUtilities.Unreachable; } }
+
         public override Accessibility DeclaredAccessibility { get { throw ExceptionUtilities.Unreachable; } }
 
         public override bool IsVirtual { get { throw ExceptionUtilities.Unreachable; } }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
@@ -165,6 +165,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        if (index != -1)
+                        {
+                            return default;
+                        }
+
+                        return (0, ((CrefTypeParameterSymbol)symbol)._declaringSyntax);
+                    });
+            }
+        }
+
         internal override void EnsureAllConstraintsAreResolved(bool early)
         {
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
@@ -164,6 +164,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         internal override void EnsureAllConstraintsAreResolved(bool early)
         {
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbolForOverriding.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbolForOverriding.cs
@@ -157,6 +157,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         internal override void EnsureAllConstraintsAreResolved(bool early)
         {
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -280,6 +280,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        if (index != -1)
+                        {
+                            return default;
+                        }
+
+                        return (0, ((LambdaSymbol)symbol)._syntax.GetReference());
+                    });
+            }
+        }
+
         public override Symbol ContainingSymbol
         {
             get { return _containingSymbol; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -322,6 +322,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray.Create(_syntax.GetReference());
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        if (index != -1)
+                        {
+                            return default;
+                        }
+
+                        return (0, ((LocalFunctionSymbol)symbol)._syntax.GetReference());
+                    });
+            }
+        }
+
         internal override bool GenerateDebugInfo => true;
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers => ImmutableArray<CustomModifier>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceClonedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceClonedParameterSymbol.cs
@@ -42,6 +42,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override bool IsParams
         {
             get { return !_suppressOptional && _originalParam.IsParams; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -117,6 +117,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public sealed override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        if (index != -1)
+                        {
+                            return default;
+                        }
+
+                        return (0, ((SourceEventSymbol)symbol)._syntaxRef);
+                    });
+            }
+        }
+
         /// <summary>
         /// Gets the syntax list of custom attributes applied on the event symbol.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -219,6 +219,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public sealed override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        if (index != -1)
+                        {
+                            return default;
+                        }
+
+                        return (0, ((SourceFieldSymbolWithSyntaxReference)symbol)._syntaxReference);
+                    });
+            }
+        }
+
         public sealed override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             return SourceDocumentationCommentUtils.GetAndCacheDocumentationComment(this, expandIncludes, ref _lazyDocComment);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLabelSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLabelSymbol.cs
@@ -100,6 +100,37 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        if (index != -1)
+                        {
+                            return default;
+                        }
+
+                        var identifierNodeOrToken = ((SourceLabelSymbol)symbol)._identifierNodeOrToken;
+                        CSharpSyntaxNode node = null;
+
+                        if (identifierNodeOrToken.IsToken)
+                        {
+                            if (identifierNodeOrToken.Parent != null)
+                                node = identifierNodeOrToken.Parent.FirstAncestorOrSelf<LabeledStatementSyntax>();
+                        }
+                        else
+                        {
+                            node = identifierNodeOrToken.AsNode().FirstAncestorOrSelf<SwitchLabelSyntax>();
+                        }
+
+                        return node is null ? default : (0, node.GetReference());
+                    });
+            }
+        }
+
         public override MethodSymbol ContainingMethod
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -456,6 +456,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        if (index != -1)
+                        {
+                            return default;
+                        }
+
+                        return (0, ((SourceLocalSymbol)symbol)._identifierToken.Parent.GetReference());
+                    });
+            }
+        }
+
         internal override bool IsCompilerGenerated
         {
             get { return false; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -869,6 +869,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        var declarations = ((SourceMemberContainerTypeSymbol)symbol).declaration.Declarations;
+                        if (index + 1 < declarations.Length)
+                        {
+                            return (index + 1, declarations[index + 1].SyntaxReference);
+                        }
+
+                        return default;
+                    });
+            }
+        }
+
         // This method behaves the same was as the base class, but avoids allocations associated with DeclaringSyntaxReferences
         internal override bool IsDefinedInSourceTree(SyntaxTree tree, TextSpan? definedWithinSpan, CancellationToken cancellationToken)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -662,6 +662,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                if (syntaxReferenceOpt is null)
+                {
+                    return SyntaxReferenceEnumerable.Empty;
+                }
+
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        if (index != -1)
+                        {
+                            return default;
+                        }
+
+                        return (0, ((SourceMemberMethodSymbol)symbol).syntaxReferenceOpt);
+                    });
+            }
+        }
+
         public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             return SourceDocumentationCommentUtils.GetAndCacheDocumentationComment(this, expandIncludes, ref lazyDocComment);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -99,6 +99,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
             => ComputeDeclaringReferencesCore();
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        var declarations = ((SourceNamespaceSymbol)symbol)._mergedDeclaration.Declarations;
+                        if (index + 1 >= declarations.Length)
+                        {
+                            return default;
+                        }
+
+                        return (index + 1, new NamespaceDeclarationSyntaxReference(declarations[index + 1].SyntaxReference));
+                    });
+            }
+        }
+
         private ImmutableArray<SyntaxReference> ComputeDeclaringReferencesCore()
         {
             // SyntaxReference in the namespace declaration points to the name node of the namespace decl node not

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
@@ -237,6 +237,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public sealed override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                if (IsImplicitlyDeclared)
+                {
+                    return SyntaxReferenceEnumerable.Empty;
+                }
+
+                return new SyntaxReferenceEnumerable(this, (symbol, index) => DeclaringSyntaxReferenceEnumerableMoveNextHelper<ParameterSyntax>(((SourceParameterSymbol)symbol)._locations, index));
+            }
+        }
+
         public sealed override TypeSymbolWithAnnotations Type
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -575,6 +575,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        if (index != -1)
+                        {
+                            return default;
+                        }
+
+                        return (0, ((SourcePropertySymbol)symbol)._syntaxRef);
+                    });
+            }
+        }
+
         public override bool IsAbstract
         {
             get { return (_modifiers & DeclarationModifiers.Abstract) != 0; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _syntaxRefs = syntaxRefs;
         }
 
-        public override ImmutableArray<Location> Locations
+        public override sealed ImmutableArray<Location> Locations
         {
             get
             {
@@ -44,11 +44,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
+        public override sealed ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
         {
             get
             {
                 return _syntaxRefs;
+            }
+        }
+
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        var syntaxReferences = ((SourceTypeParameterSymbolBase)symbol).DeclaringSyntaxReferences;
+                        if (index + 1 < syntaxReferences.Length)
+                        {
+                            return (index + 1, syntaxReferences[index + 1]);
+                        }
+
+                        return default;
+                    });
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
@@ -69,6 +69,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableArray<SyntaxReference>.Empty; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { return SyntaxReferenceEnumerable.Empty; }
+        }
+
         public override Symbol ContainingSymbol
         {
             get { return (Symbol)_containingMethod ?? _containingType; }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -289,6 +289,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         public abstract ImmutableArray<SyntaxReference> DeclaringSyntaxReferences { get; }
 
+        public abstract SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable { get; }
+
         /// <summary>
         /// Helper for implementing <see cref="DeclaringSyntaxReferences"/> for derived classes that store a location but not a 
         /// <see cref="CSharpSyntaxNode"/> or <see cref="SyntaxReference"/>.
@@ -322,6 +324,49 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return builder.ToImmutableAndFree();
+        }
+
+        internal static (int?, SyntaxReference) DeclaringSyntaxReferenceEnumerableMoveNextHelper<TNode>(ImmutableArray<Location> locations, int previousIndex)
+            where TNode : CSharpSyntaxNode
+        {
+            for (int i = previousIndex + 1; i < locations.Length; i++)
+            {
+                Location location = locations[i];
+                if (location is null)
+                {
+                    continue;
+                }
+
+                if (location.IsInSource)
+                {
+                    SyntaxToken token = location.SourceTree.GetRoot().FindToken(location.SourceSpan.Start);
+                    if (token.Kind() != SyntaxKind.None)
+                    {
+                        CSharpSyntaxNode node = token.Parent.FirstAncestorOrSelf<TNode>();
+                        if (node != null)
+                            return (i, node.GetReference());
+                    }
+                }
+            }
+
+            return default;
+        }
+
+        internal static (int?, SyntaxReference) DeclaringSyntaxReferenceEnumerableMoveNextHelper<TNode>(Location location, int previousIndex)
+            where TNode : CSharpSyntaxNode
+        {
+            if (previousIndex == -1 && location.IsInSource)
+            {
+                SyntaxToken token = location.SourceTree.GetRoot().FindToken(location.SourceSpan.Start);
+                if (token.Kind() != SyntaxKind.None)
+                {
+                    CSharpSyntaxNode node = token.Parent.FirstAncestorOrSelf<TNode>();
+                    if (node != null)
+                        return (0, node.GetReference());
+                }
+            }
+
+            return default;
         }
 
         /// <summary>
@@ -1279,6 +1324,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 return this.DeclaringSyntaxReferences;
+            }
+        }
+
+        SyntaxReferenceEnumerable ISymbol.DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return this.DeclaringSyntaxReferencesEnumerable;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedLabelSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedLabelSymbol.cs
@@ -45,6 +45,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override bool IsImplicitlyDeclared
         {
             get { return true; }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -110,6 +110,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
             => ImmutableArray<SyntaxReference>.Empty;
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+            => SyntaxReferenceEnumerable.Empty;
+
         internal override bool HasRuntimeSpecialName
             => false;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -108,6 +108,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable => SyntaxReferenceEnumerable.Empty;
+
         public override IEnumerable<string> MemberNames => SpecializedCollections.EmptyEnumerable<string>();
 
         public override NamedTypeSymbol ConstructedFrom => this;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -116,6 +116,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable => SyntaxReferenceEnumerable.Empty;
+
         public override bool IsStatic => false;
 
         public override bool IsRefLikeType => false;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -108,6 +108,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override RefKind RefKind
         {
             get { return RefKind.None; }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
@@ -154,6 +154,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override Accessibility DeclaredAccessibility
         {
             get { return ModifierUtils.EffectiveAccessibility(_modifiers); }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
@@ -182,6 +182,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override RefKind RefKind
         {
             get { return RefKind.None; }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceMethodSymbol.cs
@@ -22,6 +22,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public sealed override bool IsImplicitlyDeclared
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
@@ -330,6 +330,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override Accessibility DeclaredAccessibility
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
@@ -129,6 +129,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return (_syntaxOpt == null) ? ImmutableArray<SyntaxReference>.Empty : ImmutableArray.Create(_syntaxOpt.GetReference()); }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                if (_syntaxOpt is null)
+                {
+                    return SyntaxReferenceEnumerable.Empty;
+                }
+
+                return new SyntaxReferenceEnumerable(
+                    this,
+                    (symbol, index) =>
+                    {
+                        if (index != -1)
+                        {
+                            return default;
+                        }
+
+                        return (0, ((SynthesizedLocal)symbol)._syntaxOpt.GetReference());
+                    });
+            }
+        }
+
         internal override SyntaxNode GetDeclaratorSyntax()
         {
             Debug.Assert(_syntaxOpt != null);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -138,6 +138,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
         {
             // Emit [Dynamic] on synthesized parameter symbols when the original parameter was dynamic 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
@@ -120,6 +120,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public override RefKind RefKind
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
@@ -58,6 +58,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _originalVariable.DeclaringSyntaxReferences; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { return _originalVariable.DeclaringSyntaxReferencesEnumerable; }
+        }
+
         internal override SyntaxNode GetDeclaratorSyntax()
         {
             return _originalVariable.GetDeclaratorSyntax();

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
@@ -118,6 +118,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                if (_isImplicitlyDeclared)
+                {
+                    return SyntaxReferenceEnumerable.Empty;
+                }
+
+                return new SyntaxReferenceEnumerable(this, (symbol, index) => DeclaringSyntaxReferenceEnumerableMoveNextHelper<CSharpSyntaxNode>(((TupleErrorFieldSymbol)symbol)._locations, index));
+            }
+        }
+
         public override bool IsImplicitlyDeclared
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -181,6 +181,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                if (_isImplicitlyDeclared)
+                {
+                    return SyntaxReferenceEnumerable.Empty;
+                }
+
+                return new SyntaxReferenceEnumerable(this, (symbol, index) => DeclaringSyntaxReferenceEnumerableMoveNextHelper<CSharpSyntaxNode>(((TupleElementFieldSymbol)symbol)._locations, index));
+            }
+        }
+
         public override bool IsImplicitlyDeclared
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1176,6 +1176,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return new SyntaxReferenceEnumerable(this, (symbol, index) => DeclaringSyntaxReferenceEnumerableMoveNextHelper<CSharpSyntaxNode>(((TupleTypeSymbol)symbol)._locations, index));
+            }
+        }
+
         internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
             if ((comparison & TypeCompareKind.IgnoreTupleNames) != 0)

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedEventSymbol.cs
@@ -80,6 +80,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return _underlyingEvent.DeclaringSyntaxReferencesEnumerable;
+            }
+        }
+
         public override Accessibility DeclaredAccessibility
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedFieldSymbol.cs
@@ -178,6 +178,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return _underlyingField.DeclaringSyntaxReferencesEnumerable;
+            }
+        }
+
         public override bool IsStatic
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
@@ -94,6 +94,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return UnderlyingMethod.DeclaringSyntaxReferencesEnumerable;
+            }
+        }
+
         public override Accessibility DeclaredAccessibility
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
@@ -135,6 +135,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return _underlyingType.DeclaringSyntaxReferencesEnumerable;
+            }
+        }
+
         public override bool IsStatic
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedParameterSymbol.cs
@@ -68,6 +68,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _underlyingParameter.DeclaringSyntaxReferences; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { return _underlyingParameter.DeclaringSyntaxReferencesEnumerable; }
+        }
+
         public override ImmutableArray<CSharpAttributeData> GetAttributes()
         {
             return _underlyingParameter.GetAttributes();

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedPropertySymbol.cs
@@ -101,6 +101,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return _underlyingProperty.DeclaringSyntaxReferencesEnumerable;
+            }
+        }
+
         public override Accessibility DeclaredAccessibility
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
@@ -121,6 +121,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return _underlyingTypeParameter.DeclaringSyntaxReferencesEnumerable;
+            }
+        }
+
         public override string Name
         {
             get

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -158,6 +158,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
+
         public MockNamedTypeSymbol(string name, IEnumerable<Symbol> children, TypeKind kind = TypeKind.Class)
         {
             _name = name;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamespaceSymbol.cs
@@ -97,5 +97,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 return ImmutableArray.Create<SyntaxReference>();
             }
         }
+
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get
+            {
+                return SyntaxReferenceEnumerable.Empty;
+            }
+        }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 *REMOVED*Microsoft.CodeAnalysis.Operations.IEventAssignmentOperation.EventReference.get -> Microsoft.CodeAnalysis.Operations.IEventReferenceOperation
 Microsoft.CodeAnalysis.IFieldSymbol.IsFixedSizeBuffer.get -> bool
+Microsoft.CodeAnalysis.ISymbol.DeclaringSyntaxReferencesEnumerable.get -> Microsoft.CodeAnalysis.SyntaxReferenceEnumerable
 Microsoft.CodeAnalysis.ITypeSymbol.IsRefLikeType.get -> bool
 Microsoft.CodeAnalysis.ITypeSymbol.IsUnmanagedType.get -> bool
 Microsoft.CodeAnalysis.OperationKind.Binary = 32 -> Microsoft.CodeAnalysis.OperationKind
@@ -34,6 +35,16 @@ Microsoft.CodeAnalysis.Operations.ISwitchExpressionArmOperation.Value.get -> Mic
 Microsoft.CodeAnalysis.Operations.ISwitchExpressionOperation
 Microsoft.CodeAnalysis.Operations.ISwitchExpressionOperation.Arms.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Operations.ISwitchExpressionArmOperation>
 Microsoft.CodeAnalysis.Operations.ISwitchExpressionOperation.Value.get -> Microsoft.CodeAnalysis.IOperation
+Microsoft.CodeAnalysis.SyntaxReferenceEnumerable
+Microsoft.CodeAnalysis.SyntaxReferenceEnumerable.Empty.get -> Microsoft.CodeAnalysis.SyntaxReferenceEnumerable
+Microsoft.CodeAnalysis.SyntaxReferenceEnumerable.GetEnumerator() -> Microsoft.CodeAnalysis.SyntaxReferenceEnumerator
+Microsoft.CodeAnalysis.SyntaxReferenceEnumerable.SyntaxReferenceEnumerable(Microsoft.CodeAnalysis.ISymbol symbol, System.Func<Microsoft.CodeAnalysis.ISymbol, int, (int? nextIndex, Microsoft.CodeAnalysis.SyntaxReference syntaxReference)> moveNext) -> void
+Microsoft.CodeAnalysis.SyntaxReferenceEnumerator
+Microsoft.CodeAnalysis.SyntaxReferenceEnumerator.Current.get -> Microsoft.CodeAnalysis.SyntaxReference
+Microsoft.CodeAnalysis.SyntaxReferenceEnumerator.Dispose() -> void
+Microsoft.CodeAnalysis.SyntaxReferenceEnumerator.MoveNext() -> bool
+Microsoft.CodeAnalysis.SyntaxReferenceEnumerator.Reset() -> void
+Microsoft.CodeAnalysis.SyntaxReferenceEnumerator.SyntaxReferenceEnumerator(Microsoft.CodeAnalysis.ISymbol symbol, System.Func<Microsoft.CodeAnalysis.ISymbol, int, (int? nextIndex, Microsoft.CodeAnalysis.SyntaxReference syntaxReference)> moveNext) -> void
 abstract Microsoft.CodeAnalysis.Compilation.ClassifyCommonConversion(Microsoft.CodeAnalysis.ITypeSymbol source, Microsoft.CodeAnalysis.ITypeSymbol destination) -> Microsoft.CodeAnalysis.Operations.CommonConversion
 abstract Microsoft.CodeAnalysis.Compilation.ContainsSymbolsWithName(string name, Microsoft.CodeAnalysis.SymbolFilter filter = Microsoft.CodeAnalysis.SymbolFilter.TypeAndMember, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> bool
 abstract Microsoft.CodeAnalysis.Compilation.GetSymbolsWithName(string name, Microsoft.CodeAnalysis.SymbolFilter filter = Microsoft.CodeAnalysis.SymbolFilter.TypeAndMember, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ISymbol>

--- a/src/Compilers/Core/Portable/Symbols/DeclaringSyntaxReferenceEnumerable.cs
+++ b/src/Compilers/Core/Portable/Symbols/DeclaringSyntaxReferenceEnumerable.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis
+{
+    public readonly struct SyntaxReferenceEnumerable : IEnumerable<SyntaxReference>
+    {
+        private readonly ISymbol _symbol;
+        private readonly Func<ISymbol, int, (int? nextIndex, SyntaxReference syntaxReference)> _moveNext;
+
+        public SyntaxReferenceEnumerable(ISymbol symbol, Func<ISymbol, int, (int? nextIndex, SyntaxReference syntaxReference)> moveNext)
+        {
+            _symbol = symbol;
+            _moveNext = moveNext;
+        }
+
+        public static SyntaxReferenceEnumerable Empty =>
+            new SyntaxReferenceEnumerable(symbol: null, (symbol, index) => (default(int?), default(SyntaxReference)));
+
+        public SyntaxReferenceEnumerator GetEnumerator()
+        {
+            return new SyntaxReferenceEnumerator(_symbol, _moveNext);
+        }
+
+        IEnumerator<SyntaxReference> IEnumerable<SyntaxReference>.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Symbols/DeclaringSyntaxReferenceEnumerator.cs
+++ b/src/Compilers/Core/Portable/Symbols/DeclaringSyntaxReferenceEnumerator.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis
+{
+    public struct SyntaxReferenceEnumerator : IEnumerator<SyntaxReference>
+    {
+        private readonly ISymbol _symbol;
+        private readonly Func<ISymbol, int, (int? nextIndex, SyntaxReference syntaxReference)> _moveNext;
+        private int _index;
+        private SyntaxReference _current;
+
+        public SyntaxReferenceEnumerator(ISymbol symbol, Func<ISymbol, int, (int? nextIndex, SyntaxReference syntaxReference)> moveNext)
+        {
+            _symbol = symbol;
+            _moveNext = moveNext;
+            _index = -1;
+            _current = null;
+        }
+
+        public SyntaxReference Current => _current;
+        object IEnumerator.Current => Current;
+
+        public void Dispose()
+        {
+        }
+
+        public bool MoveNext()
+        {
+            var (nextIndex, syntaxReference) = _moveNext(_symbol, _index);
+            if (nextIndex == null)
+            {
+                _current = null;
+                return false;
+            }
+
+            _index = nextIndex.Value;
+            _current = syntaxReference;
+            return true;
+        }
+
+        public void Reset()
+        {
+            _index = -1;
+            _current = null;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Symbols/ISymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbol.cs
@@ -175,6 +175,8 @@ namespace Microsoft.CodeAnalysis
         /// </returns>
         ImmutableArray<SyntaxReference> DeclaringSyntaxReferences { get; }
 
+        SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable { get; }
+
         /// <summary>
         /// Gets the attributes for the symbol. Returns an empty <see cref="IEnumerable{ISymbolAttribute}"/>
         /// if there are no attributes.

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/DisplayClassVariable.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/DisplayClassVariable.cs
@@ -135,6 +135,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 get { throw ExceptionUtilities.Unreachable; }
             }
 
+            public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+            {
+                get { throw ExceptionUtilities.Unreachable; }
+            }
+
             public override bool IsConst
             {
                 get { return false; }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEDisplayClassFieldLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEDisplayClassFieldLocalSymbol.cs
@@ -77,5 +77,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             get { return ImmutableArray<SyntaxReference>.Empty; }
         }
+
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { return SyntaxReferenceEnumerable.Empty; }
+        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalConstantSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalConstantSymbol.cs
@@ -99,5 +99,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             get { return ImmutableArray<SyntaxReference>.Empty; }
         }
+
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { return SyntaxReferenceEnumerable.Empty; }
+        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbol.cs
@@ -102,6 +102,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return ImmutableArray<SyntaxReference>.Empty; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { return SyntaxReferenceEnumerable.Empty; }
+        }
+
         public override ImmutableArray<Location> Locations
         {
             get { return _locations; }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -370,6 +370,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { throw ExceptionUtilities.Unreachable; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { throw ExceptionUtilities.Unreachable; }
+        }
+
         public override Accessibility DeclaredAccessibility
         {
             get { return Accessibility.Internal; }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -295,6 +295,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return ImmutableArray<SyntaxReference>.Empty; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { return SyntaxReferenceEnumerable.Empty; }
+        }
+
         public override bool IsStatic
         {
             get { return true; }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
@@ -45,6 +45,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { throw ExceptionUtilities.Unreachable; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { throw ExceptionUtilities.Unreachable; }
+        }
+
         public override bool HasConstructorConstraint
         {
             get { return _sourceTypeParameter.HasConstructorConstraint; }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
@@ -127,6 +127,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return ImmutableArray<SyntaxReference>.Empty; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { return SyntaxReferenceEnumerable.Empty; }
+        }
+
         internal abstract override bool IsWritableVariable { get; }
 
         internal override EELocalSymbolBase ToOtherMethod(MethodSymbol method, TypeMap typeMap)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
@@ -63,6 +63,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { throw ExceptionUtilities.Unreachable; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { throw ExceptionUtilities.Unreachable; }
+        }
+
         public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations
         {
             get { return ImmutableArray<MethodSymbol>.Empty; }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SimpleTypeParameterSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SimpleTypeParameterSymbol.cs
@@ -83,6 +83,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { throw ExceptionUtilities.Unreachable; }
         }
 
+        public override SyntaxReferenceEnumerable DeclaringSyntaxReferencesEnumerable
+        {
+            get { throw ExceptionUtilities.Unreachable; }
+        }
+
         internal override void EnsureAllConstraintsAreResolved(bool early)
         {
         }


### PR DESCRIPTION
This is a proof of concept for a low-allocation alterative to `ISymbol.DeclaringSyntaxReferences` in response to #33129. 