### PR TITLE
DebuggerTextView: allow multiple assignments to _innerTextView.Properties[CompletionRoot]

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -310,6 +310,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             // Unsubscribe from events
             _textView.TextBuffer.PostChanged -= TextBuffer_PostChanged;
             _debuggerTextView.DisconnectFromIntellisenseControllers();
+            _debuggerTextView.CleanupSetProperties();
 
             // The buffer graph subscribes to events of its source buffers, we're no longer interested
             _projectionBuffer.DeleteSpans(0, _projectionBuffer.CurrentSnapshot.SpanCount);

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -309,8 +309,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
         {
             // Unsubscribe from events
             _textView.TextBuffer.PostChanged -= TextBuffer_PostChanged;
-            _debuggerTextView.DisconnectFromIntellisenseControllers();
-            _debuggerTextView.CleanupSetProperties();
+            _debuggerTextView.Cleanup();
 
             // The buffer graph subscribes to events of its source buffers, we're no longer interested
             _projectionBuffer.DeleteSpans(0, _projectionBuffer.CurrentSnapshot.SpanCount);

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
@@ -359,7 +359,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             return _innerTextView.GetTextViewLineContainingBufferPosition(bufferPosition);
         }
 
-        public void DisconnectFromIntellisenseControllers()
+        public void Cleanup()
         {
             // The innerTextView of the immediate window never closes, but we want
             // our completion subscribers to unsubscribe from events when this
@@ -368,10 +368,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             {
                 this.ClosedInternal?.Invoke(this, EventArgs.Empty);
             }
-        }
-
-        public void CleanupSetProperties()
-        {
+            
             _innerTextView.Properties.RemoveProperty(CompletionRoot);
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
@@ -42,7 +42,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             // The editor requires the current top buffer.
             // TODO it seems to be a hack. It should be removed.
             // Here is an issue to track: https://github.com/dotnet/roslyn/issues/31189
-            _innerTextView.Properties.AddProperty(CompletionRoot, bufferGraph.TopBuffer);
+            // Starting debugigng for the second time, we already have the property set.
+            _innerTextView.Properties[CompletionRoot] = bufferGraph.TopBuffer;
         }
 
         /// <summary>

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             // The editor requires the current top buffer.
             // TODO it seems to be a hack. It should be removed.
             // Here is an issue to track: https://github.com/dotnet/roslyn/issues/31189
-            // Starting debugigng for the second time, we already have the property set.
+            // Starting debugging for the second time, we already have the property set.
             _innerTextView.Properties[CompletionRoot] = bufferGraph.TopBuffer;
         }
 
@@ -368,6 +368,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             {
                 this.ClosedInternal?.Invoke(this, EventArgs.Empty);
             }
+        }
+
+        public void CleanupSetProperties()
+        {
+            _innerTextView.Properties.RemoveProperty(CompletionRoot);
         }
 
         public void QueuePostLayoutAction(Action action) => _innerTextView.QueuePostLayoutAction(action);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/787279
Fixes https://developercommunity.visualstudio.com/content/problem/436531/intellisense-does-not-work-in-immediate-window-in.html

**Scenario**
1. Open solution
2. Start debugging
3. Go to immediate window
4. Type something and see intellisense working
5. Stop debugging
6. Start debugging for the second time
7. Go to immediate window
8. Type something

**Expected**
Intellisense is still working

**Actual**
No intellisense is available for the second time

**Root cause**
Roslyn expects a new view to be used each time. Actually, a view was re-used and there is an internal exception when trying to set a context for the view.