### PR TITLE
Fix up all the test project launchSettings.json to allow F5 again

### DIFF
--- a/src/CodeStyle/CSharp/Tests/Properties/launchSettings.json
+++ b/src/CodeStyle/CSharp/Tests/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/CodeStyle/Core/Tests/Properties/launchSettings.json
+++ b/src/CodeStyle/Core/Tests/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/CodeStyle/VisualBasic/Tests/My Project/launchSettings.json
+++ b/src/CodeStyle/VisualBasic/Tests/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/CommandLine/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/CommandLine/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/Emit/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/Emit/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/Semantic/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/Symbol/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/Syntax/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/WinRT/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/WinRT/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Properties/launchSettings.json
+++ b/src/Compilers/Core/CodeAnalysisTest/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/Core/MSBuildTaskTests/Properties/launchSettings.json
+++ b/src/Compilers/Core/MSBuildTaskTests/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/Server/VBCSCompilerTests/Properties/launchSettings.json
+++ b/src/Compilers/Server/VBCSCompilerTests/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/VisualBasic/Test/CommandLine/My Project/launchSettings.json
+++ b/src/Compilers/VisualBasic/Test/CommandLine/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/VisualBasic/Test/Emit/My Project/launchSettings.json
+++ b/src/Compilers/VisualBasic/Test/Emit/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/VisualBasic/Test/IOperation/My Project/launchSettings.json
+++ b/src/Compilers/VisualBasic/Test/IOperation/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/VisualBasic/Test/Semantic/My Project/launchSettings.json
+++ b/src/Compilers/VisualBasic/Test/Semantic/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/VisualBasic/Test/Symbol/My Project/launchSettings.json
+++ b/src/Compilers/VisualBasic/Test/Symbol/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Compilers/VisualBasic/Test/Syntax/My Project/launchSettings.json
+++ b/src/Compilers/VisualBasic/Test/Syntax/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/EditorFeatures/CSharpTest2/Properties/launchSettings.json
+++ b/src/EditorFeatures/CSharpTest2/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/EditorFeatures/Test/Properties/launchSettings.json
+++ b/src/EditorFeatures/Test/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/EditorFeatures/Test2/My Project/launchSettings.json
+++ b/src/EditorFeatures/Test2/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/EditorFeatures/VisualBasicTest/My Project/launchSettings.json
+++ b/src/EditorFeatures/VisualBasicTest/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/Properties/launchSettings.json
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Properties/launchSettings.json
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/Properties/launchSettings.json
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/My Project/launchSettings.json
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/My Project/launchSettings.json
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Interactive/HostTest/Properties/launchSettings.json
+++ b/src/Interactive/HostTest/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Scripting/CSharpTest.Desktop/Properties/launchSettings.json
+++ b/src/Scripting/CSharpTest.Desktop/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Scripting/CSharpTest/Properties/launchSettings.json
+++ b/src/Scripting/CSharpTest/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Scripting/CoreTest.Desktop/Properties/launchSettings.json
+++ b/src/Scripting/CoreTest.Desktop/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Scripting/CoreTest/Properties/launchSettings.json
+++ b/src/Scripting/CoreTest/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Scripting/VisualBasicTest.Desktop/My Project/launchSettings.json
+++ b/src/Scripting/VisualBasicTest.Desktop/My Project/launchSettings.json
@@ -1,8 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
+    },
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Scripting/VisualBasicTest/My Project/launchSettings.json
+++ b/src/Scripting/VisualBasicTest/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/VisualStudio/CSharp/Test/Properties/launchSettings.json
+++ b/src/VisualStudio/CSharp/Test/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/VisualStudio/Core/Test.Next/Properties/launchSettings.json
+++ b/src/VisualStudio/Core/Test.Next/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/VisualStudio/Core/Test/My Project/launchSettings.json
+++ b/src/VisualStudio/Core/Test/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Properties/launchSettings.json
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Workspaces/CSharpTest/Properties/launchSettings.json
+++ b/src/Workspaces/CSharpTest/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Workspaces/CoreTest/Properties/launchSettings.json
+++ b/src/Workspaces/CoreTest/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Workspaces/MSBuildTest/Properties/launchSettings.json
+++ b/src/Workspaces/MSBuildTest/Properties/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }

--- a/src/Workspaces/VisualBasicTest/My Project/launchSettings.json
+++ b/src/Workspaces/VisualBasicTest/My Project/launchSettings.json
@@ -1,12 +1,14 @@
 {
   "profiles": {
-    "xUnit.net Console": {
-      "executablePath": "$(XUnitPath)",
-      "commandLineArgs": "$(XUnitArguments)"
+    "xUnit.net Console (32-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.x86.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     },
-    "xUnit.net WPF Runner": {
-      "executablePath": "$(XUnitWpfPath)",
-      "commandLineArgs": "$(XUnitWpfArguments)"
+    "xUnit.net Console (64-bit)": {
+      "commandName": "Executable",
+      "executablePath": "$(NuGetPackageRoot)xunit.runner.console\\$(XUnitVersion)\\tools\\net452\\xunit.console.exe",
+      "commandLineArgs": "$(TargetPath) -noshadow -verbose"
     }
   }
 }


### PR DESCRIPTION
These were broken in the switch to Arcade. It appears there's no longer proper project properties available for this so we hardcode the stuff directly.