### PR TITLE
Cache visited assemblies to improve object browser startup

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractListItemFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractListItemFactory.cs
@@ -620,6 +620,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             var projectListItemBuilder = ImmutableArray.CreateBuilder<ObjectListItem>();
             var referenceListItemBuilder = ImmutableArray.CreateBuilder<ObjectListItem>();
             HashSet<AssemblyIdentity> assemblyIdentitySet = null;
+            var visitedAssemblies = new Dictionary<string, AssemblyIdentity>();
 
             foreach (var projectId in projectIds)
             {
@@ -647,7 +648,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                     {
                         if (reference is PortableExecutableReference portableExecutableReference)
                         {
-                            var assemblyIdentity = AssemblyIdentityUtils.TryGetAssemblyIdentity(portableExecutableReference.FilePath);
+                            var assemblyIdentity = visitedAssemblies.GetOrAdd(portableExecutableReference.FilePath, filePath => AssemblyIdentityUtils.TryGetAssemblyIdentity(filePath));
                             if (assemblyIdentity != null && !assemblyIdentitySet.Contains(assemblyIdentity))
                             {
                                 assemblyIdentitySet.Add(assemblyIdentity);


### PR DESCRIPTION
This change addresses more than 50% of the Object Browser initialization time when opening it via symbol navigation in Roslyn.sln.

Fixes #33555