### PR TITLE
set no activation context on provisional tab when navigate to

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
@@ -131,36 +131,39 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 throw new InvalidOperationException(ServicesVSResources.Navigation_must_be_performed_on_the_foreground_thread);
             }
 
-            var document = OpenDocument(workspace, documentId, options);
-            if (document == null)
+            using (OpenNewDocumentStateScope(options ?? workspace.Options))
             {
-                return false;
-            }
-
-            var text = document.GetTextSynchronously(CancellationToken.None);
-            var textBuffer = text.Container.GetTextBuffer();
-
-            var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
-            if (boundedTextSpan != textSpan)
-            {
-                try
+                var document = OpenDocument(workspace, documentId);
+                if (document == null)
                 {
-                    throw new ArgumentOutOfRangeException();
+                    return false;
                 }
-                catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
+
+                var text = document.GetTextSynchronously(CancellationToken.None);
+                var textBuffer = text.Container.GetTextBuffer();
+
+                var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
+                if (boundedTextSpan != textSpan)
                 {
+                    try
+                    {
+                        throw new ArgumentOutOfRangeException();
+                    }
+                    catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
+                    {
+                    }
                 }
+
+                var vsTextSpan = text.GetVsTextSpanForSpan(boundedTextSpan);
+
+                if (IsSecondaryBuffer(workspace, documentId) &&
+                    !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
+                {
+                    return false;
+                }
+
+                return NavigateTo(textBuffer, vsTextSpan);
             }
-
-            var vsTextSpan = text.GetVsTextSpanForSpan(boundedTextSpan);
-
-            if (IsSecondaryBuffer(workspace, documentId) &&
-                !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
-            {
-                return false;
-            }
-
-            return NavigateTo(textBuffer, vsTextSpan, options ?? workspace.Options);
         }
 
         public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options)
@@ -173,24 +176,27 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 throw new InvalidOperationException(ServicesVSResources.Navigation_must_be_performed_on_the_foreground_thread);
             }
 
-            var document = OpenDocument(workspace, documentId, options);
-            if (document == null)
+            using (OpenNewDocumentStateScope(options ?? workspace.Options))
             {
-                return false;
+                var document = OpenDocument(workspace, documentId);
+                if (document == null)
+                {
+                    return false;
+                }
+
+                var text = document.GetTextSynchronously(CancellationToken.None);
+                var textBuffer = text.Container.GetTextBuffer();
+
+                var vsTextSpan = text.GetVsTextSpanForLineOffset(lineNumber, offset);
+
+                if (IsSecondaryBuffer(workspace, documentId) &&
+                    !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
+                {
+                    return false;
+                }
+
+                return NavigateTo(textBuffer, vsTextSpan);
             }
-
-            var text = document.GetTextSynchronously(CancellationToken.None);
-            var textBuffer = text.Container.GetTextBuffer();
-
-            var vsTextSpan = text.GetVsTextSpanForLineOffset(lineNumber, offset);
-
-            if (IsSecondaryBuffer(workspace, documentId) &&
-                !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
-            {
-                return false;
-            }
-
-            return NavigateTo(textBuffer, vsTextSpan, options ?? workspace.Options);
         }
 
         public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options)
@@ -203,36 +209,39 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 throw new InvalidOperationException(ServicesVSResources.Navigation_must_be_performed_on_the_foreground_thread);
             }
 
-            var document = OpenDocument(workspace, documentId, options);
-            if (document == null)
+            using (OpenNewDocumentStateScope(options ?? workspace.Options))
             {
-                return false;
-            }
-
-            var text = document.GetTextSynchronously(CancellationToken.None);
-            var textBuffer = text.Container.GetTextBuffer();
-
-            var boundedPosition = GetPositionWithinDocumentBounds(position, text.Length);
-            if (boundedPosition != position)
-            {
-                try
+                var document = OpenDocument(workspace, documentId);
+                if (document == null)
                 {
-                    throw new ArgumentOutOfRangeException();
+                    return false;
                 }
-                catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
+
+                var text = document.GetTextSynchronously(CancellationToken.None);
+                var textBuffer = text.Container.GetTextBuffer();
+
+                var boundedPosition = GetPositionWithinDocumentBounds(position, text.Length);
+                if (boundedPosition != position)
                 {
+                    try
+                    {
+                        throw new ArgumentOutOfRangeException();
+                    }
+                    catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
+                    {
+                    }
                 }
+
+                var vsTextSpan = text.GetVsTextSpanForPosition(boundedPosition, virtualSpace);
+
+                if (IsSecondaryBuffer(workspace, documentId) &&
+                    !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
+                {
+                    return false;
+                }
+
+                return NavigateTo(textBuffer, vsTextSpan);
             }
-
-            var vsTextSpan = text.GetVsTextSpanForPosition(boundedPosition, virtualSpace);
-
-            if (IsSecondaryBuffer(workspace, documentId) &&
-                !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
-            {
-                return false;
-            }
-
-            return NavigateTo(textBuffer, vsTextSpan, options ?? workspace.Options);
         }
 
         /// <summary>
@@ -265,30 +274,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return TextSpan.FromBounds(GetPositionWithinDocumentBounds(span.Start, documentLength), GetPositionWithinDocumentBounds(span.End, documentLength));
         }
 
