### PR TITLE
Fix #33253: Smart Indent does not handle fluent sequences correctly

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
@@ -251,6 +251,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                             return GetIndentationFromCommaSeparatedList(token);
                         }
 
+                    case SyntaxKind.CloseParenToken:
+                        {
+                            if (token.Parent.IsKind(SyntaxKind.ArgumentList))
+                            {
+                                return GetDefaultIndentationFromToken(token.Parent.GetFirstToken(includeZeroWidth: true));
+                            }
+
+                            // default case
+                            return GetDefaultIndentationFromToken(token);
+                        }
+
                     default:
                         {
                             return GetDefaultIndentationFromToken(token);

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
@@ -222,8 +222,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                                 return GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(nonTerminalNode.GetFirstToken(includeZeroWidth: true).SpanStart), OptionSet.GetOption(FormattingOptions.IndentationSize, token.Language));
                             }
 
-                            // default case
-                            return GetDefaultIndentationFromToken(token);
+                            goto default;
                         }
 
                     case SyntaxKind.CloseBracketToken:
@@ -237,8 +236,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                                 return GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(nonTerminalNode.GetFirstToken(includeZeroWidth: true).SpanStart));
                             }
 
-                            // default case
-                            return GetDefaultIndentationFromToken(token);
+                            goto default;
                         }
 
                     case SyntaxKind.XmlTextLiteralToken:
@@ -258,8 +256,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                                 return GetDefaultIndentationFromToken(token.Parent.GetFirstToken(includeZeroWidth: true));
                             }
 
-                            // default case
-                            return GetDefaultIndentationFromToken(token);
+                            goto default;
                         }
 
                     default:

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2743,6 +2743,29 @@ class C
 {
     public void Test()
     {
+        new List<DateTime>()
+                .Where(d => d.Kind == DateTimeKind.Local ||
+                            d.Kind == DateTimeKind.Utc)
+
+                .ToArray();
+    }
+}";
+
+            AssertSmartIndent(
+                code: code,
+                indentationLine: 7,
+                expectedIndentation: 16);
+        }
+
+        [WpfFact]
+        [WorkItem(33253, "https://github.com/dotnet/roslyn/issues/33253")]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void EnterAfterFluentSequences_3()
+        {
+            var code = @"public class Test
+{
+    public void Test()
+    {
         new List<DateTime>().Where(d => d.Kind == DateTimeKind.Local ||
                                         d.Kind == DateTimeKind.Utc)
 
@@ -2759,7 +2782,7 @@ class C
         [WpfFact]
         [WorkItem(33253, "https://github.com/dotnet/roslyn/issues/33253")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
-        public void EnterAfterFluentSequences_3()
+        public void EnterAfterFluentSequences_4()
         {
             var code = @"public class Test
 {

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2711,6 +2711,72 @@ class C
                 expectedIndentation: 16);
         }
 
+        [WpfFact]
+        [WorkItem(33253, "https://github.com/dotnet/roslyn/issues/33253")]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void EnterAfterFluentSequences_1()
+        {
+            var code = @"public class Test
+{
+    public void Test()
+    {
+        new List<DateTime>()
+            .Where(d => d.Kind == DateTimeKind.Local ||
+                        d.Kind == DateTimeKind.Utc)
+
+            .ToArray();
+    }
+}";
+
+            AssertSmartIndent(
+                code: code,
+                indentationLine: 7,
+                expectedIndentation: 12);
+        }
+
+        [WpfFact]
+        [WorkItem(33253, "https://github.com/dotnet/roslyn/issues/33253")]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void EnterAfterFluentSequences_2()
+        {
+            var code = @"public class Test
+{
+    public void Test()
+    {
+        new List<DateTime>().Where(d => d.Kind == DateTimeKind.Local ||
+                                        d.Kind == DateTimeKind.Utc)
+
+                            .ToArray();
+    }
+}";
+
+            AssertSmartIndent(
+                code: code,
+                indentationLine: 6,
+                expectedIndentation: 12);
+        }
+
+        [WpfFact]
+        [WorkItem(33253, "https://github.com/dotnet/roslyn/issues/33253")]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void EnterAfterFluentSequences_3()
+        {
+            var code = @"public class Test
+{
+    public void Test()
+    {
+        new List<DateTime>().Where(d => d.Kind == DateTimeKind.Local || d.Kind == DateTimeKind.Utc)
+
+            .ToArray();
+    }
+}";
+
+            AssertSmartIndent(
+                code: code,
+                indentationLine: 5,
+                expectedIndentation: 12);
+        }
+
         private void AssertSmartIndentInProjection(
             string markup, int expectedIndentation,
             int? expectedBlankLineIndentation = null,


### PR DESCRIPTION
This fixes #33253, as discussed with @sharwell.