### PR TITLE
Remove block comments first if selection exactly matches block.  Reso…

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CommentSelection/CommentUncommentSelectionCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/CommentSelection/CommentUncommentSelectionCommandHandler.cs
@@ -303,58 +303,76 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
         {
             var info = service.GetInfoAsync(document, span.Span.ToTextSpan(), cancellationToken).WaitAndGetResult(cancellationToken);
 
+            // If the selection is exactly a block comment, use it as priority over single line comments.
+            if (info.SupportsBlockComment && TryUncommentExactlyBlockComment(info, span, textChanges, spansToSelect))
+            {
+                return;
+            }
+
             if (info.SupportsSingleLineComment &&
                 TryUncommentSingleLineComments(info, span, textChanges, spansToSelect))
             {
                 return;
             }
 
+            // We didn't make any single line changes.  If the language supports block comments, see 
+            // if we're inside a containing block comment and uncomment that.
             if (info.SupportsBlockComment)
             {
                 UncommentContainingBlockComment(info, span, textChanges, spansToSelect);
             }
         }
 
-        private void UncommentContainingBlockComment(CommentSelectionInfo info, SnapshotSpan span, List<TextChange> textChanges, List<ITrackingSpan> spansToSelect)
+        /// <summary>
+        /// Check if the selected span matches an entire block comment.
+        /// If it does, uncomment it and return true.
+        /// </summary>
+        private bool TryUncommentExactlyBlockComment(CommentSelectionInfo info, SnapshotSpan span, List<TextChange> textChanges, List<ITrackingSpan> spansToSelect)
         {
-            // We didn't make any single line changes.  If the language supports block comments, see 
-            // if we're inside a containing block comment and uncomment that.
-
-            var positionOfStart = -1;
-            var positionOfEnd = -1;
             var spanText = span.GetText();
             var trimmedSpanText = spanText.Trim();
 
             // See if the selection includes just a block comment (plus whitespace)
             if (trimmedSpanText.StartsWith(info.BlockCommentStartString, StringComparison.Ordinal) && trimmedSpanText.EndsWith(info.BlockCommentEndString, StringComparison.Ordinal))
             {
-                positionOfStart = span.Start + spanText.IndexOf(info.BlockCommentStartString, StringComparison.Ordinal);
-                positionOfEnd = span.Start + spanText.LastIndexOf(info.BlockCommentEndString, StringComparison.Ordinal);
+                var positionOfStart = span.Start + spanText.IndexOf(info.BlockCommentStartString, StringComparison.Ordinal);
+                var positionOfEnd = span.Start + spanText.LastIndexOf(info.BlockCommentEndString, StringComparison.Ordinal);
+                UncommentPosition(info, span, textChanges, spansToSelect, positionOfStart, positionOfEnd);
+                return true;
             }
-            else
-            {
-                // See if we are (textually) contained in a block comment.
-                // This could allow a selection that spans multiple block comments to uncomment the beginning of
-                // the first and end of the last.  Oh well.
-                var text = span.Snapshot.AsText();
-                positionOfStart = text.LastIndexOf(info.BlockCommentStartString, span.Start, caseSensitive: true);
 
-                // If we found a start comment marker, make sure there isn't an end comment marker after it but before our span.
-                if (positionOfStart >= 0)
+            return false;
+        }
+
+        private void UncommentContainingBlockComment(CommentSelectionInfo info, SnapshotSpan span, List<TextChange> textChanges, List<ITrackingSpan> spansToSelect)
+        {
+            // See if we are (textually) contained in a block comment.
+            // This could allow a selection that spans multiple block comments to uncomment the beginning of
+            // the first and end of the last.  Oh well.
+            var positionOfEnd = -1;
+            var text = span.Snapshot.AsText();
+            var positionOfStart = text.LastIndexOf(info.BlockCommentStartString, span.Start, caseSensitive: true);
+
+            // If we found a start comment marker, make sure there isn't an end comment marker after it but before our span.
+            if (positionOfStart >= 0)
+            {
+                var lastEnd = text.LastIndexOf(info.BlockCommentEndString, span.Start, caseSensitive: true);
+                if (lastEnd < positionOfStart)
                 {
-                    var lastEnd = text.LastIndexOf(info.BlockCommentEndString, span.Start, caseSensitive: true);
-                    if (lastEnd < positionOfStart)
-                    {
-                        positionOfEnd = text.IndexOf(info.BlockCommentEndString, span.End, caseSensitive: true);
-                    }
-                    else if (lastEnd + info.BlockCommentEndString.Length > span.End)
-                    {
-                        // The end of the span is *inside* the end marker, so searching backwards found it.
-                        positionOfEnd = lastEnd;
-                    }
+                    positionOfEnd = text.IndexOf(info.BlockCommentEndString, span.End, caseSensitive: true);
+                }
+                else if (lastEnd + info.BlockCommentEndString.Length > span.End)
+                {
+                    // The end of the span is *inside* the end marker, so searching backwards found it.
+                    positionOfEnd = lastEnd;
                 }
             }
 
+            UncommentPosition(info, span, textChanges, spansToSelect, positionOfStart, positionOfEnd);
+        }
+
+        private void UncommentPosition(CommentSelectionInfo info, SnapshotSpan span, List<TextChange> textChanges, List<ITrackingSpan> spansToSelect, int positionOfStart, int positionOfEnd)
+        {
             if (positionOfStart < 0 || positionOfEnd < 0)
             {
                 return;

--- a/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
@@ -384,6 +384,8 @@ class Goo
                 new TextChange(new TextSpan(20, 2), string.Empty),
                 new TextChange(new TextSpan(23, 2), string.Empty),
                 new TextChange(new TextSpan(38, 2), string.Empty),
+                new TextChange(new TextSpan(49, 2), string.Empty),
+                new TextChange(new TextSpan(52, 2), string.Empty),
                 new TextChange(new TextSpan(64, 2), string.Empty),
             };
 
@@ -495,6 +497,160 @@ class Goo
         {
             var code = @"/*using |start||end|System;";
             UncommentSelection(code, Enumerable.Empty<TextChange>(), new Span(8, 0), supportBlockComments: true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CommentSelection)]
+        [WorkItem(31669, "https://github.com/dotnet/roslyn/issues/31669")]
+        public void Uncomment_BlockWithSingleInside()
+        {
+            var code = @"
+class A
+{
+    |start|/*
+    void M()
+    {
+            // A comment
+            // Another comment
+    }
+    */|end|
+}";
+
+            var expectedChanges = new[]
+            {
+                new TextChange(new TextSpan(18, 2), string.Empty),
+                new TextChange(new TextSpan(112, 2), string.Empty),
+            };
+
+            var expectedSelectedSpans = new[]
+            {
+                Span.FromBounds(18, 110)
+            };
+
+            UncommentSelection(code, expectedChanges, expectedSelectedSpans, supportBlockComments: true);
+        }
+
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CommentSelection)]
+        [WorkItem(31669, "https://github.com/dotnet/roslyn/issues/31669")]
+        public void Uncomment_BlockWithSingleInsideAndBlockSelected()
+        {
+            var code = @"
+class A
+{
+    /*
+    void |start|M|end|()
+    {
+            // A comment
+            // Another comment
+    }
+    */
+}";
+
+            var expectedChanges = new[]
+            {
+                new TextChange(new TextSpan(18, 2), string.Empty),
+                new TextChange(new TextSpan(112, 2), string.Empty),
+            };
+
+            var expectedSelectedSpans = new[]
+            {
+                Span.FromBounds(18, 110)
+            };
+
+            UncommentSelection(code, expectedChanges, expectedSelectedSpans, supportBlockComments: true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CommentSelection)]
+        [WorkItem(31669, "https://github.com/dotnet/roslyn/issues/31669")]
+        public void Uncomment_SingleLineInsideBlockAndSingleSelected()
+        {
+            var code = @"
+class A
+{
+    /*
+    void M()
+    {
+            // A |start|comm|end|ent
+            // Another comment
+    }
+    */
+}";
+
+            var expectedChanges = new[]
+            {
+                new TextChange(new TextSpan(55, 2), string.Empty),
+            };
+
+            var expectedSelectedSpans = new[]
+            {
+                Span.FromBounds(43, 65)
+            };
+
+            UncommentSelection(code, expectedChanges, expectedSelectedSpans, supportBlockComments: true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CommentSelection)]
+        [WorkItem(31669, "https://github.com/dotnet/roslyn/issues/31669")]
+        public void Uncomment_SingleLineInsideBlockAndBothSelected()
+        {
+            var code = @"
+class A
+{
+    /*
+    void |start|M()
+    {
+            // A comm|end|ent
+            // Another comment
+    }
+    */
+}";
+
+            var expectedChanges = new[]
+            {
+                new TextChange(new TextSpan(55, 2), string.Empty),
+            };
+
+            var expectedSelectedSpans = new[]
+            {
+                Span.FromBounds(22, 65)
+            };
+
+            UncommentSelection(code, expectedChanges, expectedSelectedSpans, supportBlockComments: true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CommentSelection)]
+        [WorkItem(31669, "https://github.com/dotnet/roslyn/issues/31669")]
+        public void Uncomment_SingleLinesWithBlockAndSingleInside()
+        {
+            var code = @"
+class A
+{
+    |start|///*
+    //void M()
+    //{
+    //     // A comment
+    //     // Another comment
+    //}
+    //*/|end|
+}";
+
+            var expectedChanges = new[]
+            {
+                new TextChange(new TextSpan(18, 2), string.Empty),
+                new TextChange(new TextSpan(28, 2), string.Empty),
+                new TextChange(new TextSpan(44, 2), string.Empty),
+                new TextChange(new TextSpan(53, 2), string.Empty),
+                new TextChange(new TextSpan(78, 2), string.Empty),
+                new TextChange(new TextSpan(109, 2), string.Empty),
+                new TextChange(new TextSpan(118, 2), string.Empty),
+            };
+
+            var expectedSelectedSpans = new[]
+            {
+                Span.FromBounds(14, 108)
+            };
+
+            UncommentSelection(code, expectedChanges, expectedSelectedSpans, supportBlockComments: true);
         }
 
         private static void UncommentSelection(string code, IEnumerable<TextChange> expectedChanges, Span expectedSelectedSpan, bool supportBlockComments)

