### PR TITLE
Fix deployment of ILAsm when building from VS

### DIFF
--- a/src/Tools/ILAsm/IlAsmDeploy.csproj
+++ b/src/Tools/ILAsm/IlAsmDeploy.csproj
@@ -46,7 +46,7 @@
   </PropertyGroup>
 
   <Target Name="_PublishILAsm"
-          AfterTargets="Build"
+          BeforeTargets="AfterBuild"
           Inputs="$(MSBuildThisFileFullPath)"
           Outputs="$(_IlasmIncrementalBuildMarker)">
 


### PR DESCRIPTION
It seems that msbuild sometimes does not execute target that specifies `AfterTargets="Build"` when invoked from Visual Studio. Changing it to `BeforeTargets="AfterBuild"` fixes the issue.