### PR TITLE
Short-term workaround for crash on missing member on tuple literal

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3320,7 +3320,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static Symbol AsMemberOfResultType(TypeSymbolWithAnnotations resultType, Symbol symbol)
         {
             var containingType = resultType.TypeSymbol as NamedTypeSymbol;
-            if ((object)containingType == null || containingType.IsErrorType())
+            if ((object)containingType == null || containingType.IsErrorType() || symbol is ErrorMethodSymbol)
             {
                 return symbol;
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -17,6 +17,32 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
     [CompilerTrait(CompilerFeature.NullableReferenceTypes)]
     public class NullableReferenceTypesTests : CSharpTestBase
     {
+        [Fact]
+        [WorkItem(788968, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/788968")]
+        public void MissingMethodOnTupleLiteral()
+        {
+            var source = @"
+#nullable enable
+class C
+{
+    void M()
+    {
+        (0, (string?)null).Missing();
+        _ = (0, (string?)null).Missing;
+    }
+}
+";
+            var compilation = CreateCompilation(source);
+            compilation.VerifyDiagnostics(
+                // (7,28): error CS1061: '(int, string)' does not contain a definition for 'Missing' and no accessible extension method 'Missing' accepting a first argument of type '(int, string)' could be found (are you missing a using directive or an assembly reference?)
+                //         (0, (string?)null).Missing();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Missing").WithArguments("(int, string)", "Missing").WithLocation(7, 28),
+                // (8,32): error CS1061: '(int, string)' does not contain a definition for 'Missing' and no accessible extension method 'Missing' accepting a first argument of type '(int, string)' could be found (are you missing a using directive or an assembly reference?)
+                //         _ = (0, (string?)null).Missing;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Missing").WithArguments("(int, string)", "Missing").WithLocation(8, 32)
+                );
+        }
+
         [Fact, WorkItem(31297, "https://github.com/dotnet/roslyn/issues/31297")]
         public void SuppressNullableWarning_RefSpanReturn()
         {


### PR DESCRIPTION
## Customer scenario
Nullability analysis does re-inference on methods and tuple literals. If you type `(x, y).Missing()`, the compiler and IDE will crash.

## Bugs this fixes
Relates to Watson https://devdiv.visualstudio.com/DevDiv/_workitems/edit/788968

## Workarounds, if any
You could avoid typing this, and instead use an extracted variable for the tuple `var t = (x, y); t. Missing();`

## Risk, Performance impact
Low. The mitigation is a narrow fix to avoid the crash.

## Is this a regression from a previous update?
Yes, the Watson issue appeared with preview2, when we started doing re-inference on tuple literals.

## Root cause analysis
Adding a workaround for a crash to provide more time for a full solution.

## How was the bug found?
Watson

Relates to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/788968

----

Ask-mode approval is tracked by https://devdiv.visualstudio.com/DevDiv/_workitems/edit/796819