-        private static Document OpenDocument(Workspace workspace, DocumentId documentId, OptionSet options)
+        private static Document OpenDocument(Workspace workspace, DocumentId documentId)
         {
-            options = options ?? workspace.Options;
-
             // Always open the document again, even if the document is already open in the 
             // workspace. If a document is already open in a preview tab and it is opened again 
             // in a permanent tab, this allows the document to transition to the new state.
             if (workspace.CanOpenDocuments)
             {
-                if (options.GetOption(NavigationOptions.PreferProvisionalTab))
-                {
-                    // If we're just opening the provisional tab, then do not "activate" the document
-                    // (i.e. don't give it focus).  This way if a user is just arrowing through a set 
-                    // of FindAllReferences results, they don't have their cursor placed into the document.
-                    var state = __VSNEWDOCUMENTSTATE.NDS_Provisional | __VSNEWDOCUMENTSTATE.NDS_NoActivate;
-                    using (var scope = new NewDocumentStateScope(state, VSConstants.NewDocumentStateReason.Navigation))
-                    {
-                        workspace.OpenDocument(documentId);
-                    }
-                }
-                else
-                {
-                    workspace.OpenDocument(documentId);
-                }
+                workspace.OpenDocument(documentId);
             }
 
             if (!workspace.IsDocumentOpen(documentId))
@@ -299,7 +292,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return workspace.CurrentSolution.GetDocument(documentId);
         }
 
-        private bool NavigateTo(ITextBuffer textBuffer, VsTextSpan vsTextSpan, OptionSet options)
+        private bool NavigateTo(ITextBuffer textBuffer, VsTextSpan vsTextSpan)
         {
             using (Logger.LogBlock(FunctionId.NavigationService_VSDocumentNavigationService_NavigateTo, CancellationToken.None))
             {
@@ -317,34 +310,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     return false;
                 }
 
-                if (options.GetOption(NavigationOptions.PreferProvisionalTab))
-                {
-                    // If we're just opening the provisional tab, then do not "activate" the document
-                    // (i.e. don't give it focus).  This way if a user is just arrowing through a set 
-                    // of FindAllReferences results, they don't have their cursor placed into the document.
-                    var state = __VSNEWDOCUMENTSTATE.NDS_Provisional | __VSNEWDOCUMENTSTATE.NDS_NoActivate;
-                    using (var scope = new NewDocumentStateScope(state, VSConstants.NewDocumentStateReason.Navigation))
-                    {
-                        return NavigateTo();
-                    }
-                }
-                else
-                {
-                    return NavigateTo();
-                }
-
-                bool NavigateTo()
-                {
-                    return ErrorHandler.Succeeded(
-                        textManager.NavigateToLineAndColumn2(
-                            vsTextBuffer,
-                            VSConstants.LOGVIEWID.TextView_guid,
-                            vsTextSpan.iStartLine,
-                            vsTextSpan.iStartIndex,
-                            vsTextSpan.iEndLine,
-                            vsTextSpan.iEndIndex,
-                            (uint)_VIEWFRAMETYPE.vftCodeWindow));
-                }
+                return ErrorHandler.Succeeded(
+                    textManager.NavigateToLineAndColumn2(
+                        vsTextBuffer,
+                        VSConstants.LOGVIEWID.TextView_guid,
+                        vsTextSpan.iStartLine,
+                        vsTextSpan.iStartIndex,
+                        vsTextSpan.iEndLine,
+                        vsTextSpan.iEndIndex,
+                        (uint)_VIEWFRAMETYPE.vftCodeWindow));
             }
         }
 
@@ -368,6 +342,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         private bool CanMapFromSecondaryBufferToPrimaryBuffer(Workspace workspace, DocumentId documentId, VsTextSpan spanInSecondaryBuffer)
         {
             return spanInSecondaryBuffer.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out var spanInPrimaryBuffer);
+        }
+
+        private IDisposable OpenNewDocumentStateScope(OptionSet options)
+        {
+            if (!options.GetOption(NavigationOptions.PreferProvisionalTab))
+            {
+                return null;
+            }
+
+            // If we're just opening the provisional tab, then do not "activate" the document
+            // (i.e. don't give it focus).  This way if a user is just arrowing through a set 
+            // of FindAllReferences results, they don't have their cursor placed into the document.
+            var state = __VSNEWDOCUMENTSTATE.NDS_Provisional | __VSNEWDOCUMENTSTATE.NDS_NoActivate;
+            return new NewDocumentStateScope(state, VSConstants.NewDocumentStateReason.Navigation);
         }
     }
 }


### PR DESCRIPTION
when PreferProvisionalTab option is added, work is done only in OpenDocument, but not in NavigateTo making the option useless in some cases since NavigateTo makes focus to move to provisional tab right after OpenDocument call which make sure provisional tab to not activated.

fix is following editor team's recommendation from https://devdiv.visualstudio.com/DevDiv/_workitems/edit/402396