### PR TITLE
Resolve Metadata As Source symbols in their original compilations

### DIFF
--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -63,8 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
 
             if (assemblyLocation == null)
             {
-                var referencedAssemblySymbol = compilation.GetReferencedAssemblySymbols().FirstOrDefault(referenced => referenced.Identity.Equals(symbol.ContainingAssembly?.Identity));
-                var reference = compilation.GetMetadataReference(referencedAssemblySymbol);
+                var reference = MetadataAsSourceHelpers.TryGetAssemblyReference(compilation, symbol.ContainingAssembly);
                 assemblyLocation = (reference as PortableExecutableReference)?.FilePath;
                 if (assemblyLocation == null)
                 {

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -63,7 +63,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
 
             if (assemblyLocation == null)
             {
-                var reference = compilation.GetMetadataReference(symbol.ContainingAssembly);
+                var referencedAssemblySymbol = compilation.GetReferencedAssemblySymbols().FirstOrDefault(referenced => referenced.Identity.Equals(symbol.ContainingAssembly?.Identity));
+                var reference = compilation.GetMetadataReference(referencedAssemblySymbol);
                 assemblyLocation = (reference as PortableExecutableReference)?.FilePath;
                 if (assemblyLocation == null)
                 {

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -38,13 +38,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             this.provider = provider;
         }
 
-        public async Task<Document> AddSourceToAsync(Document document, ISymbol symbol, CancellationToken cancellationToken)
+        public async Task<Document> AddSourceToAsync(Document document, Compilation symbolCompilation, ISymbol symbol, CancellationToken cancellationToken)
         {
             // Get the name of the type the symbol is in
             var containingOrThis = symbol.GetContainingTypeOrThis();
             var fullName = GetFullReflectionName(containingOrThis);
-
-            var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
 
             string assemblyLocation = null;
             var isReferenceAssembly = symbol.ContainingAssembly.GetAttributes().Any(attribute => attribute.AttributeClass.Name == nameof(ReferenceAssemblyAttribute)
@@ -63,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
 
             if (assemblyLocation == null)
             {
-                var reference = MetadataAsSourceHelpers.TryGetAssemblyReference(compilation, symbol.ContainingAssembly);
+                var reference = symbolCompilation.GetMetadataReference(symbol.ContainingAssembly);
                 assemblyLocation = (reference as PortableExecutableReference)?.FilePath;
                 if (assemblyLocation == null)
                 {
@@ -72,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             }
 
             // Decompile
-            document = PerformDecompilation(document, fullName, compilation, assemblyLocation);
+            document = PerformDecompilation(document, fullName, symbolCompilation, assemblyLocation);
 
             document = await AddAssemblyInfoRegionAsync(document, symbol, cancellationToken).ConfigureAwait(false);
 

--- a/src/EditorFeatures/Core/IDecompiledSourceService.cs
+++ b/src/EditorFeatures/Core/IDecompiledSourceService.cs
@@ -14,9 +14,10 @@ namespace Microsoft.CodeAnalysis.Editor
         /// into the given document
         /// </summary>
         /// <param name="document">The document to generate source into</param>
+        /// <param name="symbolCompilation">The <see cref="Compilation"/> in which symbol is resolved.</param>
         /// <param name="symbol">The symbol to generate source for</param>
         /// <param name="cancellationToken">To cancel document operations</param>
         /// <returns>The updated document</returns>
-        Task<Document> AddSourceToAsync(Document document, ISymbol symbol, CancellationToken cancellationToken);
+        Task<Document> AddSourceToAsync(Document document, Compilation symbolCompilation, ISymbol symbol, CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -91,6 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
             Location navigateLocation = null;
             var topLevelNamedType = MetadataAsSourceHelpers.GetTopLevelContainingNamedType(symbol);
             var symbolId = SymbolKey.Create(symbol, cancellationToken);
+            var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
 
             using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
@@ -123,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
                             var decompiledSourceService = temporaryDocument.GetLanguageService<IDecompiledSourceService>();
                             if (decompiledSourceService != null)
                             {
-                                temporaryDocument = await decompiledSourceService.AddSourceToAsync(temporaryDocument, symbol, cancellationToken).ConfigureAwait(false);
+                                temporaryDocument = await decompiledSourceService.AddSourceToAsync(temporaryDocument, compilation, symbol, cancellationToken).ConfigureAwait(false);
                             }
                             else
                             {
@@ -139,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
                     if (!useDecompiler)
                     {
                         var sourceFromMetadataService = temporaryDocument.Project.LanguageServices.GetService<IMetadataAsSourceService>();
-                        temporaryDocument = await sourceFromMetadataService.AddSourceToAsync(temporaryDocument, symbol, cancellationToken).ConfigureAwait(false);
+                        temporaryDocument = await sourceFromMetadataService.AddSourceToAsync(temporaryDocument, compilation, symbol, cancellationToken).ConfigureAwait(false);
                     }
 
                     // We have the content, so write it out to disk

--- a/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
@@ -31,11 +31,10 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
         {
         }
 
-        protected override async Task<Document> AddAssemblyInfoRegionAsync(Document document, ISymbol symbol, CancellationToken cancellationToken)
+        protected override async Task<Document> AddAssemblyInfoRegionAsync(Document document, Compilation symbolCompilation, ISymbol symbol, CancellationToken cancellationToken)
         {
             string assemblyInfo = MetadataAsSourceHelpers.GetAssemblyInfo(symbol.ContainingAssembly);
-            var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-            string assemblyPath = MetadataAsSourceHelpers.GetAssemblyDisplay(compilation, symbol.ContainingAssembly);
+            string assemblyPath = MetadataAsSourceHelpers.GetAssemblyDisplay(symbolCompilation, symbol.ContainingAssembly);
 
             var regionTrivia = SyntaxFactory.RegionDirectiveTrivia(true)
                 .WithTrailingTrivia(new[] { SyntaxFactory.Space, SyntaxFactory.PreprocessingMessage(assemblyInfo) });

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             _codeGenerationService = codeGenerationService;
         }
 
-        public async Task<Document> AddSourceToAsync(Document document, ISymbol symbol, CancellationToken cancellationToken)
+        public async Task<Document> AddSourceToAsync(Document document, Compilation symbolCompilation, ISymbol symbol, CancellationToken cancellationToken)
         {
             if (document == null)
             {
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             var docCommentFormattingService = document.GetLanguageService<IDocumentationCommentFormattingService>();
             var docWithDocComments = await ConvertDocCommentsToRegularComments(document, docCommentFormattingService, cancellationToken).ConfigureAwait(false);
 
-            var docWithAssemblyInfo = await AddAssemblyInfoRegionAsync(docWithDocComments, symbol.GetOriginalUnreducedDefinition(), cancellationToken).ConfigureAwait(false);
+            var docWithAssemblyInfo = await AddAssemblyInfoRegionAsync(docWithDocComments, symbolCompilation, symbol.GetOriginalUnreducedDefinition(), cancellationToken).ConfigureAwait(false);
             var node = await docWithAssemblyInfo.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var formattedDoc = await Formatter.FormatAsync(
                 docWithAssemblyInfo, SpecializedCollections.SingletonEnumerable(node.FullSpan), options: null, rules: GetFormattingRules(docWithAssemblyInfo), cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -68,7 +68,12 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         /// a string similar to "location unknown" will be placed in the comment inside the region
         /// instead of the path.
         /// </summary>
-        protected abstract Task<Document> AddAssemblyInfoRegionAsync(Document document, ISymbol symbol, CancellationToken cancellationToken);
+        /// <param name="document">The document to generate source into</param>
+        /// <param name="symbolCompilation">The <see cref="Compilation"/> in which symbol is resolved.</param>
+        /// <param name="symbol">The symbol to generate source for</param>
+        /// <param name="cancellationToken">To cancel document operations</param>
+        /// <returns>The updated document</returns>
+        protected abstract Task<Document> AddAssemblyInfoRegionAsync(Document document, Compilation symbolCompilation, ISymbol symbol, CancellationToken cancellationToken);
 
         protected abstract Task<Document> ConvertDocCommentsToRegularComments(Document document, IDocumentationCommentFormattingService docCommentFormattingService, CancellationToken cancellationToken);
 

--- a/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceService.cs
@@ -14,9 +14,10 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         /// which the given ISymbol is or is a part of into the given document
         /// </summary>
         /// <param name="document">The document to generate source into</param>
-        /// <param name="symbol">The symbol whose interface to generate source for</param>
+        /// <param name="symbolCompilation">The <see cref="Compilation"/> in which <paramref name="symbol"/> is resolved.</param>
+        /// <param name="symbol">The symbol to generate source for</param>
         /// <param name="cancellationToken">To cancel document operations</param>
         /// <returns>The updated document</returns>
-        Task<Document> AddSourceToAsync(Document document, ISymbol symbol, CancellationToken cancellationToken = default);
+        Task<Document> AddSourceToAsync(Document document, Compilation symbolCompilation, ISymbol symbol, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceHelpers.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceHelpers.cs
@@ -51,20 +51,8 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             // This method is only used to generate a comment at the top of Metadata-as-Source documents and
             // previous submissions are never viewed as metadata (i.e. we always have compilations) so there's no
             // need to consume compilation.ScriptCompilationInfo.PreviousScriptCompilation.
-            var assemblyReference = TryGetAssemblyReference(compilation, assemblySymbol);
+            var assemblyReference = compilation.GetMetadataReference(assemblySymbol);
             return assemblyReference?.Display ?? FeaturesResources.location_unknown;
-        }
-
-        public static MetadataReference TryGetAssemblyReference(Compilation compilation, IAssemblySymbol assemblySymbol)
-        {
-            return compilation.References.Where(r =>
-            {
-                var referencedSymbol = compilation.GetAssemblyOrModuleSymbol(r) as IAssemblySymbol;
-                return
-                    referencedSymbol != null &&
-                    referencedSymbol.MetadataName == assemblySymbol.MetadataName;
-            })
-            .FirstOrDefault();
         }
 
         public static INamedTypeSymbol GetTopLevelContainingNamedType(ISymbol symbol)

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceHelpers.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceHelpers.cs
@@ -51,9 +51,13 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             // This method is only used to generate a comment at the top of Metadata-as-Source documents and
             // previous submissions are never viewed as metadata (i.e. we always have compilations) so there's no
             // need to consume compilation.ScriptCompilationInfo.PreviousScriptCompilation.
+            var assemblyReference = TryGetAssemblyReference(compilation, assemblySymbol);
+            return assemblyReference?.Display ?? FeaturesResources.location_unknown;
+        }
 
-            // TODO (https://github.com/dotnet/roslyn/issues/6859): compilation.GetMetadataReference(assemblySymbol)?
-            var assemblyReference = compilation.References.Where(r =>
+        public static MetadataReference TryGetAssemblyReference(Compilation compilation, IAssemblySymbol assemblySymbol)
+        {
+            return compilation.References.Where(r =>
             {
                 var referencedSymbol = compilation.GetAssemblyOrModuleSymbol(r) as IAssemblySymbol;
                 return
@@ -61,8 +65,6 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                     referencedSymbol.MetadataName == assemblySymbol.MetadataName;
             })
             .FirstOrDefault();
-
-            return assemblyReference?.Display ?? FeaturesResources.location_unknown;
         }
 
         public static INamedTypeSymbol GetTopLevelContainingNamedType(ISymbol symbol)

--- a/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceService.vb
+++ b/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceService.vb
@@ -11,7 +11,6 @@ Imports Microsoft.CodeAnalysis.MetadataAsSource
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.DocumentationComments
 Imports Microsoft.CodeAnalysis.VisualBasic.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -25,10 +24,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MetadataAsSource
             MyBase.New(languageServices.GetService(Of ICodeGenerationService)())
         End Sub
 
-        Protected Overrides Async Function AddAssemblyInfoRegionAsync(document As Document, symbol As ISymbol, cancellationToken As CancellationToken) As Task(Of Document)
+        Protected Overrides Async Function AddAssemblyInfoRegionAsync(document As Document, symbolCompilation As Compilation, symbol As ISymbol, cancellationToken As CancellationToken) As Task(Of Document)
             Dim assemblyInfo = MetadataAsSourceHelpers.GetAssemblyInfo(symbol.ContainingAssembly)
-            Dim compilation = Await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(False)
-            Dim assemblyPath = MetadataAsSourceHelpers.GetAssemblyDisplay(compilation, symbol.ContainingAssembly)
+            Dim assemblyPath = MetadataAsSourceHelpers.GetAssemblyDisplay(symbolCompilation, symbol.ContainingAssembly)
 
             Dim regionTrivia = SyntaxFactory.RegionDirectiveTrivia(
                     SyntaxFactory.Token(SyntaxKind.HashToken),


### PR DESCRIPTION
Fixes a bug reported through email by @veleek 

The document in which disassembled code is added is part of a temporary project used specifically for Metadata as Source operations. The target symbol for navigation is derived from a different context, so the corresponding assembly symbol will not be an equality match. ~~We instead look up the metadata reference in the compilation using the metadata name, which accounts for the symbol mismatch and also allows for assembly version differences.~~

We now use the original compilation matching the `ISymbol` used for navigation to ensure the metadata reference can be correctly resolved.

Fixes #23478
Fixes #6859
