### PR TITLE
Include RunTests.exe and xunit.console.x86.exe in .NET event collection

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/EventLogCollector.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/EventLogCollector.cs
@@ -89,6 +89,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 "MSBuildTaskHost.exe",
                 "mspdbsrv.exe",
                 "MStest.exe",
+                "RunTests.exe",
                 "ServiceHub.Host.CLR.exe",
                 "ServiceHub.Host.CLR.x64.exe",
                 "ServiceHub.Host.CLR.x86.exe",
@@ -107,6 +108,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 "vstest.executionengine.clr20.exe",
                 "VSTest.executionEngine.exe",
                 "VSTest.executionEngine.x86.exe",
+                "xunit.console.x86.exe",
             };
 
         /// <summary>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -67,14 +67,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 var assemblyDirectory = GetAssemblyDirectory();
                 var testName = CaptureTestNameAttribute.CurrentName ?? "Unknown";
                 var logDir = Path.Combine(assemblyDirectory, "xUnitResults", "Screenshots");
-                var baseFileName = $"{DateTime.Now:HH.mm.ss}-{testName}-{eventArgs.Exception.GetType().Name}";
+                var baseFileName = $"{DateTime.UtcNow:HH.mm.ss}-{testName}-{eventArgs.Exception.GetType().Name}";
 
                 var maxLength = logDir.Length + 1 + baseFileName.Length + ".Watson.log".Length;
                 const int MaxPath = 260;
                 if (maxLength > MaxPath)
                 {
                     testName = testName.Substring(0, testName.Length - (maxLength - MaxPath));
-                    baseFileName = $"{DateTime.Now:HH.mm.ss}-{testName}-{eventArgs.Exception.GetType().Name}";
+                    baseFileName = $"{DateTime.UtcNow:HH.mm.ss}-{testName}-{eventArgs.Exception.GetType().Name}";
                 }
 
                 ScreenshotService.TakeScreenshot(Path.Combine(logDir, $"{baseFileName}.png"));


### PR DESCRIPTION
Captures logs necessary to diagnose crashes during test runs.