### PR TITLE
ChangeSignature: select parameter based on cursor position

### DIFF
--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignature_Delegates.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignature_Delegates.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ChangeSignature
         public async Task ChangeSignature_Delegates_ImplicitInvokeCalls()
         {
             var markup = @"
-delegate void $$MyDelegate(int x, string y, bool z);
+delegate void MyDelegate($$int x, string y, bool z);
 
 class C
 {
@@ -49,14 +49,15 @@ class C
         d1(true, ""Two"");
     }
 }";
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature,
+                expectedUpdatedInvocationDocumentCode: expectedUpdatedCode, expectedSelectedIndex: 0);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
         public async Task ChangeSignature_Delegates_ExplicitInvokeCalls()
         {
             var markup = @"
-delegate void $$MyDelegate(int x, string y, bool z);
+delegate void MyDelegate(int x, string $$y, bool z);
 
 class C
 {
@@ -78,14 +79,15 @@ class C
         d1.Invoke(true, ""Two"");
     }
 }";
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature,
+                expectedUpdatedInvocationDocumentCode: expectedUpdatedCode, expectedSelectedIndex: 1);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
         public async Task ChangeSignature_Delegates_BeginInvokeCalls()
         {
             var markup = @"
-delegate void $$MyDelegate(int x, string y, bool z);
+delegate void MyDelegate(int x, string y, bool z$$);
 
 class C
 {
@@ -107,7 +109,8 @@ class C
         d1.BeginInvoke(true, ""Two"", null, null);
     }
 }";
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature,
+                expectedUpdatedInvocationDocumentCode: expectedUpdatedCode, expectedSelectedIndex: 2);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
@@ -740,7 +743,8 @@ class Test
         var dele = new CD<int>.D(() => { });
     }
 }";
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature, expectedUpdatedInvocationDocumentCode: expectedUpdatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: updatedSignature,
+                expectedUpdatedInvocationDocumentCode: expectedUpdatedCode, expectedSelectedIndex: 0);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.InvocationLocation.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.InvocationLocation.cs
@@ -33,7 +33,8 @@ class MyClass
     }
 }";
 
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation,
+                expectedUpdatedInvocationDocumentCode: updatedCode, expectedSelectedIndex: 0);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
@@ -57,7 +58,8 @@ class MyClass
     }
 }";
 
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation,
+                expectedUpdatedInvocationDocumentCode: updatedCode, expectedSelectedIndex: 1);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
@@ -541,7 +543,8 @@ class Program
     }
 }";
 
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation,
+                expectedUpdatedInvocationDocumentCode: updatedCode, expectedSelectedIndex: 0);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
@@ -567,7 +570,8 @@ class Program
     }
 }";
 
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation,
+                expectedUpdatedInvocationDocumentCode: updatedCode, expectedSelectedIndex: 1);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
@@ -593,7 +597,8 @@ class Program
     }
 }";
 
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation,
+                expectedUpdatedInvocationDocumentCode: updatedCode, expectedSelectedIndex: 0);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
@@ -691,7 +696,8 @@ class Program
     }
 }";
 
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation,
+                expectedUpdatedInvocationDocumentCode: updatedCode, expectedSelectedIndex: 0);
         }
 
         #endregion
@@ -723,7 +729,8 @@ public class C
     public delegate void D(int y, int x);
 }";
 
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation,
+                expectedUpdatedInvocationDocumentCode: updatedCode, expectedSelectedIndex: 0);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
@@ -265,6 +265,8 @@ public static class CExt
     { }
 }";
 
+            // Although the `ParameterConfig` has 0 for the `SelectedIndex`, the UI dialog will make an adjustment
+            // and select parameter `y` instead because the `this` parameter cannot be moved or removed.
             await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation,
                 expectedUpdatedInvocationDocumentCode: updatedCode, expectedSelectedIndex: 0);
         }

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
@@ -246,7 +246,7 @@ public class C
 
 public static class CExt
 {
-    public static void $$M(this C goo, int x, int y, string a = ""test_a"", string b = ""test_b"", string c = ""test_c"")
+    public static void M(this $$C goo, int x, int y, string a = ""test_a"", string b = ""test_b"", string c = ""test_c"")
     { }
 }";
             var permutation = new[] { 0, 2, 1, 5, 4, 3 };
