### PR TITLE
Subscribe to and process rule set file changes

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeWatcherProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeWatcherProvider.cs
@@ -29,5 +29,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         }
 
         public FileChangeWatcher Watcher { get; }
+
+        // HACK HACK: this is to work around the SwitchToMainThread in the constructor above not
+        // being practical to run in unit tests. That SwitchToMainThread is working around a now-fixed
+        // bug in the shell where GetServiceAsync() might deadlock in the VS service manager
+        // if the UI thread was also dealing with the service at the same time. I'd remove the
+        // SwitchToMainThreadAsync right now instead of this doing this hack, but we're targeting this
+        // fix for a preview release that's too risky to do it in. Other options involve more extensive
+        // mocking or extracting of interfaces which is also just churn that will be immediately undone
+        // once we clean up the constructor either.
+        internal void TrySetFileChangeService_TestOnly(IVsFileChangeEx fileChange)
+        {
+            _fileChangeService.TrySetResult(fileChange);
+        }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
@@ -85,7 +85,28 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// <summary>
         /// Returns the active path to the rule set file that is being used by this project, or null if there isn't a rule set file.
         /// </summary>
-        public string EffectiveRuleSetFilePath => _ruleSetFile?.Target.Value.FilePath;
+        public string EffectiveRuleSetFilePath
+        {
+            get
+            {
+                // We take a lock when reading this because we might be in the middle of processing a file update on another
+                // thread.
+                lock (_gate)
+                {
+                    return _ruleSetFile?.Target.Value.FilePath;
+                }
+            }
+        }
+
+        private void DisposeOfRuleSetFile_NoLock()
+        {
+            if (_ruleSetFile != null)
+            {
+                _ruleSetFile.Target.Value.UpdatedOnDisk -= RuleSetFile_UpdatedOnDisk;
+                _ruleSetFile.Dispose();
+                _ruleSetFile = null;
+            }
+        }
 
         private void ReparseCommandLine_NoLock()
         {
@@ -101,12 +122,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             {
                 // We're changing in some way. Be careful: this might mean the path is switching to or from null, so either side so far
                 // could be changed.
-                _ruleSetFile?.Dispose();
-                _ruleSetFile = null;
+                DisposeOfRuleSetFile_NoLock();
 
                 if (effectiveRuleSetPath != null)
                 {
                     _ruleSetFile = _workspaceServices.GetRequiredService<VisualStudioRuleSetManager>().GetOrCreateRuleSet(effectiveRuleSetPath);
+                    _ruleSetFile.Target.Value.UpdatedOnDisk += RuleSetFile_UpdatedOnDisk;
                 }
             }
 
@@ -151,6 +172,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _project.ParseOptions = parseOptions;
         }
 
+        private void RuleSetFile_UpdatedOnDisk(object sender, EventArgs e)
+        {
+            lock (_gate)
+            {
+                // This event might have gotten fired "late" if the file change was already in flight. We can see if this is still our current file;
+                // it won't be if this is disposed or was already changed to a different file. We hard-cast sender to an IRuleSetFile because if it's
+                // something else that means our comparison below is definitely broken.
+                if (_ruleSetFile?.Target.Value != (IRuleSetFile)sender)
+                {
+                    return;
+                }
+
+                // The IRuleSetFile held by _ruleSetFile is now out of date. Our model is we now request a new one which will have up-to-date values.
+                DisposeOfRuleSetFile_NoLock();
+                UpdateProjectOptions_NoLock();
+            }
+        }
+
         /// <summary>
         /// Overridden by derived classes to provide a hook to modify a <see cref="CompilationOptions"/> with any host-provided values that didn't come from
         /// the command line string.
@@ -183,8 +222,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public void Dispose()
         {
-            _ruleSetFile?.Dispose();
-            _ruleSetFile = null;
+            lock (_gate)
+            {
+                DisposeOfRuleSetFile_NoLock();
+            }
         }
     }
 }

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -182,7 +182,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
                         Return _fileChangeEx
 
                     Case Else
-                        Return Nothing
+                        Throw New Exception($"{NameOf(MockServiceProvider)} does not implement {serviceType.FullName}.")
                 End Select
             End Function
 
@@ -246,6 +246,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
                 Throw New NotImplementedException()
             End Function
         End Class
+
+        Friend Sub RaiseFileChange(path As String)
+            ' Ensure we've pushed everything to the file change watcher
+            Dim fileChangeProvider = ExportProvider.GetExportedValue(Of FileChangeWatcherProvider)
+            Dim mockFileChangeService = DirectCast(ServiceProvider.GetService(GetType(SVsFileChangeEx)), MockVsFileChangeEx)
+            fileChangeProvider.TrySetFileChangeService_TestOnly(mockFileChangeService)
+            fileChangeProvider.Watcher.WaitForQueue_TestOnly()
+            mockFileChangeService.FireUpdate(path)
+        End Sub
 
         Private Class MockVsSmartOpenScope
             Implements IVsSmartOpenScope


### PR DESCRIPTION
Despite all the effort to free-thread all our ruleset handling around file change notifications, we forgot to actually subscribe to the file change notifications. This fixes that.

Fixes https://github.com/dotnet/roslyn/issues/33465.

<details><summary>Ask Mode template</summary>

### Customer scenario

Customer updates a .ruleset file. This could happen because they:

1. Change the severity of a rule in the ruleset editor. 
2. Switched source control branches.
3. Manually edited the file.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/33465

### Workarounds, if any

You'd have two options:

1. Unload/reload the impacted projects, which if you have more than one or two projects is a pain.
2. Restart Visual Studio entirely.

### Risk

Moderate. The code is straightforward but since it's adding event handlers due to file watching there's always some surprises that might happen.

### Performance impact

None.

### Is this a regression from a previous update?

Yes. We broke this in Visual Studio 2019 Preview 1 and didn't notice.

### Root cause analysis

We rewrote all of the project system handling around options, and the code that actually subscribes to the appropriate event was lost in the rewrite. We don't have any unit tests (as we now know!) and this isn't being covered via manual testing, and clearly isn't being covered by dogfooding either.

We're adding a test.

### How was the bug found?

Internal dogfooding. Thanks @AArnott.

</details>