### PR TITLE
fixed outputRefFilePath not synched at initial synchronization

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/AssetServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetServiceTests.cs
@@ -92,10 +92,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 var service = new AssetService(sessionId, storage, new RemoteWorkspace().Services.GetService<ISerializerService>());
                 await service.SynchronizeSolutionAssetsAsync(await solution.State.GetChecksumAsync(CancellationToken.None), CancellationToken.None);
 
-                foreach (var kv in map)
-                {
-                    Assert.True(storage.TryGetAsset(kv.Key, out object data));
-                }
+                TestUtils.VerifyAssetStorage(map, storage);
             }
         }
 
@@ -120,10 +117,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 var service = new AssetService(sessionId, storage, new RemoteWorkspace().Services.GetService<ISerializerService>());
                 await service.SynchronizeProjectAssetsAsync(SpecializedCollections.SingletonEnumerable(await project.State.GetChecksumAsync(CancellationToken.None)), CancellationToken.None);
 
-                foreach (var kv in map)
-                {
-                    Assert.True(storage.TryGetAsset(kv.Key, out object data));
-                }
+                TestUtils.VerifyAssetStorage(map, storage);
             }
         }
     }

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Remote.Shared;
+using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.TodoComments;
@@ -331,10 +332,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             var storage = client.AssetStorage;
 
-            foreach (var kv in map)
-            {
-                Assert.True(storage.TryGetAsset(kv.Key, out object data));
-            }
+            TestUtils.VerifyAssetStorage(map, storage);
         }
 
         private static Solution UpdateSolution(Solution solution, string projectName, string documentName, string csAddition, string vbAddition)

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -146,6 +146,30 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
+        public async Task TestNewProjectAttributes()
+        {
+            var code1 = @"class Test1 { void Method() { } }";
+
+            using (var workspace = TestWorkspace.CreateCSharp(code1))
+            {
+                var solution = workspace.CurrentSolution;
+                var projectId = solution.ProjectIds.First();
+
+                solution = workspace.CurrentSolution
+                                    .WithProjectOutputRefFilePath(projectId, "TestPath")
+                                    .WithProjectDefaultNamespace(projectId, "TestNamespace")
+                                    .WithHasAllInformation(projectId, hasAllInformation: false);
+
+                var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
+
+                var service = await GetSolutionServiceAsync(solution);
+                var synched = await service.GetSolutionAsync(solutionChecksum, CancellationToken.None);
+
+                Assert.Equal(solutionChecksum, await synched.State.GetChecksumAsync(CancellationToken.None));
+            }
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
         public async Task TestUpdatePrimaryWorkspace()
         {
             var code = @"class Test { void Method() { } }";

--- a/src/VisualStudio/Core/Test.Next/TestUtils.cs
+++ b/src/VisualStudio/Core/Test.Next/TestUtils.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.Serialization;
+using Xunit;
+
+namespace Roslyn.VisualStudio.Next.UnitTests
+{
+    internal static class TestUtils
+    {
+        public static void VerifyAssetStorage<T>(IEnumerable<KeyValuePair<Checksum, T>> items, AssetStorage storage)
+        {
+            foreach (var kv in items)
+            {
+                if (kv.Value is ChecksumCollection)
+                {
+                    // ChecksumCollection itself won't be in asset storage. since
+                    // it will be never asked from OOP side to host to sync. 
+                    // the collection is already part of 
+                    // Solution/Project/DocumentStateCheckum so syncing
+                    // state checksum automatically bring in the collection.
+                    // it only exist to calculate hierarchical checksum
+                    continue;
+                }
+
+                Assert.True(storage.TryGetAsset(kv.Key, out object data));
+            }
+        }
+    }
+}

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -1,29 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#if DEBUG
-#if false // https://github.com/dotnet/roslyn/issues/33476
-#define VALIDATE_CHECKSUM
-#endif
-#endif
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Remote.DebugUtil;
+using Microsoft.CodeAnalysis.Remote.Shared;
 using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-
-#if VALIDATE_CHECKSUM
 using System.Diagnostics;
-using System.Text;
-using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Remote.DebugUtil;
-using Microsoft.CodeAnalysis.Remote.Shared;
-#endif
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -531,6 +522,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 projectInfo.Language, projectInfo.FilePath, projectInfo.OutputFilePath,
                 compilationOptions, parseOptions,
                 documents, p2p, metadata, analyzers, additionals, projectInfo.IsSubmission)
+                .WithOutputRefFilePath(projectInfo.OutputRefFilePath)
                 .WithHasAllInformation(projectInfo.HasAllInformation)
                 .WithDefaultNamespace(projectInfo.DefaultNamespace);
         }
