### PR TITLE
Reduce allocations in the formatter

### DIFF
--- a/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
+++ b/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
@@ -160,6 +160,7 @@
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Extensions\SyntaxTokenExtensions.cs" Link="Formatting\SyntaxTokenExtensions.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Extensions\SyntaxTreeExtensions_SharedWithCodeStyle.cs" Link="Formatting\SyntaxTreeExtensions_SharedWithCodeStyle.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Extensions\SyntaxTriviaExtensions.cs" Link="Formatting\SyntaxTriviaExtensions.cs" />
+    <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Extensions\SyntaxTriviaListExtensions.cs" Link="Formatting\SyntaxTriviaListExtensions.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Extensions\TextLineExtensions.cs" Link="Formatting\TextLineExtensions.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\NormalizedTextSpanCollection.cs" Link="Formatting\NormalizedTextSpanCollection.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Utilities\AliasSymbolCache.cs" Link="AliasSymbolCache.cs" />

--- a/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
+++ b/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="$(MicrosoftVisualStudioCodingConventionsVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisCommonFixedVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
   <ItemGroup>
     <!--
@@ -30,6 +31,7 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\ExceptionUtilities.cs" Link="InternalUtilities\ExceptionUtilities.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\IReadOnlySet.cs" Link="InternalUtilities\IReadOnlySet.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\KeyValuePairUtil.cs" Link="InternalUtilities\KeyValuePairUtil.cs" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\PerformanceSensitiveAttribute.cs" Link="PerformanceSensitiveAttribute.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.cs" Link="InternalUtilities\SpecializedCollections.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.Empty.Collection.cs" Link="InternalUtilities\SpecializedCollections.Empty.Collection.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.Empty.cs" Link="InternalUtilities\SpecializedCollections.Empty.cs" />

--- a/src/CodeStyle/Core/Analyzers/Options/AnalyzerConfigOptionsExtensions.cs
+++ b/src/CodeStyle/Core/Analyzers/Options/AnalyzerConfigOptionsExtensions.cs
@@ -40,12 +40,8 @@ namespace Microsoft.CodeAnalysis
                     continue;
                 }
 
-                if (editorConfigStorageLocation.TryGetOption(
-                    stringValue,
-                    typeof(T),
-                    out var rawValue))
+                if (editorConfigStorageLocation.TryGetOption(stringValue, typeof(T), out value))
                 {
-                    value = (T)rawValue;
                     return true;
                 }
             }

--- a/src/CodeStyle/Core/Analyzers/Options/AnalyzerConfigOptionsExtensions.cs
+++ b/src/CodeStyle/Core/Analyzers/Options/AnalyzerConfigOptionsExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis
@@ -42,8 +41,7 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 if (editorConfigStorageLocation.TryGetOption(
-                    underlyingOption: null,
-                    allRawConventions: new Dictionary<string, object> { { editorConfigStorageLocation.KeyName, stringValue } },
+                    stringValue,
                     typeof(T),
                     out var rawValue))
                 {

--- a/src/Compilers/Core/Portable/InternalUtilities/PerformanceSensitiveAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/PerformanceSensitiveAttribute.cs
@@ -56,6 +56,15 @@ namespace Roslyn.Utilities
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether implicit boxing of value types is allowed.
+        /// </summary>
+        public bool AllowImplicitBoxing
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether enumeration of a generic <see cref="IEnumerable{T}"/> is allowed.
         /// </summary>
         public bool AllowGenericEnumeration

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
@@ -100,7 +100,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             public override void Format(
                 FormattingContext context,
                 ChainedFormattingRules formattingRules,
-                Action<int, TriviaData> formattingResultApplier,
+                Action<int, TokenStream, TriviaData> formattingResultApplier,
+                TokenStream tokenStream,
                 CancellationToken cancellationToken,
                 int tokenPairIndex = TokenPairIndexNotNeeded)
             {
@@ -109,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     return;
                 }
 
-                formattingResultApplier(tokenPairIndex, Format(context, formattingRules, this.LineBreaks, this.Spaces, cancellationToken));
+                formattingResultApplier(tokenPairIndex, tokenStream, Format(context, formattingRules, this.LineBreaks, this.Spaces, cancellationToken));
             }
 
             public override List<SyntaxTrivia> GetTriviaList(CancellationToken cancellationToken)

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
@@ -101,7 +101,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 FormattingContext context,
                 ChainedFormattingRules formattingRules,
                 Action<int, TokenStream, TriviaData> formattingResultApplier,
-                TokenStream tokenStream,
                 CancellationToken cancellationToken,
                 int tokenPairIndex = TokenPairIndexNotNeeded)
             {
@@ -110,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     return;
                 }
 
-                formattingResultApplier(tokenPairIndex, tokenStream, Format(context, formattingRules, this.LineBreaks, this.Spaces, cancellationToken));
+                formattingResultApplier(tokenPairIndex, context.TokenStream, Format(context, formattingRules, this.LineBreaks, this.Spaces, cancellationToken));
             }
 
             public override List<SyntaxTrivia> GetTriviaList(CancellationToken cancellationToken)

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 throw new NotImplementedException();
             }
 
