### PR TITLE
Adjust process logging for applicability to current builds

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/EventLogCollector.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/EventLogCollector.cs
@@ -98,7 +98,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 "ServiceHub.SettingsHost.exe",
                 "ServiceHub.VSDetouredHost.exe",
                 "vbc.exe",
-                "vbc2.exe",
                 "VBCSCompiler.exe",
                 "VStest.Console.Exe",
                 "VSTest.DiscoveryEngine.exe",
@@ -108,6 +107,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 "vstest.executionengine.clr20.exe",
                 "VSTest.executionEngine.exe",
                 "VSTest.executionEngine.x86.exe",
+                "xunit.console.exe",
                 "xunit.console.x86.exe",
             };
 


### PR DESCRIPTION
* Remove vbc2.exe since it's no longer used
* Add xunit.console.exe (64-bit runner)

Addresses feedback from #33512. 