### PR TITLE
Handle the newly added null coalescing assignment operation in the un…

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -6403,5 +6403,104 @@ class C
     }
 }", options: PreferDiscard);
         }
+
+        [WorkItem(33299, "https://github.com/dotnet/roslyn/issues/33299")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        public async Task NullCoalesceAssignment_01()
+        {
+            await TestMissingInRegularAndScriptWithAllOptionsAsync(
+@"class C
+{
+    public static void M(C x)
+    {
+        [|x|] = M2();
+        x ??= new C();
+    }
+
+    private static C M2() => null;
+}
+", parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+        }
+
+        [WorkItem(33299, "https://github.com/dotnet/roslyn/issues/33299")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        public async Task NullCoalesceAssignment_02()
+        {
+            await TestMissingInRegularAndScriptWithAllOptionsAsync(
+@"class C
+{
+    public static C M(C x)
+    {
+        [|x|] ??= new C();
+        return x;
+    }
+}
+", parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+        }
+
+        [WorkItem(33299, "https://github.com/dotnet/roslyn/issues/33299")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        public async Task NullCoalesceAssignment_03()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    public static void M(C x)
+    {
+        [|x|] ??= new C();
+    }
+}
+",
+@"class C
+{
+    public static void M(C x)
+    {
+        _ = x ?? new C();
+    }
+}
+", optionName: nameof(PreferDiscard), parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+        }
+
+        [WorkItem(33299, "https://github.com/dotnet/roslyn/issues/33299")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        public async Task NullCoalesceAssignment_04()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    public static C M(C x)
+    {
+        return [|x|] ??= new C();
+    }
+}
+",
+@"class C
+{
+    public static C M(C x)
+    {
+        return x ?? new C();
+    }
+}
+", optionName: nameof(PreferDiscard), parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+        }
+
+        [WorkItem(33299, "https://github.com/dotnet/roslyn/issues/33299")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        public async Task NullCoalesceAssignment_05()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    public static C M(C x)
+        => [|x|] ??= new C();
+}
+",
+@"class C
+{
+    public static C M(C x)
+        => x ?? new C();
+}
+", optionName: nameof(PreferDiscard), parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+        }
     }
 }

--- a/src/Features/CSharp/Portable/RemoveUnusedParametersAndValues/CSharpRemoveUnusedValuesCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/RemoveUnusedParametersAndValues/CSharpRemoveUnusedValuesCodeFixProvider.cs
@@ -4,8 +4,10 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues;
 
 namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedParametersAndValues
@@ -62,6 +64,64 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedParametersAndValues
                 // Switch section without any statements is an error case.
                 // Insert before containing switch statement.
                 editor.InsertBefore(switchCaseBlock.Parent, declarationStatement);
+            }
+        }
+
+        protected override SyntaxNode GetReplacementNodeForCompoundAssignment(
+            SyntaxNode originalCompoundAssignment,
+            SyntaxNode newAssignmentTarget,
+            SyntaxEditor editor,
+            ISyntaxFactsService syntaxFacts)
+        {
+            // 1. Compound assignment is changed to simple assignment.
+            // For example, "x += MethodCall();", where assignment to 'x' is redundant
+            // is replaced with "_ = MethodCall();" or "var unused = MethodCall();
+            //
+            // 2. Null coalesce assignment is changed to assignment with null coalesce
+            // expression on the right.
+            // For example, "x ??= MethodCall();", where assignment to 'x' is redundant
+            // is replaced with "_ = x ?? MethodCall();" or "var unused = x ?? MethodCall();
+            //
+            // 3. However, if the node is not parented by an expression statement then we
+            // don't generate an assignment, but just the expression.
+            // For example, "return x += MethodCall();" is replaced with "return x + MethodCall();"
+            // and "return x ??= MethodCall();" is replaced with "return x ?? MethodCall();"
+
+            if (!(originalCompoundAssignment is AssignmentExpressionSyntax assignmentExpression))
+            {
+                Debug.Fail($"Unexpected kind for originalCompoundAssignment: {originalCompoundAssignment.Kind()}");
+                return originalCompoundAssignment;
+            }
+
+            var leftOfAssignment = assignmentExpression.Left;
+            var rightOfAssignment = assignmentExpression.Right;
+
+            if (originalCompoundAssignment.Parent.IsKind(SyntaxKind.ExpressionStatement))
+            {
+                if (!originalCompoundAssignment.IsKind(SyntaxKind.CoalesceAssignmentExpression))
+                {
+                    // Case 1. Simple compound assignment parented by an expression statement.
+                    return editor.Generator.AssignmentStatement(newAssignmentTarget, rightOfAssignment);
+                }
+                else
+                {
+                    // Case 2. Null coalescing compound assignment parented by an expression statement.
+                    // Remove leading trivia from 'leftOfAssignment' as it should have been moved to 'newAssignmentTarget'.
+                    leftOfAssignment = leftOfAssignment.WithoutLeadingTrivia();
+                    return editor.Generator.AssignmentStatement(newAssignmentTarget,
+                        SyntaxFactory.BinaryExpression(SyntaxKind.CoalesceExpression, leftOfAssignment, rightOfAssignment));
+                }
+            }
+            else
+            {
+                // Case 3. Compound assignment not parented by an expression statement.
+                var mappedBinaryExpressionKind = originalCompoundAssignment.Kind().MapCompoundAssignmentKindToBinaryExpressionKind();
+                if (mappedBinaryExpressionKind == SyntaxKind.None)
+                {
+                    return originalCompoundAssignment;
+                }
+
+                return SyntaxFactory.BinaryExpression(mappedBinaryExpressionKind, leftOfAssignment, rightOfAssignment);
             }
         }
     }

--- a/src/Features/VisualBasic/Portable/RemoveUnusedParametersAndValues/VisualBasicRemoveUnusedValuesCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/RemoveUnusedParametersAndValues/VisualBasicRemoveUnusedValuesCodeFixProvider.vb
@@ -3,6 +3,7 @@
 Imports System.Composition
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Editing
+Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -41,6 +42,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedParametersAndValues
 
         Protected Overrides Function GetForEachStatementIdentifier(node As ForEachBlockSyntax) As SyntaxToken
             Throw ExceptionUtilities.Unreachable
+        End Function
+
+        Protected Overrides Function GetReplacementNodeForCompoundAssignment(originalCompoundAssignment As SyntaxNode, newAssignmentTarget As SyntaxNode, editor As SyntaxEditor, syntaxFacts As ISyntaxFactsService) As SyntaxNode
+            ' VB does not support compound assignments.
+            Throw New NotImplementedException()
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxKindExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxKindExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics;
+
 namespace Microsoft.CodeAnalysis.CSharp.Extensions
 {
     internal static class SyntaxKindExtensions
@@ -24,6 +26,49 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             return false;
+        }
+
+        public static SyntaxKind MapCompoundAssignmentKindToBinaryExpressionKind(this SyntaxKind syntaxKind)
+        {
+            switch (syntaxKind)
+            {
+                case SyntaxKind.AddAssignmentExpression:
+                    return SyntaxKind.AddExpression;
+
+                case SyntaxKind.SubtractAssignmentExpression:
+                    return SyntaxKind.SubtractExpression;
+
+                case SyntaxKind.MultiplyAssignmentExpression:
+                    return SyntaxKind.MultiplyExpression;
+
+                case SyntaxKind.DivideAssignmentExpression:
+                    return SyntaxKind.DivideExpression;
+
+                case SyntaxKind.ModuloAssignmentExpression:
+                    return SyntaxKind.ModuloExpression;
+
+                case SyntaxKind.AndAssignmentExpression:
+                    return SyntaxKind.BitwiseAndExpression;
+
+                case SyntaxKind.ExclusiveOrAssignmentExpression:
+                    return SyntaxKind.ExclusiveOrExpression;
+
+                case SyntaxKind.OrAssignmentExpression:
+                    return SyntaxKind.BitwiseOrExpression;
+
+                case SyntaxKind.LeftShiftAssignmentExpression:
+                    return SyntaxKind.LeftShiftExpression;
+
+                case SyntaxKind.RightShiftAssignmentExpression:
+                    return SyntaxKind.RightShiftExpression;
+
+                case SyntaxKind.CoalesceAssignmentExpression:
+                    return SyntaxKind.CoalesceExpression;
+
+                default:
+                    Debug.Fail($"Unhandled compound assignment kind: {syntaxKind}");
+                    return SyntaxKind.None;
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis
             if (operation.Parent is IAssignmentOperation assignmentOperation &&
                 assignmentOperation.Target == operation)
             {
-                return operation.Parent.Kind == OperationKind.CompoundAssignment || operation.Parent.Kind == OperationKind.CoalesceAssignment
+                return operation.Parent.IsAnyCompoundAssignment()
                     ? ValueUsageInfo.ReadWrite
                     : ValueUsageInfo.Write;
             }
@@ -174,6 +174,25 @@ namespace Microsoft.CodeAnalysis
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Retursn true if the given operation is a regular compound assignment,
+        /// i.e. <see cref="ICompoundAssignmentOperation"/> such as <code>a += b</code>,
+        /// or a special null coalescing compoud assignment, i.e. <see cref="ICoalesceAssignmentOperation"/>
+        /// such as <code>a ??= b</code>.
+        /// </summary>
+        public static bool IsAnyCompoundAssignment(this IOperation operation)
+        {
+            switch (operation)
+            {
+                case ICompoundAssignmentOperation _:
+                case ICoalesceAssignmentOperation _:
+                    return true;
+
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FlowAnalysis/LValueFlowCaptureProvider.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/LValueFlowCaptureProvider.cs
@@ -3,8 +3,8 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis
 {
@@ -34,44 +34,50 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         {
             // This method identifies flow capture reference operations that are target of an assignment
             // and marks them as lvalue flow captures.
-            // Note that currently the control flow graph does not contain flow captures
+            // Control flow graph can also contain flow captures
             // that are r-value captures at some point and l-values captures at other point in
-            // the flow graph. The debug only asserts in this method ensure this invariant.
-            // If these asserts fire, we should adjust this algorithm.
+            // the flow graph. Specifically, for an ICoalesceOperation a flow capture acts
+            // as both an r-value and l-value flow capture.
 
             ImmutableDictionary<CaptureId, FlowCaptureKind>.Builder lvalueFlowCaptureIdBuilder = null;
-#if DEBUG
-            var rvalueFlowCaptureIds = new HashSet<CaptureId>();
-#endif
-            foreach (var flowCaptureReference in cfg.DescendantOperations<IFlowCaptureReferenceOperation>(OperationKind.FlowCaptureReference))
+            var rvalueFlowCaptureIds = PooledHashSet<CaptureId>.GetInstance();
+
+            try
             {
-                if (flowCaptureReference.Parent is IAssignmentOperation assignment &&
-                    assignment.Target == flowCaptureReference ||
-                    flowCaptureReference.IsInLeftOfDeconstructionAssignment(out _))
+                foreach (var flowCaptureReference in cfg.DescendantOperations<IFlowCaptureReferenceOperation>(OperationKind.FlowCaptureReference))
                 {
-                    lvalueFlowCaptureIdBuilder = lvalueFlowCaptureIdBuilder ?? ImmutableDictionary.CreateBuilder<CaptureId, FlowCaptureKind>();
-                    var captureKind = flowCaptureReference.Parent is ICompoundAssignmentOperation ? FlowCaptureKind.LValueAndRValueCapture : FlowCaptureKind.LValueCapture;
-                    lvalueFlowCaptureIdBuilder.Add(flowCaptureReference.Id, captureKind);
+                    if (flowCaptureReference.Parent is IAssignmentOperation assignment &&
+                        assignment.Target == flowCaptureReference ||
+                        flowCaptureReference.IsInLeftOfDeconstructionAssignment(out _))
+                    {
+                        lvalueFlowCaptureIdBuilder = lvalueFlowCaptureIdBuilder ?? ImmutableDictionary.CreateBuilder<CaptureId, FlowCaptureKind>();
+                        var captureKind = flowCaptureReference.Parent.IsAnyCompoundAssignment() || rvalueFlowCaptureIds.Contains(flowCaptureReference.Id)
+                            ? FlowCaptureKind.LValueAndRValueCapture
+                            : FlowCaptureKind.LValueCapture;
+                        lvalueFlowCaptureIdBuilder.Add(flowCaptureReference.Id, captureKind);
+                    }
+                    else
+                    {
+                        rvalueFlowCaptureIds.Add(flowCaptureReference.Id);
+                    }
                 }
-#if DEBUG
-                else
-                {
-                    rvalueFlowCaptureIds.Add(flowCaptureReference.Id);
-                }
-#endif
-            }
 
 #if DEBUG
-            if (lvalueFlowCaptureIdBuilder != null)
-            {
-                foreach (var captureId in lvalueFlowCaptureIdBuilder.Keys)
+                if (lvalueFlowCaptureIdBuilder != null)
                 {
-                    Debug.Assert(!rvalueFlowCaptureIds.Contains(captureId), "Flow capture used as both an r-value and an l-value?");
+                    foreach (var kvp in lvalueFlowCaptureIdBuilder)
+                    {
+                        Debug.Assert(kvp.Value == FlowCaptureKind.LValueAndRValueCapture || !rvalueFlowCaptureIds.Contains(kvp.Key), "Flow capture used as both an r-value and an l-value, but with incorrect flow capture kind");
+                    }
                 }
-            }
 #endif
 
-            return lvalueFlowCaptureIdBuilder != null ? lvalueFlowCaptureIdBuilder.ToImmutable() : ImmutableDictionary<CaptureId, FlowCaptureKind>.Empty;
+                return lvalueFlowCaptureIdBuilder != null ? lvalueFlowCaptureIdBuilder.ToImmutable() : ImmutableDictionary<CaptureId, FlowCaptureKind>.Empty;
+            }
+            finally
+            {
+                rvalueFlowCaptureIds.Free();
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                     {
                         OnWriteReferenceFound(symbol, write, maybeWritten: false);
 
-                        if (operation.Kind == OperationKind.CompoundAssignment &&
+                        if (operation.IsAnyCompoundAssignment() &&
                             operation.Parent?.Kind != OperationKind.ExpressionStatement)
                         {
                             OnReadReferenceFound(symbol);
@@ -205,6 +205,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
             public override void VisitCompoundAssignment(ICompoundAssignmentOperation operation)
             {
                 base.VisitCompoundAssignment(operation);
+                ProcessPendingWritesForAssignmentTarget(operation);
+            }
+
+            public override void VisitCoalesceAssignment(ICoalesceAssignmentOperation operation)
+            {
+                base.VisitCoalesceAssignment(operation);
                 ProcessPendingWritesForAssignmentTarget(operation);
             }
 


### PR DESCRIPTION
…used parameters and values analyzer.

Unfortunately, this operation is not an ICompoundAssignmentOperation, hence needs to be handled specially by analyzers that need to analyze read/writes.
Also added support to the fixer to handle coalesce assignments.

Fixes #33299