@@ -265,7 +265,8 @@ public static class CExt
     { }
 }";
 
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation,
+                expectedUpdatedInvocationDocumentCode: updatedCode, expectedSelectedIndex: 0);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
@@ -282,7 +283,7 @@ public class C
 
 public static class CExt
 {
-    public static void $$M(this C goo, int x, int y, string a = ""test_a"", string b = ""test_b"", string c = ""test_c"")
+    public static void M(this C goo, int x$$, int y, string a = ""test_a"", string b = ""test_b"", string c = ""test_c"")
     { }
 }";
             var permutation = new[] { 0, 2, 1, 5, 4, 3 };
@@ -301,7 +302,8 @@ public static class CExt
     { }
 }";
 
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation,
+                expectedUpdatedInvocationDocumentCode: updatedCode, expectedSelectedIndex: 1);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
@@ -391,7 +393,8 @@ public static class CExt
     { }
 }";
 
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation,
+                expectedUpdatedInvocationDocumentCode: updatedCode, expectedSelectedIndex: 0);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]

--- a/src/EditorFeatures/TestUtilities/ChangeSignature/AbstractChangeSignatureTests.cs
+++ b/src/EditorFeatures/TestUtilities/ChangeSignature/AbstractChangeSignatureTests.cs
@@ -62,7 +62,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature
             string expectedErrorText = null,
             int? totalParameters = null,
             bool verifyNoDiagnostics = false,
-            ParseOptions parseOptions = null)
+            ParseOptions parseOptions = null,
+            int expectedSelectedIndex = -1)
         {
             using (var testState = ChangeSignatureTestState.Create(markup, languageName, parseOptions))
             {
@@ -102,6 +103,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature
                     {
                         Assert.True(false, CreateDiagnosticsString(diagnostics, updatedSignature, totalParameters, (await testState.InvocationDocument.GetTextAsync()).ToString()));
                     }
+                }
+
+                if (expectedSelectedIndex != -1)
+                {
+                    var parameterConfiguration = testState.GetParameterConfiguration();
+                    Assert.Equal(expectedSelectedIndex, parameterConfiguration.SelectedIndex);
                 }
             }
         }

--- a/src/EditorFeatures/TestUtilities/ChangeSignature/AbstractChangeSignatureTests.cs
+++ b/src/EditorFeatures/TestUtilities/ChangeSignature/AbstractChangeSignatureTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature
 
                 if (expectedSelectedIndex != -1)
                 {
-                    var parameterConfiguration = testState.GetParameterConfiguration();
+                    var parameterConfiguration = await testState.GetParameterConfigurationAsync();
                     Assert.Equal(expectedSelectedIndex, parameterConfiguration.SelectedIndex);
                 }
             }

--- a/src/EditorFeatures/TestUtilities/ChangeSignature/ChangeSignatureTestState.cs
+++ b/src/EditorFeatures/TestUtilities/ChangeSignature/ChangeSignatureTestState.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.ChangeSignature;
 using Microsoft.CodeAnalysis.CSharp;
@@ -81,12 +82,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature
                 CancellationToken.None);
         }
 
-        public ParameterConfiguration GetParameterConfiguration()
+        public async Task<ParameterConfiguration> GetParameterConfigurationAsync()
         {
             WpfTestRunner.RequireWpfFact($"{nameof(AbstractChangeSignatureService.ChangeSignature)} currently needs to run on a WPF Fact because it's factored in a way that tries popping up UI in some cases.");
 
-            var context = ChangeSignatureService.GetContextAsync(InvocationDocument, _testDocument.CursorPosition.Value, restrictToDeclarations: false, CancellationToken.None)
-                .WaitAndGetResult(CancellationToken.None);
+            var context = await ChangeSignatureService.GetContextAsync(InvocationDocument, _testDocument.CursorPosition.Value, restrictToDeclarations: false, CancellationToken.None);
             return context.ParameterConfiguration;
         }
 