-            public override void Format(FormattingContext context, ChainedFormattingRules formattingRules, Action<int, TokenStream, TriviaData> formattingResultApplier, TokenStream tokenStream, CancellationToken cancellationToken, int tokenPairIndex = TokenPairIndexNotNeeded)
+            public override void Format(FormattingContext context, ChainedFormattingRules formattingRules, Action<int, TokenStream, TriviaData> formattingResultApplier, CancellationToken cancellationToken, int tokenPairIndex = TokenPairIndexNotNeeded)
             {
                 throw new NotImplementedException();
             }

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 throw new NotImplementedException();
             }
 
-            public override void Format(FormattingContext context, ChainedFormattingRules formattingRules, Action<int, TriviaData> formattingResultApplier, CancellationToken cancellationToken, int tokenPairIndex = TokenPairIndexNotNeeded)
+            public override void Format(FormattingContext context, ChainedFormattingRules formattingRules, Action<int, TokenStream, TriviaData> formattingResultApplier, TokenStream tokenStream, CancellationToken cancellationToken, int tokenPairIndex = TokenPairIndexNotNeeded)
             {
                 throw new NotImplementedException();
             }

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
@@ -72,7 +72,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 FormattingContext context,
                 ChainedFormattingRules formattingRules,
                 Action<int, TokenStream, TriviaData> formattingResultApplier,
