### PR TITLE
Add FixReturnType fixer

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/FixReturnType/FixReturnTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/FixReturnType/FixReturnTypeTests.cs
@@ -1,0 +1,183 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.FixReturnType;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.FixReturnType
+{
+    [Trait(Traits.Feature, Traits.Features.CodeActionsFixReturnType)]
+    public partial class FixReturnTypeTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+            => (null, new CSharpFixReturnTypeCodeFixProvider());
+
+        [Fact]
+        public async Task Simple()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M()
+    {
+        [|return|] 1;
+    }
+}",
+@"class C
+{
+    int M()
+    {
+        return 1;
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ReturnString()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M()
+    {
+        [|return|] """";
+    }
+}",
+@"class C
+{
+    string M()
+    {
+        return """";
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ReturnNull()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class C
+{
+    void M()
+    {
+        [|return|] null;
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ReturnC()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M()
+    {
+        [|return|] new C();
+    }
+}",
+@"class C
+{
+    C M()
+    {
+        return new C();
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ReturnString_AsyncVoid()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    async void M()
+    {
+        [|return|] """";
+    }
+}",
+@"class C
+{
+    async System.Threading.Tasks.Task<string> M()
+    {
+        return """";
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ReturnString_AsyncTask()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    async System.Threading.Tasks.Task M()
+    {
+        [|return|] """";
+    }
+}",
+@"class C
+{
+    async System.Threading.Tasks.Task<string> M()
+    {
+        return """";
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ReturnString_LocalFunction()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M()
+    {
+        void local()
+        {
+            [|return|] """";
+        }
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        string local()
+        {
+            return """";
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ReturnString_AsyncVoid_LocalFunction()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M()
+    {
+        async void local()
+        {
+            [|return|] """";
+        }
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        async System.Threading.Tasks.Task<string> local()
+        {
+            return """";
+        }
+    }
+}");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/FixReturnType/FixReturnTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/FixReturnType/FixReturnTypeTests.cs
@@ -272,5 +272,19 @@ class C
     }
 }");
         }
+
+        [Fact]
+        public async Task ExpressionBodied()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    void M() => 1[||];
+}",
+@"class C
+{
+    int M() => 1[||];
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -539,6 +539,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix return type.
+        /// </summary>
+        internal static string Fix_return_type {
+            get {
+                return ResourceManager.GetString("Fix_return_type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to fixed statement.
         /// </summary>
         internal static string fixed_statement {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -168,6 +168,9 @@
   <data name="Declare_as_nullable" xml:space="preserve">
     <value>Declare as nullable</value>
   </data>
+  <data name="Fix_return_type" xml:space="preserve">
+    <value>Fix return type</value>
+  </data>
   <data name="Simplify_name_0" xml:space="preserve">
     <value>Simplify name '{0}'</value>
   </data>

--- a/src/Features/CSharp/Portable/CodeFixes/FixReturnType/CSharpFixReturnTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/FixReturnType/CSharpFixReturnTypeCodeFixProvider.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.FixReturnType
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.FixReturnType), Shared]
+    internal class CSharpFixReturnTypeCodeFixProvider : SyntaxEditorBasedCodeFixProvider
+    {
+        // error CS0127: Since 'M()' returns void, a return keyword must not be followed by an object expression
+        private const string CS0127 = nameof(CS0127);
+
+        // error CS1997: Since 'M()' is an async method that returns 'Task', a return keyword must not be followed by an object expression. Did you intend to return 'Task<T>'?
+        private const string CS1997 = nameof(CS1997);
+
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(CS0127, CS1997);
+
+        public CSharpFixReturnTypeCodeFixProvider()
+            : base(supportsFixAll: false)
+        {
+        }
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            if (await TryGetOldAndNewReturnTypeAsync(context.Document, context.Diagnostics, context.CancellationToken).ConfigureAwait(false) == default)
+            {
+                return;
+            }
+
+            context.RegisterCodeFix(
+               new MyCodeAction(c => FixAsync(context.Document, context.Diagnostics.First(), c)),
+               context.Diagnostics);
+        }
+
+        private async Task<(TypeSyntax declarationToFix, TypeSyntax fixedDeclaration)> TryGetOldAndNewReturnTypeAsync(
+            Document document, ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken)
+        {
+            Debug.Assert(diagnostics.Length == 1);
+            var location = diagnostics[0].Location;
+            var returnStatement = (ReturnStatementSyntax)location.FindNode(getInnermostNodeForTie: true, cancellationToken: cancellationToken);
+
+            var returnedValue = returnStatement.Expression;
+            if (returnedValue == null)
+            {
+                return default;
+            }
+
+            var (declarationTypeToFix, useTask) = TryGetDeclarationTypeToFix(returnStatement);
+            if (declarationTypeToFix == null)
+            {
+                return default;
+            }
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var returnedType = semanticModel.GetTypeInfo(returnedValue, cancellationToken).Type;
+            if (returnedType == null)
+            {
+                return default;
+            }
+
+            var fixedType = useTask
+                ? semanticModel.Compilation.TaskOfTType().Construct(returnedType)
+                : returnedType;
+            var fixedDeclaration = fixedType.GenerateTypeSyntax().WithTriviaFrom(declarationTypeToFix);
+
+            return (declarationTypeToFix, fixedDeclaration);
+        }
+
+        protected override async Task FixAllAsync(Document document, ImmutableArray<Diagnostic> diagnostics, SyntaxEditor editor, CancellationToken cancellationToken)
+        {
+            var (declarationTypeToFix, fixedDeclaration) =
+                await TryGetOldAndNewReturnTypeAsync(document, diagnostics, cancellationToken).ConfigureAwait(false);
+
+            editor.ReplaceNode(declarationTypeToFix, fixedDeclaration);
+            return;
+        }
+
+        private static (TypeSyntax type, bool useTask) TryGetDeclarationTypeToFix(SyntaxNode node)
+        {
+            if (!node.IsKind(SyntaxKind.ReturnStatement))
+            {
+                return default;
+            }
+
+            var containingMember = node.GetAncestors().FirstOrDefault(a => a.IsKind(
+                SyntaxKind.MethodDeclaration, SyntaxKind.PropertyDeclaration, SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression,
+                SyntaxKind.LocalFunctionStatement, SyntaxKind.AnonymousMethodExpression, SyntaxKind.ConstructorDeclaration, SyntaxKind.DestructorDeclaration,
+                SyntaxKind.OperatorDeclaration, SyntaxKind.IndexerDeclaration, SyntaxKind.EventDeclaration));
+
+            if (containingMember == null)
+            {
+                return default;
+            }
+
+            switch (containingMember)
+            {
+                case MethodDeclarationSyntax method:
+                    // void M() { return 1; }
+                    // async Task M() { return 1; }
+                    return (method.ReturnType, IsAsync(method.Modifiers));
+
+                case LocalFunctionStatementSyntax localFunction:
+                    // void local() { return 1; }
+                    // async Task local() { return 1; }
+                    return (localFunction.ReturnType, IsAsync(localFunction.Modifiers));
+
+                default:
+                    return default;
+            }
+
+            // Local functions
+            bool IsAsync(SyntaxTokenList modifiers)
+            {
+                return modifiers.Any(SyntaxKind.AsyncKeyword);
+            }
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
+                base(CSharpFeaturesResources.Fix_return_type,
+                     createChangedDocument,
+                     CSharpFeaturesResources.Fix_return_type)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Deklarovat jako s možnou hodnotou null</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">Dočasná vložená proměnná</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Als für NULL-Werte zulässig deklarieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">Inline temporär variabel</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Declara como que acepta valores NULL</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">Variable temporal en línea</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Déclarer comme nullable</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">Variable temporaire inline</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Dichiara come nullable</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">Variabile temporanea inline</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Null 許容型として宣言する</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">インラインの一時変数</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Nullable로 선언</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">인라인 임시 변수</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Zadeklaruj jako dopuszczający wartość null</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">Wstawiona zmienna tymczasowa</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Declarar como anulável</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">Variável temporária embutida</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Объявить как тип, допускающий значения null</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">Встроенная временная переменная</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Olarak null olabilecek ilan</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">Satır içi geçici değişken</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -72,6 +72,11 @@
         <target state="translated">声明成可为 null</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">内联临时变量</target>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -72,6 +72,11 @@
         <target state="translated">宣告為可為 Null</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_return_type">
+        <source>Fix return type</source>
+        <target state="new">Fix return type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Inline_temporary_variable">
         <source>Inline temporary variable</source>
         <target state="translated">內嵌暫存變數</target>

--- a/src/Features/Core/Portable/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Features/Core/Portable/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string FixFormatting = nameof(FixFormatting);
         public const string FixIncorrectFunctionReturnType = nameof(FixIncorrectFunctionReturnType);
         public const string FixIncorrectExitContinue = nameof(FixIncorrectExitContinue);
+        public const string FixReturnType = nameof(FixReturnType);
         public const string GenerateConstructor = nameof(GenerateConstructor);
         public const string GenerateEndConstruct = nameof(GenerateEndConstruct);
         public const string GenerateEnumMember = nameof(GenerateEnumMember);

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -83,6 +83,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsExtractInterface = "CodeActions.ExtractInterface";
             public const string CodeActionsExtractMethod = "CodeActions.ExtractMethod";
             public const string CodeActionsFixAllOccurrences = "CodeActions.FixAllOccurrences";
+            public const string CodeActionsFixReturnType = "CodeActions.FixReturnType";
             public const string CodeActionsFullyQualify = "CodeActions.FullyQualify";
             public const string CodeActionsImplementAbstractClass = "CodeActions.ImplementAbstractClass";
             public const string CodeActionsImplementInterface = "CodeActions.ImplementInterface";


### PR DESCRIPTION
If you have a method that returns `void` (or an async method that returns `void` or `Task`), but you have a return statement with a value, the FixReturnType fixer offers to fix the return type.

![image](https://user-images.githubusercontent.com/12466233/52908443-c82e3f00-322a-11e9-8b6d-1c8c570ecf23.png)

Update: I'll extend this PR to also handle VB.
