### PR TITLE
Compute relative folder information if we aren't given it

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/SourceFileHandlingTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/SourceFileHandlingTests.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Interop;
 using Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -27,6 +29,72 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
 
                 // Try removing it to make sure it doesn't throw
                 project.OnSourceFileRemoved("Goo.xoml");
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void AddFileExWithLinkPathUsesThatAsAFolder()
+        {
+            using (var environment = new TestEnvironment())
+            {
+                var project = CSharpHelpers.CreateCSharpProject(environment, "Test");
+
+                project.AddFileEx(@"C:\Cat.cs", linkMetadata: @"LinkFolder\Cat.cs");
+
+                var document = environment.Workspace.CurrentSolution.Projects.Single().Documents.Single();
+
+                Assert.Equal(new[] { "LinkFolder" }, document.Folders);
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void AddFileExWithLinkPathWithoutFolderWorksCorrectly()
+        {
+            using (var environment = new TestEnvironment())
+            {
+                var project = CSharpHelpers.CreateCSharpProject(environment, "Test");
+
+                project.AddFileEx(@"C:\Cat.cs", linkMetadata: @"Dog.cs");
+
+                var document = environment.Workspace.CurrentSolution.Projects.Single().Documents.Single();
+
+                Assert.Empty(document.Folders);
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void AddFileExWithNoLinkPathComputesEmptyFolder()
+        {
+            using (var environment = new TestEnvironment())
+            {
+                var project = CSharpHelpers.CreateCSharpProject(environment, "Test");
+                var projectFolder = Path.GetDirectoryName(environment.Workspace.CurrentSolution.Projects.Single().FilePath);
+
+                project.AddFileEx(Path.Combine(projectFolder, "Cat.cs"), null);
+
+                var document = environment.Workspace.CurrentSolution.Projects.Single().Documents.Single();
+
+                Assert.Empty(document.Folders);
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void AddFileExWithNoLinkPathComputesRelativeFolderPath()
+        {
+            using (var environment = new TestEnvironment())
+            {
+                var project = CSharpHelpers.CreateCSharpProject(environment, "Test");
+                var projectFolder = Path.GetDirectoryName(environment.Workspace.CurrentSolution.Projects.Single().FilePath);
+
+                project.AddFileEx(Path.Combine(projectFolder, "RelativeFolder", "Cat.cs"), null);
+
+                var document = environment.Workspace.CurrentSolution.Projects.Single().Documents.Single();
+
+                Assert.Equal(new[] { "RelativeFolder" }, document.Folders);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -31,6 +31,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
         protected IProjectCodeModel ProjectCodeModel { get; set; }
         protected VisualStudioWorkspace Workspace { get; }
 
+        /// <summary>
+        /// The path to the directory of the project. Read-only, since although you can rename
+        /// a project in Visual Studio you can't change the folder of a project without an
+        /// unload/reload.
+        /// </summary>
+        private readonly string _projectDirectory = null;
+
         private static readonly char[] PathSeparatorCharacters = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
 
         #region Mutable fields that should only be used from the UI thread
@@ -62,6 +69,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             if (projectFilePath != null && !File.Exists(projectFilePath))
             {
                 projectFilePath = null;
+            }
+
+            if (projectFilePath != null)
+            {
+                _projectDirectory = Path.GetDirectoryName(projectFilePath);
             }
 
             var projectFactory = componentModel.GetService<VisualStudioProjectFactory>();
@@ -163,7 +175,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             if (!string.IsNullOrEmpty(linkMetadata))
             {
                 var linkFolderPath = Path.GetDirectoryName(linkMetadata);
-                folders = linkFolderPath.Split(PathSeparatorCharacters).ToImmutableArray();
+                folders = linkFolderPath.Split(PathSeparatorCharacters, StringSplitOptions.RemoveEmptyEntries).ToImmutableArray();
+            }
+            else if (!string.IsNullOrEmpty(VisualStudioProject.FilePath))
+            {
+                var relativePath = PathUtilities.GetRelativePath(_projectDirectory, filename);
+                var relativePathParts = relativePath.Split(PathSeparatorCharacters);
+                folders = ImmutableArray.Create(relativePathParts, start: 0, length: relativePathParts.Length - 1);
             }
 
             VisualStudioProject.AddSourceFile(filename, sourceCodeKind, folders);


### PR DESCRIPTION
We added a new API IProjectSiteEx.AddFileEx that takes the link metadata for an item so we don't have to query an IVsHierarchy to figure out where the file is linked into. If we don't have a link though, we should compute the relative folder to the project directory and use that.

Fixes https://github.com/dotnet/roslyn/issues/33171

<details><summary>Ask Mode template</summary>

### Customer scenario

- The customer invokes a refactoring like "generate class into a new file". Instead of the file being generated into the same folder, it's put inside the root of your project
- Our "synchronize namespace and folder" refactorings won't work reliably
- Anybody calling into Document.Folders (a public API) won't get the right information

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/33171

### Workarounds, if any

Convert your project to a CPS-based project, which we don't expect customers to do (or even want to do.)

### Risk

Low.

### Performance impact

Low to moderate; we're adding some file path manipulation back into a common code path, but we believe it'll probably be cheaper than what was there in Preview 1.

### Is this a regression from a previous update?

Yes, this was broken in Preview 2.

### Root cause analysis

A refactoring to enable the old project systems to be more free-threaded had the unintended side effect of breaking how we pass along this data. This involved adding new codepaths which just didn't do what the old ones did. Tests are now added on the new code.

### How was the bug found?

Customer report that the API wasn't working properly.

</details>