-                TokenStream tokenStream,
                 CancellationToken cancellationToken,
                 int tokenPairIndex = TokenPairIndexNotNeeded)
             {
@@ -91,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
 
                 formattingResultApplier(tokenPairIndex,
-                    tokenStream,
+                    context.TokenStream,
                     new FormattedComplexTrivia(
                         context,
                         formattingRules,

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
@@ -71,7 +71,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             public override void Format(
                 FormattingContext context,
                 ChainedFormattingRules formattingRules,
-                Action<int, TriviaData> formattingResultApplier,
+                Action<int, TokenStream, TriviaData> formattingResultApplier,
+                TokenStream tokenStream,
                 CancellationToken cancellationToken,
                 int tokenPairIndex = TokenPairIndexNotNeeded)
             {
@@ -90,6 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
 
                 formattingResultApplier(tokenPairIndex,
+                    tokenStream,
                     new FormattedComplexTrivia(
                         context,
                         formattingRules,

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.OperationApplier.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.OperationApplier.cs
@@ -18,13 +18,11 @@ namespace Microsoft.CodeAnalysis.Formatting
         private class OperationApplier
         {
             private readonly FormattingContext _context;
-            private readonly TokenStream _tokenStream;
             private readonly ChainedFormattingRules _formattingRules;
 
-            public OperationApplier(FormattingContext context, TokenStream tokenStream, ChainedFormattingRules formattingRules)
+            public OperationApplier(FormattingContext context, ChainedFormattingRules formattingRules)
             {
                 _context = context;
-                _tokenStream = tokenStream;
                 _formattingRules = formattingRules;
             }
 
@@ -50,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             private bool ApplyDynamicSpacesOperation(AdjustSpacesOperation operation, int pairIndex)
             {
-                var triviaInfo = _tokenStream.GetTriviaData(pairIndex);
+                var triviaInfo = _context.TokenStream.GetTriviaData(pairIndex);
 
                 if (triviaInfo.SecondTokenIsFirstTokenOnLine)
                 {
@@ -59,18 +57,18 @@ namespace Microsoft.CodeAnalysis.Formatting
 
                 Contract.ThrowIfFalse(triviaInfo.LineBreaks == 0);
 
-                var indentation = _context.GetBaseIndentation(_tokenStream.GetToken(pairIndex + 1));
+                var indentation = _context.GetBaseIndentation(_context.TokenStream.GetToken(pairIndex + 1));
 
-                var previousToken = _tokenStream.GetToken(pairIndex);
-                _tokenStream.GetTokenLength(previousToken, out var tokenLength, out var multipleLines);
+                var previousToken = _context.TokenStream.GetToken(pairIndex);
+                _context.TokenStream.GetTokenLength(previousToken, out var tokenLength, out var multipleLines);
 
                 // get end column of previous token
-                var endColumnOfPreviousToken = multipleLines ? tokenLength : _tokenStream.GetCurrentColumn(previousToken) + tokenLength;
+                var endColumnOfPreviousToken = multipleLines ? tokenLength : _context.TokenStream.GetCurrentColumn(previousToken) + tokenLength;
 
                 // check whether current position is less than indentation
                 if (endColumnOfPreviousToken < indentation)
                 {
-                    _tokenStream.ApplyChange(pairIndex, triviaInfo.WithSpace(indentation - endColumnOfPreviousToken, _context, _formattingRules));
+                    _context.TokenStream.ApplyChange(pairIndex, triviaInfo.WithSpace(indentation - endColumnOfPreviousToken, _context, _formattingRules));
                     return true;
                 }
 
@@ -80,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             private bool ApplyPreserveSpacesOperation(AdjustSpacesOperation operation, int pairIndex)
             {
-                var triviaInfo = _tokenStream.GetTriviaData(pairIndex);
+                var triviaInfo = _context.TokenStream.GetTriviaData(pairIndex);
                 var space = operation.Space;
 
                 if (triviaInfo.SecondTokenIsFirstTokenOnLine)
@@ -95,26 +93,26 @@ namespace Microsoft.CodeAnalysis.Formatting
                     return false;
                 }
 
-                _tokenStream.ApplyChange(pairIndex, triviaInfo.WithSpace(space, _context, _formattingRules));
+                _context.TokenStream.ApplyChange(pairIndex, triviaInfo.WithSpace(space, _context, _formattingRules));
                 return true;
             }
 
             public bool ApplyForceSpacesOperation(AdjustSpacesOperation operation, int pairIndex)
             {
-                var triviaInfo = _tokenStream.GetTriviaData(pairIndex);
+                var triviaInfo = _context.TokenStream.GetTriviaData(pairIndex);
 
                 if (triviaInfo.LineBreaks == 0 && triviaInfo.Spaces == operation.Space)
                 {
                     return false;
                 }
 
-                _tokenStream.ApplyChange(pairIndex, triviaInfo.WithSpace(operation.Space, _context, _formattingRules));
+                _context.TokenStream.ApplyChange(pairIndex, triviaInfo.WithSpace(operation.Space, _context, _formattingRules));
                 return true;
             }
 
             private bool ApplySpaceIfSingleLine(AdjustSpacesOperation operation, int pairIndex)
             {
-                var triviaInfo = _tokenStream.GetTriviaData(pairIndex);
+                var triviaInfo = _context.TokenStream.GetTriviaData(pairIndex);
                 var space = operation.Space;
 
                 if (triviaInfo.SecondTokenIsFirstTokenOnLine)
@@ -129,7 +127,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     return false;
                 }
 
-                _tokenStream.ApplyChange(pairIndex, triviaInfo.WithSpace(space, _context, _formattingRules));
+                _context.TokenStream.ApplyChange(pairIndex, triviaInfo.WithSpace(space, _context, _formattingRules));
                 return true;
             }
 
@@ -151,8 +149,8 @@ namespace Microsoft.CodeAnalysis.Formatting
                     // else we leave the tokens as it is (Note: We should not preserve too. If we
                     // we do, then that will be counted as a line operation and the indentation of
                     // the second token will be modified)
-                    if (_tokenStream.TwoTokensOnSameLine(_tokenStream.GetToken(pairIndex),
-                                                        _tokenStream.GetToken(pairIndex + 1)))
+                    if (_context.TokenStream.TwoTokensOnSameLine(_context.TokenStream.GetToken(pairIndex),
+                                                        _context.TokenStream.GetToken(pairIndex + 1)))
                     {
                         return ApplyForceLinesOperation(operation, pairIndex, cancellationToken);
                     }
@@ -165,9 +163,9 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             private bool ApplyForceLinesOperation(AdjustNewLinesOperation operation, int pairIndex, CancellationToken cancellationToken)
             {
-                var triviaInfo = _tokenStream.GetTriviaData(pairIndex);
+                var triviaInfo = _context.TokenStream.GetTriviaData(pairIndex);
 
-                var indentation = _context.GetBaseIndentation(_tokenStream.GetToken(pairIndex + 1));
+                var indentation = _context.GetBaseIndentation(_context.TokenStream.GetToken(pairIndex + 1));
                 if (triviaInfo.LineBreaks == operation.Line && triviaInfo.Spaces == indentation && !triviaInfo.TreatAsElastic)
                 {
                     // things are already in the shape we want, so we don't actually need to do
@@ -176,22 +174,22 @@ namespace Microsoft.CodeAnalysis.Formatting
                 }
 
                 // well, force it regardless original content
-                _tokenStream.ApplyChange(pairIndex, triviaInfo.WithLine(operation.Line, indentation, _context, _formattingRules, cancellationToken));
+                _context.TokenStream.ApplyChange(pairIndex, triviaInfo.WithLine(operation.Line, indentation, _context, _formattingRules, cancellationToken));
                 return true;
             }
 
             public bool ApplyPreserveLinesOperation(
                 AdjustNewLinesOperation operation, int pairIndex, CancellationToken cancellationToken)
             {
-                var triviaInfo = _tokenStream.GetTriviaData(pairIndex);
+                var triviaInfo = _context.TokenStream.GetTriviaData(pairIndex);
 
                 // okay, check whether there is line between token more than we want
                 // check whether we should force it if it is less than given number
-                var indentation = _context.GetBaseIndentation(_tokenStream.GetToken(pairIndex + 1));
+                var indentation = _context.GetBaseIndentation(_context.TokenStream.GetToken(pairIndex + 1));
                 if (operation.Line > triviaInfo.LineBreaks)
                 {
                     // alright force them
-                    _tokenStream.ApplyChange(pairIndex, triviaInfo.WithLine(operation.Line, indentation, _context, _formattingRules, cancellationToken));
+                    _context.TokenStream.ApplyChange(pairIndex, triviaInfo.WithLine(operation.Line, indentation, _context, _formattingRules, cancellationToken));
                     return true;
                 }
 
@@ -199,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 if (triviaInfo.SecondTokenIsFirstTokenOnLine &&
                     indentation != triviaInfo.Spaces)
                 {
-                    _tokenStream.ApplyChange(pairIndex, triviaInfo.WithIndentation(indentation, _context, _formattingRules, cancellationToken));
+                    _context.TokenStream.ApplyChange(pairIndex, triviaInfo.WithIndentation(indentation, _context, _formattingRules, cancellationToken));
                     return true;
                 }
 
@@ -268,7 +266,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
                     case AlignTokensOption.AlignIndentationOfTokensToFirstTokenOfBaseTokenLine:
                         {
-                            if (!ApplyAlignment(_tokenStream.FirstTokenOfBaseTokenLine(operation.BaseToken), operation.Tokens, previousChangesMap, out tokenData, cancellationToken))
+                            if (!ApplyAlignment(_context.TokenStream.FirstTokenOfBaseTokenLine(operation.BaseToken), operation.Tokens, previousChangesMap, out tokenData, cancellationToken))
                             {
                                 return false;
                             }
@@ -295,14 +293,14 @@ namespace Microsoft.CodeAnalysis.Formatting
             {
                 // rather than having external new changes map, having snapshot concept
                 // in token stream might be easier to understand.
-                int baseSpaceOrIndentation = _tokenStream.GetCurrentColumn(token);
+                int baseSpaceOrIndentation = _context.TokenStream.GetCurrentColumn(token);
 
                 for (int i = 0; i < list.Count; i++)
                 {
                     var currentToken = list[i];
-                    var previousToken = _tokenStream.GetPreviousTokenData(currentToken);
+                    var previousToken = _context.TokenStream.GetPreviousTokenData(currentToken);
 
-                    var triviaInfo = _tokenStream.GetTriviaData(previousToken, currentToken);
+                    var triviaInfo = _context.TokenStream.GetTriviaData(previousToken, currentToken);
                     if (!triviaInfo.SecondTokenIsFirstTokenOnLine)
                     {
                         continue;
@@ -338,7 +336,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 }
 
                 // okay, update indentation
-                _tokenStream.ApplyChange(
+                _context.TokenStream.ApplyChange(
                     previousToken.IndexInStream,
                     triviaInfo.WithIndentation(baseSpaceOrIndentation, _context, _formattingRules, cancellationToken));
             }
@@ -354,7 +352,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                         continue;
                     }
 
-                    var tokenWithIndex = _tokenStream.GetTokenData(token);
+                    var tokenWithIndex = _context.TokenStream.GetTokenData(token);
                     if (tokenWithIndex.IndexInStream < 0)
                     {
                         // this token is not inside of the formatting span, ignore
@@ -385,10 +383,10 @@ namespace Microsoft.CodeAnalysis.Formatting
                     }
 
                     // first token was anchor token, now find last token with index
-                    var lastToken = _tokenStream.GetTokenData(endAnchorToken);
+                    var lastToken = _context.TokenStream.GetTokenData(endAnchorToken);
                     if (lastToken.IndexInStream < 0)
                     {
-                        lastToken = _tokenStream.LastTokenInStream;
+                        lastToken = _context.TokenStream.LastTokenInStream;
                     }
 
                     ApplyBaseTokenIndentationChangesFromTo(firstToken, firstToken, lastToken, newChangesMap, cancellationToken);
@@ -407,7 +405,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 // can this run parallel? at least finding out all first token on line.
                 for (var pairIndex = firstToken.IndexInStream; pairIndex < lastToken.IndexInStream; pairIndex++)
                 {
-                    var triviaInfo = _tokenStream.GetTriviaData(pairIndex);
+                    var triviaInfo = _context.TokenStream.GetTriviaData(pairIndex);
                     if (!triviaInfo.SecondTokenIsFirstTokenOnLine)
                     {
                         continue;
@@ -422,7 +420,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     // bail fast here.
                     // if an entity is in the map, then it means indentation has been applied to the token pair already.
                     // no reason to do same work again.
-                    var currentToken = _tokenStream.GetToken(pairIndex + 1);
+                    var currentToken = _context.TokenStream.GetToken(pairIndex + 1);
                     if (previousChangesMap.ContainsKey(currentToken))
                     {
                         continue;
@@ -455,7 +453,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 previousChangesMap.Add(currentToken, triviaInfo.Spaces);
 
                 // okay, update indentation
-                _tokenStream.ApplyChange(pairIndex, triviaInfo.WithIndentation(indentation, _context, _formattingRules, cancellationToken));
+                _context.TokenStream.ApplyChange(pairIndex, triviaInfo.WithIndentation(indentation, _context, _formattingRules, cancellationToken));
             }
 
             public bool ApplyBaseTokenIndentationChangesFromTo(
@@ -467,9 +465,9 @@ namespace Microsoft.CodeAnalysis.Formatting
             {
                 Contract.ThrowIfFalse(baseToken.RawKind != 0 && startToken.RawKind != 0 && endToken.RawKind != 0);
 
-                var baseTokenWithIndex = _tokenStream.GetTokenData(baseToken);
-                var firstTokenWithIndex = _tokenStream.GetTokenData(startToken).GetPreviousTokenData();
-                var lastTokenWithIndex = _tokenStream.GetTokenData(endToken);
+                var baseTokenWithIndex = _context.TokenStream.GetTokenData(baseToken);
+                var firstTokenWithIndex = _context.TokenStream.GetTokenData(startToken).GetPreviousTokenData();
+                var lastTokenWithIndex = _context.TokenStream.GetTokenData(endToken);
 
                 return ApplyBaseTokenIndentationChangesFromTo(
                     baseTokenWithIndex, firstTokenWithIndex, lastTokenWithIndex, previousChangesMap, cancellationToken);
@@ -502,7 +500,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     // okay, this token is not moved, check one before me as long as it is on the same line
                     var tokenPairIndex = tokenWithIndex.IndexInStream - 1;
                     if (tokenPairIndex < 0 ||
-                        _tokenStream.GetTriviaData(tokenPairIndex).SecondTokenIsFirstTokenOnLine)
+                        _context.TokenStream.GetTriviaData(tokenPairIndex).SecondTokenIsFirstTokenOnLine)
                     {
                         return false;
                     }
@@ -523,8 +521,8 @@ namespace Microsoft.CodeAnalysis.Formatting
                     return false;
                 }
 
-                startToken = startToken.IndexInStream < 0 ? _tokenStream.FirstTokenInStream : startToken;
-                endToken = endToken.IndexInStream < 0 ? _tokenStream.LastTokenInStream : endToken;
+                startToken = startToken.IndexInStream < 0 ? _context.TokenStream.FirstTokenInStream : startToken;
+                endToken = endToken.IndexInStream < 0 ? _context.TokenStream.LastTokenInStream : endToken;
 
                 ApplyIndentationDeltaFromTo(startToken, endToken, indentationDelta, previousChangesMap, cancellationToken);
                 return true;
@@ -533,7 +531,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             public bool ApplyAnchorIndentation(
                 int pairIndex, Dictionary<SyntaxToken, int> previousChangesMap, CancellationToken cancellationToken)
             {
-                var triviaInfo = _tokenStream.GetTriviaData(pairIndex);
+                var triviaInfo = _context.TokenStream.GetTriviaData(pairIndex);
 
                 if (!triviaInfo.SecondTokenIsFirstTokenOnLine)
                 {
@@ -546,7 +544,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     return false;
                 }
 
-                var firstTokenOnLine = _tokenStream.GetToken(pairIndex + 1);
+                var firstTokenOnLine = _context.TokenStream.GetToken(pairIndex + 1);
                 var indentation = triviaInfo.Spaces + _context.GetAnchorDeltaFromOriginalColumn(firstTokenOnLine);
 
                 if (triviaInfo.Spaces != indentation)
@@ -555,7 +553,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     previousChangesMap.Add(firstTokenOnLine, triviaInfo.Spaces);
 
                     // okay, update indentation
-                    _tokenStream.ApplyChange(pairIndex, triviaInfo.WithIndentation(indentation, _context, _formattingRules, cancellationToken));
+                    _context.TokenStream.ApplyChange(pairIndex, triviaInfo.WithIndentation(indentation, _context, _formattingRules, cancellationToken));
                     return true;
                 }
 

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.Partitioner.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.Partitioner.cs
@@ -15,17 +15,14 @@ namespace Microsoft.CodeAnalysis.Formatting
             private const int MinimumItemsPerPartition = 30000;
 
             private readonly FormattingContext _context;
-            private readonly TokenStream _tokenStream;
             private readonly TokenPairWithOperations[] _operationPairs;
 
-            public Partitioner(FormattingContext context, TokenStream tokenStream, TokenPairWithOperations[] operationPairs)
+            public Partitioner(FormattingContext context, TokenPairWithOperations[] operationPairs)
             {
                 Contract.ThrowIfNull(context);
-                Contract.ThrowIfNull(tokenStream);
                 Contract.ThrowIfNull(operationPairs);
 
                 _context = context;
-                _tokenStream = tokenStream;
                 _operationPairs = operationPairs;
             }
 
@@ -68,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                             break;
                         }
 
-                        var nextTokenWithIndex = _tokenStream.GetTokenData(nextToken);
+                        var nextTokenWithIndex = _context.TokenStream.GetTokenData(nextToken);
                         if (nextTokenWithIndex.IndexInStream < 0)
                         {
                             // first token for next partition is out side of valid token stream

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractFormatEngine.cs
@@ -284,7 +284,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/30819", AllowCaptures = false)]
         private void ApplyTriviaOperations(FormattingContext context, CancellationToken cancellationToken)
         {
-            void regularApplier(int tokenPairIndex, TriviaData info, TokenStream ts)
+            void regularApplier(int tokenPairIndex, TokenStream ts, TriviaData info)
             {
                 ts.ApplyChange(tokenPairIndex, info);
             }
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 triviaInfo.Format(
                     ctx,
                     formattingRules,
-                    (int tokenPairIndex1, TokenStream ts, TriviaData info) => regularApplier(tokenPairIndex1, info, ts),
+                    (int tokenPairIndex1, TokenStream ts, TriviaData info) => regularApplier(tokenPairIndex1, ts, info),
                     ct,
                     tokenPairIndex);
             }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.FormattedWhitespace.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.FormattedWhitespace.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             }
 
             public override void Format(
-                FormattingContext context, ChainedFormattingRules formattingRules, Action<int, TokenStream, TriviaData> formattingResultApplier, TokenStream tokenStream, CancellationToken cancellationToken, int tokenPairIndex = TokenPairIndexNotNeeded)
+                FormattingContext context, ChainedFormattingRules formattingRules, Action<int, TokenStream, TriviaData> formattingResultApplier, CancellationToken cancellationToken, int tokenPairIndex = TokenPairIndexNotNeeded)
             {
                 throw new NotImplementedException();
             }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.FormattedWhitespace.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.FormattedWhitespace.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             }
 
             public override void Format(
-                FormattingContext context, ChainedFormattingRules formattingRules, Action<int, TriviaData> formattingResultApplier, CancellationToken cancellationToken, int tokenPairIndex = TokenPairIndexNotNeeded)
+                FormattingContext context, ChainedFormattingRules formattingRules, Action<int, TokenStream, TriviaData> formattingResultApplier, TokenStream tokenStream, CancellationToken cancellationToken, int tokenPairIndex = TokenPairIndexNotNeeded)
             {
                 throw new NotImplementedException();
             }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.ModifiedWhitespace.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.ModifiedWhitespace.cs
@@ -78,11 +78,10 @@ namespace Microsoft.CodeAnalysis.Formatting
                 FormattingContext context,
                 ChainedFormattingRules formattingRules,
                 Action<int, TokenStream, TriviaData> formattingResultApplier,
-                TokenStream tokenStream,
                 CancellationToken cancellationToken,
                 int tokenPairIndex = TokenPairIndexNotNeeded)
             {
-                formattingResultApplier(tokenPairIndex, tokenStream, new FormattedWhitespace(this.OptionSet, this.LineBreaks, this.Spaces, this.Language));
+                formattingResultApplier(tokenPairIndex, context.TokenStream, new FormattedWhitespace(this.OptionSet, this.LineBreaks, this.Spaces, this.Language));
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.ModifiedWhitespace.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.ModifiedWhitespace.cs
@@ -77,11 +77,12 @@ namespace Microsoft.CodeAnalysis.Formatting
             public override void Format(
                 FormattingContext context,
                 ChainedFormattingRules formattingRules,
-                Action<int, TriviaData> formattingResultApplier,
+                Action<int, TokenStream, TriviaData> formattingResultApplier,
+                TokenStream tokenStream,
                 CancellationToken cancellationToken,
                 int tokenPairIndex = TokenPairIndexNotNeeded)
             {
-                formattingResultApplier(tokenPairIndex, new FormattedWhitespace(this.OptionSet, this.LineBreaks, this.Spaces, this.Language));
+                formattingResultApplier(tokenPairIndex, tokenStream, new FormattedWhitespace(this.OptionSet, this.LineBreaks, this.Spaces, this.Language));
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
@@ -79,7 +79,6 @@ namespace Microsoft.CodeAnalysis.Formatting
                 FormattingContext context,
                 ChainedFormattingRules formattingRules,
                 Action<int, TokenStream, TriviaData> formattingResultApplier,
-                TokenStream tokenStream,
                 CancellationToken cancellationToken,
                 int tokenPairIndex = TokenPairIndexNotNeeded)
             {

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
@@ -78,7 +78,8 @@ namespace Microsoft.CodeAnalysis.Formatting
             public override void Format(
                 FormattingContext context,
                 ChainedFormattingRules formattingRules,
-                Action<int, TriviaData> formattingResultApplier,
+                Action<int, TokenStream, TriviaData> formattingResultApplier,
+                TokenStream tokenStream,
                 CancellationToken cancellationToken,
                 int tokenPairIndex = TokenPairIndexNotNeeded)
             {

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TriviaData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TriviaData.cs
@@ -50,7 +50,6 @@ namespace Microsoft.CodeAnalysis.Formatting
             FormattingContext context,
             ChainedFormattingRules formattingRules,
             Action<int, TokenStream, TriviaData> formattingResultApplier,
-            TokenStream tokenStream,
             CancellationToken cancellationToken,
             int tokenPairIndex = TokenPairIndexNotNeeded);
     }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TriviaData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TriviaData.cs
@@ -49,7 +49,8 @@ namespace Microsoft.CodeAnalysis.Formatting
         public abstract void Format(
             FormattingContext context,
             ChainedFormattingRules formattingRules,
-            Action<int, TriviaData> formattingResultApplier,
+            Action<int, TokenStream, TriviaData> formattingResultApplier,
+            TokenStream tokenStream,
             CancellationToken cancellationToken,
             int tokenPairIndex = TokenPairIndexNotNeeded);
     }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocation`1.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocation`1.cs
@@ -54,26 +54,28 @@ namespace Microsoft.CodeAnalysis.Options
         {
             if (allRawConventions.TryGetValue(KeyName, out object value))
             {
-                return TryGetOption(value.ToString(), type, out result);
+                var ret = TryGetOption(value.ToString(), type, out var typedResult);
+                result = typedResult;
+                return ret;
             }
 
             result = null;
             return false;
         }
 
-        internal bool TryGetOption(string value, Type type, out object result)
+        internal bool TryGetOption(string value, Type type, out T result)
         {
             var optionalValue = _parseValue(value, type);
             if (optionalValue.HasValue)
             {
                 result = optionalValue.Value;
+                return result != null;
             }
             else
             {
-                result = null;
+                result = default;
+                return false;
             }
-
-            return result != null;
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocation`1.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocation`1.cs
@@ -54,21 +54,26 @@ namespace Microsoft.CodeAnalysis.Options
         {
             if (allRawConventions.TryGetValue(KeyName, out object value))
             {
-                var optionalValue = _parseValue(value.ToString(), type);
-                if (optionalValue.HasValue)
-                {
-                    result = optionalValue.Value;
-                }
-                else
-                {
-                    result = null;
-                }
-
-                return result != null;
+                return TryGetOption(value.ToString(), type, out result);
             }
 
             result = null;
             return false;
+        }
+
+        internal bool TryGetOption(string value, Type type, out object result)
+        {
+            var optionalValue = _parseValue(value, type);
+            if (optionalValue.HasValue)
+            {
+                result = optionalValue.Value;
+            }
+            else
+            {
+                result = null;
+            }
+
+            return result != null;
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxTriviaListExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxTriviaListExtensions.cs
@@ -1,9 +1,24 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
     internal static class SyntaxTriviaListExtensions
     {
+        public static SyntaxTrivia? FirstOrNullable(this SyntaxTriviaList triviaList, Func<SyntaxTrivia, bool> predicate)
+        {
+            foreach (var trivia in triviaList)
+            {
+                if (predicate(trivia))
+                {
+                    return trivia;
+                }
+            }
+
+            return null;
+        }
+
         public static SyntaxTrivia LastOrDefault(this SyntaxTriviaList triviaList)
             => triviaList.Any() ? triviaList.Last() : default;
     }

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTreeExtensions_SharedWithCodeStyle.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTreeExtensions_SharedWithCodeStyle.vb
@@ -88,11 +88,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             Return False
         End Function
 
+        <PerformanceSensitive("https://github.com/dotnet/roslyn/issues/30819", AllowCaptures:=False)>
         Private Function PartOfMultilineLambdaFooter(node As SyntaxNode) As Boolean
-            Return node.AncestorsAndSelf.
-                Where(Function(n) TypeOf n Is MultiLineLambdaExpressionSyntax).
-                OfType(Of MultiLineLambdaExpressionSyntax).
-                Any(Function(n) n.EndSubOrFunctionStatement Is node)
+            For Each n In node.AncestorsAndSelf
+                Dim multiLine = TryCast(n, MultiLineLambdaExpressionSyntax)
+                If multiLine Is Nothing Then
+                    Continue For
+                End If
+
+                If (multiLine.EndSubOrFunctionStatement Is node) Then
+                    Return True
+                End If
+            Next
+
+            Return False
         End Function
     End Module
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTreeExtensions_SharedWithCodeStyle.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTreeExtensions_SharedWithCodeStyle.vb
@@ -68,6 +68,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             Return False
         End Function
 
+        <PerformanceSensitive("https://github.com/dotnet/roslyn/issues/30819", AllowImplicitBoxing:=False)>
         Private Function GetTrailingColonTrivia(statement As StatementSyntax) As SyntaxTrivia?
             If Not statement.HasTrailingTrivia Then
                 Return Nothing

--- a/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
@@ -37,11 +37,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             End If
 
             Dim combinedTrivia = previousToken.TrailingTrivia.Concat(currentToken.LeadingTrivia)
-
-            If ColonTriviaFollowedByLineContinuation(combinedTrivia) Then
-                Return FormattingOperations.CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines)
-            End If
-
             Dim lastTrivia = combinedTrivia.LastOrDefault(AddressOf ColonOrLineContinuationTrivia)
             If lastTrivia.RawKind = SyntaxKind.ColonTrivia Then
                 Return FormattingOperations.CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines)
@@ -100,21 +95,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
         Private Function ColonOrLineContinuationTrivia(trivia As SyntaxTrivia) As Boolean
             Return trivia.RawKind = SyntaxKind.ColonTrivia OrElse trivia.RawKind = SyntaxKind.LineContinuationTrivia
-        End Function
-
-        Private Function ColonTriviaFollowedByLineContinuation(triviaList As IEnumerable(Of SyntaxTrivia)) As Boolean
-            Dim previousTrivia As SyntaxTrivia = Nothing
-            For Each trivia In triviaList
-                If previousTrivia.RawKind = SyntaxKind.None OrElse trivia.RawKind = SyntaxKind.None Then
-                    Continue For
-                End If
-
-                If previousTrivia.RawKind = SyntaxKind.ColonTrivia AndAlso trivia.RawKind = SyntaxKind.LineContinuationTrivia Then
-                    Return True
-                End If
-            Next
-
-            Return False
         End Function
 
         Private Function ContainEndOfLine(previousToken As SyntaxToken, nextToken As SyntaxToken) As Boolean

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
@@ -58,11 +58,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Public Overrides Sub Format(context As FormattingContext,
                                         formattingRules As ChainedFormattingRules,
                                         formattingResultApplier As Action(Of Integer, TokenStream, TriviaData),
-                                        tokenStream As TokenStream,
                                         cancellationToken As CancellationToken,
                                         Optional tokenPairIndex As Integer = TokenPairIndexNotNeeded)
                 If Me.ContainsChanges Then
-                    formattingResultApplier(tokenPairIndex, tokenStream, Me)
+                    formattingResultApplier(tokenPairIndex, context.TokenStream, Me)
                 End If
             End Sub
         End Class

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.AbstractLineBreakTrivia.vb
@@ -57,11 +57,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
             Public Overrides Sub Format(context As FormattingContext,
                                         formattingRules As ChainedFormattingRules,
-                                        formattingResultApplier As Action(Of Integer, TriviaData),
+                                        formattingResultApplier As Action(Of Integer, TokenStream, TriviaData),
+                                        tokenStream As TokenStream,
                                         cancellationToken As CancellationToken,
                                         Optional tokenPairIndex As Integer = TokenPairIndexNotNeeded)
                 If Me.ContainsChanges Then
-                    formattingResultApplier(tokenPairIndex, Me)
+                    formattingResultApplier(tokenPairIndex, tokenStream, Me)
                 End If
             End Sub
         End Class

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.vb
@@ -90,14 +90,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
             Public Overrides Sub Format(context As FormattingContext,
                                         formattingRules As ChainedFormattingRules,
-                                        formattingResultApplier As Action(Of Integer, TriviaData),
+                                        formattingResultApplier As Action(Of Integer, TokenStream, TriviaData),
+                                        tokenStream As TokenStream,
                                         cancellationToken As CancellationToken,
                                         Optional tokenPairIndex As Integer = TokenPairIndexNotNeeded)
                 If Not ShouldFormat(context) Then
                     Return
                 End If
 
-                formattingResultApplier(tokenPairIndex, Format(context, formattingRules, Me.LineBreaks, Me.Spaces, cancellationToken))
+                formattingResultApplier(tokenPairIndex, tokenStream, Format(context, formattingRules, Me.LineBreaks, Me.Spaces, cancellationToken))
             End Sub
 
             Public Overrides Function GetTextChanges(span As TextSpan) As IEnumerable(Of TextChange)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.vb
@@ -91,14 +91,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Public Overrides Sub Format(context As FormattingContext,
                                         formattingRules As ChainedFormattingRules,
                                         formattingResultApplier As Action(Of Integer, TokenStream, TriviaData),
-                                        tokenStream As TokenStream,
                                         cancellationToken As CancellationToken,
                                         Optional tokenPairIndex As Integer = TokenPairIndexNotNeeded)
                 If Not ShouldFormat(context) Then
                     Return
                 End If
 
-                formattingResultApplier(tokenPairIndex, tokenStream, Format(context, formattingRules, Me.LineBreaks, Me.Spaces, cancellationToken))
+                formattingResultApplier(tokenPairIndex, context.TokenStream, Format(context, formattingRules, Me.LineBreaks, Me.Spaces, cancellationToken))
             End Sub
 
             Public Overrides Function GetTextChanges(span As TextSpan) As IEnumerable(Of TextChange)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.vb
@@ -63,7 +63,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
             Public Overrides Sub Format(context As FormattingContext,
                                         formattingRules As ChainedFormattingRules,
-                                        formattingResultApplier As Action(Of Integer, TriviaData),
+                                        formattingResultApplier As Action(Of Integer, TokenStream, TriviaData),
+                                        tokenStream As TokenStream,
                                         cancellationToken As CancellationToken,
                                         Optional tokenPairIndex As Integer = TokenPairIndexNotNeeded)
                 Throw New NotImplementedException()

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.vb
@@ -64,7 +64,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Public Overrides Sub Format(context As FormattingContext,
                                         formattingRules As ChainedFormattingRules,
                                         formattingResultApplier As Action(Of Integer, TokenStream, TriviaData),
-                                        tokenStream As TokenStream,
                                         cancellationToken As CancellationToken,
                                         Optional tokenPairIndex As Integer = TokenPairIndexNotNeeded)
                 Throw New NotImplementedException()

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.vb
@@ -70,7 +70,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Public Overrides Sub Format(context As FormattingContext,
                                         formattingRules As ChainedFormattingRules,
                                         formattingResultApplier As Action(Of Integer, TokenStream, TriviaData),
-                                        tokenStream As TokenStream,
                                         cancellationToken As CancellationToken,
                                         Optional tokenPairIndex As Integer = TokenPairIndexNotNeeded)
                 Contract.ThrowIfFalse(Me.SecondTokenIsFirstTokenOnLine)
@@ -88,7 +87,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
                 formattingResultApplier(
                     tokenPairIndex,
-                    tokenStream,
+                    context.TokenStream,
                     New FormattedComplexTrivia(context, formattingRules, Me._original.Token1, Me._original.Token2, Me.LineBreaks, Me.Spaces, Me._original.OriginalString, cancellationToken))
             End Sub
 

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.vb
@@ -69,7 +69,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
             Public Overrides Sub Format(context As FormattingContext,
                                         formattingRules As ChainedFormattingRules,
-                                        formattingResultApplier As Action(Of Integer, TriviaData),
+                                        formattingResultApplier As Action(Of Integer, TokenStream, TriviaData),
+                                        tokenStream As TokenStream,
                                         cancellationToken As CancellationToken,
                                         Optional tokenPairIndex As Integer = TokenPairIndexNotNeeded)
                 Contract.ThrowIfFalse(Me.SecondTokenIsFirstTokenOnLine)
@@ -87,6 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
                 formattingResultApplier(
                     tokenPairIndex,
+                    tokenStream,
                     New FormattedComplexTrivia(context, formattingRules, Me._original.Token1, Me._original.Token2, Me.LineBreaks, Me.Spaces, Me._original.OriginalString, cancellationToken))
             End Sub
 


### PR DESCRIPTION
Builds on #33170 

This change reduces allocations in `AbstractFormatEngine.Format` by 70% (numbers before this change exceeded 10GiB while compiling Roslyn.sln).

| Item | Allocation fraction |
| --- | --- |
| Dictionary in TryGetEditorConfigOption | 39.6% |
| GetAdjustNewLinesOperation | 15.7% |
| ApplyTriviaOperations | 6.8% |
| TryGetOption | 4.4% |
| GetTrailingColonTrivia | 1.7% |
| ColonTriviaFollowedByLineContinuation (#33170) | 1.6% |
| PartOfMultilineLambdaFooter | 0.9% |