### PR TITLE
Fix issue #33242: ExtractMethodCodeRefactoringProvider throws invalid cast when used within the body of a constructor expression-member body

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -11083,5 +11083,31 @@ interface Program
 }";
             await TestExtractMethodAsync(code, expected);
         }
+
+        [WorkItem(33242, "https://github.com/dotnet/roslyn/issues/33242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        public async Task ExtractMethodInExpressionBodiedConstructors()
+        {
+            var code = @"
+class Foo
+{
+    private readonly string _bar;
+
+    private Foo(string bar) => _bar = [|bar|];
+}";
+            var expected = @"
+class Foo
+{
+    private readonly string _bar;
+
+    private Foo(string bar) => _bar = GetBar(bar);
+
+    private static string GetBar(string bar)
+    {
+        return bar;
+    }
+}";
+            await TestExtractMethodAsync(code, expected);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -11109,5 +11109,31 @@ class Foo
 }";
             await TestExtractMethodAsync(code, expected);
         }
+
+        [WorkItem(33242, "https://github.com/dotnet/roslyn/issues/33242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        public async Task ExtractMethodInExpressionBodiedFinalizers()
+        {
+            var code = @"
+class Foo
+{
+    bool finalized;
+
+    ~Foo() => finalized = [|true|];
+}";
+            var expected = @"
+class Foo
+{
+    bool finalized;
+
+    ~Foo() => finalized = NewMethod();
+
+    private static bool NewMethod()
+    {
+        return true;
+    }
+}";
+            await TestExtractMethodAsync(code, expected);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
@@ -293,6 +293,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((OperatorDeclarationSyntax)memberDeclaration).ExpressionBody;
                 case SyntaxKind.ConversionOperatorDeclaration:
                     return ((ConversionOperatorDeclarationSyntax)memberDeclaration).ExpressionBody;
+                case SyntaxKind.ConstructorDeclaration:
+                    return ((ConstructorDeclarationSyntax)memberDeclaration).ExpressionBody;
                 default:
                     return null;
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
@@ -295,6 +295,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((ConversionOperatorDeclarationSyntax)memberDeclaration).ExpressionBody;
                 case SyntaxKind.ConstructorDeclaration:
                     return ((ConstructorDeclarationSyntax)memberDeclaration).ExpressionBody;
+                case SyntaxKind.DestructorDeclaration:
+                    return ((DestructorDeclarationSyntax)memberDeclaration).ExpressionBody;
                 default:
                     return null;
             }


### PR DESCRIPTION
Fixes #33242 
This crash was caused by [`CSharpCodeGenerator.CreateStatementsOrInitializerToInsertAtCallSiteAsync()` ](https://github.com/dotnet/roslyn/blob/de57f6daeee86908cc9dcd0386d2f66d60e8cee1/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs#L137-L140) not evaluating the expression bodied constructor as such, since [`MemberDeclarationSyntaxExtensions.GetExpressionBody()`](https://github.com/dotnet/roslyn/blob/de57f6daeee86908cc9dcd0386d2f66d60e8cee1/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs#L282-L299) wasn't updated yet to handle expression bodied constructors.

It seemed most appropriate to handle that in `MemberDeclarationSyntaxExtensions`, and not in `CSharpMethodExtractor.CSharpCodeGenerator`.