### PR TITLE
Make IPropertySubpattern Internal

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1996,6 +1996,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 boundNode.Syntax,
                 isImplicit: boundNode.WasCompilerGenerated);
         }
+
         private IOperation CreateUsingLocalDeclarationsOperation(BoundUsingLocalDeclarations boundNode)
         {
             //TODO: Implement UsingLocalDeclaration operations correctly.
@@ -2006,6 +2007,43 @@ namespace Microsoft.CodeAnalysis.Operations
                                                  constantValue: default,
                                                  getChildren: () => ImmutableArray.Create<IOperation>(CreateBoundMultipleLocalDeclarationsOperation((BoundMultipleLocalDeclarations)boundNode)),
                                                  isImplicit: false);
+        }
+
+        internal IPropertySubpatternOperation CreatePropertySubpattern(BoundSubpattern subpattern)
+        {
+            SyntaxNode syntax = subpattern.Syntax;
+            return new CSharpLazyPropertySubpatternOperation(this, subpattern, syntax, _semanticModel);
+        }
+
+        internal IOperation CreatePropertySubpatternMember(Symbol symbol, SyntaxNode syntax)
+        {
+            var nameSyntax = (syntax is SubpatternSyntax subpatSyntax ? subpatSyntax.NameColon?.Name : null) ?? syntax;
+            bool isImplicit = nameSyntax != syntax;
+            switch (symbol)
+            {
+                case FieldSymbol field:
+                    {
+                        var constantValue = field.ConstantValue is null ? default(Optional<object>) : new Optional<object>(field.ConstantValue);
+                        var receiver = new InstanceReferenceOperation(
+                            InstanceReferenceKind.PatternInput, _semanticModel, nameSyntax, field.ContainingType, constantValue, isImplicit: true);
+                        return new FieldReferenceOperation(
+                            field, isDeclaration: false, receiver, _semanticModel, nameSyntax, field.Type.TypeSymbol, constantValue, isImplicit: isImplicit);
+                    }
+                case PropertySymbol property:
+                    {
+                        var receiver = new InstanceReferenceOperation(
+                            InstanceReferenceKind.PatternInput, _semanticModel, nameSyntax, property.ContainingType, constantValue: default, isImplicit: true);
+                        return new PropertyReferenceOperation(
+                            property, receiver, ImmutableArray<IArgumentOperation>.Empty, _semanticModel, nameSyntax, property.Type.TypeSymbol,
+                            constantValue: default, isImplicit: isImplicit);
+                    }
+                case null:
+                    return null;
+                default:
+                    // We should expose the symbol in this case somehow:
+                    // https://github.com/dotnet/roslyn/issues/33175
+                    return OperationFactory.CreateInvalidOperation(_semanticModel, nameSyntax, ImmutableArray<IOperation>.Empty, isImplicit: true);
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -2040,7 +2040,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 default:
                     // We should expose the symbol in this case somehow:
                     // https://github.com/dotnet/roslyn/issues/33175
-                    return OperationFactory.CreateInvalidOperation(_semanticModel, nameSyntax, ImmutableArray<IOperation>.Empty, isImplicit: true);
+                    return OperationFactory.CreateInvalidOperation(_semanticModel, nameSyntax, ImmutableArray<IOperation>.Empty, isImplicit);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp;
@@ -14,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private static readonly IConvertibleConversion s_boxedIdentityConversion = Conversion.Identity;
 
-        private static Optional<object> ConvertToOptional(ConstantValue value)
+        internal static Optional<object> ConvertToOptional(ConstantValue value)
         {
             return value != null && !value.IsBad ? new Optional<object>(value.Value) : default(Optional<object>);
         }
@@ -552,6 +553,16 @@ namespace Microsoft.CodeAnalysis.Operations
 
                 return BinaryOperatorKind.None;
             }
+        }
+
+        internal IPropertySubpatternOperation CreatePropertySubpattern(BoundSubpattern subpattern)
+        {
+            Symbol symbol = subpattern.Symbol;
+            BoundPattern pattern = subpattern.Pattern;
+            SyntaxNode syntax = subpattern.Syntax;
+            bool isImplicit = subpattern.WasCompilerGenerated;
+
+            return new CSharpLazyPropertySubpatternOperation(this, syntax, symbol, pattern, _semanticModel);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp;
@@ -553,16 +552,6 @@ namespace Microsoft.CodeAnalysis.Operations
 
                 return BinaryOperatorKind.None;
             }
-        }
-
-        internal IPropertySubpatternOperation CreatePropertySubpattern(BoundSubpattern subpattern)
-        {
-            Symbol symbol = subpattern.Symbol;
-            BoundPattern pattern = subpattern.Pattern;
-            SyntaxNode syntax = subpattern.Syntax;
-            bool isImplicit = subpattern.WasCompilerGenerated;
-
-            return new CSharpLazyPropertySubpatternOperation(this, syntax, symbol, pattern, _semanticModel);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
@@ -1504,8 +1504,8 @@ namespace Microsoft.CodeAnalysis.Operations
                    syntax: boundRecursivePattern.Syntax,
                    isImplicit: boundRecursivePattern.WasCompilerGenerated)
         {
-            this._operationFactory = operationFactory;
-            this._boundRecursivePattern = boundRecursivePattern;
+            _operationFactory = operationFactory;
+            _boundRecursivePattern = boundRecursivePattern;
 
         }
         public override ImmutableArray<IPatternOperation> CreateDeconstructionSubpatterns()
@@ -1522,56 +1522,27 @@ namespace Microsoft.CodeAnalysis.Operations
 
     internal sealed partial class CSharpLazyPropertySubpatternOperation : LazyPropertySubpatternOperation
     {
-        private readonly Symbol _symbol;
-        private readonly BoundPattern _pattern;
+        private readonly BoundSubpattern _subpattern;
         private readonly CSharpOperationFactory _operationFactory;
-        private readonly SemanticModel _semanticModel;
 
         public CSharpLazyPropertySubpatternOperation(
             CSharpOperationFactory operationFactory,
+            BoundSubpattern subpattern,
             SyntaxNode syntax,
-            Symbol symbol,
-            BoundPattern pattern,
             SemanticModel semanticModel)
             : base(semanticModel, syntax, false)
         {
-            this._symbol = symbol;
-            this._pattern = pattern;
-            this._operationFactory = operationFactory;
+            _subpattern = subpattern;
+            _operationFactory = operationFactory;
         }
         public override IOperation CreateMember()
         {
-            var nameSyntax = (Syntax is SubpatternSyntax subpatSyntax ? subpatSyntax.NameColon?.Name : null) ?? Syntax;
-            bool isImplicit = nameSyntax != Syntax;
-            switch (_symbol)
-            {
-                case FieldSymbol field:
-                    {
-                        var constantValue = field.ConstantValue is null ? default(Optional<object>) : new Optional<object>(field.ConstantValue);
-                        var receiver = new InstanceReferenceOperation(
-                            InstanceReferenceKind.PatternInput, OwningSemanticModel, nameSyntax, field.ContainingType, constantValue, isImplicit: true);
-                        return new FieldReferenceOperation(
-                            field, isDeclaration: false, receiver, this.OwningSemanticModel, nameSyntax, field.Type.TypeSymbol, constantValue, isImplicit: isImplicit);
-                    }
-                case PropertySymbol property:
-                    {
-                        var receiver = new InstanceReferenceOperation(
-                            InstanceReferenceKind.PatternInput, OwningSemanticModel, nameSyntax, property.ContainingType, constantValue: default, isImplicit: true);
-                        return new PropertyReferenceOperation(
-                            property, receiver, ImmutableArray<IArgumentOperation>.Empty, this.OwningSemanticModel, nameSyntax, property.Type.TypeSymbol,
-                            constantValue: default, isImplicit: isImplicit);
-                    }
-                case null:
-                    return null;
-                default:
-                    // PROTOTYPE(ngafter): how are errors handled here?
-                    throw ExceptionUtilities.UnexpectedValue(_symbol);
-            }
+            return _operationFactory.CreatePropertySubpatternMember(_subpattern.Symbol, Syntax);
         }
 
         public override IPatternOperation CreatePattern()
         {
-            return (IPatternOperation)_operationFactory.Create(this._pattern);
+            return (IPatternOperation)_operationFactory.Create(_subpattern.Pattern);
         }
     }
 
