### PR TITLE
Expand RemoveAllComments to have more in depth logic 

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -1172,5 +1172,216 @@ class Class2
             await TestMoveTypeToNewFileAsync(
                 code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
+
+        [WorkItem(31377, "https://github.com/dotnet/roslyn/issues/31377")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task TestLeadingCommentInContainer()
+        {
+            var code =
+@"// Banner Text
+using System;
+
+class Class1
+// Leading comment
+{
+    class [||]Class2
+    {
+    }
+
+    void Foo()
+    {
+        Console.WriteLine();
+    }
+
+    public int I() => 5;
+}
+";
+            var codeAfterMove = @"// Banner Text
+using System;
+
+partial class Class1
+// Leading comment
+{
+
+    void Foo()
+    {
+        Console.WriteLine();
+    }
+
+    public int I() => 5;
+}
+";
+
+            var expectedDocumentName = "Class2.cs";
+            var destinationDocumentText = @"// Banner Text
+
+partial class Class1
+{
+    class Class2
+    {
+    }
+}
+";
+
+            await TestMoveTypeToNewFileAsync(
+                code, codeAfterMove, expectedDocumentName, destinationDocumentText);
+        }
+
+        [WorkItem(31377, "https://github.com/dotnet/roslyn/issues/31377")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task TestLeadingCommentInContainer2()
+        {
+            var code =
+@"// Banner Text
+using System;
+
+class Class1
+{ // Leading comment
+    class [||]Class2
+    {
+    }
+
+    void Foo()
+    {
+        Console.WriteLine();
+    }
+
+    public int I() => 5;
+}
+";
+            var codeAfterMove = @"// Banner Text
+using System;
+
+partial class Class1
+{ // Leading comment
+
+    void Foo()
+    {
+        Console.WriteLine();
+    }
+
+    public int I() => 5;
+}
+";
+
+            var expectedDocumentName = "Class2.cs";
+            var destinationDocumentText = @"// Banner Text
+
+partial class Class1
+{
+    class Class2
+    {
+    }
+}
+";
+
+            await TestMoveTypeToNewFileAsync(
+                code, codeAfterMove, expectedDocumentName, destinationDocumentText);
+        }
+
+        [WorkItem(31377, "https://github.com/dotnet/roslyn/issues/31377")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task TestTrailingCommentInContainer()
+        {
+            var code =
+@"// Banner Text
+using System;
+
+class Class1
+{
+    class [||]Class2
+    {
+    }
+
+    void Foo()
+    {
+        Console.WriteLine();
+    }
+
+    public int I() => 5;
+    // End of class document
+}
+";
+            var codeAfterMove = @"// Banner Text
+using System;
+
+partial class Class1
+{
+
+    void Foo()
+    {
+        Console.WriteLine();
+    }
+
+    public int I() => 5;
+    // End of class document
+}
+";
+
+            var expectedDocumentName = "Class2.cs";
+            var destinationDocumentText = @"// Banner Text
+
+partial class Class1
+{
+    class Class2
+    {
+    }
+}
+";
+
+            await TestMoveTypeToNewFileAsync(
+                code, codeAfterMove, expectedDocumentName, destinationDocumentText);
+        }
+
+        [WorkItem(31377, "https://github.com/dotnet/roslyn/issues/31377")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task TestTrailingCommentInContainer2()
+        {
+            var code =
+@"// Banner Text
+using System;
+
+class Class1
+{
+    class [||]Class2
+    {
+    }
+
+    void Foo()
+    {
+        Console.WriteLine();
+    }
+
+    public int I() => 5;
+} // End of class document
+";
+            var codeAfterMove = @"// Banner Text
+using System;
+
+partial class Class1
+{
+
+    void Foo()
+    {
+        Console.WriteLine();
+    }
+
+    public int I() => 5;
+} // End of class document
+";
+
+            var expectedDocumentName = "Class2.cs";
+            var destinationDocumentText = @"// Banner Text
+
+partial class Class1
+{
+    class Class2
+    {
+    }
+}";
+
+            await TestMoveTypeToNewFileAsync(
+                code, codeAfterMove, expectedDocumentName, destinationDocumentText);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaListExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaListExtensions.cs
@@ -46,5 +46,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         {
             return triviaList.SkipWhile(t => t.Kind() == SyntaxKind.WhitespaceTrivia);
         }
+
+        /// <summary>
+        /// Takes an INCLUSIVE range of trivia from the trivia list. 
+        /// </summary>
+        public static IEnumerable<SyntaxTrivia> TakeRange(this SyntaxTriviaList triviaList, int start, int end)
+        {
+            while (start <= end)
+            {
+                yield return triviaList[start++];
+            }
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -864,11 +864,25 @@ namespace Microsoft.CodeAnalysis.Editing
         public SyntaxNode RemoveAllAttributes(SyntaxNode declaration)
             => this.RemoveNodes(declaration, this.GetAttributes(declaration).Concat(this.GetReturnAttributes(declaration)));
 
-        internal SyntaxNode RemoveAllComments(SyntaxNode declaration)
+        /// <summary>
+        /// Removes comments from leading and trailing trivia, as well
+        /// as potentially removing comments from opening and closing tokens.
+        /// </summary>
+        internal abstract SyntaxNode RemoveAllComments(SyntaxNode node);
+
+        internal SyntaxNode RemoveLeadingAndTrailingComments(SyntaxNode node)
         {
-            return declaration.WithLeadingTrivia(declaration.GetLeadingTrivia().Where(t => !IsRegularOrDocComment(t)))
-                              .WithTrailingTrivia(declaration.GetTrailingTrivia().Where(t => !IsRegularOrDocComment(t)));
+            return node.WithLeadingTrivia(RemoveCommentLines(node.GetLeadingTrivia()))
+                .WithTrailingTrivia(RemoveCommentLines(node.GetTrailingTrivia()));
         }
+
+        internal SyntaxToken RemoveLeadingAndTrailingComments(SyntaxToken token)
+        {
+            return token.WithLeadingTrivia(RemoveCommentLines(token.LeadingTrivia))
+                .WithTrailingTrivia(RemoveCommentLines(token.TrailingTrivia));
+        }
+
+        internal abstract SyntaxTriviaList RemoveCommentLines(SyntaxTriviaList syntaxTriviaList);
 
         internal abstract bool IsRegularOrDocComment(SyntaxTrivia trivia);
 

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -4166,6 +4166,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Return trivia.IsRegularOrDocComment()
         End Function
 
+        Friend Overrides Function RemoveAllComments(node As SyntaxNode) As SyntaxNode
+            Return RemoveLeadingAndTrailingComments(node)
+        End Function
+
+        Friend Overrides Function RemoveCommentLines(syntaxList As SyntaxTriviaList) As SyntaxTriviaList
+            Return syntaxList.Where(Function(s) Not IsRegularOrDocComment(s)).ToSyntaxTriviaList()
+        End Function
 #End Region
 
 #Region "Patterns"


### PR DESCRIPTION
Make RemoveAllComments special case TypeDeclarations to remove 
leading and trailing comments on the open/close tokens as well in csharp.

Separate out the logic for RemoveAllComments and RemoveLeadingAndTrailingComments since the behavior could be different based on the syntax passed in. RemoveLeadingAndTrailingComments only works on leading and trailing syntax. 

Fixes #31377 