--- a/src/EditorFeatures/TestUtilities/ChangeSignature/ChangeSignatureTestState.cs
+++ b/src/EditorFeatures/TestUtilities/ChangeSignature/ChangeSignatureTestState.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.ChangeSignature;
 using Microsoft.VisualStudio.Composition;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature
 {
@@ -78,6 +79,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature
                     this.ErrorSeverity = severity;
                 },
                 CancellationToken.None);
+        }
+
+        public ParameterConfiguration GetParameterConfiguration()
+        {
+            WpfTestRunner.RequireWpfFact($"{nameof(AbstractChangeSignatureService.ChangeSignature)} currently needs to run on a WPF Fact because it's factored in a way that tries popping up UI in some cases.");
+
+            var context = ChangeSignatureService.GetContextAsync(InvocationDocument, _testDocument.CursorPosition.Value, restrictToDeclarations: false, CancellationToken.None)
+                .WaitAndGetResult(CancellationToken.None);
+            return context.ParameterConfiguration;
         }
 
         private static readonly IExportProviderFactory s_exportProviderFactory =

--- a/src/EditorFeatures/TestUtilities/ChangeSignature/TestChangeSignatureOptionsService.cs
+++ b/src/EditorFeatures/TestUtilities/ChangeSignature/TestChangeSignatureOptionsService.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature
                 IsCancelled = IsCancelled,
                 UpdatedSignature = new SignatureChange(
                     parameters,
-                    UpdatedSignature == null ? parameters : ParameterConfiguration.Create(UpdatedSignature.Select(i => list[i]).ToList(), parameters.ThisParameter != null))
+                    UpdatedSignature == null ? parameters : ParameterConfiguration.Create(UpdatedSignature.Select(i => list[i]).ToList(), parameters.ThisParameter != null, selectedIndex: 0))
             };
         }
     }

--- a/src/EditorFeatures/VisualBasicTest/ChangeSignature/ChangeSignature_Delegates.vb
+++ b/src/EditorFeatures/VisualBasicTest/ChangeSignature/ChangeSignature_Delegates.vb
@@ -45,13 +45,14 @@ Class C
     End Sub
 End Class
 ]]></Text>.NormalizedValue()
-            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=updatedSignature, expectedUpdatedInvocationDocumentCode:=expectedUpdatedCode)
+            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=updatedSignature,
+                                                     expectedUpdatedInvocationDocumentCode:=expectedUpdatedCode, expectedSelectedIndex:=0)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>
         Public Async Function TestChangeSignature_Delegates_ExplicitInvokeCalls() As Task
             Dim markup = <Text><![CDATA[
-Delegate Sub $$MySub(x As Integer, y As String, z As Boolean)
+Delegate Sub MySub($$x As Integer, y As String, z As Boolean)
 
 Class C
     Sub M()
@@ -71,13 +72,14 @@ Class C
     End Sub
 End Class
 ]]></Text>.NormalizedValue()
-            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=updatedSignature, expectedUpdatedInvocationDocumentCode:=expectedUpdatedCode)
+            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=updatedSignature,
+                                                     expectedUpdatedInvocationDocumentCode:=expectedUpdatedCode, expectedSelectedIndex:=0)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>
         Public Async Function TestChangeSignature_Delegates_BeginInvokeCalls() As Task
             Dim markup = <Text><![CDATA[
-Delegate Sub $$MySub(x As Integer, y As String, z As Boolean)
+Delegate Sub MySub(x As Integer$$, y As String, z As Boolean)
 
 Class C
     Sub M()
@@ -97,13 +99,14 @@ Class C
     End Sub
 End Class
 ]]></Text>.NormalizedValue()
-            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=updatedSignature, expectedUpdatedInvocationDocumentCode:=expectedUpdatedCode)
+            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=updatedSignature,
+                                                     expectedUpdatedInvocationDocumentCode:=expectedUpdatedCode, expectedSelectedIndex:=0)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>
         Public Async Function TestChangeSignature_Delegates_SubLambdas() As Task
             Dim markup = <Text><![CDATA[
-Delegate Sub $$MySub(x As Integer, y As String, z As Boolean)
+Delegate Sub MySub(x As Integer, $$y As String, z As Boolean)
 
 Class C
     Sub M()
@@ -137,13 +140,14 @@ Class C
     End Sub
 End Class
 ]]></Text>.NormalizedValue()