@@ -635,64 +627,31 @@ namespace Microsoft.CodeAnalysis.Remote
             return builder.ToImmutableAndFree();
         }
 
-        private async Task ValidateChecksumAsync(Checksum givenSolutionChecksum, Solution solution)
+        private async Task ValidateChecksumAsync(Checksum checksumFromRequest, Solution incrementalSolutionBuilt)
         {
-#if VALIDATE_CHECKSUM
-            var currentSolutionChecksum = await solution.State.GetChecksumAsync(_cancellationToken).ConfigureAwait(false);
-
-            if (givenSolutionChecksum == currentSolutionChecksum)
+#if DEBUG
+            var currentSolutionChecksum = await incrementalSolutionBuilt.State.GetChecksumAsync(CancellationToken.None).ConfigureAwait(false);
+            if (checksumFromRequest == currentSolutionChecksum)
             {
                 return;
             }
 
-            var map = await solution.GetAssetMapAsync(_cancellationToken).ConfigureAwait(false);
-            await RemoveDuplicateChecksumsAsync(givenSolutionChecksum, map).ConfigureAwait(false);
+            var solutionFromScratch = await CreateSolutionFromScratchAsync(checksumFromRequest).ConfigureAwait(false);
 
-            foreach (var kv in map.Where(kv => kv.Value is ChecksumWithChildren).ToList())
+            await TestUtils.AssertChecksumsAsync(_assetService, checksumFromRequest, solutionFromScratch, incrementalSolutionBuilt).ConfigureAwait(false);
+
+            async Task<Solution> CreateSolutionFromScratchAsync(Checksum checksum)
             {
-                map.Remove(kv.Key);
+                var solutionInfo = await CreateSolutionInfoAsync(checksum).ConfigureAwait(false);
+                var workspace = new TemporaryWorkspace(solutionInfo);
+
+                return workspace.CurrentSolution;
             }
-
-            var sb = new StringBuilder();
-            foreach (var kv in map)
-            {
-                sb.AppendLine($"{kv.Key.ToString()}, {kv.Value.ToString()}");
-            }
-
-            Logger.Log(FunctionId.SolutionCreator_AssetDifferences, sb.ToString());
-
-            Debug.Fail("Differences detected in solution checksum: " + sb.ToString());
 #else
 
             // have this to avoid error on async
             await Task.CompletedTask.ConfigureAwait(false);
 #endif
         }
-
-#if VALIDATE_CHECKSUM
-        private async Task RemoveDuplicateChecksumsAsync(Checksum givenSolutionChecksum, Dictionary<Checksum, object> map)
-        {
-            var solutionChecksums = await _assetService.GetAssetAsync<SolutionStateChecksums>(givenSolutionChecksum, _cancellationToken).ConfigureAwait(false);
-            map.RemoveChecksums(solutionChecksums);
-
-            foreach (var projectChecksum in solutionChecksums.Projects)
-            {
-                var projectChecksums = await _assetService.GetAssetAsync<ProjectStateChecksums>(projectChecksum, _cancellationToken).ConfigureAwait(false);
-                map.RemoveChecksums(projectChecksums);
-
-                foreach (var documentChecksum in projectChecksums.Documents)
-                {
-                    var documentChecksums = await _assetService.GetAssetAsync<DocumentStateChecksums>(documentChecksum, _cancellationToken).ConfigureAwait(false);
-                    map.RemoveChecksums(documentChecksums);
-                }
-
-                foreach (var documentChecksum in projectChecksums.AdditionalDocuments)
-                {
-                    var documentChecksums = await _assetService.GetAssetAsync<DocumentStateChecksums>(documentChecksum, _cancellationToken).ConfigureAwait(false);
-                    map.RemoveChecksums(documentChecksums);
-                }
-            }
-        }
-#endif
     }
 }

