### PR TITLE
Fix stack overflow where overload resolution gets parameter type attributes

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1559,8 +1559,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                    ref useSiteDiagnostics,
                                                    out okToDowngradeToNeither);
 
-                var type1Normalized = type1.NormalizeTaskTypes(Compilation);
-                var type2Normalized = type2.NormalizeTaskTypes(Compilation);
+                var type1Normalized = type1;
+                var type2Normalized = type2;
+                if ((_binder.Flags & BinderFlags.AttributeArgument) == BinderFlags.None)
+                {
+                    type1Normalized = type1.NormalizeTaskTypes(Compilation);
+                    type2Normalized = type2.NormalizeTaskTypes(Compilation);
+                }
 
                 if (r == BetterResult.Neither)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1561,6 +1561,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var type1Normalized = type1;
                 var type2Normalized = type2;
+
+                // Normalizing task types can cause attributes to be bound on the type,
+                // and attribute arguments may call overloaded methods in error cases.
+                // To avoid a stack overflow, we must not normalize task types within attribute arguments.
                 if (!_binder.InAttributeArgument)
                 {
                     type1Normalized = type1.NormalizeTaskTypes(Compilation);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1561,7 +1561,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var type1Normalized = type1;
                 var type2Normalized = type2;
-                if ((_binder.Flags & BinderFlags.AttributeArgument) == BinderFlags.None)
+                if (!_binder.InAttributeArgument)
                 {
                     type1Normalized = type1.NormalizeTaskTypes(Compilation);
                     type2Normalized = type2.NormalizeTaskTypes(Compilation);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1661,8 +1661,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // We might have got out of the loop above early and allSame isn't completely calculated.
             // We need to ensure that we are not going to skip over the next 'if' because of that.
-            // This condition requires the methods being compared have parameters of identical types but different ref kinds.
-            // See RefOmittedComCall_OverloadResolution_MultipleArguments_ErrorCases for an example.
+            // One way we can break out of the above loop early is when the corresponding method parameters have identical types
+            // but different ref kinds. See RefOmittedComCall_OverloadResolution_MultipleArguments_ErrorCases for an example.
             if (allSame && m1ParametersUsedIncludingExpansionAndOptional == m2ParametersUsedIncludingExpansionAndOptional)
             {
                 // Complete comparison for the remaining parameter types

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1628,7 +1628,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         continue;
                     }
 
-                    Debug.Assert(!allSame);
                     result = BetterResult.Neither;
                     break;
                 }
@@ -1659,6 +1658,48 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             GetParameterCounts(m1, arguments, out m1ParameterCount, out m1ParametersUsedIncludingExpansionAndOptional);
             GetParameterCounts(m2, arguments, out m2ParameterCount, out m2ParametersUsedIncludingExpansionAndOptional);
+
+            // We might have got out of the loop above early and allSame isn't completely calculated.
+            // We need to ensure that we are not going to skip over the next 'if' because of that.
+            // This condition requires the methods being compared have parameters of identical types but different ref kinds.
+            // See RefOmittedComCall_OverloadResolution_MultipleArguments_ErrorCases for an example.
+            if (allSame && m1ParametersUsedIncludingExpansionAndOptional == m2ParametersUsedIncludingExpansionAndOptional)
+            {
+                // Complete comparison for the remaining parameter types
+                for (i = i + 1; i < arguments.Count; ++i)
+                {
+                    var argumentKind = arguments[i].Kind;
+
+                    // If these are both applicable varargs methods and we're looking at the __arglist argument
+                    // then clearly neither of them is going to be better in this argument.
+                    if (argumentKind == BoundKind.ArgListOperator)
+                    {
+                        Debug.Assert(i == arguments.Count - 1);
+                        Debug.Assert(m1.Member.GetIsVararg() && m2.Member.GetIsVararg());
+                        continue;
+                    }
+
+                    var parameter1 = GetParameter(i, m1.Result, m1LeastOverridenParameters);
+                    var type1 = GetParameterType(parameter1, m1.Result);
+
+                    var parameter2 = GetParameter(i, m2.Result, m2LeastOverridenParameters);
+                    var type2 = GetParameterType(parameter2, m2.Result);
+
+                    var type1Normalized = type1;
+                    var type2Normalized = type2;
+                    if (!_binder.InAttributeArgument)
+                    {
+                        type1Normalized = type1.NormalizeTaskTypes(Compilation);
+                        type2Normalized = type2.NormalizeTaskTypes(Compilation);
+                    }
+
+                    if (Conversions.ClassifyImplicitConversionFromType(type1Normalized, type2Normalized, ref useSiteDiagnostics).Kind != ConversionKind.Identity)
+                    {
+                        allSame = false;
+                        break;
+                    }
+                }
+            }
 
             // SPEC VIOLATION: When checking for matching parameter type sequences {P1, P2, …, PN} and {Q1, Q2, …, QN},
             //                 native compiler includes types of optional parameters. We partially duplicate this behavior

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -8980,6 +8980,37 @@ namespace a
                 Diagnostic(ErrorCode.ERR_BadAttributeParamType, "Command").WithArguments("Fx", "a.Class1.CommandAttribute.FxCommand").WithLocation(22, 4));
         }
 
