### PR TITLE
Convert to struct has errors on uninitiated members

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -1092,32 +1092,33 @@ class Test
 internal struct NewStruct
 {
     public int a;
+    public object Item2;
 
     public NewStruct(int a, object item2)
     {
         this.a = a;
-        this.Item2 = item2;
+        Item2 = item2;
     }
 
     public override bool Equals(object obj)
     {
         return obj is NewStruct other &&
                a == other.a &&
-               System.Collections.Generic.EqualityComparer<object>.Default.Equals(this.Item2, other.Item2);
+               System.Collections.Generic.EqualityComparer<object>.Default.Equals(Item2, other.Item2);
     }
 
     public override int GetHashCode()
     {
         var hashCode = 913311208;
         hashCode = hashCode * -1521134295 + a.GetHashCode();
-        hashCode = hashCode * -1521134295 + System.Collections.Generic.EqualityComparer<object>.Default.GetHashCode(this.Item2);
+        hashCode = hashCode * -1521134295 + System.Collections.Generic.EqualityComparer<object>.Default.GetHashCode(Item2);
         return hashCode;
     }
 
     public void Deconstruct(out int a, out object item2)
     {
         a = this.a;
-        item2 = this.Item2;
+        item2 = Item2;
     }
 
     public static implicit operator (int a, object) (NewStruct value)
@@ -1905,31 +1906,34 @@ class Test
 
 internal struct NewStruct
 {
+    public int Item1;
+    public int Item2;
+
     public NewStruct(int item1, int item2)
     {
-        this.Item1 = item1;
-        this.Item2 = item2;
+        Item1 = item1;
+        Item2 = item2;
     }
 
     public override bool Equals(object obj)
     {
         return obj is NewStruct other &&
-               this.Item1 == other.Item1 &&
-               this.Item2 == other.Item2;
+               Item1 == other.Item1 &&
+               Item2 == other.Item2;
     }
 
     public override int GetHashCode()
     {
         var hashCode = -1030903623;
-        hashCode = hashCode * -1521134295 + this.Item1.GetHashCode();
-        hashCode = hashCode * -1521134295 + this.Item2.GetHashCode();
+        hashCode = hashCode * -1521134295 + Item1.GetHashCode();
+        hashCode = hashCode * -1521134295 + Item2.GetHashCode();
         return hashCode;
     }
 
     public void Deconstruct(out int item1, out int item2)
     {
-        item1 = this.Item1;
-        item2 = this.Item2;
+        item1 = Item1;
+        item2 = Item2;
     }
 
     public static implicit operator (int, int) (NewStruct value)

--- a/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -88,6 +88,138 @@ internal struct NewStruct
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertSingleTupleTypeNoNames()
+        {
+            var text = @"
+class Test
+{
+    void Method()
+    {
+        var t1 = [||](1, 2);
+    }
+}
+";
+            var expected = @"
+class Test
+{
+    void Method()
+    {
+        var t1 = new {|Rename:NewStruct|}(1, 2);
+    }
+}
+
+internal struct NewStruct
+{
+    public int Item1;
+    public int Item2;
+
+    public NewStruct(int item1, int item2)
+    {
+        Item1 = item1;
+        Item2 = item2;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is NewStruct other &&
+               Item1 == other.Item1 &&
+               Item2 == other.Item2;
+    }
+
+    public override int GetHashCode()
+    {
+        var hashCode = -1030903623;
+        hashCode = hashCode * -1521134295 + Item1.GetHashCode();
+        hashCode = hashCode * -1521134295 + Item2.GetHashCode();
+        return hashCode;
+    }
+
+    public void Deconstruct(out int item1, out int item2)
+    {
+        item1 = Item1;
+        item2 = Item2;
+    }
+
+    public static implicit operator (int, int) (NewStruct value)
+    {
+        return (value.Item1, value.Item2);
+    }
+
+    public static implicit operator NewStruct((int, int) value)
+    {
+        return new NewStruct(value.Item1, value.Item2);
+    }
+}";
+            await TestInRegularAndScriptAsync(text, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
+        public async Task ConvertSingleTupleTypePartialNames()
+        {
+            var text = @"
+class Test
+{
+    void Method()
+    {
+        var t1 = [||](1, b: 2);
+    }
+}
+";
+            var expected = @"
+class Test
+{
+    void Method()
+    {
+        var t1 = new {|Rename:NewStruct|}(1, b: 2);
+    }
+}
+
+internal struct NewStruct
+{
+    public int Item1;
+    public int b;
+
+    public NewStruct(int item1, int b)
+    {
+        Item1 = item1;
+        this.b = b;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is NewStruct other &&
+               Item1 == other.Item1 &&
+               b == other.b;
+    }
+
+    public override int GetHashCode()
+    {
+        var hashCode = 174326978;
+        hashCode = hashCode * -1521134295 + Item1.GetHashCode();
+        hashCode = hashCode * -1521134295 + b.GetHashCode();
+        return hashCode;
+    }
+
+    public void Deconstruct(out int item1, out int b)
+    {
+        item1 = Item1;
+        b = this.b;
+    }
+
+    public static implicit operator (int, int b) (NewStruct value)
+    {
+        return (value.Item1, value.b);
+    }
+
+    public static implicit operator NewStruct((int, int b) value)
+    {
+        return new NewStruct(value.Item1, value.b);
+    }
+}";
+            await TestInRegularAndScriptAsync(text, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
         public async Task ConvertFromType()
         {
             var text = @"

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -80,6 +80,124 @@ End Structure
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertSingleTupleTypeNoNames() As Task
+            Dim text = "
+class Test
+    sub Method()
+        dim t1 = [||](1, 2)
+    end sub
+end class
+"
+            Dim expected = "
+class Test
+    sub Method()
+        dim t1 = New {|Rename:NewStruct|}(1, 2)
+    end sub
+end class
+
+Friend Structure NewStruct
+    Public Item1 As Integer
+    Public Item2 As Integer
+
+    Public Sub New(item1 As Integer, item2 As Integer)
+        Me.Item1 = item1
+        Me.Item2 = item2
+    End Sub
+
+    Public Overrides Function Equals(obj As Object) As Boolean
+        If Not (TypeOf obj Is NewStruct) Then
+            Return False
+        End If
+
+        Dim other = DirectCast(obj, NewStruct)
+        Return Item1 = other.Item1 AndAlso
+               Item2 = other.Item2
+    End Function
+
+    Public Overrides Function GetHashCode() As Integer
+        Dim hashCode As Long = -1030903623
+        hashCode = (hashCode * -1521134295 + Item1.GetHashCode()).GetHashCode()
+        hashCode = (hashCode * -1521134295 + Item2.GetHashCode()).GetHashCode()
+        Return hashCode
+    End Function
+
+    Public Sub Deconstruct(ByRef item1 As Integer, ByRef item2 As Integer)
+        item1 = Me.Item1
+        item2 = Me.Item2
+    End Sub
+
+    Public Shared Widening Operator CType(value As NewStruct) As (Integer, Integer)
+        Return (value.Item1, value.Item2)
+    End Operator
+
+    Public Shared Widening Operator CType(value As (Integer, Integer)) As NewStruct
+        Return New NewStruct(value.Item1, value.Item2)
+    End Operator
+End Structure
+"
+            Await TestInRegularAndScriptAsync(text, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
+        Public Async Function ConvertSingleTupleTypePartialNames() As Task
+            Dim text = "
+class Test
+    sub Method()
+        dim t1 = [||](1, b:=2)
+    end sub
+end class
+"
+            Dim expected = "
+class Test
+    sub Method()
+        dim t1 = New {|Rename:NewStruct|}(1, b:=2)
+    end sub
+end class
+
+Friend Structure NewStruct
+    Public Item1 As Integer
+    Public b As Integer
+
+    Public Sub New(item1 As Integer, b As Integer)
+        Me.Item1 = item1
+        Me.b = b
+    End Sub
+
+    Public Overrides Function Equals(obj As Object) As Boolean
+        If Not (TypeOf obj Is NewStruct) Then
+            Return False
+        End If
+
+        Dim other = DirectCast(obj, NewStruct)
+        Return Item1 = other.Item1 AndAlso
+               b = other.b
+    End Function
+
+    Public Overrides Function GetHashCode() As Integer
+        Dim hashCode As Long = 174326978
+        hashCode = (hashCode * -1521134295 + Item1.GetHashCode()).GetHashCode()
+        hashCode = (hashCode * -1521134295 + b.GetHashCode()).GetHashCode()
+        Return hashCode
+    End Function
+
+    Public Sub Deconstruct(ByRef item1 As Integer, ByRef b As Integer)
+        item1 = Me.Item1
+        b = Me.b
+    End Sub
+
+    Public Shared Widening Operator CType(value As NewStruct) As (Integer, b As Integer)
+        Return (value.Item1, value.b)
+    End Operator
+
+    Public Shared Widening Operator CType(value As (Integer, b As Integer)) As NewStruct
+        Return New NewStruct(value.Item1, value.b)
+    End Operator
+End Structure
+"
+            Await TestInRegularAndScriptAsync(text, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
         Public Async Function ConvertFromType() As Task
             Dim text = "
 class Test

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -1611,6 +1611,9 @@ class Test
 end class
 
 Friend Structure NewStruct
+    Public Item1 As Integer
+    Public Item2 As Integer
+
     Public Sub New(item1 As Integer, item2 As Integer)
         Me.Item1 = item1
         Me.Item2 = item2
@@ -1622,14 +1625,14 @@ Friend Structure NewStruct
         End If
 
         Dim other = DirectCast(obj, NewStruct)
-        Return Me.Item1 = other.Item1 AndAlso
-               Me.Item2 = other.Item2
+        Return Item1 = other.Item1 AndAlso
+               Item2 = other.Item2
     End Function
 
     Public Overrides Function GetHashCode() As Integer
         Dim hashCode As Long = -1030903623
-        hashCode = (hashCode * -1521134295 + Me.Item1.GetHashCode()).GetHashCode()
-        hashCode = (hashCode * -1521134295 + Me.Item2.GetHashCode()).GetHashCode()
+        hashCode = (hashCode * -1521134295 + Item1.GetHashCode()).GetHashCode()
+        hashCode = (hashCode * -1521134295 + Item2.GetHashCode()).GetHashCode()
         Return hashCode
     End Function
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService.cs
@@ -228,8 +228,8 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
 
             // Filter out the members that are implicitly declared.  They're implicit, hence we do
-            // not want an explicit declaration.
-            var filteredMembers = membersList.Where(m => !m.IsImplicitlyDeclared);
+            // not want an explicit declaration. The only exception are fields generated from implicit tuple fields.
+            var filteredMembers = membersList.Where(m => !m.IsImplicitlyDeclared || m.IsTupleField());
 
             return options.AutoInsertionLocation
                 ? AddMembersToAppropiateLocationInDestination(destination, filteredMembers, availableIndices, options, cancellationToken)


### PR DESCRIPTION
### Customer scenario
1. Have code

```cs
public class Class
{
    void MyMethod()
    {
        var tuple = (3, "string");
    }
```

2. Place cursor before open parenthesis and type (Ctrl+.) to open codefixes
3. Choose "convert to struct" and run the refactoring.

**Expected**
The code generated is valid.

**Actual**
The code generated is invalid: it misses definitions for fields corresponding to non-named in the tuple such as Item1, Item2 and so on.

### Bugs this fixes
#33407

### Workarounds, if any
Manually add code for those fields.

### Risk
Low

### Performance impact
None

### Is this a regression from a previous update?
This is a new feature just added. It was added with this defect.

### Root cause analysis
Test cases actually covered the situation but code provided in those tests cases contained errors. We may need to consider adding a validation of code generated in test scenarios.

### How was the bug found?
Internal customers