### PR TITLE
Add vsBranch and ibcSourceBranch to PublishData.json

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -5,49 +5,59 @@
             "version": "2.10.*",
             "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
             "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
-            "channels": [ "dev15.9"]
+            "channels": [ "dev15.9"],
+            "vsBranch": "rel/d15.9"
         },
         "dev16.0-preview3-vs-deps": {
             "nugetKind": ["Shipping", "NonShipping"],
             "version": "3.0.*",
             "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
             "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
-            "channels": [ "dev16.0p3" ]
+            "channels": [ "dev16.0p3" ],
+            "vsBranch": "lab/d16.0stg"
         },
         "dev16.0-vs-deps": {
             "nugetKind": ["Shipping", "NonShipping"],
             "version": "3.0.*",
             "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
             "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
-            "channels": [ "dev16.0", "dev16.0p4" ]
+            "channels": [ "dev16.0", "dev16.0p4" ],
+            "vsBranch": "rel/d16.0"
         },
         "master-vs-deps": {
             "nugetKind": ["Shipping", "NonShipping"],
             "version": "3.1.*",
             "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
             "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
-            "channels": [ "dev16.1", "dev16.1p1" ]
+            "channels": [ "dev16.1", "dev16.1p1" ],
+            "vsBranch": "lab/ml"
         },
         "features/NullableReferenceTypes": {
             "nugetKind": "PerBuildPreRelease",
             "version": "2.6.*",
             "nuget": [ "https://dotnet.myget.org/F/roslyn-nonnull/api/v2/package" ],
             "vsix": [ "https://dotnet.myget.org/F/roslyn-nonnull/vsix/upload" ],
-            "channels": [ "nonnull" ]
+            "channels": [ "nonnull" ],
+            "vsBranch": "lab/ml",
+            "ibcSourceBranch": "master-vs-deps"
         },
         "features/dataflow": {
             "nugetKind": "PerBuildPreRelease",
             "version": "2.8.*",
             "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
             "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
-            "channels": [ "dataflow" ]
+            "channels": [ "dataflow" ],
+            "vsBranch": "lab/ml",
+            "ibcSourceBranch": "master-vs-deps"
         },
         "features/editorconfig-in-compiler": {
             "nugetKind": ["Shipping", "NonShipping"],
             "version": "2.11.*",
             "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
             "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
-            "channels": [ "editorconfig" ]
+            "channels": [ "editorconfig" ],
+            "vsBranch": "lab/ml",
+            "ibcSourceBranch": "master-vs-deps"
         }
     },
     "releases": {


### PR DESCRIPTION
`vsBranch` is the VS branch that the Roslyn branch inserts to
`ibcSourceBranch` is the Roslyn branch that produced IBC data that should be consumed by official build of the branch. If not specified it's the branch itself.

Adding these values will allow us to control what IBC data are consumed by each branch.
Ad-hoc feature/dev branches will be able to set the values at queue time.