+        [Fact, WorkItem(33388, "https://github.com/dotnet/roslyn/issues/33388")]
+        public void AttributeCrashRepro_33388()
+        {
+            string source = @"
+using System;
+
+public static class C
+{
+    public static int M(object obj) => 42;
+    public static int M(C2 c2) => 42;
+}
+
+public class RecAttribute : Attribute
+{
+    public RecAttribute(int i)
+    {
+        this.i = i;
+    }
+
+    private int i;
+}
+
+[Rec(C.M(null))]
+public class C2
+{
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -9008,7 +9008,10 @@ public class C2
 }
 ";
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (20,6): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+                // [Rec(C.M(null))]
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "C.M(null)").WithLocation(20, 6));
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeMoreTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeMoreTests.cs
@@ -1331,26 +1331,19 @@ using System.Threading.Tasks;
 
 class A : Attribute
 {
-    public A(Func<MyTask<int>> f) { }
-    public A(Func<Task<short>> f) { }
+    public A(int i) { }
 }
-[A(async () => 1)]
+class B
+{
+    public static int F(Func<MyTask<C>> t) => 1;
+    public static int F(Func<Task<object>> t) => 2;
+}
+[A(B.F(async () => null))]
 class C
 {
 }
 
 
-[AsyncMethodBuilder(typeof(MyTaskMethodBuilder))]
-class MyTask
-{
-    internal Awaiter GetAwaiter() => null;
-    internal class Awaiter : INotifyCompletion
-    {
-        public void OnCompleted(Action a) { }
-        internal bool IsCompleted => true;
-        internal void GetResult() { }
-    }
-}
 [AsyncMethodBuilder(typeof(MyTaskMethodBuilder<>))]
 class MyTask<T>
 {
@@ -1361,17 +1354,6 @@ class MyTask<T>
         internal bool IsCompleted => true;
         internal T GetResult() => default(T);
     }
-}
-class MyTaskMethodBuilder
-{
-    public static MyTaskMethodBuilder Create() => null;
-    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
-    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
-    public void SetException(Exception e) { }
-    public void SetResult() { }
-    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
-    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
-    public MyTask Task => default(MyTask);
 }
 class MyTaskMethodBuilder<T>
 {
@@ -1390,9 +1372,9 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
 
             var compilation = CreateCompilation(source);
             compilation.VerifyDiagnostics(
-                // (11,2): error CS0181: Attribute constructor parameter 'f' has type 'Func<MyTask<int>>', which is not a valid attribute parameter type
-                // [A(async () => 1)]
-                Diagnostic(ErrorCode.ERR_BadAttributeParamType, "A").WithArguments("f", "System.Func<MyTask<int>>").WithLocation(11, 2));
+                // (15,4): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+                // [A(B.F(async () => null))]
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "B.F(async () => null)").WithLocation(15, 4));
         }
     }
 }


### PR DESCRIPTION
Fixes #33388 by refraining from normalizing task-like types when binding an attribute argument.

I'd like to make sure I completely understand the implications of this change. If we stop normalizing task-like parameters to attribute constructors, what user-facing consequences could possibly occur?