-            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=updatedSignature, expectedUpdatedInvocationDocumentCode:=expectedUpdatedCode)
+            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=updatedSignature,
+                                                     expectedUpdatedInvocationDocumentCode:=expectedUpdatedCode, expectedSelectedIndex:=1)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>
         Public Async Function TestChangeSignature_Delegates_FunctionLambdas() As Task
             Dim markup = <Text><![CDATA[
-Delegate Function $$MyFunc(x As Integer, y As String, z As Boolean) As Integer
+Delegate Function MyFunc(x As Integer, y As String, $$z As Boolean) As Integer
 
 Class C
     Sub M()
@@ -181,7 +185,8 @@ Class C
     End Sub
 End Class
 ]]></Text>.NormalizedValue()
-            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=updatedSignature, expectedUpdatedInvocationDocumentCode:=expectedUpdatedCode)
+            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=updatedSignature,
+                                                     expectedUpdatedInvocationDocumentCode:=expectedUpdatedCode, expectedSelectedIndex:=2)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>

--- a/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParametersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParametersTests.vb
@@ -146,7 +146,7 @@ End Class
 
 Module CExt
     <System.Runtime.CompilerServices.Extension()>
-    $$Public Sub M(ByVal this As C, x As Integer, y As Integer, Optional a As String = "test_a", Optional b As String = "test_b", Optional c As String = "test_c")
+    Public Sub M($$ByVal this As C, x As Integer, y As Integer, Optional a As String = "test_a", Optional b As String = "test_b", Optional c As String = "test_c")
     End Sub
 End Module]]></Text>.NormalizedValue()
             Dim permutation = {0, 2, 1, 5, 4, 3}
@@ -163,7 +163,10 @@ Module CExt
     End Sub
 End Module]]></Text>.NormalizedValue()
 
-            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=permutation, expectedUpdatedInvocationDocumentCode:=updatedCode)
+            ' Although the `ParameterConfig` has 0 for the `SelectedIndex`, the UI dialog will make an adjustment
+            ' and select parameter `y` instead because the `this` parameter cannot be moved or removed.
+            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=permutation,
+                                                     expectedUpdatedInvocationDocumentCode:=updatedCode, expectedSelectedIndex:=0)
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -138,41 +138,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             return parameters == null ? 0 : GetParameterIndex(parameters.Parameters, position);
         }
 
-        /// <summary>
-        /// Given the cursor position, find which parameter is selected.
-        /// Returns 0 as the default value. Note that the ChangeSignature dialog adjusts the selection for
-        /// the `this` parameter in extension methods (the selected index won't remain 0).
-        /// </summary>
-        private static int GetParameterIndex(SeparatedSyntaxList<ParameterSyntax> parameters, int position)
-        {
-            if (parameters.Count == 0)
-            {
-                return 0;
-            }
-
-            if (position < parameters.Span.Start)
-            {
-                return 0;
-            }
-
-            if (position > parameters.Span.End)
-            {
-                return 0;
-            }
-
-            for (int i = 0; i < parameters.Count - 1; i++)
-            {
-                // `$$,` points to the argument before the separator
-                // but `,$$` points to the argument following the separator
-                if (position <= parameters.GetSeparator(i).Span.Start)
-                {
-                    return i;
-                }
-            }
-
-            return parameters.Count - 1;
-        }
-
         private SyntaxNode GetMatchingNode(SyntaxNode node, bool restrictToDeclarations)
         {
             var matchKinds = restrictToDeclarations

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -135,13 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
         private static int TryGetSelectedIndexFromDeclaration(int position, SyntaxNode matchingNode)
         {
             var parameters = matchingNode.ChildNodes().OfType<BaseParameterListSyntax>().SingleOrDefault();
-            var selectedIndex = 0;
-            if (parameters != null)
-            {
-                selectedIndex = GetParameterIndex(parameters.Parameters, position);
-            }
-
-            return selectedIndex;
+            return parameters == null ? 0 : GetParameterIndex(parameters.Parameters, position);
         }
 
         /// <summary>

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
         private static int TryGetSelectedIndexFromDeclaration(int position, SyntaxNode matchingNode)
         {
             var parameters = matchingNode.ChildNodes().OfType<BaseParameterListSyntax>().SingleOrDefault();
-            return parameters == null ? 0 : GetParameterIndex(parameters.Parameters, position);
+            return parameters != null ? GetParameterIndex(parameters.Parameters, position) : 0;
         }
 
         private SyntaxNode GetMatchingNode(SyntaxNode node, bool restrictToDeclarations)

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             SyntaxKind.ParenthesizedLambdaExpression,
             SyntaxKind.SimpleLambdaExpression);
 
