### PR TITLE
SendInput using scan codes when available

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys.cs
@@ -196,11 +196,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Input
         private void SendInputs(NativeMethods.INPUT[] inputs)
         {
             var foregroundWindow = IntPtr.Zero;
-            var inputBlocked = false;
 
             try
             {
-                inputBlocked = IntegrationHelper.BlockInput();
                 foregroundWindow = IntegrationHelper.GetForegroundWindow();
 
                 _visualStudioInstance.ActivateMainWindow();
@@ -212,11 +210,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Input
                 if (foregroundWindow != IntPtr.Zero)
                 {
                     IntegrationHelper.SetForegroundWindow(foregroundWindow);
-                }
-
-                if (inputBlocked)
-                {
-                    IntegrationHelper.UnblockInput();
                 }
             }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys.cs
@@ -195,23 +195,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Input
 
         private void SendInputs(NativeMethods.INPUT[] inputs)
         {
-            var foregroundWindow = IntPtr.Zero;
+            _visualStudioInstance.ActivateMainWindow();
 
-            try
-            {
-                foregroundWindow = IntegrationHelper.GetForegroundWindow();
-
-                _visualStudioInstance.ActivateMainWindow();
-
-                IntegrationHelper.SendInput(inputs);
-            }
-            finally
-            {
-                if (foregroundWindow != IntPtr.Zero)
-                {
-                    IntegrationHelper.SetForegroundWindow(foregroundWindow);
-                }
-            }
+            IntegrationHelper.SendInput(inputs);
 
             _visualStudioInstance.WaitForApplicationIdle(CancellationToken.None);
         }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys.cs
@@ -108,22 +108,42 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Input
 
         private static void AddInputs(List<NativeMethods.INPUT> inputs, VirtualKey virtualKey, uint dwFlags)
         {
-            var input = new NativeMethods.INPUT
+            NativeMethods.INPUT input;
+            var scanCode = NativeMethods.MapVirtualKey((uint)virtualKey, NativeMethods.MAPVK_VK_TO_VSC);
+            if (scanCode != 0)
             {
-                Type = NativeMethods.INPUT_KEYBOARD,
-                ki = new NativeMethods.KEYBDINPUT
+                input = new NativeMethods.INPUT
                 {
-                    wVk = (ushort)virtualKey,
-                    wScan = 0,
-                    dwFlags = dwFlags,
-                    time = 0,
-                    dwExtraInfo = IntPtr.Zero
-                }
-            };
-
-            if (IsExtendedKey(virtualKey))
+                    Type = NativeMethods.INPUT_KEYBOARD,
+                    ki = new NativeMethods.KEYBDINPUT
+                    {
+                        wVk = 0,
+                        wScan = (ushort)scanCode,
+                        dwFlags = dwFlags | NativeMethods.KEYEVENTF_SCANCODE,
+                        time = 0,
+                        dwExtraInfo = IntPtr.Zero
+                    }
+                };
+            }
+            else
             {
-                input.ki.dwFlags |= NativeMethods.KEYEVENTF_EXTENDEDKEY;
+                input = new NativeMethods.INPUT
+                {
+                    Type = NativeMethods.INPUT_KEYBOARD,
+                    ki = new NativeMethods.KEYBDINPUT
+                    {
+                        wVk = (ushort)virtualKey,
+                        wScan = 0,
+                        dwFlags = dwFlags,
+                        time = 0,
+                        dwExtraInfo = IntPtr.Zero
+                    }
+                };
+
+                if (IsExtendedKey(virtualKey))
+                {
+                    input.ki.dwFlags |= NativeMethods.KEYEVENTF_EXTENDEDKEY;
+                }
             }
 
             inputs.Add(input);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
@@ -180,6 +180,40 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             var activeWindow = NativeMethods.GetLastActivePopup(window);
             activeWindow = NativeMethods.IsWindowVisible(activeWindow) ? activeWindow : window;
             NativeMethods.SwitchToThisWindow(activeWindow, true);