@@ -1592,8 +1563,8 @@ namespace Microsoft.CodeAnalysis.Operations
                    syntax: boundITuplePattern.Syntax,
                    isImplicit: boundITuplePattern.WasCompilerGenerated)
         {
-            this._operationFactory = operationFactory;
-            this._boundITuplePattern = boundITuplePattern;
+            _operationFactory = operationFactory;
+            _boundITuplePattern = boundITuplePattern;
 
         }
         public override ImmutableArray<IPatternOperation> CreateDeconstructionSubpatterns()
@@ -1661,8 +1632,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public CSharpLazySwitchExpressionOperation(CSharpOperationFactory operationFactory, BoundSwitchExpression boundSwitchExpression, SemanticModel semanticModel)
             : base(boundSwitchExpression.Type, semanticModel, boundSwitchExpression.Syntax, boundSwitchExpression.WasCompilerGenerated)
         {
-            this._operationFactory = operationFactory;
-            this._switchExpression = boundSwitchExpression;
+            _operationFactory = operationFactory;
+            _switchExpression = boundSwitchExpression;
         }
 
         protected override IOperation CreateValue()
@@ -1683,8 +1654,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public CSharpLazySwitchExpressionArmOperation(CSharpOperationFactory operationFactory, BoundSwitchExpressionArm boundSwitchExpressionArm, SemanticModel semanticModel)
             : base(boundSwitchExpressionArm.Locals.Cast<CSharp.Symbols.LocalSymbol, ILocalSymbol>(), semanticModel, boundSwitchExpressionArm.Syntax, boundSwitchExpressionArm.WasCompilerGenerated)
         {
-            this._operationFactory = operationFactory;
-            this._switchExpressionArm = boundSwitchExpressionArm;
+            _operationFactory = operationFactory;
+            _switchExpressionArm = boundSwitchExpressionArm;
         }
 
         protected override IOperation CreateGuard()

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
@@ -1516,7 +1516,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public override ImmutableArray<IPropertySubpatternOperation> CreatePropertySubpatterns()
         {
             return _boundRecursivePattern.Properties.IsDefault ? ImmutableArray<IPropertySubpatternOperation>.Empty :
-                _boundRecursivePattern.Properties.SelectAsArray((p, fac) => fac.CreatePropertySubpattern(p), _operationFactory);
+                _boundRecursivePattern.Properties.SelectAsArray((p, fac) => fac.CreatePropertySubpattern(p, MatchedType), _operationFactory);
         }
     }
 
@@ -1524,20 +1524,23 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly BoundSubpattern _subpattern;
         private readonly CSharpOperationFactory _operationFactory;
+        private readonly ITypeSymbol _matchedType;
 
         public CSharpLazyPropertySubpatternOperation(
             CSharpOperationFactory operationFactory,
             BoundSubpattern subpattern,
+            ITypeSymbol matchedType,
             SyntaxNode syntax,
             SemanticModel semanticModel)
-            : base(semanticModel, syntax, false)
+            : base(semanticModel, syntax, isImplicit: false)
         {
             _subpattern = subpattern;
             _operationFactory = operationFactory;
+            _matchedType = matchedType;
         }
         public override IOperation CreateMember()
         {
-            return _operationFactory.CreatePropertySubpatternMember(_subpattern.Symbol, Syntax);
+            return _operationFactory.CreatePropertySubpatternMember(_subpattern.Symbol, _matchedType, Syntax);
         }
 
         public override IPatternOperation CreatePattern()

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationNodes.cs
@@ -1516,7 +1516,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public override ImmutableArray<IPropertySubpatternOperation> CreatePropertySubpatterns()
         {
             return _boundRecursivePattern.Properties.IsDefault ? ImmutableArray<IPropertySubpatternOperation>.Empty :
-                _boundRecursivePattern.Properties.SelectAsArray((p, fac) => fac.CreatePropertySubpattern(p, MatchedType), _operationFactory);
+                _boundRecursivePattern.Properties.SelectAsArray((p, recursivePattern) => recursivePattern._operationFactory.CreatePropertySubpattern(p, recursivePattern.MatchedType), this);
         }
     }
 

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IIsPatternExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IIsPatternExpression.cs
@@ -650,48 +650,69 @@ class C
 Block[B0] - Entry
     Statements (0)
     Next (Regular) Block[B1]
-        Entering: {R1}
-
+        Entering: {R1} {R2}
 .locals {R1}
 {
     Locals: [System.Int32? y]
-    Block[B1] - Block
-        Predecessors: [B0]
-        Statements (2)
-            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b = x is var y;')
-              Expression: 
-                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b = x is var y')
-                  Left: 
+    .locals {R2}
+    {
+        CaptureIds: [0] [1]
+        Block[B1] - Block
+            Predecessors: [B0]
+            Statements (3)
+                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'b')
+                  Value: 
                     IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
-                  Right: 
-                    IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'x is var y')
-                      Value: 
-                        IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.Int32?) (Syntax: 'x')
-                      Pattern: 
-                        IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'var y') (InputType: System.Int32?, DeclaredSymbol: System.Int32? y, MatchesNull: True)
-
-            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b2 = x2 is 1;')
-              Expression: 
-                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b2 = x2 is 1')
-                  Left: 
-                    IParameterReferenceOperation: b2 (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b2')
-                  Right: 
-                    IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'x2 is 1')
-                      Value: 
-                        IParameterReferenceOperation: x2 (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'x2')
-                      Pattern: 
-                        IConstantPatternOperation (OperationKind.ConstantPattern, Type: null) (Syntax: '1') (InputType: System.Int32)
+                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'x')
+                  Value: 
+                    IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.Int32?) (Syntax: 'x')
+                IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b = x is var y;')
+                  Expression: 
+                    ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b = x is var y')
+                      Left: 
+                        IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Boolean, IsImplicit) (Syntax: 'b')
+                      Right: 
+                        IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'x is var y')
                           Value: 
