### PR TITLE
Add various bits of telemetry around DocumentClosed handling

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/EventMap.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EventMap.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Roslyn.Utilities
 {
@@ -165,12 +166,25 @@ namespace Roslyn.Utilities
 
             public void RaiseEvent(Action<TEventHandler> invoker)
             {
-                if (this.HasHandlers)
+                // The try/catch here is to find additional telemetry for https://devdiv.visualstudio.com/DevDiv/_queries/query/71ee8553-7220-4b2a-98cf-20edab701fd1/.
+                // We've realized there's a problem with our eventing, where if an exception is encountered while calling into subscribers to Workspace events,
+                // we won't notify all of the callers. The expectation is such an exception would be thrown to the SafeStartNew in the workspace's event queue that
+                // will raise that as a fatal exception, but OperationCancelledExceptions might be able to propagate through and fault the task we are using in the
+                // chain. I'm choosing to use ReportWithoutCrashAndPropagate, because if our theory here is correct, it seems the first exception isn't actually
+                // causing crashes, and so if it turns out this is a very common situation I don't want to make a often-benign situation fatal.
+                try
                 {
-                    foreach (var registry in _registries)
+                    if (this.HasHandlers)
                     {
-                        registry.Invoke(invoker);
+                        foreach (var registry in _registries)
+                        {
+                            registry.Invoke(invoker);
+                        }
                     }
+                }
+                catch (Exception e) when (FatalError.ReportWithoutCrashAndPropagate(e))
+                {
+                    throw ExceptionUtilities.Unreachable;
                 }
             }
         }


### PR DESCRIPTION
@sharwell and I have been looking at a bug for several days where we crash here:

https://github.com/dotnet/roslyn/blob/0930558690fda8c7e9bf8a50f4e5e66995fb1380/src/EditorFeatures/Core.Wpf/Options/EditorConfigDocumentOptionsProvider.cs#L75

because the DocumentId is already marked as open. Given there are a number of guards to ensure a document that's not open can't be opened a second time, our only guess is that a previous close was never received by the EditorConfigDocumentOptionsProvider.

This is adding some try/catches to attempt to prove that theory. Since we're really not sure which it might be and how often it might be happening, I'm adding non-fatal reporting to ensure we don't make a problem that happens during close _and then reopening_ something that crashes on the close itself.

<details><summary>Ask Mode template</summary>

### Customer scenario

Some users are experiencing crashes when the open a file that was previously opened. We don't have a good understanding of why this is happening, and Windows Error Reporting telemetry hasn't given us a full heap dump to understand it either. Our next best course of action is to add additional exception reporting points to attempt to understand it more.

### Bugs this fixes

This provides extra help to diagnose https://devdiv.visualstudio.com/DevDiv/_workitems/edit/742115, but does _not_ actually fix it.

### Workarounds, if any

We don't know the bug yet, but our only other option is to just keep waiting for heap dumps.

### Risk

Low. We're using our "report non fatal exception but keep propagating the exception" intentionally, so if the underlying exception is happening more often than we expect we won't make things worse.

### Performance impact

None.

### Is this a regression from a previous update?

Root cause is unknown at this time.

### Root cause analysis

Root cause is unknown at this time.

### How was the bug found?

Windows Error Reporting.

</details>