-        public override async Task<ISymbol> GetInvocationSymbolAsync(
+        public override async Task<(ISymbol symbol, int selectedIndex)> GetInvocationSymbolAsync(
             Document document, int position, bool restrictToDeclarations, CancellationToken cancellationToken)
         {
             var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
@@ -90,27 +90,28 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             var matchingNode = GetMatchingNode(token.Parent, restrictToDeclarations);
             if (matchingNode == null)
             {
-                return null;
+                return default;
             }
 
             // Don't show change-signature in the random whitespace/trivia for code.
             if (!matchingNode.Span.IntersectsWith(position))
             {
-                return null;
+                return default;
             }
 
             // If we're actually on the declaration of some symbol, ensure that we're
             // in a good location for that symbol (i.e. not in the attributes/constraints).
             if (!InSymbolHeader(matchingNode, position))
             {
-                return null;
+                return default;
             }
 
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var symbol = semanticModel.GetDeclaredSymbol(matchingNode, cancellationToken);
             if (symbol != null)
             {
-                return symbol;
+                var selectedIndex = TryGetSelectedIndexFromDeclaration(position, matchingNode);
+                return (symbol, selectedIndex);
             }
 
             if (matchingNode.IsKind(SyntaxKind.ObjectCreationExpression))
@@ -122,13 +123,60 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
                     var typeSymbol = semanticModel.GetSymbolInfo(objectCreation.Type, cancellationToken).Symbol;
                     if (typeSymbol != null && typeSymbol.IsKind(SymbolKind.NamedType) && (typeSymbol as ITypeSymbol).TypeKind == TypeKind.Delegate)
                     {
-                        return typeSymbol;
+                        return (typeSymbol, 0);
                     }
                 }
             }
 
             var symbolInfo = semanticModel.GetSymbolInfo(matchingNode, cancellationToken);
-            return symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+            return (symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault(), 0);
+        }
+
+        private static int TryGetSelectedIndexFromDeclaration(int position, SyntaxNode matchingNode)
+        {
+            var parameters = matchingNode.ChildNodes().OfType<BaseParameterListSyntax>().SingleOrDefault();
+            var selectedIndex = 0;
+            if (parameters != null)
+            {
+                selectedIndex = GetParameterIndex(parameters.Parameters, position);
+            }
+
+            return selectedIndex;
+        }
+
+        /// <summary>
+        /// Given the cursor position, find which parameter is selected.
+        /// Returns 0 as the default value. Note that the ChangeSignature dialog adjusts the selection for
+        /// the `this` parameter in extension methods (the selected index won't remain 0).
+        /// </summary>
+        private static int GetParameterIndex(SeparatedSyntaxList<ParameterSyntax> parameters, int position)
+        {
+            if (parameters.Count == 0)
+            {
+                return 0;
+            }
+
+            if (position < parameters.Span.Start)
+            {
+                return 0;
+            }
+
+            if (position > parameters.Span.End)
+            {
+                return 0;
+            }
+
+            for (int i = 0; i < parameters.Count - 1; i++)
+            {
+                // `$$,` points to the argument before the separator
+                // but `,$$` points to the argument following the separator
+                if (position <= parameters.GetSeparator(i).Span.Start)
+                {
+                    return i;
+                }
+            }
+
+            return parameters.Count - 1;
         }
 
         private SyntaxNode GetMatchingNode(SyntaxNode node, bool restrictToDeclarations)

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -533,5 +533,40 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
 
             return parametersToPermute;
         }