--- a/src/Workspaces/Remote/Core/Shared/Extensions.cs
+++ b/src/Workspaces/Remote/Core/Shared/Extensions.cs
@@ -76,6 +76,13 @@ namespace Microsoft.CodeAnalysis.Remote.Shared
         private static HashSet<Checksum> Flatten(ChecksumWithChildren checksums)
         {
             var set = new HashSet<Checksum>();
+            set.AppendChecksums(checksums);
+
+            return set;
+        }
+
+        public static void AppendChecksums(this HashSet<Checksum> set, ChecksumWithChildren checksums)
+        {
             set.Add(checksums.Checksum);
 
             foreach (var child in checksums.Children)
@@ -87,14 +94,9 @@ namespace Microsoft.CodeAnalysis.Remote.Shared
 
                 if (child is ChecksumCollection collection)
                 {
-                    foreach (var item in collection)
-                    {
-                        set.Add(item);
-                    }
+                    set.AppendChecksums(collection);
                 }
             }
-
-            return set;
         }
     }
 }

--- a/src/Workspaces/Remote/Core/TestUtils.cs
+++ b/src/Workspaces/Remote/Core/TestUtils.cs
@@ -1,6 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Remote.Shared;
 using Microsoft.CodeAnalysis.Serialization;
 
 namespace Microsoft.CodeAnalysis.Remote.DebugUtil