-                            ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
-
-        Next (Regular) Block[B2]
-            Leaving: {R1}
+                            IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'x')
+                          Pattern: 
+                            IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'var y') (InputType: System.Int32?, DeclaredSymbol: System.Int32? y, MatchesNull: True)
+            Next (Regular) Block[B2]
+                Leaving: {R2}
+                Entering: {R3}
+    }
+    .locals {R3}
+    {
+        CaptureIds: [2] [3]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (3)
+                IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'b2')
+                  Value: 
+                    IParameterReferenceOperation: b2 (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b2')
+                IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'x2')
+                  Value: 
+                    IParameterReferenceOperation: x2 (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'x2')
+                IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b2 = x2 is 1;')
+                  Expression: 
+                    ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b2 = x2 is 1')
+                      Left: 
+                        IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Boolean, IsImplicit) (Syntax: 'b2')
+                      Right: 
+                        IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'x2 is 1')
+                          Value: 
+                            IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.Int32, IsImplicit) (Syntax: 'x2')
+                          Pattern: 
+                            IConstantPatternOperation (OperationKind.ConstantPattern, Type: null) (Syntax: '1') (InputType: System.Int32)
+                              Value: 
+                                ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+            Next (Regular) Block[B3]
+                Leaving: {R3} {R1}
+    }
 }
-
-Block[B2] - Exit
-    Predecessors: [B1]
-    Statements (0)
-";
+Block[B3] - Exit
+    Predecessors: [B2]
+    Statements (0)";
             var expectedDiagnostics = DiagnosticDescription.None;
 
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
@@ -715,22 +736,28 @@ Block[B0] - Entry
     Statements (0)
     Next (Regular) Block[B1]
         Entering: {R1}
-
 .locals {R1}
 {
     Locals: [(System.Int32 X, System.Int32 Y) p] [System.Int32 z]
+    CaptureIds: [0] [1]
     Block[B1] - Block
         Predecessors: [B0]
-        Statements (1)
+        Statements (3)
+            IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'b')
+              Value: 
+                IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
+            IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'x')
+              Value: 
+                IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: (System.Int32 X, System.Int32 Y)?) (Syntax: 'x')
             IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b = x is (1 ...  var z } p;')
               Expression: 
                 ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b = x is (1 ... : var z } p')
                   Left: 
-                    IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
+                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Boolean, IsImplicit) (Syntax: 'b')
                   Right: 
                     IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'x is (1, _) ... : var z } p')
                       Value: 
-                        IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: (System.Int32 X, System.Int32 Y)?) (Syntax: 'x')
+                        IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: (System.Int32 X, System.Int32 Y)?, IsImplicit) (Syntax: 'x')
                       Pattern: 
                         IRecursivePatternOperation (OperationKind.RecursivePattern, Type: null) (Syntax: '(1, _) { It ... : var z } p') (InputType: (System.Int32 X, System.Int32 Y)?, DeclaredSymbol: (System.Int32 X, System.Int32 Y) p, MatchedType: (System.Int32 X, System.Int32 Y), DeconstructSymbol: null)
                           DeconstructionSubpatterns (2):
@@ -739,17 +766,19 @@ Block[B0] - Entry
                                   ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
                               IDiscardPatternOperation (OperationKind.DiscardPattern, Type: null) (Syntax: '_') (InputType: System.Int32)
                           PropertySubpatterns (1):
-                            MatchedSymbol: System.Int32 (System.Int32 X, System.Int32 Y).Item1, Pattern: 
-                                IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'var z') (InputType: System.Int32, DeclaredSymbol: System.Int32 z, MatchesNull: True)
-
+                              IPropertySubpatternOperation (OperationKind.None, Type: null) (Syntax: 'Item1: var z')
+                                Member: 
+                                  IFieldReferenceOperation: System.Int32 (System.Int32 X, System.Int32 Y).Item1 (OperationKind.FieldReference, Type: System.Int32, IsImplicit) (Syntax: 'Item1')
+                                    Instance Receiver: 
+                                      IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: (System.Int32 X, System.Int32 Y)?, IsImplicit) (Syntax: 'x')
+                                Pattern: 
+                                  IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'var z') (InputType: System.Int32, DeclaredSymbol: System.Int32 z, MatchesNull: True)
         Next (Regular) Block[B2]
             Leaving: {R1}
 }
-
 Block[B2] - Exit
     Predecessors: [B1]
-    Statements (0)
-";
+    Statements (0)";
             var expectedDiagnostics = DiagnosticDescription.None;
 
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
@@ -882,7 +911,8 @@ IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'tu
             Value: 
               ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
       PropertySubpatterns (1):
-          IPropertySubpatternOperation (OperationKind.None, Type: null) (Syntax: 'Item1: int x')Member: 
+          IPropertySubpatternOperation (OperationKind.None, Type: null) (Syntax: 'Item1: int x')
+            Member: 
               IFieldReferenceOperation: System.Int32 (System.Int32 X, System.Int32 Y).Item1 (OperationKind.FieldReference, Type: System.Int32, IsImplicit) (Syntax: 'Item1')
                 Instance Receiver: 
                   IInstanceReferenceOperation (ReferenceKind: PatternInput) (OperationKind.InstanceReference, Type: (System.Int32 X, System.Int32 Y), IsImplicit) (Syntax: 'Item1')
@@ -921,7 +951,8 @@ IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean, IsInvalid) (
             Value: 
               ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
       PropertySubpatterns (1):
-          IPropertySubpatternOperation (OperationKind.None, Type: null, IsInvalid) (Syntax: 'NotFound: int x')Member: 
+          IPropertySubpatternOperation (OperationKind.None, Type: null, IsInvalid) (Syntax: 'NotFound: int x')
+            Member: 
               null
             Pattern: 
               IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'int x') (InputType: ?, DeclaredSymbol: System.Int32 x, MatchesNull: False)

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IIsPatternExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IIsPatternExpression.cs
@@ -650,69 +650,45 @@ class C
 Block[B0] - Entry
     Statements (0)
     Next (Regular) Block[B1]
