### PR TITLE
Remove OptProf tests that are not currently supported

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -13,14 +13,12 @@
         {
           "container": "TeamEng",
           "testCases": [
-            "TeamEng.OptProfTest.vs_debugger_interop_managedclient",
             "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble"
           ]
         },
         {
           "container": "VSLanguages",
           "testCases": [
-            "VSLanguages.Managed.vs_perf_DesignTime_editor_navigate_NavigateTo_cs"
           ]
         },
         {
@@ -29,7 +27,6 @@
             "VSPE.OptProfTests.vs_asl_cs_scenario",
             "VSPE.OptProfTests.vs_asl_vb_scenario",
             "VSPE.OptProfTests.vs_ddbvtqa_vbwi",
-            "VSPE.OptProfTests.vs_env_solution_createnewproject_vb_winformsapp",
             "VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs",
             "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest",
             "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment",


### PR DESCRIPTION
The removed RPS tests are not supported in the training environment right now.