### PR TITLE
Fix failure to print test results

### DIFF
--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -160,8 +160,7 @@ namespace RunTests
         private void PrintFailedTestResult(TestResult testResult)
         {
             // Save out the error output for easy artifact inspecting
-            var outputLogPath = Path.Combine(_options.LogFilesOutputDirectory, $"xUnit Failure: {testResult.DisplayName}.log");
-            File.WriteAllText(outputLogPath, testResult.StandardOutput ?? "");
+            var outputLogPath = Path.Combine(_options.LogFilesOutputDirectory, $"xUnitFailure-{testResult.DisplayName}.log");
 
             ConsoleUtil.WriteLine($"Errors {testResult.AssemblyName}");
             ConsoleUtil.WriteLine(testResult.ErrorOutput);
@@ -169,6 +168,8 @@ namespace RunTests
             // TODO: Put this in the log and take it off the ConsoleUtil output to keep it simple?
             ConsoleUtil.WriteLine($"Command: {testResult.CommandLine}");
             ConsoleUtil.WriteLine($"xUnit output log: {outputLogPath}");
+
+            File.WriteAllText(outputLogPath, testResult.StandardOutput ?? "");
 
             if (!string.IsNullOrEmpty(testResult.ErrorOutput))
             {


### PR DESCRIPTION
Fixes this message following a failed integration test run:

```
Unhandled Exception: System.NotSupportedException: The given path's format is not supported.
   at System.Security.Permissions.FileIOPermission.EmulateFileIOPermissionChecks(String fullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.StreamWriter.CreateFile(String path, Boolean append, Boolean checkHost)
   at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding, Int32 bufferSize, Boolean checkHost)
   at System.IO.File.InternalWriteAllText(String path, String contents, Encoding encoding, Boolean checkHost)
   at RunTests.TestRunner.PrintFailedTestResult(TestResult testResult) in /_/src/Tools/Source/RunTests/TestRunner.cs:line 166
   at RunTests.TestRunner.Print(List`1 testResults) in /_/src/Tools/Source/RunTests/TestRunner.cs:line 130
   at RunTests.TestRunner.<RunAllAsync>d__3.MoveNext() in /_/src/Tools/Source/RunTests/TestRunner.cs:line 117
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at RunTests.Program.<RunCore>d__5.MoveNext() in /_/src/Tools/Source/RunTests/Program.cs:line 107
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at RunTests.Program.<Run>d__4.MoveNext() in /_/src/Tools/Source/RunTests/Program.cs:line 88
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at RunTests.Program.Main(String[] args) in /_/src/Tools/Source/RunTests/Program.cs:line 47
```