-        Entering: {R1} {R2}
+        Entering: {R1}
 .locals {R1}
 {
     Locals: [System.Int32? y]
-    .locals {R2}
-    {
-        CaptureIds: [0] [1]
-        Block[B1] - Block
-            Predecessors: [B0]
-            Statements (3)
-                IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'b')
-                  Value: 
+    Block[B1] - Block
+        Predecessors: [B0]
+        Statements (2)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b = x is var y;')
+              Expression: 
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b = x is var y')
+                  Left: 
                     IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
-                IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'x')
-                  Value: 
-                    IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.Int32?) (Syntax: 'x')
-                IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b = x is var y;')
-                  Expression: 
-                    ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b = x is var y')
-                      Left: 
-                        IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Boolean, IsImplicit) (Syntax: 'b')
-                      Right: 
-                        IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'x is var y')
-                          Value: 
-                            IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Int32?, IsImplicit) (Syntax: 'x')
-                          Pattern: 
-                            IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'var y') (InputType: System.Int32?, DeclaredSymbol: System.Int32? y, MatchesNull: True)
-            Next (Regular) Block[B2]
-                Leaving: {R2}
-                Entering: {R3}
-    }
-    .locals {R3}
-    {
-        CaptureIds: [2] [3]
-        Block[B2] - Block
-            Predecessors: [B1]
-            Statements (3)
-                IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'b2')
-                  Value: 
+                  Right: 
+                    IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'x is var y')
+                      Value: 
+                        IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.Int32?) (Syntax: 'x')
+                      Pattern: 
+                        IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'var y') (InputType: System.Int32?, DeclaredSymbol: System.Int32? y, MatchesNull: True)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b2 = x2 is 1;')
+              Expression: 
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b2 = x2 is 1')
+                  Left: 
                     IParameterReferenceOperation: b2 (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b2')
-                IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'x2')
-                  Value: 
-                    IParameterReferenceOperation: x2 (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'x2')
-                IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b2 = x2 is 1;')
-                  Expression: 
-                    ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b2 = x2 is 1')
-                      Left: 
-                        IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Boolean, IsImplicit) (Syntax: 'b2')
-                      Right: 
-                        IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'x2 is 1')
+                  Right: 
+                    IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'x2 is 1')
+                      Value: 
+                        IParameterReferenceOperation: x2 (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'x2')
+                      Pattern: 
+                        IConstantPatternOperation (OperationKind.ConstantPattern, Type: null) (Syntax: '1') (InputType: System.Int32)
                           Value: 
-                            IFlowCaptureReferenceOperation: 3 (OperationKind.FlowCaptureReference, Type: System.Int32, IsImplicit) (Syntax: 'x2')
-                          Pattern: 
-                            IConstantPatternOperation (OperationKind.ConstantPattern, Type: null) (Syntax: '1') (InputType: System.Int32)
-                              Value: 
-                                ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
-            Next (Regular) Block[B3]
-                Leaving: {R3} {R1}
-    }
+                            ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+        Next (Regular) Block[B2]
+            Leaving: {R1}
 }
-Block[B3] - Exit
-    Predecessors: [B2]
-    Statements (0)";
+Block[B2] - Exit
+    Predecessors: [B1]
+    Statements (0)
+";
+
             var expectedDiagnostics = DiagnosticDescription.None;
 
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
@@ -731,6 +707,42 @@ class C
     }/*</bind>*/
 }
 ";
+
+            var compilation = CreateCompilation(source);
+            compilation.VerifyDiagnostics();
+
+            string expectedOperationTree = @"
+IBlockOperation (1 statements, 2 locals) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+  Locals: Local_1: (System.Int32 X, System.Int32 Y) p
+    Local_2: System.Int32 z
+  IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b = x is (1 ...  var z } p;')
+    Expression: 
+      ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b = x is (1 ... : var z } p')
+        Left: 
+          IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
+        Right: 
+          IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'x is (1, _) ... : var z } p')
+            Value: 
+              IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: (System.Int32 X, System.Int32 Y)?) (Syntax: 'x')
+            Pattern: 
+              IRecursivePatternOperation (OperationKind.RecursivePattern, Type: null) (Syntax: '(1, _) { It ... : var z } p') (InputType: (System.Int32 X, System.Int32 Y)?, DeclaredSymbol: (System.Int32 X, System.Int32 Y) p, MatchedType: (System.Int32 X, System.Int32 Y), DeconstructSymbol: null)
+                DeconstructionSubpatterns (2):
+                    IConstantPatternOperation (OperationKind.ConstantPattern, Type: null) (Syntax: '1') (InputType: System.Int32)
+                      Value: 
+                        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+                    IDiscardPatternOperation (OperationKind.DiscardPattern, Type: null) (Syntax: '_') (InputType: System.Int32)
+                PropertySubpatterns (1):
+                    IPropertySubpatternOperation (OperationKind.None, Type: null) (Syntax: 'Item1: var z')
+                      Member: 
+                        IFieldReferenceOperation: System.Int32 (System.Int32 X, System.Int32 Y).Item1 (OperationKind.FieldReference, Type: System.Int32) (Syntax: 'Item1')
+                          Instance Receiver: 
+                            IInstanceReferenceOperation (ReferenceKind: PatternInput) (OperationKind.InstanceReference, Type: (System.Int32 X, System.Int32 Y), IsImplicit) (Syntax: 'Item1')
+                      Pattern: 
+                        IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'var z') (InputType: System.Int32, DeclaredSymbol: System.Int32 z, MatchesNull: True)
+";
+
+            VerifyOperationTreeForTest<BlockSyntax>(compilation, expectedOperationTree);
+
             string expectedFlowGraph = @"
 Block[B0] - Entry
     Statements (0)
@@ -739,25 +751,18 @@ Block[B0] - Entry
 .locals {R1}
 {
     Locals: [(System.Int32 X, System.Int32 Y) p] [System.Int32 z]
-    CaptureIds: [0] [1]
     Block[B1] - Block
         Predecessors: [B0]
-        Statements (3)
-            IFlowCaptureOperation: 0 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'b')
-              Value: 
-                IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
-            IFlowCaptureOperation: 1 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: 'x')
-              Value: 
-                IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: (System.Int32 X, System.Int32 Y)?) (Syntax: 'x')
+        Statements (1)
             IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b = x is (1 ...  var z } p;')
               Expression: 
                 ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b = x is (1 ... : var z } p')
                   Left: 
-                    IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Boolean, IsImplicit) (Syntax: 'b')
+                    IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
                   Right: 
                     IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'x is (1, _) ... : var z } p')
                       Value: 
-                        IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: (System.Int32 X, System.Int32 Y)?, IsImplicit) (Syntax: 'x')
+                        IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: (System.Int32 X, System.Int32 Y)?) (Syntax: 'x')
                       Pattern: 
                         IRecursivePatternOperation (OperationKind.RecursivePattern, Type: null) (Syntax: '(1, _) { It ... : var z } p') (InputType: (System.Int32 X, System.Int32 Y)?, DeclaredSymbol: (System.Int32 X, System.Int32 Y) p, MatchedType: (System.Int32 X, System.Int32 Y), DeconstructSymbol: null)
                           DeconstructionSubpatterns (2):
@@ -768,9 +773,9 @@ Block[B0] - Entry
                           PropertySubpatterns (1):
                               IPropertySubpatternOperation (OperationKind.None, Type: null) (Syntax: 'Item1: var z')
                                 Member: 
-                                  IFieldReferenceOperation: System.Int32 (System.Int32 X, System.Int32 Y).Item1 (OperationKind.FieldReference, Type: System.Int32, IsImplicit) (Syntax: 'Item1')
+                                  IFieldReferenceOperation: System.Int32 (System.Int32 X, System.Int32 Y).Item1 (OperationKind.FieldReference, Type: System.Int32) (Syntax: 'Item1')
                                     Instance Receiver: 
-                                      IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: (System.Int32 X, System.Int32 Y)?, IsImplicit) (Syntax: 'x')
+                                      IInstanceReferenceOperation (ReferenceKind: PatternInput) (OperationKind.InstanceReference, Type: (System.Int32 X, System.Int32 Y), IsImplicit) (Syntax: 'Item1')
                                 Pattern: 
                                   IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'var z') (InputType: System.Int32, DeclaredSymbol: System.Int32 z, MatchesNull: True)
         Next (Regular) Block[B2]
