### PR TITLE
Delete unnecessary code around Workspace eventing

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioTaskSchedulerFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioTaskSchedulerFactory.cs
@@ -30,51 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         public override IWorkspaceTaskScheduler CreateEventingTaskQueue()
         {
-            // When we are creating the workspace, we might not actually have established what the UI thread is, since
-            // we might be getting created via MEF. So we'll allow the queue to be created now, and once we actually need
-            // to queue something we'll then start using the task queue from there.
-            // In Visual Studio, we raise these events on the UI thread. At this point we should know
-            // exactly which thread that is.
-            return new VisualStudioTaskScheduler(this);
-        }
-
-        private class VisualStudioTaskScheduler : IWorkspaceTaskScheduler
-        {
-            private readonly Lazy<WorkspaceTaskQueue> _queue;
-            private readonly VisualStudioTaskSchedulerFactory _factory;
-
-            public VisualStudioTaskScheduler(VisualStudioTaskSchedulerFactory factory)
-            {
-                _factory = factory;
-                _queue = new Lazy<WorkspaceTaskQueue>(CreateQueue);
-            }
-
-            private WorkspaceTaskQueue CreateQueue()
-            {
-                // At this point, we have to know what the UI thread is.
-                Contract.ThrowIfFalse(_factory._threadingContext.HasMainThread);
-                return new WorkspaceTaskQueue(_factory, new JoinableTaskFactoryTaskScheduler(_factory._threadingContext.JoinableTaskFactory));
-            }
-
-            public Task ScheduleTask(Action taskAction, string taskName, CancellationToken cancellationToken = default)
-            {
-                return _queue.Value.ScheduleTask(taskAction, taskName, cancellationToken);
-            }
-
-            public Task<T> ScheduleTask<T>(Func<T> taskFunc, string taskName, CancellationToken cancellationToken = default)
-            {
-                return _queue.Value.ScheduleTask(taskFunc, taskName, cancellationToken);
-            }
-
-            public Task ScheduleTask(Func<Task> taskFunc, string taskName, CancellationToken cancellationToken = default)
-            {
-                return _queue.Value.ScheduleTask(taskFunc, taskName, cancellationToken);
-            }
-
-            public Task<T> ScheduleTask<T>(Func<Task<T>> taskFunc, string taskName, CancellationToken cancellationToken = default)
-            {
-                return _queue.Value.ScheduleTask(taskFunc, taskName, cancellationToken);
-            }
+            return new WorkspaceTaskQueue(this, new JoinableTaskFactoryTaskScheduler(_threadingContext.JoinableTaskFactory));
         }
 
         private class JoinableTaskFactoryTaskScheduler : TaskScheduler


### PR DESCRIPTION
We had some code in the VS layer that was trying to work around the fact that we might be MEF created on a background thread, when were didn't know what the UI thread was. It tried to assert that the first actual workspace mutation would happen on the UI thread, and so it was safe to create the queue at that point. This is silly now for two reasons:

1. We're using the IThreadingContext which knows what the main thread is directly and without any ceremony
2. We now do indeed do workspace mutations on other threads. It's still the case that the first mutation is on the UI thread today but that's a limitation we are actively wanting to excise.