### PR TITLE
Re-enable mono CI build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,11 +176,10 @@ jobs:
         _args: --testCoreClr
         _name: CoreClr
         _configuration: Debug
-# Skip mono build leg until dpkg issues are resolved - For more details https://github.com/dotnet/roslyn/issues/33161
-#      mono:
-#        _args: --testMono --docker
-#        _name: Mono
-#        _configuration: Debug
+      mono:
+        _args: --testMono --docker
+        _name: Mono
+        _configuration: Debug
   timeoutInMinutes: 90
   steps:
     - script: ./eng/cibuild.sh --configuration $(_configuration) --prepareMachine $(_args)


### PR DESCRIPTION
Updated builds seem to be deploying as per this comment https://github.com/dotnet/roslyn/issues/33161#issuecomment-461047323

Closes https://github.com/dotnet/roslyn/issues/33161