### PR TITLE
Fix crash in classification service

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
             private void EnqueueParseSnapshotTask(Document newDocument)
             {
-                if (newDocument != null)
+                if (newDocument != null && newDocument.SupportsSyntaxTree)
                 {
                     _workQueue.EnqueueBackgroundTask(c => this.EnqueueParseSnapshotWorkerAsync(newDocument, c), GetType() + ".EnqueueParseSnapshotTask.1", CancellationToken.None);
                 }

--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -178,6 +178,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
             private void EnqueueParseSnapshotTask(Document newDocument)
             {
+                // When renaming a file's extension through VS when it's opened in editor, 
+                // the content type might change and the content type changed event can be 
+                // raised before the renaming propagate through VS workspace. As a result, 
+                // the document we got (based on the buffer) could still be the one in the workspace
+                // before rename happened. This would cause us problem if the document is supported 
+                // by workspace but not a roslyn language (e.g. xaml, F#, etc.), since none of the roslyn 
+                // language services would be available.
+                //
+                // If this is the case, we will not parse the snapshot. It's OK to ignore the request
+                // because when the buffer eventually get associated with the correct document in roslyn
+                // workspace, we will be invoked again.
+                //
+                // For example, if you open a xaml from from a WPF project in designer view,
+                // and then rename file extension from .xaml to .cs, then the document we received
+                // here would still belong to the special "-xaml" project.
+
                 if (newDocument != null && newDocument.SupportsSyntaxTree)
                 {
                     _workQueue.EnqueueBackgroundTask(c => this.EnqueueParseSnapshotWorkerAsync(newDocument, c), GetType() + ".EnqueueParseSnapshotTask.1", CancellationToken.None);

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlighterViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlighterViewTaggerProvider.cs
@@ -57,7 +57,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
         {
             var cancellationToken = context.CancellationToken;
             var document = documentSnapshotSpan.Document;
-            if (document == null)
+
+            // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/763988
+            // It turns out a document might be associated with a project of wrong language, e.g. C# document in a Xaml project. 
+            // Even though we couldn't repro the crash above, a fix is made in one of possibly multiple code paths that could cause 
+            // us to end up in this situation. 
+            // Regardless of the effective of the fix, we want to enhance the guard aginst such scenario here until an audit in 
+            // workspace is completed to eliminate the root cause.
+            if (document?.SupportsSyntaxTree != true)
             {
                 return;
             }

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlightingService.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlightingService.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -28,21 +27,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
         public IEnumerable<TextSpan> GetHighlights(
              SyntaxNode root, int position, CancellationToken cancellationToken)
         {
-            try
-            {
-                return _highlighters.Where(h => h.Metadata.Language == root.Language)
-                                   .Select(h => h.Value.GetHighlights(root, position, cancellationToken))
-                                   .WhereNotNull()
-                                   .Flatten()
-                                   .Distinct();
-            }
-            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
-            {
-                // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/763988
-                // We still couldn't identify the root cause for the linked bug above. 
-                // Since high lighting failure is not important enough to crash VS, change crash to NFW.
-                return SpecializedCollections.EmptyEnumerable<TextSpan>();
-            }
+            return _highlighters.Where(h => h.Metadata.Language == root.Language)
+                                .Select(h => h.Value.GetHighlights(root, position, cancellationToken))
+                                .WhereNotNull()
+                                .Flatten()
+                                .Distinct();
         }
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
@@ -137,7 +138,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             }
         }
 
-        private void OnDocumentMonikerChanged(IVsHierarchy hierarchy, string oldMoniker, string newMoniker)
+        private void OnDocumentMonikerChanged(uint docCookie, IVsHierarchy hierarchy, string oldMoniker, string newMoniker)
         {
             // If the moniker change only involves casing differences then the project system will
             // not remove & add the file again with the new name, so we should not clear any state.
@@ -161,7 +162,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                 project.RemoveSourceFile(oldMoniker);
             }
 
-            project.AddSourceFile(newMoniker);
+            var info = _rdt.Value.GetDocumentInfo(docCookie);
+            var buffer = TryGetTextBufferFromDocData(info.DocData);
+
+            if (buffer != null && buffer.ContentType.IsOfType(ContentTypeNames.XamlContentType))
+            {
+                project.AddSourceFile(newMoniker);
+            }
         }
 
         private void OnDocumentClosed(uint docCookie)
@@ -173,6 +180,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                 {
                     project.RemoveSourceFile(info.Moniker);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Tries to return an ITextBuffer representing the document from the document's DocData.
+        /// </summary>
+        /// <param name="docData">The DocData from the running document table.</param>
+        /// <returns>The ITextBuffer. If one could not be found, this returns null.</returns>
+        private ITextBuffer TryGetTextBufferFromDocData(object docData)
+        {
+            if (docData is IVsTextBuffer vsTestBuffer)
+            {
+                return _editorAdaptersFactory.GetDocumentBuffer(vsTestBuffer);
+            }
+            else
+            {
+                return null;
             }
         }
     }

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
@@ -165,6 +165,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             var info = _rdt.Value.GetDocumentInfo(docCookie);
             var buffer = TryGetTextBufferFromDocData(info.DocData);
 
+            // If the file extension changed which causes the content type to change
+            // (e.g. from .xaml to .cs) we should not add the new document to Xaml project.
             if (buffer != null && buffer.ContentType.IsOfType(ContentTypeNames.XamlContentType))
             {
                 project.AddSourceFile(newMoniker);

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener_IVsRunningDocTableEvents3.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener_IVsRunningDocTableEvents3.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
         {
             if ((grfAttribs & (uint)__VSRDTATTRIB.RDTA_MkDocument) != 0)
             {
-                this.OnDocumentMonikerChanged(pHierOld, pszMkDocumentOld, pszMkDocumentNew);
+                this.OnDocumentMonikerChanged(docCookie, pHierOld, pszMkDocumentOld, pszMkDocumentNew);
             }
 
             return VSConstants.S_OK;


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/33168/commits/d94f2129de2a511e8cba353b404e847d1f479b8a Fix #33167 

https://github.com/dotnet/roslyn/pull/33168/commits/8d4e28ea25fb92d807aa2017bf4f62fa71a32e74 is an attempt to (at least partially) fix internal bug [763988](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/763988). Since we still don't know the root cause, and we don't wanna crash VS for highlighting failure, change crash to NFW instead.