### PR TITLE
Fix the navigation bar tests for VS2019

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc_NavigationBar.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc_NavigationBar.cs
@@ -3,11 +3,17 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess.ReflectionExtensions;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+using IObjectWithSite = Microsoft.VisualStudio.OLE.Interop.IObjectWithSite;
+using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 {
@@ -81,6 +87,28 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         private static UIElement GetNavbar(IWpfTextView textView)
         {
+            // Visual Studio 2019
+            var editorAdaptersFactoryService = GetComponentModelService<IVsEditorAdaptersFactoryService>();
+            var viewAdapter = editorAdaptersFactoryService.GetViewAdapter(textView);
+
+            // Make sure we have the top pane
+            //
+            // The docs are wrong. When a secondary view exists, it is the secondary view which is on top. The primary
+            // view is only on top when there is no secondary view.
+            var codeWindow = TryGetCodeWindow(viewAdapter);
+            if (ErrorHandler.Succeeded(codeWindow.GetSecondaryView(out var secondaryViewAdapter)))
+            {
+                viewAdapter = secondaryViewAdapter;
+            }
+
+            var textViewHost = editorAdaptersFactoryService.GetWpfTextViewHost(viewAdapter);
+            var dropDownMargin = textViewHost.GetTextViewMargin("DropDownMargin");
+            if (dropDownMargin != null)
+            {
+                return ((Decorator)dropDownMargin.VisualElement).Child;
+            }
+
+            // Visual Studio 2017
             var control = textView.VisualElement;
             while (control != null)
             {
@@ -95,6 +123,73 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             var topMarginControl = control.GetPropertyValue<ContentControl>("TopMarginControl");
             var vsDropDownBarAdapterMargin = topMarginControl.Content as UIElement;
             return vsDropDownBarAdapterMargin;
+        }
+
+        private static IVsCodeWindow TryGetCodeWindow(IVsTextView textView)
+        {
+            if (textView == null)
+            {
+                throw new ArgumentNullException(nameof(textView));
+            }
+
+            if (!(textView is IObjectWithSite objectWithSite))
+            {
+                return null;
+            }
+
+            var riid = typeof(IOleServiceProvider).GUID;
+            objectWithSite.GetSite(ref riid, out var ppvSite);
+            if (ppvSite == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            IOleServiceProvider oleServiceProvider = null;
+            try
+            {
+                oleServiceProvider = Marshal.GetObjectForIUnknown(ppvSite) as IOleServiceProvider;
+            }
+            finally
+            {
+                Marshal.Release(ppvSite);
+            }
+
+            if (oleServiceProvider == null)
+            {
+                return null;
+            }
+
+            var guidService = typeof(SVsWindowFrame).GUID;
+            riid = typeof(IVsWindowFrame).GUID;
+            if (ErrorHandler.Failed(oleServiceProvider.QueryService(ref guidService, ref riid, out var ppvObject)) || ppvObject == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            IVsWindowFrame frame = null;
+            try
+            {
+                frame = Marshal.GetObjectForIUnknown(ppvObject) as IVsWindowFrame;
+            }
+            finally
+            {
+                Marshal.Release(ppvObject);
+            }
+
+            riid = typeof(IVsCodeWindow).GUID;
+            if (ErrorHandler.Failed(frame.QueryViewInterface(ref riid, out ppvObject)) || ppvObject == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            try
+            {
+                return Marshal.GetObjectForIUnknown(ppvObject) as IVsCodeWindow;
+            }
+            finally
+            {
+                Marshal.Release(ppvObject);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes failures to run navigation bar tests in Visual Studio 2019.

* The **dev16.0-vs-deps** branch needs this change before we can complete an integration test pass
* The **master** branch needs this change so developers can run tests locally

**dev16.0** is the common ancestor branch to address both of the above.