### PR TITLE
Ensure we don't run off the end of the string when parsing \x1

### DIFF
--- a/src/Workspaces/CSharp/Portable/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
+++ b/src/Workspaces/CSharp/Portable/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
@@ -261,7 +261,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.VirtualChars
                     return false;
                 }
 
-                var endIndex = index + 1;
                 for (var i = 0; i < 4; i++)
                 {
                     var ch2 = tokenText[index + i];
@@ -272,7 +271,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.VirtualChars
                     }
 
                     intChar = (intChar << 4) + HexValue(ch2);
-                    endIndex++;
                 }
 
                 character = (char)intChar;

--- a/src/Workspaces/CSharp/Portable/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
+++ b/src/Workspaces/CSharp/Portable/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.VirtualChars
                 }
 
                 var endIndex = index;
-                for (var i = 0; i < 4; i++)
+                for (var i = 0; i < 4 && endIndex < tokenText.Length; i++)
                 {
                     var ch2 = tokenText[index + i];
                     if (!IsHexDigit(ch2))

--- a/src/Workspaces/CSharpTest/EmbeddedLanguages/VirtualChars/CSharpVirtualCharServiceTests.cs
+++ b/src/Workspaces/CSharpTest/EmbeddedLanguages/VirtualChars/CSharpVirtualCharServiceTests.cs
@@ -166,6 +166,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.VirtualChars
         }
 
         [Fact]
+        public void TestValidHex1EscapeInInterpolatedString()
+        {
+            Test(@"$""\xa""", @"['\u000A',[2,5]]");
+        }
+
+        [Fact]
         public void TestValidHex2Escape()
         {
             Test(@"""\xaa""", @"['\u00AA',[1,5]]");

--- a/src/Workspaces/CSharpTest/EmbeddedLanguages/VirtualChars/CSharpVirtualCharServiceTests.cs
+++ b/src/Workspaces/CSharpTest/EmbeddedLanguages/VirtualChars/CSharpVirtualCharServiceTests.cs
@@ -94,15 +94,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.VirtualChars
             Test("$@\"{{\"", "['{',[3,5]]");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/29172")]
-        public void TestReverseInterpolatedVerbatimString()
+        [Fact]
+        public void TestBracesInReverseInterpolatedVerbatimSimpleString()
         {
-            // This will need to be fixed once @$ strings come online.
-            // This is tracked with https://github.com/dotnet/roslyn/issues/29172
-            var token = GetStringToken("@$\"{{\"", allowFailure: true);
-            Assert.True(token == default);
-
-            TestFailure("@$\"{{\"");
+            Test("@$\"{{\"", "['{',[3,5]]");
         }
 
         [Fact]


### PR DESCRIPTION
The code was assuming that there is a " at the end of the string token which it could use to safely bail. In the case of interpolated strings, the token is just the stuff up to the next interpolated hole, where there might not be any marker at all. Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/746365.

While I was here, I saw a test was skipped for a new language feature, and I correctly implemented the test.

<details><summary>Ask Mode template</summary>

### Customer scenario

User opens a source file that contains a Unicode escape like "\x01" inside of an interpolated string. Visual Studio might crash.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/746365

### Workarounds, if any

Don't use this code pattern. The user won't have any way to understand that this code pattern is causing the issue though.

### Risk

Low. Just adding a bounds check.

### Performance impact

None.

### Is this a regression from a previous update?

It's a regression from Visual Studio 2017. We added a new feature that does additional classification of string literals; this was crashing in that code because it wasn't expecting a string of the right form.

### Root cause analysis

This is an oversight in a corner case of the language: plenty of tests were added in regular strings, but not interpolated strings. A test has been added.

### How was the bug found?

Watson reports.

</details>