+
+        /// <summary>
+        /// Given the cursor position, find which parameter is selected.
+        /// Returns 0 as the default value. Note that the ChangeSignature dialog adjusts the selection for
+        /// the `this` parameter in extension methods (the selected index won't remain 0).
+        /// </summary>
+        protected static int GetParameterIndex<TNode>(SeparatedSyntaxList<TNode> parameters, int position) where TNode : SyntaxNode
+        {
+            if (parameters.Count == 0)
+            {
+                return 0;
+            }
+
+            if (position < parameters.Span.Start)
+            {
+                return 0;
+            }
+
+            if (position > parameters.Span.End)
+            {
+                return 0;
+            }
+
+            for (int i = 0; i < parameters.Count - 1; i++)
+            {
+                // `$$,` points to the argument before the separator
+                // but `,$$` points to the argument following the separator
+                if (position <= parameters.GetSeparator(i).Span.Start)
+                {
+                    return i;
+                }
+            }
+
+            return parameters.Count - 1;
+        }
     }
 }

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -539,7 +539,8 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         /// Returns 0 as the default value. Note that the ChangeSignature dialog adjusts the selection for
         /// the `this` parameter in extension methods (the selected index won't remain 0).
         /// </summary>
-        protected static int GetParameterIndex<TNode>(SeparatedSyntaxList<TNode> parameters, int position) where TNode : SyntaxNode
+        protected static int GetParameterIndex<TNode>(SeparatedSyntaxList<TNode> parameters, int position)
+            where TNode : SyntaxNode
         {
             if (parameters.Count == 0)
             {

--- a/src/Features/Core/Portable/ChangeSignature/ParameterConfiguration.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ParameterConfiguration.cs
@@ -10,16 +10,18 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         public readonly List<IParameterSymbol> ParametersWithoutDefaultValues;
         public readonly List<IParameterSymbol> RemainingEditableParameters;
         public readonly IParameterSymbol ParamsParameter;
+        public readonly int SelectedIndex;
 
-        public ParameterConfiguration(IParameterSymbol thisParameter, List<IParameterSymbol> parametersWithoutDefaultValues, List<IParameterSymbol> remainingEditableParameters, IParameterSymbol paramsParameter)
+        public ParameterConfiguration(IParameterSymbol thisParameter, List<IParameterSymbol> parametersWithoutDefaultValues, List<IParameterSymbol> remainingEditableParameters, IParameterSymbol paramsParameter, int selectedIndex)
         {
             this.ThisParameter = thisParameter;
             this.ParametersWithoutDefaultValues = parametersWithoutDefaultValues;
             this.RemainingEditableParameters = remainingEditableParameters;
             this.ParamsParameter = paramsParameter;
+            this.SelectedIndex = selectedIndex;
         }
 
-        public static ParameterConfiguration Create(List<IParameterSymbol> parameters, bool isExtensionMethod)
+        public static ParameterConfiguration Create(List<IParameterSymbol> parameters, bool isExtensionMethod, int selectedIndex)
         {
             IParameterSymbol thisParameter = null;
             var parametersWithoutDefaultValues = new List<IParameterSymbol>();
@@ -49,7 +51,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
                 (seenDefaultValues ? remainingReorderableParameters : parametersWithoutDefaultValues).Add(param);
             }
 
-            return new ParameterConfiguration(thisParameter, parametersWithoutDefaultValues, remainingReorderableParameters, paramsParameter);
+            return new ParameterConfiguration(thisParameter, parametersWithoutDefaultValues, remainingReorderableParameters, paramsParameter, selectedIndex);
         }
 
         public List<IParameterSymbol> ToListOfParameters()

--- a/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
+++ b/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
@@ -104,7 +104,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
             Dim semanticModel = Await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(False)
             Dim symbol = TryGetDeclaredSymbol(semanticModel, matchingNode, token, cancellationToken)
             If symbol IsNot Nothing Then
-                Return (symbol, 0)
+                Dim selectedIndex = TryGetSelectedIndexFromDeclaration(position, matchingNode)
+                Return (symbol, selectedIndex)
             End If
 
             If matchingNode.Kind() = SyntaxKind.ObjectCreationExpression Then
@@ -119,6 +120,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
 
             Dim symbolInfo = semanticModel.GetSymbolInfo(matchingNode, cancellationToken)
             Return (If(symbolInfo.Symbol, symbolInfo.CandidateSymbols.FirstOrDefault()), 0)
+        End Function
+
+        Private Function TryGetSelectedIndexFromDeclaration(position As Integer, matchingNode As SyntaxNode) As Integer
+            Dim parameters = matchingNode.ChildNodes().OfType(Of ParameterListSyntax)().SingleOrDefault()
+            Return If(parameters Is Nothing, 0, GetParameterIndex(parameters.Parameters, position))
         End Function
 
         Private Function GetMatchingNode(node As SyntaxNode, restrictToDeclarations As Boolean) As SyntaxNode

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialogViewModel.cs
@@ -39,12 +39,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
             _classificationFormatMap = classificationFormatMap;
             _classificationTypeMap = classificationTypeMap;
 
-            int startingSelectedIndex = 0;
-
             if (parameters.ThisParameter != null)
             {
-                startingSelectedIndex++;
-
                 _thisParameter = new ParameterViewModel(this, parameters.ThisParameter);
                 _disabledParameters.Add(parameters.ThisParameter);
             }
@@ -59,7 +55,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
 
             _parameterGroup1 = parameters.ParametersWithoutDefaultValues.Select(p => new ParameterViewModel(this, p)).ToList();
             _parameterGroup2 = parameters.RemainingEditableParameters.Select(p => new ParameterViewModel(this, p)).ToList();
-            this.SelectedIndex = startingSelectedIndex;
+
+            var selectedIndex = parameters.SelectedIndex;
+            this.SelectedIndex = (parameters.ThisParameter != null && selectedIndex == 0) ? 1 : selectedIndex;
         }
 
         public int GetStartingSelectionIndex()
