### PR TITLE
Bootstrap builds should use ExitingTraceListener

### DIFF
--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -25,6 +25,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
 
         private static int MainCore(string[] args)
         {
+#if BOOTSTRAP
+            ExitingTraceListener.Install();
+#endif
+
 #if NET472
             var loader = new DesktopAnalyzerAssemblyLoader();
 #else

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -14,6 +14,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             NameValueCollection appSettings;
             try
             {
+#if BOOTSTRAP
+                ExitingTraceListener.Install();
+#endif
+
 #if NET472
                 appSettings = System.Configuration.ConfigurationManager.AppSettings;
 #else

--- a/src/Compilers/Shared/ExitingTraceListener.cs
+++ b/src/Compilers/Shared/ExitingTraceListener.cs
@@ -24,6 +24,12 @@ namespace Microsoft.CodeAnalysis.CommandLine
             Exit(message);
         }
 
+        internal static void Install()
+        {
+            Trace.Listeners.Clear();
+            Trace.Listeners.Add(new ExitingTraceListener());
+        }
+
         private static void Exit(string originalMessage)
         {
             var builder = new StringBuilder();

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -25,6 +25,10 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
 
         private static int MainCore(string[] args)
         {
+#if BOOTSTRAP
+            ExitingTraceListener.Install();
+#endif
+
 #if NET472
             var loader = new DesktopAnalyzerAssemblyLoader();
 #else


### PR DESCRIPTION
The bootstrap builds of the compiler today are using the default trace
listener which presents a dialog. That means when a `Debug.Assert` call
fires we end up hanging the build in Azure.

The intent was always for the bootstrap builds to use the
`ExitingTraceListener`. This way they exit with a crash and call stack
that allows the compiler team to diagnose the failure.

The behavior of `Debug.Assert` showing a dialog is the most likely
explanation for our current random hangs in the determinism leg. That is
the only place we still use a `DEBUG + BOOTSTRAP` build. The symptoms
line up. If that's the case this will start showing us the stack trace
of the assert.