--- a/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
@@ -529,6 +529,68 @@ class A
             UncommentSelection(code, expectedChanges, expectedSelectedSpans, supportBlockComments: true);
         }
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CommentSelection)]
+        [WorkItem(31669, "https://github.com/dotnet/roslyn/issues/31669")]
+        public void Uncomment_BlockWithSingleInsideAndSelectionIncludesNewLines()
+        {
+            var code = @"
+class A
+{
+|start|
+    /*
+    void M()
+    {
+            // A comment
+            // Another comment
+    }
+    */
+|end|
+}";
+
+            var expectedChanges = new[]
+            {
+                new TextChange(new TextSpan(20, 2), string.Empty),
+                new TextChange(new TextSpan(114, 2), string.Empty),
+            };
+
+            var expectedSelectedSpans = new[]
+            {
+                Span.FromBounds(20, 112)
+            };
+
+            UncommentSelection(code, expectedChanges, expectedSelectedSpans, supportBlockComments: true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CommentSelection)]
+        [WorkItem(31669, "https://github.com/dotnet/roslyn/issues/31669")]
+        public void Uncomment_BlockWithSingleInsideAndSelectionStartsWithSpaces()
+        {
+            var code = @"
+class A
+{
+|start|    /*
+    void M()
+    {
+            // A comment
+            // Another comment
+    }
+    */
+|end|}";
+
+            var expectedChanges = new[]
+            {
+                new TextChange(new TextSpan(18, 2), string.Empty),
+                new TextChange(new TextSpan(112, 2), string.Empty),
+            };
+
+            var expectedSelectedSpans = new[]
+            {
+                Span.FromBounds(18, 110)
+            };
+
+            UncommentSelection(code, expectedChanges, expectedSelectedSpans, supportBlockComments: true);
+        }
+
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CommentSelection)]
         [WorkItem(31669, "https://github.com/dotnet/roslyn/issues/31669")]


### PR DESCRIPTION
…lves #31669 

Checks to see if the selection spans exactly a block comment.  If so, remove that first rather than removing any single line comments inside the block comment.