### PR TITLE
Revert "set no activation context on provisional tab when navigate to"

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
@@ -131,39 +131,36 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 throw new InvalidOperationException(ServicesVSResources.Navigation_must_be_performed_on_the_foreground_thread);
             }
 
-            using (OpenNewDocumentStateScope(options ?? workspace.Options))
+            var document = OpenDocument(workspace, documentId, options);
+            if (document == null)
             {
-                var document = OpenDocument(workspace, documentId);
-                if (document == null)
-                {
-                    return false;
-                }
-
-                var text = document.GetTextSynchronously(CancellationToken.None);
-                var textBuffer = text.Container.GetTextBuffer();
-
-                var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
-                if (boundedTextSpan != textSpan)
-                {
-                    try
-                    {
-                        throw new ArgumentOutOfRangeException();
-                    }
-                    catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
-                    {
-                    }
-                }
-
-                var vsTextSpan = text.GetVsTextSpanForSpan(boundedTextSpan);
-
-                if (IsSecondaryBuffer(workspace, documentId) &&
-                    !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
-                {
-                    return false;
-                }
-
-                return NavigateTo(textBuffer, vsTextSpan);
+                return false;
             }
+
+            var text = document.GetTextSynchronously(CancellationToken.None);
+            var textBuffer = text.Container.GetTextBuffer();
+
+            var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
+            if (boundedTextSpan != textSpan)
+            {
+                try
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+                catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
+                {
+                }
+            }
+
+            var vsTextSpan = text.GetVsTextSpanForSpan(boundedTextSpan);
+
+            if (IsSecondaryBuffer(workspace, documentId) &&
+                !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
+            {
+                return false;
+            }
+
+            return NavigateTo(textBuffer, vsTextSpan);
         }
 
         public bool TryNavigateToLineAndOffset(Workspace workspace, DocumentId documentId, int lineNumber, int offset, OptionSet options)
@@ -176,27 +173,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 throw new InvalidOperationException(ServicesVSResources.Navigation_must_be_performed_on_the_foreground_thread);
             }
 
-            using (OpenNewDocumentStateScope(options ?? workspace.Options))
+            var document = OpenDocument(workspace, documentId, options);
+            if (document == null)
             {
-                var document = OpenDocument(workspace, documentId);
-                if (document == null)
-                {
-                    return false;
-                }
-
-                var text = document.GetTextSynchronously(CancellationToken.None);
-                var textBuffer = text.Container.GetTextBuffer();
-
-                var vsTextSpan = text.GetVsTextSpanForLineOffset(lineNumber, offset);
-
-                if (IsSecondaryBuffer(workspace, documentId) &&
-                    !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
-                {
-                    return false;
-                }
-
-                return NavigateTo(textBuffer, vsTextSpan);
+                return false;
             }
+
+            var text = document.GetTextSynchronously(CancellationToken.None);
+            var textBuffer = text.Container.GetTextBuffer();
+
+            var vsTextSpan = text.GetVsTextSpanForLineOffset(lineNumber, offset);
+
+            if (IsSecondaryBuffer(workspace, documentId) &&
+                !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
+            {
+                return false;
+            }
+
+            return NavigateTo(textBuffer, vsTextSpan);
         }
 
         public bool TryNavigateToPosition(Workspace workspace, DocumentId documentId, int position, int virtualSpace, OptionSet options)
@@ -209,39 +203,36 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 throw new InvalidOperationException(ServicesVSResources.Navigation_must_be_performed_on_the_foreground_thread);
             }
 
-            using (OpenNewDocumentStateScope(options ?? workspace.Options))
+            var document = OpenDocument(workspace, documentId, options);
+            if (document == null)
             {
-                var document = OpenDocument(workspace, documentId);
-                if (document == null)
-                {
-                    return false;
-                }
-
-                var text = document.GetTextSynchronously(CancellationToken.None);
-                var textBuffer = text.Container.GetTextBuffer();
-
-                var boundedPosition = GetPositionWithinDocumentBounds(position, text.Length);
-                if (boundedPosition != position)
-                {
-                    try
-                    {
-                        throw new ArgumentOutOfRangeException();
-                    }
-                    catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
-                    {
-                    }
-                }
-
-                var vsTextSpan = text.GetVsTextSpanForPosition(boundedPosition, virtualSpace);
-
-                if (IsSecondaryBuffer(workspace, documentId) &&
-                    !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
-                {
-                    return false;
-                }
-
-                return NavigateTo(textBuffer, vsTextSpan);
+                return false;
             }
+
+            var text = document.GetTextSynchronously(CancellationToken.None);
+            var textBuffer = text.Container.GetTextBuffer();
+
+            var boundedPosition = GetPositionWithinDocumentBounds(position, text.Length);
+            if (boundedPosition != position)
+            {
+                try
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+                catch (ArgumentOutOfRangeException e) when (FatalError.ReportWithoutCrash(e))
+                {
+                }
+            }
+
+            var vsTextSpan = text.GetVsTextSpanForPosition(boundedPosition, virtualSpace);
+
+            if (IsSecondaryBuffer(workspace, documentId) &&
+                !vsTextSpan.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out vsTextSpan))
+            {
+                return false;
+            }
+
+            return NavigateTo(textBuffer, vsTextSpan);
         }
 
         /// <summary>
