### PR TITLE
Document ref enumerator disposal compat break

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - VS2019.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - VS2019.md
@@ -81,3 +81,26 @@ Each entry should include a short description of the break, followed by either a
 
 10. Previously, reference assemblies were emitted including embedded resources. In Visual Studio 2019, embedded resources are no longer emitted into ref assemblies.
   See https://github.com/dotnet/roslyn/issues/31197
+
+11. Ref structs now support disposal via pattern. A ref struct enumerator with an accessible `void Dispose()` method will now have it invoked at the end of enumeration, where it would not have been before:
+``` c#
+public class C
+{
+    public ref struct RefEnumerator
+    {
+        public int Current => 0;
+        public bool MoveNext() => false;
+        public void Dispose() => Console.WriteLine("Called in C# 8.0 only");
+    }
+
+    public RefEnumerator GetEnumerator() => new RefEnumerator();
+
+    public static void Main()
+    {
+        foreach(var x in new C())
+        {
+        }
+        // RefEnumerator.Dispose() will be called here in C# 8.0
+    }
+}
+```

--- a/docs/compilers/CSharp/Compiler Breaking Changes - VS2019.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - VS2019.md
@@ -82,7 +82,7 @@ Each entry should include a short description of the break, followed by either a
 10. Previously, reference assemblies were emitted including embedded resources. In Visual Studio 2019, embedded resources are no longer emitted into ref assemblies.
   See https://github.com/dotnet/roslyn/issues/31197
 
-11. Ref structs now support disposal via pattern. A ref struct enumerator with an accessible `void Dispose()` method will now have it invoked at the end of enumeration, where it would not have been before:
+11. Ref structs now support disposal via pattern. A ref struct enumerator with an accessible `void Dispose()` instance method will now have it invoked at the end of enumeration, regardless of whether the struct type implements IDisposable:
 ``` c#
 public class C
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenForEachTests.cs
@@ -1698,6 +1698,39 @@ class DisposableEnumerator
         }
 
         [Fact]
+        public void TestForEachPatternDisposableIgnoredForCSharp7_3()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}
+
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+ref struct DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+    public void Dispose() { System.Console.WriteLine(""Done with DisposableEnumerator""); }
+}";
+            var compilation = CompileAndVerify(source, parseOptions: TestOptions.Regular7_3, expectedOutput: @"
+1
+2
+3");
+        }
+
+        [Fact]
         public void TestForEachNested()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
@@ -3131,7 +3131,7 @@ ref struct DisposableEnumerator
             var boundNode = GetBoundForEachStatement(text, TestOptions.Regular7_3);
             var enumeratorInfo = boundNode.EnumeratorInfoOpt;
 
-            Assert.Equal(null, enumeratorInfo.DisposeMethod);
+            Assert.Null(enumeratorInfo.DisposeMethod);
         }
 
         private static BoundForEachStatement GetBoundForEachStatement(string text, CSharpParseOptions options = null, params DiagnosticDescription[] diagnostics)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
@@ -1872,7 +1872,7 @@ public class Test
   }
 }
 ";
-            var boundNode = GetBoundForEachStatement(text,
+            var boundNode = GetBoundForEachStatement(text, TestOptions.Regular,
                 // (6,13): error CS1525: Invalid expression term 'int'
                 //     foreach(int; i < 5; i++)
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(6, 13),
@@ -3100,9 +3100,43 @@ ref struct DisposableEnumerator
             Assert.Equal("void DisposableEnumerator.Dispose()", enumeratorInfo.DisposeMethod.ToTestDisplayString());
         }
 
-        private static BoundForEachStatement GetBoundForEachStatement(string text, params DiagnosticDescription[] diagnostics)
+        [Fact]
+        public void TestPatternDisposeRefStruct_7_3()
         {
-            var tree = Parse(text);
+            var text = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in new Enumerable1())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}
+
+class Enumerable1
+{
+    public DisposableEnumerator GetEnumerator() { return new DisposableEnumerator(); }
+}
+
+ref struct DisposableEnumerator
+{
+    int x;
+    public int Current { get { return x; } }
+    public bool MoveNext() { return ++x < 4; }
+    public void Dispose() {  }
+}";
+
+            var boundNode = GetBoundForEachStatement(text, TestOptions.Regular7_3);
+            var enumeratorInfo = boundNode.EnumeratorInfoOpt;
+
+            Assert.Equal(null, enumeratorInfo.DisposeMethod);
+        }
+
+        private static BoundForEachStatement GetBoundForEachStatement(string text, CSharpParseOptions options = null, params DiagnosticDescription[] diagnostics)
+        {
+            var tree = Parse(text, options: options);
             var comp = CreateCompilationWithMscorlib40AndSystemCore(new[] { tree });
 
             comp.VerifyDiagnostics(diagnostics);


### PR DESCRIPTION
Documents the breaking change of calling `Dispose` on a ref struct enumerator.