@@ -779,6 +784,92 @@ Block[B0] - Entry
 Block[B2] - Exit
     Predecessors: [B1]
     Statements (0)";
+
+            VerifyFlowGraphForTest<BlockSyntax>(compilation, expectedFlowGraph);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow, CompilerFeature.Patterns)]
+        [Fact]
+        public void IsPattern_NoControlFlow_03()
+        {
+            string source = @"
+class C
+{
+    void M((int X, (int Y, int Z))? tuple, bool b)
+    /*<bind>*/{
+        b = tuple is (1, _) { Item1: var x, Item2: { Y: 1, Z: var z } } p;
+    }/*</bind>*/
+}
+";
+
+            string expectedFlowGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1}
+.locals {R1}
+{
+    Locals: [(System.Int32 X, (System.Int32 Y, System.Int32 Z)) p] [System.Int32 x] [System.Int32 z]
+    Block[B1] - Block
+        Predecessors: [B0]
+        Statements (1)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'b = tuple i ... ar z } } p;')
+              Expression: 
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Boolean) (Syntax: 'b = tuple i ... var z } } p')
+                  Left: 
+                    IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
+                  Right: 
+                    IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'tuple is (1 ... var z } } p')
+                      Value: 
+                        IParameterReferenceOperation: tuple (OperationKind.ParameterReference, Type: (System.Int32 X, (System.Int32 Y, System.Int32 Z))?) (Syntax: 'tuple')
+                      Pattern: 
+                        IRecursivePatternOperation (OperationKind.RecursivePattern, Type: null) (Syntax: '(1, _) { It ... var z } } p') (InputType: (System.Int32 X, (System.Int32 Y, System.Int32 Z))?, DeclaredSymbol: (System.Int32 X, (System.Int32 Y, System.Int32 Z)) p, MatchedType: (System.Int32 X, (System.Int32 Y, System.Int32 Z)), DeconstructSymbol: null)
+                          DeconstructionSubpatterns (2):
+                              IConstantPatternOperation (OperationKind.ConstantPattern, Type: null) (Syntax: '1') (InputType: System.Int32)
+                                Value: 
+                                  ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+                              IDiscardPatternOperation (OperationKind.DiscardPattern, Type: null) (Syntax: '_') (InputType: (System.Int32 Y, System.Int32 Z))
+                          PropertySubpatterns (2):
+                              IPropertySubpatternOperation (OperationKind.None, Type: null) (Syntax: 'Item1: var x')
+                                Member: 
+                                  IFieldReferenceOperation: System.Int32 (System.Int32 X, (System.Int32 Y, System.Int32 Z)).Item1 (OperationKind.FieldReference, Type: System.Int32) (Syntax: 'Item1')
+                                    Instance Receiver: 
+                                      IInstanceReferenceOperation (ReferenceKind: PatternInput) (OperationKind.InstanceReference, Type: (System.Int32 X, (System.Int32 Y, System.Int32 Z)), IsImplicit) (Syntax: 'Item1')
+                                Pattern: 
+                                  IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'var x') (InputType: System.Int32, DeclaredSymbol: System.Int32 x, MatchesNull: True)
+                              IPropertySubpatternOperation (OperationKind.None, Type: null) (Syntax: 'Item2: { Y: ...  Z: var z }')
+                                Member: 
+                                  IFieldReferenceOperation: (System.Int32 Y, System.Int32 Z) (System.Int32 X, (System.Int32 Y, System.Int32 Z)).Item2 (OperationKind.FieldReference, Type: (System.Int32 Y, System.Int32 Z)) (Syntax: 'Item2')
+                                    Instance Receiver: 
+                                      IInstanceReferenceOperation (ReferenceKind: PatternInput) (OperationKind.InstanceReference, Type: (System.Int32 X, (System.Int32 Y, System.Int32 Z)), IsImplicit) (Syntax: 'Item2')
+                                Pattern: 
+                                  IRecursivePatternOperation (OperationKind.RecursivePattern, Type: null) (Syntax: '{ Y: 1, Z: var z }') (InputType: (System.Int32 Y, System.Int32 Z), DeclaredSymbol: null, MatchedType: (System.Int32 Y, System.Int32 Z), DeconstructSymbol: null)
+                                    DeconstructionSubpatterns (0)
+                                    PropertySubpatterns (2):
+                                        IPropertySubpatternOperation (OperationKind.None, Type: null) (Syntax: 'Y: 1')
+                                          Member: 
+                                            IFieldReferenceOperation: System.Int32 (System.Int32 Y, System.Int32 Z).Y (OperationKind.FieldReference, Type: System.Int32) (Syntax: 'Y')
+                                              Instance Receiver: 
+                                                IInstanceReferenceOperation (ReferenceKind: PatternInput) (OperationKind.InstanceReference, Type: (System.Int32 Y, System.Int32 Z), IsImplicit) (Syntax: 'Y')
+                                          Pattern: 
+                                            IConstantPatternOperation (OperationKind.ConstantPattern, Type: null) (Syntax: '1') (InputType: System.Int32)
+                                              Value: 
+                                                ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+                                        IPropertySubpatternOperation (OperationKind.None, Type: null) (Syntax: 'Z: var z')
+                                          Member: 
+                                            IFieldReferenceOperation: System.Int32 (System.Int32 Y, System.Int32 Z).Z (OperationKind.FieldReference, Type: System.Int32) (Syntax: 'Z')
+                                              Instance Receiver: 
+                                                IInstanceReferenceOperation (ReferenceKind: PatternInput) (OperationKind.InstanceReference, Type: (System.Int32 Y, System.Int32 Z), IsImplicit) (Syntax: 'Z')
+                                          Pattern: 
+                                            IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'var z') (InputType: System.Int32, DeclaredSymbol: System.Int32 z, MatchesNull: True)
+        Next (Regular) Block[B2]
+            Leaving: {R1}
+}
+Block[B2] - Exit
+    Predecessors: [B1]
+    Statements (0)
+";
+
             var expectedDiagnostics = DiagnosticDescription.None;
 
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
@@ -913,7 +1004,7 @@ IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'tu
       PropertySubpatterns (1):
           IPropertySubpatternOperation (OperationKind.None, Type: null) (Syntax: 'Item1: int x')
             Member: 
-              IFieldReferenceOperation: System.Int32 (System.Int32 X, System.Int32 Y).Item1 (OperationKind.FieldReference, Type: System.Int32, IsImplicit) (Syntax: 'Item1')
+              IFieldReferenceOperation: System.Int32 (System.Int32 X, System.Int32 Y).Item1 (OperationKind.FieldReference, Type: System.Int32) (Syntax: 'Item1')
                 Instance Receiver: 
                   IInstanceReferenceOperation (ReferenceKind: PatternInput) (OperationKind.InstanceReference, Type: (System.Int32 X, System.Int32 Y), IsImplicit) (Syntax: 'Item1')
             Pattern: 
@@ -924,7 +1015,7 @@ IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean) (Syntax: 'tu
             VerifyOperationTreeAndDiagnosticsForTest<IsPatternExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
         }
 