@@ -156,7 +154,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 _originalParameterConfiguration.ThisParameter,
                 _parameterGroup1.Where(p => !p.IsRemoved).Select(p => p.ParameterSymbol).ToList(),
                 _parameterGroup2.Where(p => !p.IsRemoved).Select(p => p.ParameterSymbol).ToList(),
-                (_paramsParameter == null || _paramsParameter.IsRemoved) ? null : _paramsParameter.ParameterSymbol);
+                (_paramsParameter == null || _paramsParameter.IsRemoved) ? null : _paramsParameter.ParameterSymbol,
+                selectedIndex: -1);
         }
 
         private static SymbolDisplayFormat s_symbolDeclarationDisplayFormat = new SymbolDisplayFormat(

--- a/src/VisualStudio/Core/Test/ChangeSignature/ChangeSignatureViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/ChangeSignature/ChangeSignatureViewModelTests.vb
@@ -357,7 +357,7 @@ class MyClass
 
                 Dim viewModel = New ChangeSignatureDialogViewModel(
                     New TestNotificationService(),
-                    ParameterConfiguration.Create(symbol.GetParameters().ToList(), symbol.IsExtensionMethod()),
+                    ParameterConfiguration.Create(symbol.GetParameters().ToList(), symbol.IsExtensionMethod(), selectedIndex:=0),
                     symbol,
                     workspace.ExportProvider.GetExportedValue(Of IClassificationFormatMapService)().GetClassificationFormatMap("text"),
                     workspace.ExportProvider.GetExportedValue(Of ClassificationTypeMap)())


### PR DESCRIPTION
Previously, the ChangeSignature dialog would always open with the default selection (ie. the first movable or removable parameter).
With this PR, if you select a parameter in a declaration and invoke ChangeSignature, that parameter will be selected.

![image](https://user-images.githubusercontent.com/12466233/52904696-7b277a00-31e4-11e9-91bf-2141f894fa69.png)

![image](https://user-images.githubusercontent.com/12466233/52904704-89759600-31e4-11e9-849c-0a6fb077f465.png)

If this PR is ok so far, I'll make the same change on the VB side.