@@ -274,14 +265,30 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return TextSpan.FromBounds(GetPositionWithinDocumentBounds(span.Start, documentLength), GetPositionWithinDocumentBounds(span.End, documentLength));
         }
 
-        private static Document OpenDocument(Workspace workspace, DocumentId documentId)
+        private static Document OpenDocument(Workspace workspace, DocumentId documentId, OptionSet options)
         {
+            options = options ?? workspace.Options;
+
             // Always open the document again, even if the document is already open in the 
             // workspace. If a document is already open in a preview tab and it is opened again 
             // in a permanent tab, this allows the document to transition to the new state.
             if (workspace.CanOpenDocuments)
             {
-                workspace.OpenDocument(documentId);
+                if (options.GetOption(NavigationOptions.PreferProvisionalTab))
+                {
+                    // If we're just opening the provisional tab, then do not "activate" the document
+                    // (i.e. don't give it focus).  This way if a user is just arrowing through a set 
+                    // of FindAllReferences results, they don't have their cursor placed into the document.
+                    var state = __VSNEWDOCUMENTSTATE.NDS_Provisional | __VSNEWDOCUMENTSTATE.NDS_NoActivate;
+                    using (var scope = new NewDocumentStateScope(state, VSConstants.NewDocumentStateReason.Navigation))
+                    {
+                        workspace.OpenDocument(documentId);
+                    }
+                }
+                else
+                {
+                    workspace.OpenDocument(documentId);
+                }
             }
 
             if (!workspace.IsDocumentOpen(documentId))
@@ -312,13 +319,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                 return ErrorHandler.Succeeded(
                     textManager.NavigateToLineAndColumn2(
-                        vsTextBuffer,
-                        VSConstants.LOGVIEWID.TextView_guid,
-                        vsTextSpan.iStartLine,
-                        vsTextSpan.iStartIndex,
-                        vsTextSpan.iEndLine,
-                        vsTextSpan.iEndIndex,
-                        (uint)_VIEWFRAMETYPE.vftCodeWindow));
+                        vsTextBuffer, VSConstants.LOGVIEWID.TextView_guid, vsTextSpan.iStartLine, vsTextSpan.iStartIndex, vsTextSpan.iEndLine, vsTextSpan.iEndIndex, (uint)_VIEWFRAMETYPE.vftCodeWindow));
             }
         }
 
@@ -342,20 +343,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         private bool CanMapFromSecondaryBufferToPrimaryBuffer(Workspace workspace, DocumentId documentId, VsTextSpan spanInSecondaryBuffer)
         {
             return spanInSecondaryBuffer.TryMapSpanFromSecondaryBufferToPrimaryBuffer(workspace, documentId, out var spanInPrimaryBuffer);
-        }
-
-        private IDisposable OpenNewDocumentStateScope(OptionSet options)
-        {
-            if (!options.GetOption(NavigationOptions.PreferProvisionalTab))
-            {
-                return null;
-            }
-
-            // If we're just opening the provisional tab, then do not "activate" the document
-            // (i.e. don't give it focus).  This way if a user is just arrowing through a set 
-            // of FindAllReferences results, they don't have their cursor placed into the document.
-            var state = __VSNEWDOCUMENTSTATE.NDS_Provisional | __VSNEWDOCUMENTSTATE.NDS_NoActivate;
-            return new NewDocumentStateScope(state, VSConstants.NewDocumentStateReason.Navigation);
         }
     }
 }


### PR DESCRIPTION
Reverts dotnet/roslyn#33400

Integration tests caught this change as a regression. This pull request reverts the breaking change with no alteration so it can be resubmitted in the future.