-        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow, CompilerFeature.Patterns)]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Patterns)]
         [Fact]
         public void IsPattern_BadRecursivePattern_01()
         {
@@ -953,7 +1044,8 @@ IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean, IsInvalid) (
       PropertySubpatterns (1):
           IPropertySubpatternOperation (OperationKind.None, Type: null, IsInvalid) (Syntax: 'NotFound: int x')
             Member: 
-              null
+              IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'NotFound')
+                Children(0)
             Pattern: 
               IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null) (Syntax: 'int x') (InputType: ?, DeclaredSymbol: System.Int32 x, MatchesNull: False)
 ";
@@ -964,6 +1056,79 @@ IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean, IsInvalid) (
             };
 
             VerifyOperationTreeAndDiagnosticsForTest<IsPatternExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Patterns)]
+        [Fact]
+        public void IsPattern_BadRecursivePattern_02()
+        {
+            var vbSource = @"
+Public Class C1
+    Public Property Prop(index As Integer) As Integer
+        Get
+            Return 1
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+";
+
+            var vbCompilation = CreateVisualBasicCompilation(vbSource);
+
+            var source = @"
+class C
+{
+    void M1(object o, bool b)
+    {
+        b = /*<bind>*/o is C1 { Prop[1]: var x }/*</bind>*/;
+    }
+}";
+
+            var compilation = CreateCompilation(source, new[] { vbCompilation.EmitToImageReference() });
+            compilation.VerifyDiagnostics(
+                // (6,33): error CS8503: A property subpattern requires a reference to the property or field to be matched, e.g. '{ Name: Prop[1] }'
+                //         b = /*<bind>*/o is C1 { Prop[1]: var x }/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_PropertyPatternNameMissing, "Prop[1]").WithArguments("Prop[1]").WithLocation(6, 33),
+                // (6,33): error CS0103: The name 'Prop' does not exist in the current context
+                //         b = /*<bind>*/o is C1 { Prop[1]: var x }/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Prop").WithArguments("Prop").WithLocation(6, 33),
+                // (6,40): error CS1003: Syntax error, ',' expected
+                //         b = /*<bind>*/o is C1 { Prop[1]: var x }/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_SyntaxError, ":").WithArguments(",", ":").WithLocation(6, 40),
+                // (6,42): error CS1003: Syntax error, ',' expected
+                //         b = /*<bind>*/o is C1 { Prop[1]: var x }/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "var").WithArguments(",", "").WithLocation(6, 42));
+
+            var expectedOperationTree = @"
+IIsPatternOperation (OperationKind.IsPattern, Type: System.Boolean, IsInvalid) (Syntax: 'o is C1 { P ... 1]: var x }')
+  Value: 
+    IParameterReferenceOperation: o (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o')
+  Pattern: 
+    IRecursivePatternOperation (OperationKind.RecursivePattern, Type: null, IsInvalid) (Syntax: 'C1 { Prop[1]: var x }') (InputType: System.Object, DeclaredSymbol: null, MatchedType: C1, DeconstructSymbol: null)
+      DeconstructionSubpatterns (0)
+      PropertySubpatterns (2):
+          IPropertySubpatternOperation (OperationKind.None, Type: null, IsInvalid) (Syntax: 'Prop[1]')
+            Member: 
+              IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'Prop[1]')
+                Children(0)
+            Pattern: 
+              IConstantPatternOperation (OperationKind.ConstantPattern, Type: null, IsInvalid) (Syntax: 'Prop[1]') (InputType: ?)
+                Value: 
+                  IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'Prop[1]')
+                    Children(2):
+                        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsInvalid) (Syntax: '1')
+                        IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'Prop')
+                          Children(0)
+          IPropertySubpatternOperation (OperationKind.None, Type: null, IsInvalid) (Syntax: 'var x')
+            Member: 
+              IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: 'var x')
+                Children(0)
+            Pattern: 
+              IDeclarationPatternOperation (OperationKind.DeclarationPattern, Type: null, IsInvalid) (Syntax: 'var x') (InputType: ?, DeclaredSymbol: ? x, MatchesNull: True)
+";
+
+            VerifyOperationTreeForTest<IsPatternExpressionSyntax>(compilation, expectedOperationTree);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow, CompilerFeature.Patterns)]

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6547,18 +6547,28 @@ oneMoreTime:
                 operation.Syntax, IsImplicit(operation));
         }
 
-        public override IOperation VisitRecursivePattern(IRecursivePatternOperation operation, int? argument)
+        internal override IOperation VisitRecursivePattern(IRecursivePatternOperation operation, int? argument)
         {
             return new RecursivePatternOperation(
                 inputType: operation.InputType,
                 matchedType: operation.MatchedType,
                 operation.DeconstructSymbol,
                 operation.DeconstructionSubpatterns.SelectAsArray(p => (IPatternOperation)Visit(p)),
-                operation.PropertySubpatterns.SelectAsArray(p => (p.Item1, (IPatternOperation)Visit(p.Item2))),
+                operation.PropertySubpatterns.SelectAsArray(p => (IPropertySubpatternOperation)Visit(p)),
                 operation.DeclaredSymbol,
                 semanticModel: null,
                 operation.Syntax,
                 IsImplicit(operation));
+        }
+
+        internal override IOperation VisitPropertySubpattern(IPropertySubpatternOperation operation, int? argument)
+        {
+            return new PropertySubpatternOperation(
+                semanticModel: null,
+                operation.Syntax,
+                IsImplicit(operation),
+                Visit(operation.Member),
+                (IPatternOperation)Visit(operation.Pattern));
         }
 
         public override IOperation VisitDelegateCreation(IDelegateCreationOperation operation, int? captureIdForResult)

--- a/src/Compilers/Core/Portable/Operations/IPropertySubpatternOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IPropertySubpatternOperation.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Operations
+{
+    /// <summary>
+    /// Represents an element of a property subpattern, which identifies a member to be matched and the
+    /// pattern to match it against.
+    /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
+    internal interface IPropertySubpatternOperation : IOperation
+    {
+        /// <summary>
+        /// The member being matched in a property subpattern.  This can be a <see cref="IMemberReferenceOperation"/>
+        /// in non-error cases, or PROTOTYPE(ngafter) WHAT in error cases.
+        /// </summary>
+        IOperation Member { get; }
+
+        /// <summary>
+        /// The pattern to which the member is matched in a property subpattern.
+        /// </summary>
+        IPatternOperation Pattern { get; }
+    }
+}
+

--- a/src/Compilers/Core/Portable/Operations/IPropertySubpatternOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IPropertySubpatternOperation.cs
@@ -14,8 +14,10 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         /// <summary>
         /// The member being matched in a property subpattern.  This can be a <see cref="IMemberReferenceOperation"/>
-        /// in non-error cases, or PROTOTYPE(ngafter) WHAT in error cases.
+        /// in non-error cases, or an <see cref="IInvalidOperation"/> in error cases.
         /// </summary>
+        // The symbol should be exposed for error cases somehow:
+        // https://github.com/dotnet/roslyn/issues/33175
         IOperation Member { get; }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Operations/IRecursivePatternOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IRecursivePatternOperation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Operations
     /// This interface is reserved for implementation by its associated APIs. We reserve the right to
     /// change it in the future.
     /// </remarks>
