### PR TITLE
Call ProjectCodeModel.OnSourceFileRemoved when we remove files 

### DIFF
--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -2,6 +2,7 @@
 
 Imports System.Threading
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Text
 
@@ -10,10 +11,18 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
     ''' This class watches for buffer-based events, tracks the dirty regions, and invokes the formatter as appropriate
     ''' </summary>
     Partial Friend Class CommitBufferManager
+        Inherits ForegroundThreadAffinitizedObject
+
         Private ReadOnly _buffer As ITextBuffer
         Private ReadOnly _commitFormatter As ICommitFormatter
         Private ReadOnly _inlineRenameService As IInlineRenameService
+
         Private _referencingViews As Integer
+
+        ''' <summary>
+        ''' An object to use as a sync lock for <see cref="_referencingViews"/>.
+        ''' </summary>
+        Private ReadOnly _referencingViewsLock As Object = New Object()
 
         ''' <summary>
         ''' The tracking span which is the currently "dirty" region in the buffer. May be null if there is no dirty region.
@@ -30,7 +39,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
         Public Sub New(
             buffer As ITextBuffer,
             commitFormatter As ICommitFormatter,
-            inlineRenameService As IInlineRenameService)
+            inlineRenameService As IInlineRenameService,
+            threadingContext As IThreadingContext)
+            MyBase.New(threadingContext, assertIsForeground:=False)
 
             Contract.ThrowIfNull(buffer)
             Contract.ThrowIfNull(commitFormatter)
@@ -41,34 +52,34 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             _inlineRenameService = inlineRenameService
         End Sub
 
-        Private Sub Connect()
-            AddHandler _buffer.Changing, AddressOf OnTextBufferChanging
-            AddHandler _buffer.Changed, AddressOf OnTextBufferChanged
-        End Sub
-
-        Private Sub Disconnect()
-            RemoveHandler _buffer.Changed, AddressOf OnTextBufferChanged
-            RemoveHandler _buffer.Changing, AddressOf OnTextBufferChanging
-        End Sub
-
         Public Sub AddReferencingView()
-            _referencingViews += 1
+            ThisCanBeCalledOnAnyThread()
 
-            If _referencingViews = 1 Then
-                Connect()
-            End If
+            SyncLock _referencingViewsLock
+                _referencingViews += 1
+
+                If _referencingViews = 1 Then
+                    AddHandler _buffer.Changing, AddressOf OnTextBufferChanging
+                    AddHandler _buffer.Changed, AddressOf OnTextBufferChanged
+                End If
+            End SyncLock
         End Sub
 
         Public Sub RemoveReferencingView()
-            ' If someone enables line commit with a file already open, we might end up decrementing
-            ' the ref count too many times, so only do work if we are still above 0.
-            If _referencingViews > 0 Then
-                _referencingViews -= 1
+            ThisCanBeCalledOnAnyThread()
 
-                If _referencingViews = 0 Then
-                    Disconnect()
+            SyncLock _referencingViewsLock
+                ' If someone enables line commit with a file already open, we might end up decrementing
+                ' the ref count too many times, so only do work if we are still above 0.
+                If _referencingViews > 0 Then
+                    _referencingViews -= 1
+
+                    If _referencingViews = 0 Then
+                        RemoveHandler _buffer.Changed, AddressOf OnTextBufferChanged
+                        RemoveHandler _buffer.Changing, AddressOf OnTextBufferChanging
+                    End If
                 End If
-            End If
+            End SyncLock
         End Sub
 
         Public ReadOnly Property HasDirtyRegion As Boolean
@@ -128,7 +139,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                         Dim endCharIndex = 0
                         info.SpanToFormat.GetLinesAndCharacters(startLineNumber, startCharIndex, endLineNumber, endCharIndex)
                         If endLineNumber - startLineNumber > 7000 Then
-                            useSemantics = false
+                            useSemantics = False
                         End If
                     End If
 

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManagerFactory.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManagerFactory.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Composition
+Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.VisualStudio.Text
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
@@ -8,15 +9,17 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
     Friend Class CommitBufferManagerFactory
         Private ReadOnly _commitFormatter As ICommitFormatter
         Private ReadOnly _inlineRenameService As IInlineRenameService
+        Private ReadOnly _threadingContext As IThreadingContext
 
         <ImportingConstructor()>
-        Public Sub New(commitFormatter As ICommitFormatter, inlineRenameService As IInlineRenameService)
+        Public Sub New(commitFormatter As ICommitFormatter, inlineRenameService As IInlineRenameService, threadingContext As IThreadingContext)
             _commitFormatter = commitFormatter
             _inlineRenameService = inlineRenameService
+            _threadingContext = threadingContext
         End Sub
 
         Public Function CreateForBuffer(buffer As ITextBuffer) As CommitBufferManager
-            Return buffer.Properties.GetOrCreateSingletonProperty(Function() New CommitBufferManager(buffer, _commitFormatter, _inlineRenameService))
+            Return buffer.Properties.GetOrCreateSingletonProperty(Function() New CommitBufferManager(buffer, _commitFormatter, _inlineRenameService, _threadingContext))
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
@@ -3,6 +3,7 @@
 Imports System.Threading
 Imports System.Xml.Linq
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
 Imports Microsoft.CodeAnalysis.Text
@@ -51,7 +52,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
 
             _formatter = New FormatterMock(workspace)
             _inlineRenameService = New InlineRenameServiceMock()
-            Dim commitManagerFactory As New CommitBufferManagerFactory(_formatter, _inlineRenameService)
+            Dim commitManagerFactory As New CommitBufferManagerFactory(_formatter, _inlineRenameService, workspace.GetService(Of IThreadingContext))
 
             ' Make sure the manager exists for the buffer
             Dim commitManager = commitManagerFactory.CreateForBuffer(Buffer)

--- a/src/VisualStudio/Core/Def/Implementation/CodeModel/IProjectCodeModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeModel/IProjectCodeModel.cs
@@ -6,7 +6,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 {
     internal interface IProjectCodeModel
     {
-        EnvDTE.FileCodeModel GetOrCreateFileCodeModel(string filePath);
         EnvDTE.FileCodeModel GetOrCreateFileCodeModel(string filePath, object parent);
         EnvDTE.CodeModel GetOrCreateRootCodeModel(Project parent);
         void OnSourceFileRemoved(string fileName);

--- a/src/VisualStudio/Core/Def/Implementation/CodeModel/IProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeModel/IProjectCodeModelFactory.cs
@@ -8,5 +8,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
     internal interface IProjectCodeModelFactory
     {
         IProjectCodeModel CreateProjectCodeModel(ProjectId id, ICodeModelInstanceFactory codeModelInstanceFactory);
+        EnvDTE.FileCodeModel GetOrCreateFileCodeModel(ProjectId id, string filePath);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Extensions;
@@ -13,7 +14,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
-    internal partial class InvisibleEditor : IInvisibleEditor
+    internal partial class InvisibleEditor : ForegroundThreadAffinitizedObject, IInvisibleEditor
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly string _filePath;
@@ -42,6 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// projects in the solution.</para>
         /// </remarks>
         public InvisibleEditor(IServiceProvider serviceProvider, string filePath, IVsHierarchy hierarchyOpt, bool needsSave, bool needsUndoDisabled)
+            : base(serviceProvider.GetMefService<IThreadingContext>(), assertIsForeground: true)
         {
             _serviceProvider = serviceProvider;
             _filePath = filePath;
@@ -144,6 +146,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// </summary>
         public void Dispose()
         {
+            AssertIsForeground();
+
             _buffer = null;
             _vsTextLines = null;
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         }
 
         /// <remarks>
-        /// <para>The optional project is used to obtain an <see cref="IVsProject"/> 1nstance. When this instance is
+        /// <para>The optional project is used to obtain an <see cref="IVsProject"/> instance. When this instance is
         /// provided, Visual Studio will use <see cref="IVsProject.IsDocumentInProject"/> to attempt to locate the
         /// specified file within a project. If no project is specified, Visual Studio falls back to using
         /// <see cref="IVsUIShellOpenDocument4.IsDocumentInAProject2"/>, which performs a much slower query of all

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -180,6 +180,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             }
 
             VisualStudioProject.RemoveSourceFile(filename);
+            ProjectCodeModel.OnSourceFileRemoved(filename);
         }
 
         protected void RefreshBinOutputPath()

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelObject.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelObject.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 {

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
@@ -36,11 +36,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             _codeModelInstanceFactory = codeModelInstanceFactory;
         }
 
-        private bool IsZombied
-        {
-            get { return _zombied; }
-        }
-
         /// <summary>
         /// Look for an existing instance of FileCodeModel in our cache.
         /// Return null if there is no active FCM for "fileName".
@@ -138,7 +133,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         public EnvDTE.CodeModel GetOrCreateRootCodeModel(EnvDTE.Project parent)
         {
-            if (this.IsZombied)
+            if (_zombied)
             {
                 Debug.Fail("Cannot access root code model after code model was shutdown!");
                 throw Exceptions.ThrowEUnexpected();
@@ -185,7 +180,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 instance.Object.Shutdown();
             }
 
-            _zombied = false;
+            _zombied = true;
         }
 
         public void OnSourceFileRemoved(string fileName)

--- a/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModel.cs
@@ -112,11 +112,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             _codeModelCache?.OnSourceFileRenaming(filePath, newFilePath);
         }
 
-        EnvDTE.FileCodeModel IProjectCodeModel.GetOrCreateFileCodeModel(string filePath)
-        {
-            return this.GetOrCreateFileCodeModel(filePath).Handle;
-        }
-
         EnvDTE.FileCodeModel IProjectCodeModel.GetOrCreateFileCodeModel(string filePath, object parent)
         {
             return this.GetOrCreateFileCodeModel(filePath, parent).Handle;

--- a/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using EnvDTE;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Shell;
@@ -74,6 +75,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         {
             _projectCodeModels.TryGetValue(id, out var projectCodeModel);
             return projectCodeModel;
+        }
+
+        public EnvDTE.FileCodeModel GetOrCreateFileCodeModel(ProjectId id, string filePath)
+        {
+            return GetProjectCodeModel(id).GetOrCreateFileCodeModel(filePath).Handle;
         }
 
         public void ScheduleDeferredCleanupTask(Action a)

--- a/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
@@ -7,12 +7,13 @@ using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 {
     [Export(typeof(IProjectCodeModelFactory))]
     [Export(typeof(ProjectCodeModelFactory))]
-    internal sealed class ProjectCodeModelFactory : IProjectCodeModelFactory
+    internal sealed class ProjectCodeModelFactory : IProjectCodeModelFactory, IDisposable
     {
         private readonly ConcurrentDictionary<ProjectId, ProjectCodeModel> _projectCodeModels = new ConcurrentDictionary<ProjectId, ProjectCodeModel>();
 
@@ -21,12 +22,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         private readonly IThreadingContext _threadingContext;
 
+        /// <summary>
+        /// A collection of cleanup tasks that were deferred to the UI thread. In some cases, we have to clean up
+        /// certain things on the UI thread but it's not critical when those are cleared up. This just exists so we can
+        /// wait on them to be shut down before we shut down VS entirely.
+        /// </summary>
+        private readonly JoinableTaskCollection _deferredCleanupTasks;
+
         [ImportingConstructor]
         public ProjectCodeModelFactory(VisualStudioWorkspace visualStudioWorkspace, [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider, IThreadingContext threadingContext)
         {
             _visualStudioWorkspace = visualStudioWorkspace;
             _serviceProvider = serviceProvider;
             _threadingContext = threadingContext;
+            _deferredCleanupTasks = new JoinableTaskCollection(threadingContext.JoinableTaskContext);
+            _deferredCleanupTasks.DisplayName = nameof(ProjectCodeModelFactory) + "." + nameof(_deferredCleanupTasks);
         }
 
         public IProjectCodeModel CreateProjectCodeModel(ProjectId id, ICodeModelInstanceFactory codeModelInstanceFactory)
@@ -64,6 +74,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         {
             _projectCodeModels.TryGetValue(id, out var projectCodeModel);
             return projectCodeModel;
+        }
+
+        public void ScheduleDeferredCleanupTask(Action a)
+        {
+            _deferredCleanupTasks.Add(_threadingContext.JoinableTaskFactory.StartOnIdle(a, VsTaskRunContext.UIThreadNormalPriority));
+        }
+
+        void IDisposable.Dispose()
+        {
+            _deferredCleanupTasks.Join();
         }
     }
 }

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -188,6 +188,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         public void RemoveSourceFile(string filePath)
         {
             _visualStudioProject.RemoveSourceFile(filePath);
+            _projectCodeModel.OnSourceFileRemoved(filePath);
         }
 
         public void AddAdditionalFile(string filePath, bool isInCurrentContext = true)

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -29,48 +29,21 @@ namespace Microsoft.VisualStudio.LanguageServices
     internal class RoslynVisualStudioWorkspace : VisualStudioWorkspaceImpl
     {
         private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _streamingPresenters;
-        private readonly Lazy<ProjectCodeModelFactory> _projectCodeModelFactory;
 
         [ImportingConstructor]
         private RoslynVisualStudioWorkspace(
             ExportProvider exportProvider,
             [ImportMany] IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters,
             [ImportMany] IEnumerable<IDocumentOptionsProviderFactory> documentOptionsProviderFactories,
-            Lazy<ProjectCodeModelFactory> projectCodeModelFactory,
             [Import(typeof(SVsServiceProvider))] IAsyncServiceProvider asyncServiceProvider)
             : base(exportProvider, asyncServiceProvider)
         {
             _streamingPresenters = streamingPresenters;
-            _projectCodeModelFactory = projectCodeModelFactory;
 
             foreach (var providerFactory in documentOptionsProviderFactories)
             {
                 Services.GetRequiredService<IOptionService>().RegisterDocumentOptionsProvider(providerFactory.Create(this));
             }
-        }
-
-        public override EnvDTE.FileCodeModel GetFileCodeModel(DocumentId documentId)
-        {
-            if (documentId == null)
-            {
-                throw new ArgumentNullException(nameof(documentId));
-            }
-
-            var project = CurrentSolution.GetProject(documentId.ProjectId);
-            if (project == null)
-            {
-                throw new ArgumentException(ServicesVSResources.The_given_DocumentId_did_not_come_from_the_Visual_Studio_workspace, nameof(documentId));
-            }
-
-            var documentFilePath = GetFilePath(documentId);
-            if (documentFilePath == null)
-            {
-                throw new ArgumentException(ServicesVSResources.The_given_DocumentId_did_not_come_from_the_Visual_Studio_workspace, nameof(documentId));
-            }
-
-            IProjectCodeModel projectCodeModel = _projectCodeModelFactory.Value.GetProjectCodeModel(project.Id);
-
-            return projectCodeModel.GetOrCreateFileCodeModel(documentFilePath);
         }
 
         internal override IInvisibleEditor OpenInvisibleEditor(DocumentId documentId)

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCodeModelLifetimeTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCodeModelLifetimeTests.vb
@@ -1,0 +1,44 @@
+﻿Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.VisualBasicHelpers
+Imports Microsoft.VisualStudio.Shell.Interop
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
+    <[UseExportProvider]>
+    Public Class VisualBasicCodeModelLifetimeTests
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
+        <WorkItem(33080, "https://github.com/dotnet/roslyn/issues/33080")>
+        Public Sub RemovingAndReAddingSourceFileWorksCorrectly()
+            Using environment = New TestEnvironment()
+                Dim project = CreateVisualBasicProject(environment, "Test")
+
+                ' Add the file we're adding and removing to our MockHierarchy, so CodeModel operations correctly work
+                Dim project3 = DirectCast(project.Hierarchy, IVsProject3)
+                project3.AddItem(42, VSADDITEMOPERATION.VSADDITEMOP_CLONEFILE, "Z:\SourceFile.vb", Nothing, Nothing, Nothing, Nothing)
+
+                project.AddFile("Z:\SourceFile.vb", Nothing, False)
+
+                ' Confirm that we are able to get a file code model
+                Dim originalDocumentId = environment.Workspace.CurrentSolution.Projects.Single().DocumentIds.Single()
+                Assert.NotNull(originalDocumentId)
+                Dim originalFileCodeModel = environment.Workspace.GetFileCodeModel(originalDocumentId)
+                Assert.NotNull(originalDocumentId)
+
+                project.RemoveFile("Z:\SourceFile.vb", Nothing)
+                Assert.Throws(Of ArgumentException)(Sub() environment.Workspace.GetFileCodeModel(originalDocumentId))
+
+                ' Add it back in
+                project.AddFile("Z:\SourceFile.vb", Nothing, False)
+                Dim newDocumentId = environment.Workspace.CurrentSolution.Projects.Single().DocumentIds.Single()
+                Dim newFileCodeModel = environment.Workspace.GetFileCodeModel(newDocumentId)
+
+                Assert.NotSame(originalDocumentId, newDocumentId)
+                Assert.NotSame(originalFileCodeModel, newFileCodeModel)
+
+                project.Disconnect()
+            End Using
+        End Sub
+    End Class
+End Namespace

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/MockHierarchy.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/MockHierarchy.vb
@@ -6,6 +6,7 @@ Imports System.Runtime.InteropServices
 Imports Microsoft.VisualStudio.Shell
 Imports Roslyn.Utilities
 Imports System.IO
+Imports Moq
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
     Public NotInheritable Class MockHierarchy
@@ -19,6 +20,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
         Private _projectName As String
         Private _projectBinPath As String
         Private ReadOnly _projectCapabilities As String
+        Private ReadOnly _projectMock As Mock(Of EnvDTE.Project) = New Mock(Of EnvDTE.Project)(MockBehavior.Strict)
 
         Private ReadOnly _eventSinks As New Dictionary(Of UInteger, IVsHierarchyEvents)
         Private ReadOnly _hierarchyItems As New Dictionary(Of UInteger, String)
@@ -102,6 +104,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
         End Function
 
         Public Function GetProperty(itemid As UInteger, propid As Integer, ByRef pvar As Object) As Integer Implements IVsHierarchy.GetProperty
+
             If propid = __VSHPROPID.VSHPROPID_ProjectName Then
                 pvar = _projectName
                 Return VSConstants.S_OK
@@ -113,6 +116,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
                     pvar = "References"
                     Return VSConstants.S_OK
                 End If
+            ElseIf propid = __VSHPROPID.VSHPROPID_ExtObject Then
+                Dim projectItemMock As Mock(Of EnvDTE.ProjectItem) = New Mock(Of EnvDTE.ProjectItem)(MockBehavior.Strict)
+                projectItemMock.SetupGet(Function(m) m.ContainingProject).Returns(_projectMock.Object)
+                projectItemMock.SetupGet(Function(m) m.FileNames(1)).Returns(_hierarchyItems(itemid))
+
+                pvar = projectItemMock.Object
+                Return VSConstants.S_OK
             End If
 
             Return VSConstants.E_NOTIMPL

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -25,6 +25,7 @@ Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Moq
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
 
@@ -59,6 +60,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
             ExportProvider = s_exportProviderFactory.Value.CreateExportProvider()
             _workspace = ExportProvider.GetExportedValue(Of VisualStudioWorkspaceImpl)
             ThreadingContext = ExportProvider.GetExportedValue(Of IThreadingContext)()
+            Interop.WrapperPolicy.s_ComWrapperFactory = MockComWrapperFactory.Instance
 
             Dim mockServiceProvider As MockServiceProvider = ExportProvider.GetExportedValue(Of MockServiceProvider)()
             mockServiceProvider.MockMonitorSelection = New MockShellMonitorSelection(solutionIsFullyLoaded)
@@ -85,10 +87,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
             Public Overrides Sub DisplayReferencedSymbols(solution As Microsoft.CodeAnalysis.Solution, referencedSymbols As IEnumerable(Of ReferencedSymbol))
                 Throw New NotImplementedException()
             End Sub
-
-            Public Overrides Function GetFileCodeModel(documentId As DocumentId) As EnvDTE.FileCodeModel
-                Throw New NotImplementedException()
-            End Function
 
             Public Overrides Function TryGoToDefinition(symbol As ISymbol, project As Microsoft.CodeAnalysis.Project, cancellationToken As CancellationToken) As Boolean
                 Throw New NotImplementedException()


### PR DESCRIPTION
**REVIEW NOTE:** commit-at-a-time is highly recommended here.

In the project system refactoring to support free-threaded initialization, I lost this call which was causing removing and readding files to do bad things. This fixes it. The fix is more complicated than just adding the call back in, because we now allow document removal to happen on a background thread which we didn't allow before, and so bit of work that must happen on the UI thread must now be deferred until a later cleanup point.

Fixes #33080.

<details><summary>Ask Mode template</summary>

### Customer scenario

Customer deletes a Windows Form from a project, and then adds a new one with the same name. Rather than opening the designer again, the designer fails to load.

### Bugs this fixes

#33080

### Workarounds, if any

After you get into this state, restart Visual Studio.

### Risk

Moderate; the area we're touching (CodeModel object lifetimes) is always tricky, but since it's an API that many features are built on a lot of not obvious things might be broken.

### Performance impact

None.

### Is this a regression from a previous update?

Yes, this was broken in our big project system refactoring to improve performance in Preview 1.

### Root cause analysis

We didn't have any tests that tested CodeModel object life times. We've added functional tests to test that.

### How was the bug found?

Customer report.

</details>