@@ -9,23 +16,117 @@ namespace Microsoft.CodeAnalysis.Remote.DebugUtil
     {
         public static void RemoveChecksums(this Dictionary<Checksum, object> map, ChecksumWithChildren checksums)
         {
-            map.Remove(checksums.Checksum);
+            var set = new HashSet<Checksum>();
+            set.AppendChecksums(checksums);
 
-            foreach (var child in checksums.Children)
+            RemoveChecksums(map, set);
+        }
+
+        public static void RemoveChecksums(this Dictionary<Checksum, object> map, IEnumerable<Checksum> checksums)
+        {
+            foreach (var checksum in checksums)
             {
-                if (child is Checksum checksum)
+                map.Remove(checksum);
+            }
+        }
+
+        internal static async Task AssertChecksumsAsync(
+            AssetService assetService,
+            Checksum checksumFromRequest,
+            Solution solutionFromScratch,
+            Solution incrementalSolutionBuilt)
+        {
+#if DEBUG
+            var sb = new StringBuilder();
+            var allChecksumsFromRequest = await GetAllChildrenChecksumsAsync(checksumFromRequest).ConfigureAwait(false);
+
+            var assetMapFromNewSolution = await solutionFromScratch.GetAssetMapAsync(CancellationToken.None).ConfigureAwait(false);
+            var assetMapFromIncrementalSolution = await incrementalSolutionBuilt.GetAssetMapAsync(CancellationToken.None).ConfigureAwait(false);
+
+            // check 4 things
+            // 1. first see if we create new solution from scratch, it works as expected (indicating a bug in incremental update)
+            var mismatch1 = assetMapFromNewSolution.Where(p => !allChecksumsFromRequest.Contains(p.Key)).ToList();
+            AppendMismatch(mismatch1, "assets only in new solutoin but not in the request", sb);
+
+            // 2. second check what items is mismatching for incremental solution
+            var mismatch2 = assetMapFromIncrementalSolution.Where(p => !allChecksumsFromRequest.Contains(p.Key)).ToList();
+            AppendMismatch(mismatch2, "assets only in the incremental solution but not in the request", sb);
+
+            // 3. check whether solution created from scratch and incremental one have any mismatch
+            var mismatch3 = assetMapFromNewSolution.Where(p => !assetMapFromIncrementalSolution.ContainsKey(p.Key)).ToList();
+            AppendMismatch(mismatch3, "assets only in new solution but not in incremental solution", sb);
+
+            var mismatch4 = assetMapFromIncrementalSolution.Where(p => !assetMapFromNewSolution.ContainsKey(p.Key)).ToList();
+            AppendMismatch(mismatch4, "assets only in incremental solution but not in new solution", sb);
+
+            // 4. see what item is missing from request
+            var mismatch5 = await GetAssetFromAssetServiceAsync(allChecksumsFromRequest.Except(assetMapFromNewSolution.Keys)).ConfigureAwait(false);
+            AppendMismatch(mismatch5, "assets only in the request but not in new solution", sb);
+
+            var mismatch6 = await GetAssetFromAssetServiceAsync(allChecksumsFromRequest.Except(assetMapFromIncrementalSolution.Keys)).ConfigureAwait(false);
+            AppendMismatch(mismatch6, "assets only in the request but not in incremental solution", sb);
+
+            var result = sb.ToString();
+            if (result.Length > 0)
+            {
+                Logger.Log(FunctionId.SolutionCreator_AssetDifferences, result);
+                Debug.Fail("Differences detected in solution checksum: " + result);
+            }
+
+            void AppendMismatch(List<KeyValuePair<Checksum, object>> items, string title, StringBuilder stringBuilder)
+            {
+                if (items.Count == 0)
                 {
-                    map.Remove(checksum);
+                    return;
                 }
 
-                if (child is ChecksumCollection collection)
+                stringBuilder.AppendLine(title);
+                foreach (var kv in items)
                 {
-                    foreach (var item in collection)
+                    stringBuilder.AppendLine($"{kv.Key.ToString()}, {kv.Value.ToString()}");
+                }
+
+                stringBuilder.AppendLine();
+            }
+
+            async Task<List<KeyValuePair<Checksum, object>>> GetAssetFromAssetServiceAsync(IEnumerable<Checksum> checksums)
+            {
+                var items = new List<KeyValuePair<Checksum, object>>();
+
+                foreach (var checksum in checksums)
+                {
+                    items.Add(new KeyValuePair<Checksum, object>(checksum, await assetService.GetAssetAsync<object>(checksum, CancellationToken.None).ConfigureAwait(false)));
+                }
+
+                return items;
+            }
+
+            async Task<HashSet<Checksum>> GetAllChildrenChecksumsAsync(Checksum solutionChecksum)
+            {
+                var set = new HashSet<Checksum>();
+
+                var solutionChecksums = await assetService.GetAssetAsync<SolutionStateChecksums>(solutionChecksum, CancellationToken.None).ConfigureAwait(false);
+                set.AppendChecksums(solutionChecksums);
+
+                foreach (var projectChecksum in solutionChecksums.Projects)
+                {
+                    var projectChecksums = await assetService.GetAssetAsync<ProjectStateChecksums>(projectChecksum, CancellationToken.None).ConfigureAwait(false);
+                    set.AppendChecksums(projectChecksums);
+
+                    foreach (var documentChecksum in projectChecksums.Documents.Concat(projectChecksums.AdditionalDocuments))
                     {
-                        map.Remove(item);
+                        var documentChecksums = await assetService.GetAssetAsync<DocumentStateChecksums>(documentChecksum, CancellationToken.None).ConfigureAwait(false);
+                        set.AppendChecksums(documentChecksums);
                     }
                 }
+
+                return set;
             }
+#else
+
+            // have this to avoid error on async
+            await Task.CompletedTask.ConfigureAwait(false);
+#endif
         }
     }
 }


### PR DESCRIPTION
OutputRefFilePath didn't get synched at the initial synchronization but synched correctly on an incremental update.

we had test for an incremental update but didn't have a test covering initial sync.

also added more debugging code to spot issue easier.

fix https://github.com/dotnet/roslyn/issues/33476