### PR TITLE
Ensure pipename argument quoted

### DIFF
--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -378,10 +378,16 @@ namespace Microsoft.CodeAnalysis.CommandLine
             }
         }
 
-        internal static bool TryCreateServerCore(string clientDir, string pipeName)
+        internal static (string processFilePath, string commandLineArguments, string toolFilePath) GetServerProcessInfo(string clientDir, string pipeName)
         {
             var serverPathWithoutExtension = Path.Combine(clientDir, "VBCSCompiler");
-            var serverInfo = RuntimeHostInfo.GetProcessInfo(serverPathWithoutExtension, $"-pipename:{pipeName}");
+            var commandLineArgs = $@"""-pipename:{pipeName}""";
+            return RuntimeHostInfo.GetProcessInfo(serverPathWithoutExtension, commandLineArgs);
+        }
+
+        internal static bool TryCreateServerCore(string clientDir, string pipeName)
+        {
+            var serverInfo = GetServerProcessInfo(clientDir, pipeName);
 
             if (!File.Exists(serverInfo.toolFilePath))
             {
@@ -480,7 +486,24 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 return null;
             }
 
-            return $"{userName}.{(isAdmin ? 'T' : 'F')}.{basePipeName}";
+            return GetPipeNameCore(userName, isAdmin, basePipeName);
+        }
+
+        internal static string GetPipeNameCore(string userName, bool isAdmin, string basePipeName)
+        {
+            var pipeName = $"{userName}.{(isAdmin ? 'T' : 'F')}.{basePipeName}";
+
+            // The pipe name is passed between processes as a command line argument as a 
+            // quoted value. Unfortunately we can't use ProcessStartInfo.ArgumentList as 
+            // we still target net472 (API only available on CoreClr + netstandard). To 
+            // make the problem approachable we remove the troublesome characters.
+            //
+            // This does mean if two users on the same machine are building simultaneously
+            // and the user names differ only be a " or / and a _ then there will be a 
+            // conflict. That seems rather obscure though.
+            return pipeName
+                .Replace('"', '_')
+                .Replace('\\', '_');
         }
 
         /// <summary>

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -225,6 +225,12 @@ namespace Roslyn.Test.Utilities
         public override string SkipReason => "Test not supported on Mono";
     }
 
+    public class CoreClrOnly : ExecutionCondition
+    {
+        public override bool ShouldSkip => !ExecutionConditionUtil.IsCoreClr;
+        public override string SkipReason => "Test only supported on CoreClr";
+    }
+
     public class DesktopOnly : ExecutionCondition
     {
         public override bool ShouldSkip => !ExecutionConditionUtil.IsDesktop;


### PR DESCRIPTION
The name for the named pipe used between MSBuild and VBCSCompiler is
generated from a combination of values including the current user name,
specifically `%USERNAME%`. It is possible for this value to have spaces
in it and hence the argument must be quoted when passing it to the
command line of VBCSCompiler instances.

Regression initially introduced: #32257