### PR TITLE
Show Add Imports first in suggested actions

### DIFF
--- a/src/Features/Core/Portable/AddImport/References/ProjectSymbolReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/ProjectSymbolReference.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             protected override CodeActionPriority GetPriority(Document document)
             {
-                // The only normal priority fix we have is when we find a hit in our
+                // The only high priority fix we have is when we find a hit in our
                 // own project and we don't need to do a rename.  Anything else (i.e.
                 // we need to add a project reference, or we need to rename) is low
                 // priority.
@@ -62,7 +62,8 @@ namespace Microsoft.CodeAnalysis.AddImport
                 {
                     if (SearchResult.DesiredNameMatchesSourceName(document))
                     {
-                        // The name doesn't change.  This is a normal priority action.
+                        // Set priority to high so Add Imports will appear above other suggested actions
+                        // https://github.com/dotnet/roslyn/pull/33214
                         return CodeActionPriority.High;
                     }
                 }

--- a/src/Features/Core/Portable/AddImport/References/ProjectSymbolReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/ProjectSymbolReference.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                     if (SearchResult.DesiredNameMatchesSourceName(document))
                     {
                         // The name doesn't change.  This is a normal priority action.
-                        return CodeActionPriority.Medium;
+                        return CodeActionPriority.High;
                     }
                 }
 


### PR DESCRIPTION
fixes https://github.com/dotnet/roslyn/issues/25470

Both Add Imports and Remove Unused Variables have the same priority, so the tie is broken by their proximity to the caret.  Thus, add imports is listed 2nd.

This PR changes AddImports priority form Medium to High.  No other extensions are using CodeActionPriority.High so AddImports will now always be listed first.

Related issue https://github.com/dotnet/roslyn/issues/20487 suggests finding a better approach than ordering by proximity since it doesn't always give the desired order. 