### PR TITLE
 Analyze ref/out arguments as output assignments

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -15017,7 +15017,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Nullability of reference types in argument of type &apos;{0}&apos; doesn&apos;t match target type &apos;{1}&apos; for parameter &apos;{2}&apos; in &apos;{3}&apos;..
+        ///   Looks up a localized string similar to Differences in nullability of reference types in argument of type &apos;{0}&apos; prevent it from being used as an input of type &apos;{1}&apos; for parameter &apos;{2}&apos; in &apos;{3}&apos;..
         /// </summary>
         internal static string WRN_NullabilityMismatchInArgument {
             get {
@@ -15026,11 +15026,29 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Nullability of reference types in argument doesn&apos;t match target type..
+        ///   Looks up a localized string similar to Differences in nullability of reference types in argument prevent it from being used as an input for target parameter..
         /// </summary>
         internal static string WRN_NullabilityMismatchInArgument_Title {
             get {
                 return ResourceManager.GetString("WRN_NullabilityMismatchInArgument_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Differences in nullability of reference types in argument of type &apos;{0}&apos; prevent it from being used as an output of type &apos;{1}&apos; for parameter &apos;{2}&apos; in &apos;{3}&apos;..
+        /// </summary>
+        internal static string WRN_NullabilityMismatchInArgumentForOutput {
+            get {
+                return ResourceManager.GetString("WRN_NullabilityMismatchInArgumentForOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Differences in nullability of reference types in argument prevent it from being used as an output for target parameter..
+        /// </summary>
+        internal static string WRN_NullabilityMismatchInArgumentForOutput_Title {
+            get {
+                return ResourceManager.GetString("WRN_NullabilityMismatchInArgumentForOutput_Title", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -15026,7 +15026,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Value cannot be used as an input for parameter due to differences in the nullability of reference types..
+        ///   Looks up a localized string similar to Argument cannot be used as an input for parameter due to differences in the nullability of reference types..
         /// </summary>
         internal static string WRN_NullabilityMismatchInArgument_Title {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -15017,7 +15017,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Differences in nullability of reference types in argument of type &apos;{0}&apos; prevent it from being used as an input of type &apos;{1}&apos; for parameter &apos;{2}&apos; in &apos;{3}&apos;..
+        ///   Looks up a localized string similar to Argument of type &apos;{0}&apos; cannot be used as an input of type &apos;{1}&apos; for parameter &apos;{2}&apos; in &apos;{3}&apos; due to differences in the nullability of reference types..
         /// </summary>
         internal static string WRN_NullabilityMismatchInArgument {
             get {
@@ -15026,7 +15026,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Differences in nullability of reference types in argument prevent it from being used as an input for target parameter..
+        ///   Looks up a localized string similar to Value cannot be used as an input for parameter due to differences in the nullability of reference types..
         /// </summary>
         internal static string WRN_NullabilityMismatchInArgument_Title {
             get {
@@ -15035,7 +15035,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Differences in nullability of reference types in argument of type &apos;{0}&apos; prevent it from being used as an output of type &apos;{1}&apos; for parameter &apos;{2}&apos; in &apos;{3}&apos;..
+        ///   Looks up a localized string similar to Argument of type &apos;{0}&apos; cannot be used as an output of type &apos;{1}&apos; for parameter &apos;{2}&apos; in &apos;{3}&apos; due to differences in the nullability of reference types..
         /// </summary>
         internal static string WRN_NullabilityMismatchInArgumentForOutput {
             get {
@@ -15044,7 +15044,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Differences in nullability of reference types in argument prevent it from being used as an output for target parameter..
+        ///   Looks up a localized string similar to Argument cannot be used as an output for parameter due to differences in the nullability of reference types..
         /// </summary>
         internal static string WRN_NullabilityMismatchInArgumentForOutput_Title {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5416,10 +5416,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Nullability of reference types in value doesn't match target type.</value>
   </data>
   <data name="WRN_NullabilityMismatchInArgument" xml:space="preserve">
-    <value>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</value>
+    <value>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</value>
   </data>
   <data name="WRN_NullabilityMismatchInArgument_Title" xml:space="preserve">
-    <value>Nullability of reference types in argument doesn't match target type.</value>
+    <value>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</value>
+  </data>
+  <data name="WRN_NullabilityMismatchInArgumentForOutput" xml:space="preserve">
+    <value>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</value>
+  </data>
+  <data name="WRN_NullabilityMismatchInArgumentForOutput_Title" xml:space="preserve">
+    <value>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</value>
   </data>
   <data name="WRN_NullabilityMismatchInReturnTypeOfTargetDelegate" xml:space="preserve">
     <value>Nullability of reference types in return type of '{0}' doesn't match the target delegate '{1}'.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5416,16 +5416,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Nullability of reference types in value doesn't match target type.</value>
   </data>
   <data name="WRN_NullabilityMismatchInArgument" xml:space="preserve">
-    <value>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</value>
+    <value>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</value>
   </data>
   <data name="WRN_NullabilityMismatchInArgument_Title" xml:space="preserve">
-    <value>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</value>
+    <value>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</value>
   </data>
   <data name="WRN_NullabilityMismatchInArgumentForOutput" xml:space="preserve">
-    <value>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</value>
+    <value>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</value>
   </data>
   <data name="WRN_NullabilityMismatchInArgumentForOutput_Title" xml:space="preserve">
-    <value>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</value>
+    <value>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</value>
   </data>
   <data name="WRN_NullabilityMismatchInReturnTypeOfTargetDelegate" xml:space="preserve">
     <value>Nullability of reference types in return type of '{0}' doesn't match the target delegate '{1}'.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5419,7 +5419,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</value>
   </data>
   <data name="WRN_NullabilityMismatchInArgument_Title" xml:space="preserve">
-    <value>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</value>
+    <value>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</value>
   </data>
   <data name="WRN_NullabilityMismatchInArgumentForOutput" xml:space="preserve">
     <value>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1652,7 +1652,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_NullabilityMismatchInReturnTypeOfTargetDelegate = 8621,
         WRN_NullabilityMismatchInParameterTypeOfTargetDelegate = 8622,
         ERR_ExplicitNullableAttribute = 8623,
-        // Available = 8624,
+        WRN_NullabilityMismatchInArgumentForOutput = 8624,
         WRN_NullAsNonNullable = 8625,
         // Available = 8626,
         ERR_NullableUnconstrainedTypeParameter = 8627,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             builder.Add(getId(ErrorCode.WRN_UninitializedNonNullableField));
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInAssignment));
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInArgument));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput));
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate));
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate));
             builder.Add(getId(ErrorCode.WRN_NullAsNonNullable));
@@ -382,6 +383,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_UninitializedNonNullableField:
                 case ErrorCode.WRN_NullabilityMismatchInAssignment:
                 case ErrorCode.WRN_NullabilityMismatchInArgument:
+                case ErrorCode.WRN_NullabilityMismatchInArgumentForOutput:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate:
                 case ErrorCode.WRN_NullAsNonNullable:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4214,7 +4214,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TypeSymbolWithAnnotations rightType = VisitOptionalImplicitConversion(right, leftLValueType, UseLegacyWarnings(left), AssignmentKind.Assignment);
                 TrackNullableStateForAssignment(right, leftLValueType, MakeSlot(left), rightType, MakeSlot(right));
                 // https://github.com/dotnet/roslyn/issues/30066 Check node.Type.IsErrorType() instead?
-                ResultType = node.HasErrors ? TypeSymbolWithAnnotations.Create(node.Type) : rightType;
+                var result = node.HasErrors ? TypeSymbolWithAnnotations.Create(node.Type) : rightType;
+                SetResult(result, result);
             }
 
             return null;
@@ -4934,14 +4935,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitPointerIndirectionOperator(BoundPointerIndirectionOperator node)
         {
             var result = base.VisitPointerIndirectionOperator(node);
-            SetResult(node);
+            var type = TypeSymbolWithAnnotations.Create( node.Type);
+            SetResult(type, type);
             return result;
         }
 
         public override BoundNode VisitPointerElementAccess(BoundPointerElementAccess node)
         {
             var result = base.VisitPointerElementAccess(node);
-            SetResult(node);
+            var type = TypeSymbolWithAnnotations.Create( node.Type);
+            SetResult(type, type);
             return result;
         }
 
@@ -4962,7 +4965,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitRefValueOperator(BoundRefValueOperator node)
         {
             var result = base.VisitRefValueOperator(node);
-            SetResult(node);
+            var type = TypeSymbolWithAnnotations.Create(node.Type);
+            SetResult(type, type);
             return result;
         }
 

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -208,6 +208,7 @@
                 case ErrorCode.WRN_NullabilityMismatchInArgument:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate:
+                case ErrorCode.WRN_NullabilityMismatchInArgumentForOutput:
                 case ErrorCode.WRN_NullAsNonNullable:
                 case ErrorCode.WRN_NullableValueTypeMayBeNull:
                 case ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint:

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">Typ odkazu s možnou hodnotou null v argumentu typu {0} neodpovídá cílovému typu {1} parametru {2} v {3}.</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">Typ odkazu s možnou hodnotou null v argumentu typu {0} neodpovídá cílovému typu {1} parametru {2} v {3}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">Typ odkazu s možnou hodnotou null v argumentu neodpovídá cílovému typu.</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">Typ odkazu s možnou hodnotou null v argumentu neodpovídá cílovému typu.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Typ odkazu s možnou hodnotou null v argumentu typu {0} neodpovídá cílovému typu {1} parametru {2} v {3}.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Typ odkazu s možnou hodnotou null v argumentu neodpovídá cílovému typu.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Typ odkazu s možnou hodnotou null v argumentu neodpovídá cílovému typu.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Die NULL-Zulässigkeit von Verweistypen im Argument entspricht nicht dem Zieltyp.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">Die NULL-Zulässigkeit von Verweistypen im Argument vom Typ "{0}" entspricht nicht dem Zieltyp "{1}" für den Parameter "{2}" in "{3}".</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">Die NULL-Zulässigkeit von Verweistypen im Argument vom Typ "{0}" entspricht nicht dem Zieltyp "{1}" für den Parameter "{2}" in "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">Die NULL-Zulässigkeit von Verweistypen im Argument entspricht nicht dem Zieltyp.</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">Die NULL-Zulässigkeit von Verweistypen im Argument entspricht nicht dem Zieltyp.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Die NULL-Zulässigkeit von Verweistypen im Argument vom Typ "{0}" entspricht nicht dem Zieltyp "{1}" für den Parameter "{2}" in "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Die NULL-Zulässigkeit von Verweistypen im Argument entspricht nicht dem Zieltyp.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">La nulabilidad de los tipos de referencia del argumento de tipo "{0}" no coincide con el tipo de destino "{1}" para el parámetro "{2}" en "{3}".</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">La nulabilidad de los tipos de referencia del argumento de tipo "{0}" no coincide con el tipo de destino "{1}" para el parámetro "{2}" en "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">La nulabilidad de los tipos de referencia del argumento no coincide con el tipo de destino</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">La nulabilidad de los tipos de referencia del argumento no coincide con el tipo de destino</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">La nulabilidad de los tipos de referencia del argumento no coincide con el tipo de destino</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">La nulabilidad de los tipos de referencia del argumento de tipo "{0}" no coincide con el tipo de destino "{1}" para el parámetro "{2}" en "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">La nulabilidad de los tipos de referencia del argumento no coincide con el tipo de destino</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">La nullabilité des types référence dans l'argument de type '{0}' ne correspond pas au type cible '{1}' pour le paramètre '{2}' dans '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">La nullabilité des types référence dans l'argument ne correspond pas au type cible.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">La nullabilité des types référence dans l'argument ne correspond pas au type cible.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">La nullabilité des types référence dans l'argument de type '{0}' ne correspond pas au type cible '{1}' pour le paramètre '{2}' dans '{3}'.</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">La nullabilité des types référence dans l'argument de type '{0}' ne correspond pas au type cible '{1}' pour le paramètre '{2}' dans '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">La nullabilité des types référence dans l'argument ne correspond pas au type cible.</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">La nullabilité des types référence dans l'argument ne correspond pas au type cible.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">Il supporto dei valori Null dei tipi riferimento nell'argomento di tipo '{0}' non corrisponde al tipo di destinazione '{1}' per il parametro '{2}' in '{3}'.</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">Il supporto dei valori Null dei tipi riferimento nell'argomento di tipo '{0}' non corrisponde al tipo di destinazione '{1}' per il parametro '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">Il supporto dei valori Null dei tipi riferimento nell'argomento non corrisponde al tipo di destinazione.</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">Il supporto dei valori Null dei tipi riferimento nell'argomento non corrisponde al tipo di destinazione.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Il supporto dei valori Null dei tipi riferimento nell'argomento non corrisponde al tipo di destinazione.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Il supporto dei valori Null dei tipi riferimento nell'argomento di tipo '{0}' non corrisponde al tipo di destinazione '{1}' per il parametro '{2}' in '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Il supporto dei valori Null dei tipi riferimento nell'argomento non corrisponde al tipo di destinazione.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">'{0}' 型の引数における参照型の Null 許容性が、'{3}' 内のパラメーター '{2}' に関する対象の型 '{1}' と一致しません。</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">'{0}' 型の引数における参照型の Null 許容性が、'{3}' 内のパラメーター '{2}' に関する対象の型 '{1}' と一致しません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">引数における参照型の Null 許容性が、対象の型と一致しません。</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">引数における参照型の Null 許容性が、対象の型と一致しません。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">'{0}' 型の引数における参照型の Null 許容性が、'{3}' 内のパラメーター '{2}' に関する対象の型 '{1}' と一致しません。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">引数における参照型の Null 許容性が、対象の型と一致しません。</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">引数における参照型の Null 許容性が、対象の型と一致しません。</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">인수에 있는 참조 형식 Null 허용 여부가 대상 형식과 일치하지 않습니다.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">'{0}' 형식의 인수에 있는 참조 형식 Null 허용 여부가 '{3}'의 매개 변수 '{2}'에 대한 '{1}' 대상 형식과 일치하지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">인수에 있는 참조 형식 Null 허용 여부가 대상 형식과 일치하지 않습니다.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">'{0}' 형식의 인수에 있는 참조 형식 Null 허용 여부가 '{3}'의 매개 변수 '{2}'에 대한 '{1}' 대상 형식과 일치하지 않습니다.</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">'{0}' 형식의 인수에 있는 참조 형식 Null 허용 여부가 '{3}'의 매개 변수 '{2}'에 대한 '{1}' 대상 형식과 일치하지 않습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">인수에 있는 참조 형식 Null 허용 여부가 대상 형식과 일치하지 않습니다.</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">인수에 있는 참조 형식 Null 허용 여부가 대상 형식과 일치하지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Obsługa wartości null dla typów referencyjnych w argumencie typu „{0}” jest niezgodna z typem docelowym „{1}” dla parametru „{2}” w „{3}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Obsługa wartości null dla typów referencyjnych w argumencie jest niezgodna z typem docelowym.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Obsługa wartości null dla typów referencyjnych w argumencie jest niezgodna z typem docelowym.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">Obsługa wartości null dla typów referencyjnych w argumencie typu „{0}” jest niezgodna z typem docelowym „{1}” dla parametru „{2}” w „{3}”.</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">Obsługa wartości null dla typów referencyjnych w argumencie typu „{0}” jest niezgodna z typem docelowym „{1}” dla parametru „{2}” w „{3}”.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">Obsługa wartości null dla typów referencyjnych w argumencie jest niezgodna z typem docelowym.</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">Obsługa wartości null dla typów referencyjnych w argumencie jest niezgodna z typem docelowym.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">A anulabilidade de tipos de referência em um argumento do tipo '{0}' não coincide com o tipo de destino '{1}' para o parâmetro '{2}' em '{3}'.</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">A anulabilidade de tipos de referência em um argumento do tipo '{0}' não coincide com o tipo de destino '{1}' para o parâmetro '{2}' em '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">A anulabilidade de tipos de referência no argumento não corresponde ao tipo de destino.</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">A anulabilidade de tipos de referência no argumento não corresponde ao tipo de destino.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">A anulabilidade de tipos de referência em um argumento do tipo '{0}' não coincide com o tipo de destino '{1}' para o parâmetro '{2}' em '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">A anulabilidade de tipos de referência no argumento não corresponde ao tipo de destino.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">A anulabilidade de tipos de referência no argumento não corresponde ao tipo de destino.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">Допустимость значения NULL для ссылочных типов в аргументе типа "{0}" не соответствует целевому типу "{1}" для параметра "{2}" в "{3}".</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">Допустимость значения NULL для ссылочных типов в аргументе типа "{0}" не соответствует целевому типу "{1}" для параметра "{2}" в "{3}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">Допустимость значения NULL для ссылочных типов в аргументе не соответствует целевому типу.</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">Допустимость значения NULL для ссылочных типов в аргументе не соответствует целевому типу.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Допустимость значения NULL для ссылочных типов в аргументе типа "{0}" не соответствует целевому типу "{1}" для параметра "{2}" в "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Допустимость значения NULL для ссылочных типов в аргументе не соответствует целевому типу.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Допустимость значения NULL для ссылочных типов в аргументе не соответствует целевому типу.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">'{0}' türündeki bağımsız değişken için başvuru türlerinin boş değer atanabilirliği, '{3}' içindeki '{2}' parametresi için '{1}' hedef türüyle eşleşmiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Bağımsız değişkendeki başvuru türlerinin boş değer atanabilirliği hedef tür ile eşleşmiyor.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">'{0}' türündeki bağımsız değişken için başvuru türlerinin boş değer atanabilirliği, '{3}' içindeki '{2}' parametresi için '{1}' hedef türüyle eşleşmiyor.</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">'{0}' türündeki bağımsız değişken için başvuru türlerinin boş değer atanabilirliği, '{3}' içindeki '{2}' parametresi için '{1}' hedef türüyle eşleşmiyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">Bağımsız değişkendeki başvuru türlerinin boş değer atanabilirliği hedef tür ile eşleşmiyor.</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">Bağımsız değişkendeki başvuru türlerinin boş değer atanabilirliği hedef tür ile eşleşmiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">Bağımsız değişkendeki başvuru türlerinin boş değer atanabilirliği hedef tür ile eşleşmiyor.</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1038,22 +1038,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">类型“{0}”的实参中引用类型的为 Null 性与“{3}”中形参“{2}”的目标类型“{1}”不匹配。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">参数中的引用类型的为 Null 性与目标类型不匹配。</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1053,7 +1053,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">参数中的引用类型的为 Null 性与目标类型不匹配。</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1038,13 +1038,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">类型“{0}”的实参中引用类型的为 Null 性与“{3}”中形参“{2}”的目标类型“{1}”不匹配。</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">类型“{0}”的实参中引用类型的为 Null 性与“{3}”中形参“{2}”的目标类型“{1}”不匹配。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">参数中的引用类型的为 Null 性与目标类型不匹配。</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">参数中的引用类型的为 Null 性与目标类型不匹配。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1333,22 +1333,22 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <source>Argument of type '{0}' cannot be used as an input of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">型別 '{0}' 的引數中參考型別可 Null 性與 '{3}' 中參數 '{2}' 的目標型別 '{1}' 不符合。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
-        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <source>Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</source>
+        <target state="new">Argument of type '{0}' cannot be used as an output of type '{1}' for parameter '{2}' in '{3}' due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
-        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
+        <source>Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</source>
+        <target state="new">Argument cannot be used as an output for parameter due to differences in the nullability of reference types.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">引數中參考型別的可 Null 性與目標型別不符合。</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1333,13 +1333,23 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument">
-        <source>Nullability of reference types in argument of type '{0}' doesn't match target type '{1}' for parameter '{2}' in '{3}'.</source>
-        <target state="translated">型別 '{0}' 的引數中參考型別可 Null 性與 '{3}' 中參數 '{2}' 的目標型別 '{1}' 不符合。</target>
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an input of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="needs-review-translation">型別 '{0}' 的引數中參考型別可 Null 性與 '{3}' 中參數 '{2}' 的目標型別 '{1}' 不符合。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput">
+        <source>Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</source>
+        <target state="new">Differences in nullability of reference types in argument of type '{0}' prevent it from being used as an output of type '{1}' for parameter '{2}' in '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_NullabilityMismatchInArgumentForOutput_Title">
+        <source>Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</source>
+        <target state="new">Differences in nullability of reference types in argument prevent it from being used as an output for target parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Nullability of reference types in argument doesn't match target type.</source>
-        <target state="translated">引數中參考型別的可 Null 性與目標型別不符合。</target>
+        <source>Differences in nullability of reference types in argument prevent it from being used as an input for target parameter.</source>
+        <target state="needs-review-translation">引數中參考型別的可 Null 性與目標型別不符合。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInAssignment">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1348,7 +1348,7 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInArgument_Title">
-        <source>Value cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
+        <source>Argument cannot be used as an input for parameter due to differences in the nullability of reference types.</source>
         <target state="needs-review-translation">引數中參考型別的可 Null 性與目標型別不符合。</target>
         <note />
       </trans-unit>

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -453,10 +453,10 @@ public class B2 : A<object?>
 }";
             var comp2 = CreateCompilation(new[] { source2 }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyDiagnostics(
-                // (8,14): warning CS8620: Nullability of reference types in argument of type 'B1' doesn't match target type 'A<object?>' for parameter 'y' in 'void C.F(A<object> x, A<object?> y)'.
+                // (8,14): warning CS8620: Argument of type 'B1' cannot be used as an input of type 'A<object?>' for parameter 'y' in 'void C.F(A<object> x, A<object?> y)' due to differences in the nullability of reference types.
                 //         F(x, x);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("B1", "A<object?>", "y", "void C.F(A<object> x, A<object?> y)").WithLocation(8, 14),
-                // (9,11): warning CS8620: Nullability of reference types in argument of type 'B2' doesn't match target type 'A<object>' for parameter 'x' in 'void C.F(A<object> x, A<object?> y)'.
+                // (9,11): warning CS8620: Argument of type 'B2' cannot be used as an input of type 'A<object>' for parameter 'x' in 'void C.F(A<object> x, A<object?> y)' due to differences in the nullability of reference types.
                 //         F(y, y);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("B2", "A<object>", "x", "void C.F(A<object> x, A<object?> y)").WithLocation(9, 11));
         }
@@ -508,10 +508,10 @@ public class B : I<object?>
 }";
             var comp2 = CreateCompilation(new[] { source2 }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyDiagnostics(
-                // (9,14): warning CS8620: Nullability of reference types in argument of type 'A' doesn't match target type 'I<object?>' for parameter 'y' in 'void C.F(I<object> x, I<object?> y)'.
+                // (9,14): warning CS8620: Argument of type 'A' cannot be used as an input of type 'I<object?>' for parameter 'y' in 'void C.F(I<object> x, I<object?> y)' due to differences in the nullability of reference types.
                 //         F(x, x);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("A", "I<object?>", "y", "void C.F(I<object> x, I<object?> y)").WithLocation(9, 14),
-                // (10,11): warning CS8620: Nullability of reference types in argument of type 'B' doesn't match target type 'I<object>' for parameter 'x' in 'void C.F(I<object> x, I<object?> y)'.
+                // (10,11): warning CS8620: Argument of type 'B' cannot be used as an input of type 'I<object>' for parameter 'x' in 'void C.F(I<object> x, I<object?> y)' due to differences in the nullability of reference types.
                 //         F(y, y);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("B", "I<object>", "x", "void C.F(I<object> x, I<object?> y)").WithLocation(10, 11));
         }
@@ -558,7 +558,7 @@ public class B : I<(object X, object? Y)>
 }";
             var comp2 = CreateCompilation(new[] { source2 }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyDiagnostics(
-                // (9,11): warning CS8620: Nullability of reference types in argument of type 'B' doesn't match target type 'I<(object, object)>' for parameter 'a' in 'void C.F(I<(object, object)> a, I<(object, object?)> b)'.
+                // (9,11): warning CS8620: Argument of type 'B' cannot be used as an input of type 'I<(object, object)>' for parameter 'a' in 'void C.F(I<(object, object)> a, I<(object, object?)> b)' due to differences in the nullability of reference types.
                 //         F(b, b);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "b").WithArguments("B", "I<(object, object)>", "a", "void C.F(I<(object, object)> a, I<(object, object?)> b)").WithLocation(9, 11));
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -14902,6 +14902,78 @@ public class C
         }
 
         [Fact]
+        [WorkItem(29295, "https://github.com/dotnet/roslyn/issues/29295")]
+        public void CatchException()
+        {
+            var c = CreateCompilation(@"
+class C
+{
+    void M()
+    {
+        try
+        {
+            System.Console.WriteLine();
+        }
+        catch (System.Exception e)
+        {
+            e.ToString();
+        }
+    }
+}
+", options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(29295, "https://github.com/dotnet/roslyn/issues/29295")]
+        public void CatchException_WithWhenIsOperator()
+        {
+            var c = CreateCompilation(@"
+class C
+{
+    void M()
+    {
+        try
+        {
+            System.Console.WriteLine();
+        }
+        catch (System.Exception e) when (!(e is System.ArgumentException))
+        {
+            e.ToString();
+        }
+    }
+}
+", options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(29295, "https://github.com/dotnet/roslyn/issues/29295")]
+        public void CatchException_NullableType()
+        {
+            var c = CreateCompilation(@"
+class C
+{
+    void M()
+    {
+        try
+        {
+            System.Console.WriteLine();
+        }
+        catch (System.Exception? e)
+        {
+            e.ToString();
+        }
+    }
+}
+", options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void MethodWithGenericArrayOutParameter_WithNonNullArgument()
         {
             CSharpCompilation c = CreateCompilation(new[] { @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -13173,16 +13173,16 @@ class CL0<T>
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (12,16): warning CS8620: Differences in nullability of reference types in argument of type 'CL0<string?>' prevent it from being used as an input of type 'CL0<string>' for parameter 'x' in 'void C.M1(ref CL0<string> x)'.
+                // (12,16): warning CS8620: Argument of type 'CL0<string?>' cannot be used as an input of type 'CL0<string>' for parameter 'x' in 'void C.M1(ref CL0<string> x)' due to differences in the nullability of reference types.
                 //         M1(ref x1);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x1").WithArguments("CL0<string?>", "CL0<string>", "x", "void C.M1(ref CL0<string> x)").WithLocation(12, 16),
-                // (12,16): warning CS8624: Differences in nullability of reference types in argument of type 'CL0<string?>' prevent it from being used as an output of type 'CL0<string>' for parameter 'x' in 'void C.M1(ref CL0<string> x)'.
+                // (12,16): warning CS8624: Argument of type 'CL0<string?>' cannot be used as an output of type 'CL0<string>' for parameter 'x' in 'void C.M1(ref CL0<string> x)' due to differences in the nullability of reference types.
                 //         M1(ref x1);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "x1").WithArguments("CL0<string?>", "CL0<string>", "x", "void C.M1(ref CL0<string> x)").WithLocation(12, 16),
-                // (19,16): warning CS8624: Differences in nullability of reference types in argument of type 'CL0<string>' prevent it from being used as an output of type 'CL0<string?>' for parameter 'x' in 'void C.M2(out CL0<string?> x)'.
+                // (19,16): warning CS8624: Argument of type 'CL0<string>' cannot be used as an output of type 'CL0<string?>' for parameter 'x' in 'void C.M2(out CL0<string?> x)' due to differences in the nullability of reference types.
                 //         M2(out x2);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "x2").WithArguments("CL0<string>", "CL0<string?>", "x", "void C.M2(out CL0<string?> x)").WithLocation(19, 16),
-                // (26,12): warning CS8620: Differences in nullability of reference types in argument of type 'CL0<string?>' prevent it from being used as an input of type 'CL0<string>' for parameter 'x' in 'void C.M3(CL0<string> x)'.
+                // (26,12): warning CS8620: Argument of type 'CL0<string?>' cannot be used as an input of type 'CL0<string>' for parameter 'x' in 'void C.M3(CL0<string> x)' due to differences in the nullability of reference types.
                 //         M3(x3);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x3").WithArguments("CL0<string?>", "CL0<string>", "x", "void C.M3(CL0<string> x)").WithLocation(26, 12)
                 );
@@ -14551,29 +14551,6 @@ public class C
         }
 
         [Fact]
-        public void MethodWithRefNullableParameter()
-        {
-            CSharpCompilation c = CreateCompilation(new[] { @"
-public class C
-{
-    public void Main()
-    {
-        string? s = ""hello"";
-        M(ref s);
-        s.ToString(); // 1
-    }
-    public static void M(ref string? value) => throw null!;
-}
-" }, options: WithNonNullTypesTrue());
-
-            c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
-                //         s.ToString(); // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9)
-                );
-        }
-
-        [Fact]
         public void MethodWithRefNullableParameter_WithNonNullableRefArgument()
         {
             CSharpCompilation c = CreateCompilation(new[] { @"
@@ -15020,11 +14997,11 @@ class C
 {
     public void M()
     {
-        string? s = string.Empty;
+        string? s = """";
         M(ref s);
         s.ToString(); // 1
 
-        string s2 = string.Empty;
+        string s2 = """";
         M(ref s2); // 2
         s2.ToString(); // 3
     }
@@ -15047,6 +15024,30 @@ class C
 
         [Fact]
         [WorkItem(26739, "https://github.com/dotnet/roslyn/issues/26739")]
+        public void RefParameter_TopLevelNullability_AlwaysSet()
+        {
+            var c = CreateCompilation(@"
+class C
+{
+    public void M()
+    {
+        string? s = null;
+        M(ref s);
+        s.ToString();
+    }
+    void M(ref string s) => throw null!;
+}
+", options: WithNonNullTypesTrue());
+
+            c.VerifyDiagnostics(
+                // (7,15): warning CS8604: Possible null reference argument for parameter 's' in 'void C.M(ref string s)'.
+                //         M(ref s);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "s").WithArguments("s", "void C.M(ref string s)").WithLocation(7, 15)
+                );
+        }
+
+        [Fact]
+        [WorkItem(26739, "https://github.com/dotnet/roslyn/issues/26739")]
         public void RefParameter_TopLevelNullability_Suppressed()
         {
             var c = CreateCompilation(@"
@@ -15054,11 +15055,11 @@ class C
 {
     public void M()
     {
-        string? s = string.Empty;
+        string? s = """";
         M(ref s!);
         s.ToString(); // no warning
 
-        string s2 = string.Empty;
+        string s2 = """";
         M(ref s2!); // no warning
         s2.ToString(); // no warning
     }
@@ -15076,8 +15077,8 @@ class C
             var c = CreateCompilation(@"
 class C
 {
-    string field = string.Empty;
-    string Property { get; set; } = string.Empty;
+    string field = """";
+    string Property { get; set; } = """";
     public void M()
     {
         M(ref null); // 1
@@ -15124,11 +15125,11 @@ public class C
 {
     public void M()
     {
-        string? s = string.Empty;
+        string? s = """";
         this.M(ref s);
         s.ToString(); // 1
 
-        string s2 = string.Empty;
+        string s2 = """";
         this.M(ref s2); // 2
         s2.ToString(); // 3
     }
@@ -15208,7 +15209,7 @@ class C<T>
         M(ref s);
         s.ToString();
 
-        M(ref s2); // 1
+        M(ref s2); // 1, 2
         s2.ToString();
     }
     void M(ref C<string?> s) => throw null!;
@@ -15216,11 +15217,11 @@ class C<T>
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,15): warning CS8620: Differences in nullability of reference types in argument of type 'C<string>' prevent it from being used as an input of type 'C<string?>' for parameter 's' in 'void C<T>.M(ref C<string?> s)'.
-                //         M(ref s2); // 1
+                // (9,15): warning CS8620: Argument of type 'C<string>' cannot be used as an input of type 'C<string?>' for parameter 's' in 'void C<T>.M(ref C<string?> s)' due to differences in the nullability of reference types.
+                //         M(ref s2); // 1, 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "s2").WithArguments("C<string>", "C<string?>", "s", "void C<T>.M(ref C<string?> s)").WithLocation(9, 15),
-                // (9,15): warning CS8624: Differences in nullability of reference types in argument of type 'C<string>' prevent it from being used as an output of type 'C<string?>' for parameter 's' in 'void C<T>.M(ref C<string?> s)'.
-                //         M(ref s2); // 1
+                // (9,15): warning CS8624: Argument of type 'C<string>' cannot be used as an output of type 'C<string?>' for parameter 's' in 'void C<T>.M(ref C<string?> s)' due to differences in the nullability of reference types.
+                //         M(ref s2); // 1, 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "s2").WithArguments("C<string>", "C<string?>", "s", "void C<T>.M(ref C<string?> s)").WithLocation(9, 15)
                 );
         }
@@ -15234,7 +15235,7 @@ class C<T>
 {
     public void M()
     {
-        string? s = string.Empty;
+        string? s = """";
         var v1 = M(ref s, s);
         s.ToString(); // 1
         v1.ToString();
@@ -15284,13 +15285,16 @@ class C
     void G(ref string? s) => throw null!;
     public void M()
     {
-        string s = string.Empty;
+        string s = """";
         G(ref F(s = null));
     }
 }
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
+                // (8,16): warning CS0219: The variable 's' is assigned but its value is never used
+                //         string s = "";
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "s").WithArguments("s").WithLocation(8, 16),
                 // (9,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         G(ref F(s = null));
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(9, 21)
@@ -15307,8 +15311,8 @@ class C
     void F(ref string? s) => throw null!;
     public void M(bool b)
     {
-        string? s = string.Empty;
-        string? s2 = string.Empty;
+        string? s = """";
+        string? s2 = """";
         F(ref (b ? ref s : ref s2));
         s.ToString(); // 1
         s2.ToString(); // 2
@@ -15331,11 +15335,11 @@ class C
 {
     public void M()
     {
-        string? s = string.Empty;
+        string? s = """";
         M(out s);
         s.ToString(); // 1
 
-        string s2 = string.Empty;
+        string s2 = """";
         M(out s2); // 2
         s2.ToString(); // 3
     }
@@ -15397,11 +15401,11 @@ class C
 {
     public void M()
     {
-        string? s = string.Empty;
+        string? s = """";
         M(out s!);
         s.ToString(); // no warning
 
-        string s2 = string.Empty;
+        string s2 = """";
         M(out s2!); // no warning
         s2.ToString(); // no warning
     }
@@ -15476,7 +15480,7 @@ class C<T>
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,15): warning CS8624: Differences in nullability of reference types in argument of type 'C<string>' prevent it from being used as an output of type 'C<string?>' for parameter 's' in 'void C<T>.M(out C<string?> s)'.
+                // (9,15): warning CS8624: Argument of type 'C<string>' cannot be used as an output of type 'C<string?>' for parameter 's' in 'void C<T>.M(out C<string?> s)' due to differences in the nullability of reference types.
                 //         M(out s2); // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "s2").WithArguments("C<string>", "C<string?>", "s", "void C<T>.M(out C<string?> s)").WithLocation(9, 15)
                 );
@@ -15491,7 +15495,7 @@ class C<T>
 {
     public void M()
     {
-        string? s = string.Empty;
+        string? s = """";
         var v1 = M(out s, s);
         s.ToString(); // 1
         v1.ToString();
@@ -29571,10 +29575,10 @@ class C<T>
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (13,10): warning CS8624: Differences in nullability of reference types in argument of type 'IIn<object?>' prevent it from being used as an output of type 'IIn<object>' for parameter 'x' in 'void C<object>.Deconstruct(out IIn<object> x, out IOut<object> y)'.
+                // (13,10): warning CS8624: Argument of type 'IIn<object?>' cannot be used as an output of type 'IIn<object>' for parameter 'x' in 'void C<object>.Deconstruct(out IIn<object> x, out IOut<object> y)' due to differences in the nullability of reference types.
                 //         (x, y) = c;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "x").WithArguments("IIn<object?>", "IIn<object>", "x", "void C<object>.Deconstruct(out IIn<object> x, out IOut<object> y)").WithLocation(13, 10),
-                // (19,13): warning CS8624: Differences in nullability of reference types in argument of type 'IOut<object>' prevent it from being used as an output of type 'IOut<object?>' for parameter 'y' in 'void C<object?>.Deconstruct(out IIn<object?> x, out IOut<object?> y)'.
+                // (19,13): warning CS8624: Argument of type 'IOut<object>' cannot be used as an output of type 'IOut<object?>' for parameter 'y' in 'void C<object?>.Deconstruct(out IIn<object?> x, out IOut<object?> y)' due to differences in the nullability of reference types.
                 //         (x, y) = c;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "y").WithArguments("IOut<object>", "IOut<object?>", "y", "void C<object?>.Deconstruct(out IIn<object?> x, out IOut<object?> y)").WithLocation(19, 13)
                 );
@@ -31412,16 +31416,16 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,15): warning CS8624: Differences in nullability of reference types in argument of type 'I<object>' prevent it from being used as an output of type 'I<object?>' for parameter 'x' in 'void C.G(out I<object?> x, out IIn<object?> y, out IOut<object?> z)'.
+                // (8,15): warning CS8624: Argument of type 'I<object>' cannot be used as an output of type 'I<object?>' for parameter 'x' in 'void C.G(out I<object?> x, out IIn<object?> y, out IOut<object?> z)' due to differences in the nullability of reference types.
                 //         G(out x, out y, out z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "x").WithArguments("I<object>", "I<object?>", "x", "void C.G(out I<object?> x, out IIn<object?> y, out IOut<object?> z)").WithLocation(8, 15),
-                // (8,29): warning CS8624: Differences in nullability of reference types in argument of type 'IOut<object>' prevent it from being used as an output of type 'IOut<object?>' for parameter 'z' in 'void C.G(out I<object?> x, out IIn<object?> y, out IOut<object?> z)'.
+                // (8,29): warning CS8624: Argument of type 'IOut<object>' cannot be used as an output of type 'IOut<object?>' for parameter 'z' in 'void C.G(out I<object?> x, out IIn<object?> y, out IOut<object?> z)' due to differences in the nullability of reference types.
                 //         G(out x, out y, out z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "z").WithArguments("IOut<object>", "IOut<object?>", "z", "void C.G(out I<object?> x, out IIn<object?> y, out IOut<object?> z)").WithLocation(8, 29),
-                // (12,15): warning CS8624: Differences in nullability of reference types in argument of type 'I<object?>' prevent it from being used as an output of type 'I<object>' for parameter 'x' in 'void C.F(out I<object> x, out IIn<object> y, out IOut<object> z)'.
+                // (12,15): warning CS8624: Argument of type 'I<object?>' cannot be used as an output of type 'I<object>' for parameter 'x' in 'void C.F(out I<object> x, out IIn<object> y, out IOut<object> z)' due to differences in the nullability of reference types.
                 //         F(out x, out y, out z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "x").WithArguments("I<object?>", "I<object>", "x", "void C.F(out I<object> x, out IIn<object> y, out IOut<object> z)").WithLocation(12, 15),
-                // (12,22): warning CS8624: Differences in nullability of reference types in argument of type 'IIn<object?>' prevent it from being used as an output of type 'IIn<object>' for parameter 'y' in 'void C.F(out I<object> x, out IIn<object> y, out IOut<object> z)'.
+                // (12,22): warning CS8624: Argument of type 'IIn<object?>' cannot be used as an output of type 'IIn<object>' for parameter 'y' in 'void C.F(out I<object> x, out IIn<object> y, out IOut<object> z)' due to differences in the nullability of reference types.
                 //         F(out x, out y, out z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "y").WithArguments("IIn<object?>", "IIn<object>", "y", "void C.F(out I<object> x, out IIn<object> y, out IOut<object> z)").WithLocation(12, 22)
                 );
@@ -31447,28 +31451,28 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,15): warning CS8620: Differences in nullability of reference types in argument of type 'I<object>' prevent it from being used as an input of type 'I<object?>' for parameter 'x' in 'void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)'.
+                // (8,15): warning CS8620: Argument of type 'I<object>' cannot be used as an input of type 'I<object?>' for parameter 'x' in 'void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)' due to differences in the nullability of reference types.
                 //         G(ref x, ref y, ref z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("I<object>", "I<object?>", "x", "void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)").WithLocation(8, 15),
-                // (8,15): warning CS8624: Differences in nullability of reference types in argument of type 'I<object>' prevent it from being used as an output of type 'I<object?>' for parameter 'x' in 'void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)'.
+                // (8,15): warning CS8624: Argument of type 'I<object>' cannot be used as an output of type 'I<object?>' for parameter 'x' in 'void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)' due to differences in the nullability of reference types.
                 //         G(ref x, ref y, ref z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "x").WithArguments("I<object>", "I<object?>", "x", "void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)").WithLocation(8, 15),
-                // (8,22): warning CS8620: Differences in nullability of reference types in argument of type 'IIn<object>' prevent it from being used as an input of type 'IIn<object?>' for parameter 'y' in 'void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)'.
+                // (8,22): warning CS8620: Argument of type 'IIn<object>' cannot be used as an input of type 'IIn<object?>' for parameter 'y' in 'void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)' due to differences in the nullability of reference types.
                 //         G(ref x, ref y, ref z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("IIn<object>", "IIn<object?>", "y", "void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)").WithLocation(8, 22),
-                // (8,29): warning CS8624: Differences in nullability of reference types in argument of type 'IOut<object>' prevent it from being used as an output of type 'IOut<object?>' for parameter 'z' in 'void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)'.
+                // (8,29): warning CS8624: Argument of type 'IOut<object>' cannot be used as an output of type 'IOut<object?>' for parameter 'z' in 'void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)' due to differences in the nullability of reference types.
                 //         G(ref x, ref y, ref z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "z").WithArguments("IOut<object>", "IOut<object?>", "z", "void C.G(ref I<object?> x, ref IIn<object?> y, ref IOut<object?> z)").WithLocation(8, 29),
-                // (12,15): warning CS8620: Differences in nullability of reference types in argument of type 'I<object?>' prevent it from being used as an input of type 'I<object>' for parameter 'x' in 'void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)'.
+                // (12,15): warning CS8620: Argument of type 'I<object?>' cannot be used as an input of type 'I<object>' for parameter 'x' in 'void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)' due to differences in the nullability of reference types.
                 //         F(ref x, ref y, ref z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("I<object?>", "I<object>", "x", "void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)").WithLocation(12, 15),
-                // (12,15): warning CS8624: Differences in nullability of reference types in argument of type 'I<object?>' prevent it from being used as an output of type 'I<object>' for parameter 'x' in 'void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)'.
+                // (12,15): warning CS8624: Argument of type 'I<object?>' cannot be used as an output of type 'I<object>' for parameter 'x' in 'void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)' due to differences in the nullability of reference types.
                 //         F(ref x, ref y, ref z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "x").WithArguments("I<object?>", "I<object>", "x", "void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)").WithLocation(12, 15),
-                // (12,22): warning CS8624: Differences in nullability of reference types in argument of type 'IIn<object?>' prevent it from being used as an output of type 'IIn<object>' for parameter 'y' in 'void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)'.
+                // (12,22): warning CS8624: Argument of type 'IIn<object?>' cannot be used as an output of type 'IIn<object>' for parameter 'y' in 'void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)' due to differences in the nullability of reference types.
                 //         F(ref x, ref y, ref z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "y").WithArguments("IIn<object?>", "IIn<object>", "y", "void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)").WithLocation(12, 22),
-                // (12,29): warning CS8620: Differences in nullability of reference types in argument of type 'IOut<object?>' prevent it from being used as an input of type 'IOut<object>' for parameter 'z' in 'void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)'.
+                // (12,29): warning CS8620: Argument of type 'IOut<object?>' cannot be used as an input of type 'IOut<object>' for parameter 'z' in 'void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)' due to differences in the nullability of reference types.
                 //         F(ref x, ref y, ref z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "z").WithArguments("IOut<object?>", "IOut<object>", "z", "void C.F(ref I<object> x, ref IIn<object> y, ref IOut<object> z)").WithLocation(12, 29)
                 );
@@ -38074,25 +38078,25 @@ class C
                 // (10,15): warning CS8604: Possible null reference argument for parameter 'a' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)'.
                 //         F(ref b, ref c, ref d, ref a); // warn 1, 2, 3 and 4
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "b").WithArguments("a", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(10, 15),
-                // (10,22): warning CS8620: Differences in nullability of reference types in argument of type 'List<string?>' prevent it from being used as an input of type 'List<string>' for parameter 'b' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)'.
+                // (10,22): warning CS8620: Argument of type 'List<string?>' cannot be used as an input of type 'List<string>' for parameter 'b' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)' due to differences in the nullability of reference types.
                 //         F(ref b, ref c, ref d, ref a); // warn 1, 2, 3 and 4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "c").WithArguments("List<string?>", "List<string>", "b", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(10, 22),
                 // (10,22): warning CS8601: Possible null reference assignment.
                 //         F(ref b, ref c, ref d, ref a); // warn 1, 2, 3 and 4
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c").WithLocation(10, 22),
-                // (10,22): warning CS8624: Differences in nullability of reference types in argument of type 'List<string?>' prevent it from being used as an output of type 'List<string>' for parameter 'b' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)'.
+                // (10,22): warning CS8624: Argument of type 'List<string?>' cannot be used as an output of type 'List<string>' for parameter 'b' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)' due to differences in the nullability of reference types.
                 //         F(ref b, ref c, ref d, ref a); // warn 1, 2, 3 and 4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "c").WithArguments("List<string?>", "List<string>", "b", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(10, 22),
                 // (10,29): warning CS8604: Possible null reference argument for parameter 'c' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)'.
                 //         F(ref b, ref c, ref d, ref a); // warn 1, 2, 3 and 4
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "d").WithArguments("c", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(10, 29),
-                // (10,36): warning CS8620: Differences in nullability of reference types in argument of type 'List<string>' prevent it from being used as an input of type 'List<string?>' for parameter 'd' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)'.
+                // (10,36): warning CS8620: Argument of type 'List<string>' cannot be used as an input of type 'List<string?>' for parameter 'd' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)' due to differences in the nullability of reference types.
                 //         F(ref b, ref c, ref d, ref a); // warn 1, 2, 3 and 4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "a").WithArguments("List<string>", "List<string?>", "d", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(10, 36),
                 // (10,36): warning CS8601: Possible null reference assignment.
                 //         F(ref b, ref c, ref d, ref a); // warn 1, 2, 3 and 4
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "a").WithLocation(10, 36),
-                // (10,36): warning CS8624: Differences in nullability of reference types in argument of type 'List<string>' prevent it from being used as an output of type 'List<string?>' for parameter 'd' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)'.
+                // (10,36): warning CS8624: Argument of type 'List<string>' cannot be used as an output of type 'List<string?>' for parameter 'd' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)' due to differences in the nullability of reference types.
                 //         F(ref b, ref c, ref d, ref a); // warn 1, 2, 3 and 4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "a").WithArguments("List<string>", "List<string?>", "d", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(10, 36)
                 );
@@ -38137,28 +38141,28 @@ class C
                 // (15,22): error CS0165: Use of unassigned local variable 'c'
                 //         F(ref b, ref c, ref d, ref a);
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "c").WithArguments("c").WithLocation(15, 22),
+                // (15,22): warning CS8620: Argument of type 'List<string?>' cannot be used as an input of type 'List<string>' for parameter 'b' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)' due to differences in the nullability of reference types.
+                //         F(ref b, ref c, ref d, ref a);
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "c").WithArguments("List<string?>", "List<string>", "b", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(15, 22),
+                // (15,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         F(ref b, ref c, ref d, ref a);
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c").WithLocation(15, 22),
+                // (15,22): warning CS8624: Argument of type 'List<string?>' cannot be used as an output of type 'List<string>' for parameter 'b' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)' due to differences in the nullability of reference types.
+                //         F(ref b, ref c, ref d, ref a);
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "c").WithArguments("List<string?>", "List<string>", "b", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(15, 22),
                 // (15,29): error CS0165: Use of unassigned local variable 'd'
                 //         F(ref b, ref c, ref d, ref a);
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "d").WithArguments("d").WithLocation(15, 29),
                 // (15,36): error CS0165: Use of unassigned local variable 'a'
                 //         F(ref b, ref c, ref d, ref a);
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "a").WithArguments("a").WithLocation(15, 36),
-                // (15,22): warning CS8620: Differences in nullability of reference types in argument of type 'List<string?>' prevent it from being used as an input of type 'List<string>' for parameter 'b' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)'.
-                //         F(ref b, ref c, ref d, ref a);
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "c").WithArguments("List<string?>", "List<string>", "b", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(15, 22),
-                // (15,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         F(ref b, ref c, ref d, ref a);
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c").WithLocation(15, 22),
-                // (15,22): warning CS8624: Differences in nullability of reference types in argument of type 'List<string?>' prevent it from being used as an output of type 'List<string>' for parameter 'b' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)'.
-                //         F(ref b, ref c, ref d, ref a);
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "c").WithArguments("List<string?>", "List<string>", "b", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(15, 22),
-                // (15,36): warning CS8620: Differences in nullability of reference types in argument of type 'List<string>' prevent it from being used as an input of type 'List<string?>' for parameter 'd' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)'.
+                // (15,36): warning CS8620: Argument of type 'List<string>' cannot be used as an input of type 'List<string?>' for parameter 'd' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)' due to differences in the nullability of reference types.
                 //         F(ref b, ref c, ref d, ref a);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "a").WithArguments("List<string>", "List<string?>", "d", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(15, 36),
                 // (15,36): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         F(ref b, ref c, ref d, ref a);
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "a").WithLocation(15, 36),
-                // (15,36): warning CS8624: Differences in nullability of reference types in argument of type 'List<string>' prevent it from being used as an output of type 'List<string?>' for parameter 'd' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)'.
+                // (15,36): warning CS8624: Argument of type 'List<string>' cannot be used as an output of type 'List<string?>' for parameter 'd' in 'void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)' due to differences in the nullability of reference types.
                 //         F(ref b, ref c, ref d, ref a);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "a").WithArguments("List<string>", "List<string?>", "d", "void C.F(ref List<string> a, ref List<string>? b, ref List<string?> c, ref List<string?>? d)").WithLocation(15, 36),
                 // (23,15): error CS0165: Use of unassigned local variable 'b'
@@ -38204,13 +38208,13 @@ class C
                 // (11,22): warning CS8601: Possible null reference assignment.
                 //         F(out b, out c, out d, out a); // warn on `c` and `a`
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c").WithLocation(11, 22),
-                // (11,22): warning CS8624: Differences in nullability of reference types in argument of type 'List<string?>' prevent it from being used as an output of type 'List<string>' for parameter 'b' in 'void C.F(out List<string> a, out List<string>? b, out List<string?> c, out List<string?>? d)'.
+                // (11,22): warning CS8624: Argument of type 'List<string?>' cannot be used as an output of type 'List<string>' for parameter 'b' in 'void C.F(out List<string> a, out List<string>? b, out List<string?> c, out List<string?>? d)' due to differences in the nullability of reference types.
                 //         F(out b, out c, out d, out a); // warn on `c` and `a`
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "c").WithArguments("List<string?>", "List<string>", "b", "void C.F(out List<string> a, out List<string>? b, out List<string?> c, out List<string?>? d)").WithLocation(11, 22),
                 // (11,36): warning CS8601: Possible null reference assignment.
                 //         F(out b, out c, out d, out a); // warn on `c` and `a`
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "a").WithLocation(11, 36),
-                // (11,36): warning CS8624: Differences in nullability of reference types in argument of type 'List<string>' prevent it from being used as an output of type 'List<string?>' for parameter 'd' in 'void C.F(out List<string> a, out List<string>? b, out List<string?> c, out List<string?>? d)'.
+                // (11,36): warning CS8624: Argument of type 'List<string>' cannot be used as an output of type 'List<string?>' for parameter 'd' in 'void C.F(out List<string> a, out List<string>? b, out List<string?> c, out List<string?>? d)' due to differences in the nullability of reference types.
                 //         F(out b, out c, out d, out a); // warn on `c` and `a`
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "a").WithArguments("List<string>", "List<string?>", "d", "void C.F(out List<string> a, out List<string>? b, out List<string?> c, out List<string?>? d)").WithLocation(11, 36)
                 );
@@ -42204,22 +42208,22 @@ static class E
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,15): warning CS8620: Differences in nullability of reference types in argument of type '(string, string)' prevent it from being used as an input of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)'.
+                // (7,15): warning CS8620: Argument of type '(string, string)' cannot be used as an input of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)' due to differences in the nullability of reference types.
                 //         F(ref t1).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "t1").WithArguments("(string, string)", "(string, string?)", "t", "string C.F<string>(ref (string, string?) t)").WithLocation(7, 15),
-                // (7,15): warning CS8624: Differences in nullability of reference types in argument of type '(string, string)' prevent it from being used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)'.
+                // (7,15): warning CS8624: Argument of type '(string, string)' cannot be used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)' due to differences in the nullability of reference types.
                 //         F(ref t1).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "t1").WithArguments("(string, string)", "(string, string?)", "t", "string C.F<string>(ref (string, string?) t)").WithLocation(7, 15),
-                // (11,15): warning CS8620: Differences in nullability of reference types in argument of type '(string?, string)' prevent it from being used as an input of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)'.
+                // (11,15): warning CS8620: Argument of type '(string?, string)' cannot be used as an input of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)' due to differences in the nullability of reference types.
                 //         F(ref t3).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "t3").WithArguments("(string?, string)", "(string, string?)", "t", "string C.F<string>(ref (string, string?) t)").WithLocation(11, 15),
-                // (11,15): warning CS8624: Differences in nullability of reference types in argument of type '(string?, string)' prevent it from being used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)'.
+                // (11,15): warning CS8624: Argument of type '(string?, string)' cannot be used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)' due to differences in the nullability of reference types.
                 //         F(ref t3).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "t3").WithArguments("(string?, string)", "(string, string?)", "t", "string C.F<string>(ref (string, string?) t)").WithLocation(11, 15),
-                // (13,15): warning CS8620: Differences in nullability of reference types in argument of type '(string?, string?)' prevent it from being used as an input of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)'.
+                // (13,15): warning CS8620: Argument of type '(string?, string?)' cannot be used as an input of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)' due to differences in the nullability of reference types.
                 //         F(ref t4).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "t4").WithArguments("(string?, string?)", "(string, string?)", "t", "string C.F<string>(ref (string, string?) t)").WithLocation(13, 15),
-                // (13,15): warning CS8624: Differences in nullability of reference types in argument of type '(string?, string?)' prevent it from being used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)'.
+                // (13,15): warning CS8624: Argument of type '(string?, string?)' cannot be used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(ref (string, string?) t)' due to differences in the nullability of reference types.
                 //         F(ref t4).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "t4").WithArguments("(string?, string?)", "(string, string?)", "t", "string C.F<string>(ref (string, string?) t)").WithLocation(13, 15)
                 );
@@ -42242,13 +42246,13 @@ static class E
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,15): warning CS8624: Differences in nullability of reference types in argument of type '(string, string)' prevent it from being used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(out (string, string?) t)'.
+                // (6,15): warning CS8624: Argument of type '(string, string)' cannot be used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(out (string, string?) t)' due to differences in the nullability of reference types.
                 //         F(out (string, string) t1).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "(string, string) t1").WithArguments("(string, string)", "(string, string?)", "t", "string C.F<string>(out (string, string?) t)").WithLocation(6, 15),
-                // (8,15): warning CS8624: Differences in nullability of reference types in argument of type '(string?, string)' prevent it from being used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(out (string, string?) t)'.
+                // (8,15): warning CS8624: Argument of type '(string?, string)' cannot be used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(out (string, string?) t)' due to differences in the nullability of reference types.
                 //         F(out (string?, string) t3).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "(string?, string) t3").WithArguments("(string?, string)", "(string, string?)", "t", "string C.F<string>(out (string, string?) t)").WithLocation(8, 15),
-                // (9,15): warning CS8624: Differences in nullability of reference types in argument of type '(string?, string?)' prevent it from being used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(out (string, string?) t)'.
+                // (9,15): warning CS8624: Argument of type '(string?, string?)' cannot be used as an output of type '(string, string?)' for parameter 't' in 'string C.F<string>(out (string, string?) t)' due to differences in the nullability of reference types.
                 //         F(out (string?, string?) t4).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput, "(string?, string?) t4").WithArguments("(string?, string?)", "(string, string?)", "t", "string C.F<string>(out (string, string?) t)").WithLocation(9, 15)
                 );

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -285,6 +285,7 @@ class X
                         case ErrorCode.WRN_UninitializedNonNullableField:
                         case ErrorCode.WRN_NullabilityMismatchInAssignment:
                         case ErrorCode.WRN_NullabilityMismatchInArgument:
+                        case ErrorCode.WRN_NullabilityMismatchInArgumentForOutput:
                         case ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate:
                         case ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate:
                         case ErrorCode.WRN_NullAsNonNullable:


### PR DESCRIPTION
`VisitArgumentConversion` tracks an invocation with a `ref` argument as an assignment from argument result to parameter, then from parameter to argument as l-value.
To achieve that without visiting the argument twice, I removed `VisitLValue` and keep track of l-value types when visiting expressions. The `NullableWalker._resultType` is now a pair of TSWAs (one for result type and the other for l-value type).

I made a small adjustment to the order of parameters for some methods, so that the BoundExpression and the TSWA for a given input would be grouped together. For example, `TrackNullableStateForAssignment(BoundExpression value, TypeSymbolWithAnnotations valueType, TypeSymbolWithAnnotations targetType, ...)` (which is easier to read than previous order).

Fixes https://github.com/dotnet/roslyn/issues/26739
Fixes https://github.com/dotnet/roslyn/issues/29958