+
+            if (!NativeMethods.SetForegroundWindow(activeWindow))
+            {
+                if (!NativeMethods.AllocConsole())
+                {
+                    Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+
+                try
+                {
+                    var consoleWindow = NativeMethods.GetConsoleWindow();
+                    if (consoleWindow == IntPtr.Zero)
+                    {
+                        throw new InvalidOperationException("Failed to obtain the console window.");
+                    }
+
+                    if (!NativeMethods.SetWindowPos(consoleWindow, IntPtr.Zero, 0, 0, 0, 0, NativeMethods.SWP_NOZORDER))
+                    {
+                        Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                    }
+                }
+                finally
+                {
+                    if (!NativeMethods.FreeConsole())
+                    {
+                        Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                    }
+                }
+
+                if (!NativeMethods.SetForegroundWindow(activeWindow))
+                {
+                    throw new InvalidOperationException("Failed to set the foreground window.");
+                }
+            }
         }
 
         public static void SendInput(NativeMethods.INPUT[] inputs)

--- a/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
@@ -178,6 +178,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         public static void SetForegroundWindow(IntPtr window)
         {
             var activeWindow = NativeMethods.GetLastActivePopup(window);
+            activeWindow = NativeMethods.IsWindowVisible(activeWindow) ? activeWindow : window;
             NativeMethods.SwitchToThisWindow(activeWindow, true);
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
@@ -26,27 +26,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
     /// </summary>
     internal static class IntegrationHelper
     {
-        public static bool BlockInput()
-        {
-            var success = NativeMethods.BlockInput(true);
-
-            if (!success)
-            {
-                var hresult = Marshal.GetHRForLastWin32Error();
-
-                if (hresult == VSConstants.E_ACCESSDENIED)
-                {
-                    Debug.WriteLine("Input cannot be blocked because the system requires Administrative privileges.");
-                }
-                else
-                {
-                    Debug.WriteLine("Input cannot be blocked because another thread has blocked the input.");
-                }
-            }
-
-            return success;
-        }
-
         public static void CreateDirectory(string path, bool deleteExisting = false)
         {
             if (deleteExisting)
@@ -430,17 +409,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             while (dte == null);
 
             return (DTE)dte;
-        }
-
-        public static void UnblockInput()
-        {
-            var success = NativeMethods.BlockInput(false);
-
-            if (!success)
-            {
-                var hresult = Marshal.GetHRForLastWin32Error();
-                throw new ExternalException("Input cannot be unblocked because it was blocked by another thread.", hresult);
-            }
         }
 
         public static async Task WaitForResultAsync<T>(Func<T> action, T expectedResult)

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
@@ -112,10 +112,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
 
         [DllImport(User32, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool BlockInput([MarshalAs(UnmanagedType.Bool)] bool fBlockIt);
-
-        [DllImport(User32, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool EnumWindows([MarshalAs(UnmanagedType.FunctionPtr)] WNDENUMPROC lpEnumFunc, IntPtr lParam);
 
         [DllImport(User32)]

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
@@ -20,6 +20,17 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
         [DllImport(Kernel32)]
         public static extern uint GetCurrentThreadId();
 
+        [DllImport(Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool AllocConsole();
+
+        [DllImport(Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool FreeConsole();
+
+        [DllImport(Kernel32, SetLastError = false)]
+        public static extern IntPtr GetConsoleWindow();
+
         #endregion
 
         #region ole32.dll
@@ -146,6 +157,16 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
 
         [DllImport(User32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern IntPtr SendMessage(IntPtr hWnd, uint uMsg, IntPtr wParam, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder lParam);
+
+        [DllImport(User32, SetLastError = false)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport(User32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+
+        public const uint SWP_NOZORDER = 4;
 
         [DllImport(User32, SetLastError = true)]
         public static extern IntPtr GetLastActivePopup(IntPtr hWnd);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
@@ -153,6 +153,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
         [DllImport(User32, SetLastError = true)]
         public static extern void SwitchToThisWindow(IntPtr hWnd, [MarshalAs(UnmanagedType.Bool)] bool fUnknown);
 
+        [DllImport(User32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsWindowVisible(IntPtr hWnd);
+
         [DllImport(User32, CharSet = CharSet.Unicode)]
         public static extern short VkKeyScan(char ch);
 


### PR DESCRIPTION
Builds on #33514 and #33513.

* Use hardware scan codes instead of virtual key codes where applicable, since some builds of Windows handle these more reliably ([internal reference](https://microsoft.visualstudio.com/OS/_workitems/edit/13780108)).
* Force focus to devenv before using `SendInput` to ensure input sequences are cleanly entered.