-    public interface IRecursivePatternOperation : IPatternOperation
+    internal interface IRecursivePatternOperation : IPatternOperation
     {
         /// <summary>
         /// The type accepted for the recursive pattern.
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Operations
         /// <summary>
         /// This contains the (symbol, property) pairs within a property subpattern.
         /// </summary>
-        ImmutableArray<(ISymbol, IPatternOperation)> PropertySubpatterns { get; }
+        ImmutableArray<IPropertySubpatternOperation> PropertySubpatterns { get; }
 
         /// <summary>
         /// Symbol declared by the pattern.

--- a/src/Compilers/Core/Portable/Operations/InstanceReferenceKind.cs
+++ b/src/Compilers/Core/Portable/Operations/InstanceReferenceKind.cs
@@ -17,5 +17,9 @@ namespace Microsoft.CodeAnalysis.Operations
         /// anonymous type creation initializer, or to the object being referred to in a VB With statement.
         /// </summary>
         ImplicitReceiver,
+        /// <summary>
+        /// Reference to the value being matching in a property subpattern.
+        /// </summary>
+        PatternInput,
     }
 }

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -552,7 +552,7 @@ namespace Microsoft.CodeAnalysis.Operations
         internal override IOperation VisitPropertySubpattern(IPropertySubpatternOperation operation, object argument)
         {
             return new PropertySubpatternOperation(
-                semanticModel: null,
+                semanticModel: ((Operation)operation).OwningSemanticModel,
                 operation.Syntax,
                 operation.IsImplicit,
                 Visit(operation.Member),

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -535,7 +535,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 ((Operation)operation).OwningSemanticModel, operation.Syntax, operation.IsImplicit);
         }
 
-        public override IOperation VisitRecursivePattern(IRecursivePatternOperation operation, object argument)
+        internal override IOperation VisitRecursivePattern(IRecursivePatternOperation operation, object argument)
         {
             return new RecursivePatternOperation(
                 operation.InputType,
@@ -547,6 +547,16 @@ namespace Microsoft.CodeAnalysis.Operations
                 ((Operation)operation).OwningSemanticModel,
                 operation.Syntax,
                 operation.IsImplicit);
+        }
+
+        internal override IOperation VisitPropertySubpattern(IPropertySubpatternOperation operation, object argument)
+        {
+            return new PropertySubpatternOperation(
+                semanticModel: null,
+                operation.Syntax,
+                operation.IsImplicit,
+                Visit(operation.Member),
+                Visit(operation.Pattern));
         }
 
         public override IOperation VisitPatternCaseClause(IPatternCaseClauseOperation operation, object argument)

--- a/src/Compilers/Core/Portable/Operations/OperationNodes.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationNodes.cs
@@ -8158,7 +8158,9 @@ namespace Microsoft.CodeAnalysis.Operations
             {
                 if (_lazyMember == s_unset)
                 {
-                    Interlocked.CompareExchange(ref _lazyMember, CreateMember(), s_unset);
+                    var member = CreateMember();
+                    SetParentOperation(member, this);
+                    Interlocked.CompareExchange(ref _lazyMember, member, s_unset);
                 }
 
                 return _lazyMember;
@@ -8170,7 +8172,9 @@ namespace Microsoft.CodeAnalysis.Operations
             {
                 if (_lazyPattern == s_unsetPattern)
                 {
-                    Interlocked.CompareExchange(ref _lazyPattern, CreatePattern(), s_unsetPattern);
+                    var pattern = CreatePattern();
+                    SetParentOperation(pattern, this);
+                    Interlocked.CompareExchange(ref _lazyPattern, pattern, s_unsetPattern);
                 }
 
                 return _lazyPattern;

--- a/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
@@ -505,7 +505,12 @@ namespace Microsoft.CodeAnalysis.Operations
             DefaultVisit(operation);
         }
 
-        public virtual void VisitRecursivePattern(IRecursivePatternOperation operation)
+        internal virtual void VisitRecursivePattern(IRecursivePatternOperation operation)
+        {
+            DefaultVisit(operation);
+        }
+
+        internal virtual void VisitPropertySubpattern(IPropertySubpatternOperation operation)
         {
             DefaultVisit(operation);
         }
@@ -1113,7 +1118,12 @@ namespace Microsoft.CodeAnalysis.Operations
             return DefaultVisit(operation, argument);
         }
 
