### PR TITLE
Enable preview version for certain target frameworks

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -48,6 +48,12 @@
       <PdbFile Condition="'$(PdbFile)' == '' AND '$(OutputType)' == 'winmdobj' AND '$(_DebugSymbolsProduced)' == 'true'">$(IntermediateOutputPath)$(TargetName).compile.pdb</PdbFile>
     </PropertyGroup>
 
+    <PropertyGroup>
+      <LangVersion Condition="'$(LangVersion)' == '' AND
+        (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion)' == 'v3.0') OR
+         ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion)' == 'v2.1'))">preview</LangVersion>
+    </PropertyGroup>
+
     <!-- Condition is to filter out the _CoreCompileResourceInputs so that it doesn't pass in culture resources to the compiler -->
     <Csc Condition="'%(_CoreCompileResourceInputs.WithCulture)' != 'true'"
          AdditionalLibPaths="$(AdditionalLibPaths)"


### PR DESCRIPTION
Enable 'preview' langversion in our MSBuild .targets file for projects targeting netcoreapp3.0 or netstandard2.1. A warning is already provided in the dotnet SDK when using these preview versions (well, netstandard2.1 doesn't have a shipping preview yet, but presumably it will behave like netcoreapp3.0) so we can automatically upgrade the compiler to Preview when using them.