### PR TITLE
Do not skip editorconfig integration tests

### DIFF
--- a/src/EditorFeatures/TestUtilities/Threading/CriticalWpfFactAttribute.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/CriticalWpfFactAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Roslyn.Test.Utilities
+{
+    /// <summary>
+    /// Indicates a <see cref="WpfFactAttribute"/> test which is essential to product quality and cannot be skipped.
+    /// </summary>
+    public class CriticalWpfFactAttribute : WpfFactAttribute
+    {
+        [Obsolete("Critical tests cannot be skipped.", error: true)]
+        public new string Skip
+        {
+            get { return base.Skip; }
+            set { base.Skip = value; }
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities/Threading/CriticalWpfTheoryAttribute.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/CriticalWpfTheoryAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Roslyn.Test.Utilities
+{
+    /// <summary>
+    /// Indicates a <see cref="WpfTheoryAttribute"/> test which is essential to product quality and cannot be skipped.
+    /// </summary>
+    public class CriticalWpfTheoryAttribute : WpfTheoryAttribute
+    {
+        [Obsolete("Critical tests cannot be skipped.", error: true)]
+        public new string Skip
+        {
+            get { return base.Skip; }
+            set { base.Skip = value; }
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -140,7 +140,8 @@ class C
             VisualStudio.Editor.Verify.TextContains("Second?.");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/30015")]
+        // DO NOT SKIP THIS TEST. IT MUST PASS.
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.EditorConfig)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         [WorkItem(15003, "https://github.com/dotnet/roslyn/issues/15003")]

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -140,8 +140,7 @@ class C
             VisualStudio.Editor.Verify.TextContains("Second?.");
         }
 
-        // DO NOT SKIP THIS TEST. IT MUST PASS.
-        [WpfFact]
+        [CriticalWpfFact]
         [Trait(Traits.Feature, Traits.Features.EditorConfig)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         [WorkItem(15003, "https://github.com/dotnet/roslyn/issues/15003")]

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFormatting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFormatting.cs
@@ -269,8 +269,7 @@ class Program
 }");
         }
 
-        // DO NOT SKIP THIS TEST. IT MUST PASS.
-        [WpfFact]
+        [CriticalWpfFact]
         [Trait(Traits.Feature, Traits.Features.EditorConfig)]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(15003, "https://github.com/dotnet/roslyn/issues/15003")]

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFormatting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFormatting.cs
@@ -269,7 +269,8 @@ class Program
 }");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/30015")]
+        // DO NOT SKIP THIS TEST. IT MUST PASS.
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.EditorConfig)]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(15003, "https://github.com/dotnet/roslyn/issues/15003")]


### PR DESCRIPTION
* Add `CriticalWpfFactAttribute` and `CriticalWpfTheoryAttribute` for essential tests that cannot be skipped
* Unskip critical .editorconfig Fix All tests (there are _no other tests_ covering these feature areas, so these tests are essential to ensuring product quality)

Related to #30015