-        public virtual TResult VisitRecursivePattern(IRecursivePatternOperation operation, TArgument argument)
+        internal virtual TResult VisitRecursivePattern(IRecursivePatternOperation operation, TArgument argument)
+        {
+            return DefaultVisit(operation, argument);
+        }
+
+        internal virtual TResult VisitPropertySubpattern(IPropertySubpatternOperation operation, TArgument argument)
         {
             return DefaultVisit(operation, argument);
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -17,15 +17,10 @@ Microsoft.CodeAnalysis.Operations.IDeclarationPatternOperation.MatchedType.get -
 Microsoft.CodeAnalysis.Operations.IDeclarationPatternOperation.MatchesNull.get -> bool
 Microsoft.CodeAnalysis.Operations.IDiscardPatternOperation
 Microsoft.CodeAnalysis.Operations.IPatternOperation.InputType.get -> Microsoft.CodeAnalysis.ITypeSymbol
+Microsoft.CodeAnalysis.Operations.InstanceReferenceKind.PatternInput = 2 -> Microsoft.CodeAnalysis.Operations.InstanceReferenceKind
 Microsoft.CodeAnalysis.SymbolDisplayPartKind.ConstantName = 30 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
 Microsoft.CodeAnalysis.SymbolDisplayPartKind.EnumMemberName = 28 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
 Microsoft.CodeAnalysis.SymbolDisplayPartKind.ExtensionMethodName = 29 -> Microsoft.CodeAnalysis.SymbolDisplayPartKind
-Microsoft.CodeAnalysis.Operations.IRecursivePatternOperation
-Microsoft.CodeAnalysis.Operations.IRecursivePatternOperation.DeclaredSymbol.get -> Microsoft.CodeAnalysis.ISymbol
-Microsoft.CodeAnalysis.Operations.IRecursivePatternOperation.DeconstructSymbol.get -> Microsoft.CodeAnalysis.ISymbol
-Microsoft.CodeAnalysis.Operations.IRecursivePatternOperation.DeconstructionSubpatterns.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Operations.IPatternOperation>
-Microsoft.CodeAnalysis.Operations.IRecursivePatternOperation.MatchedType.get -> Microsoft.CodeAnalysis.ITypeSymbol
-Microsoft.CodeAnalysis.Operations.IRecursivePatternOperation.PropertySubpatterns.get -> System.Collections.Immutable.ImmutableArray<(Microsoft.CodeAnalysis.ISymbol, Microsoft.CodeAnalysis.Operations.IPatternOperation)>
 Microsoft.CodeAnalysis.Operations.ISwitchExpressionArmOperation
 Microsoft.CodeAnalysis.Operations.ISwitchExpressionArmOperation.Guard.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Operations.ISwitchExpressionArmOperation.Locals.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ILocalSymbol>
@@ -218,7 +213,6 @@ virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitIsNull(Microsoft
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitRangeOperation(Microsoft.CodeAnalysis.Operations.IRangeOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitReDim(Microsoft.CodeAnalysis.Operations.IReDimOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitReDimClause(Microsoft.CodeAnalysis.Operations.IReDimClauseOperation operation) -> void
-virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitRecursivePattern(Microsoft.CodeAnalysis.Operations.IRecursivePatternOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitStaticLocalInitializationSemaphore(Microsoft.CodeAnalysis.FlowAnalysis.IStaticLocalInitializationSemaphoreOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitSwitchExpression(Microsoft.CodeAnalysis.Operations.ISwitchExpressionOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitSwitchExpressionArm(Microsoft.CodeAnalysis.Operations.ISwitchExpressionArmOperation operation) -> void
@@ -233,7 +227,6 @@ virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.V
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitRangeOperation(Microsoft.CodeAnalysis.Operations.IRangeOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitReDim(Microsoft.CodeAnalysis.Operations.IReDimOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitReDimClause(Microsoft.CodeAnalysis.Operations.IReDimClauseOperation operation, TArgument argument) -> TResult
-virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitRecursivePattern(Microsoft.CodeAnalysis.Operations.IRecursivePatternOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitStaticLocalInitializationSemaphore(Microsoft.CodeAnalysis.FlowAnalysis.IStaticLocalInitializationSemaphoreOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitSwitchExpression(Microsoft.CodeAnalysis.Operations.ISwitchExpressionOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitSwitchExpressionArm(Microsoft.CodeAnalysis.Operations.ISwitchExpressionArmOperation operation, TArgument argument) -> TResult

--- a/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/ControlFlowGraphVerifier.cs
@@ -1728,14 +1728,16 @@ endRegion:
 
                 case OperationKind.InstanceReference:
                     // Implicit instance receivers, except for anonymous type creations, are expected to have been removed when dealing with creations.
-                    return ((IInstanceReferenceOperation)n).ReferenceKind == InstanceReferenceKind.ContainingTypeInstance ||
-                        ((IInstanceReferenceOperation)n).ReferenceKind == InstanceReferenceKind.ImplicitReceiver &&
-                        n.Type.IsAnonymousType &&
-                        n.Parent is IPropertyReferenceOperation propertyReference &&
-                        propertyReference.Instance == n &&
-                        propertyReference.Parent is ISimpleAssignmentOperation simpleAssignment &&
-                        simpleAssignment.Target == propertyReference &&
-                        simpleAssignment.Parent.Kind == OperationKind.AnonymousObjectCreation;
+                    var instanceReference = (IInstanceReferenceOperation)n;
+                    return instanceReference.ReferenceKind == InstanceReferenceKind.ContainingTypeInstance ||
+                        instanceReference.ReferenceKind == InstanceReferenceKind.PatternInput ||
+                        (instanceReference.ReferenceKind == InstanceReferenceKind.ImplicitReceiver &&
+                         n.Type.IsAnonymousType &&
+                         n.Parent is IPropertyReferenceOperation propertyReference &&
+                         propertyReference.Instance == n &&
+                         propertyReference.Parent is ISimpleAssignmentOperation simpleAssignment &&
+                         simpleAssignment.Target == propertyReference &&
+                         simpleAssignment.Parent.Kind == OperationKind.AnonymousObjectCreation);
 
                 case OperationKind.None:
                     return !(n is IPlaceholderOperation);

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -1762,7 +1762,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             LogNewLine();
         }
 
-        public override void VisitRecursivePattern(IRecursivePatternOperation operation)
+        internal override void VisitRecursivePattern(IRecursivePatternOperation operation)
         {
             LogString(nameof(IRecursivePatternOperation));
             LogPatternProperties(operation);
@@ -1773,11 +1773,17 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             LogNewLine();
 
             VisitArray(operation.DeconstructionSubpatterns, $"{nameof(operation.DeconstructionSubpatterns)} ", true, true);
-            VisitArrayCommon(operation.PropertySubpatterns, $"{nameof(operation.PropertySubpatterns)} ", true, true, subpat =>
-            {
-                LogSymbol(subpat.Item1, "MatchedSymbol");
-                Visit(subpat.Item2, ", Pattern");
-            });
+            VisitArray(operation.PropertySubpatterns, $"{nameof(operation.PropertySubpatterns)} ", true, true);
+        }
+
+        internal override void VisitPropertySubpattern(IPropertySubpatternOperation operation)
+        {
+            LogString(nameof(IPropertySubpatternOperation));
+            LogCommonProperties(operation);
+            LogNewLine();
+
+            Visit(operation.Member, $"{nameof(operation.Member)}");
+            Visit(operation.Pattern, $"{nameof(operation.Pattern)}");
         }
 
         public override void VisitIsPattern(IIsPatternOperation operation)

--- a/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
@@ -1197,7 +1197,16 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         internal override void VisitPropertySubpattern(IPropertySubpatternOperation operation)
         {
-            Assert.True(operation.Member is IMemberReferenceOperation || operation.Member is IInvalidOperation);
+            Assert.NotNull(operation.Pattern);
+            var children = new IOperation[] { operation.Member, operation.Pattern };
+            AssertEx.Equal(children, operation.Children);
+
+            if (operation.Member.Kind == OperationKind.Invalid)
+            {
+                return;
+            }
+
+            Assert.True(operation.Member is IMemberReferenceOperation);
             var member = (IMemberReferenceOperation)operation.Member;
             switch (member.Member)
             {
@@ -1209,10 +1218,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     Assert.True(false, $"Unexpected symbol {symbol}");
                     break;
             }
-
-            Assert.NotNull(operation.Pattern);
-            var children = new IOperation[] { operation.Member, operation.Pattern };
-            AssertEx.Equal(children, operation.Children);
         }
 
         public override void VisitSwitchExpression(ISwitchExpressionOperation operation)

--- a/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationVisitor.cs
@@ -1197,12 +1197,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         internal override void VisitPropertySubpattern(IPropertySubpatternOperation operation)
         {
-            Assert.True(operation.Member is IMemberReferenceOperation);
+            Assert.True(operation.Member is IMemberReferenceOperation || operation.Member is IInvalidOperation);
             var member = (IMemberReferenceOperation)operation.Member;
             switch (member.Member)
             {
-                case null: // error case
-                    break;
                 case IFieldSymbol field:
                 case IPropertySymbol prop:
                 case IErrorTypeSymbol error:

--- a/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis
@@ -57,7 +58,7 @@ namespace Microsoft.CodeAnalysis
                         //
                         return ValueUsageInfo.Write;
 
-                    case IRecursivePatternOperation _:
+                    case IOperation iop when iop.GetType().GetInterfaces().Any(i => i.Name == "IRecursivePatternOperation"):
                         // A declaration pattern within a recursive pattern is a
                         // write for the declared local.
                         // For example, 'x' is defined and assigned the value from 'obj' below:


### PR DESCRIPTION
Updates the structure of IPropertySubpattern to be what we decided in the IOperation design meeting, and makes the implementation internal until we finalize C# 8.
Fixes https://github.com/dotnet/roslyn/issues/33018.