### PR TITLE
F# Typing '.' after fully typing out a symbol does not trigger completion

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -107,7 +107,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             var filterText = session.ApplicableToSpan.GetText(session.ApplicableToSpan.TextBuffer.CurrentSnapshot) + typeChar;
             if (Helpers.IsFilterCharacter(roslynItem, typeChar, filterText))
-            { 
+            {
+                // Returning Cancel means we keep the current session and consider the character for further filtering.
                 return new AsyncCompletionData.CommitResult(isHandled: true, AsyncCompletionData.CommitBehavior.CancelCommit);
             }
 
@@ -119,7 +120,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             // Tab, Enter and Null (call invoke commit) are always commit characters. 
             if (typeChar != '\t' && typeChar != '\n' && typeChar != '\0' && !IsCommitCharacter(serviceRules, roslynItem, typeChar, filterText))
             {
-                return new AsyncCompletionData.CommitResult(isHandled: true, AsyncCompletionData.CommitBehavior.CancelCommit);
+                // Returning None means we complete the current session with a void commit. 
+                // The Editor then will try to trigger a new completion session for the character.
+                return new AsyncCompletionData.CommitResult(isHandled: true, AsyncCompletionData.CommitBehavior.None);
             }
 
             if (!session.Properties.TryGetProperty(CompletionSource.TriggerSnapshot, out ITextSnapshot triggerSnapshot))


### PR DESCRIPTION
### Customer scenario
Typing `System.` in F#

**Expected**
Have a completion for dot

**Actual**
Have no completion for dot

![image](https://user-images.githubusercontent.com/5455484/53211839-7f460400-35f7-11e9-8cc3-fa663c4c9e13.png)

### Bugs this fixes
https://github.com/Microsoft/visualfsharp/issues/6266

### Workarounds, if any
None

### Risk
Low

### Performance impact
None

### Is this a regression from a previous update?
None

### Root cause analysis
Dot (as some other characters) is a potential commit character in F# but it is removed from actual commit characters. Roslyn does not provide a correct support for such situations in the new completion because Roslyn does not have such cases in C# and VB. Priorities of Commit vs Filter differ between the old completion and the new completion. This causes the issue.

### How was the bug found?
Internal customers