### PR TITLE
Don't run ResizeCompactsAllDead on Mono

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/WeakListTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/WeakListTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
             GC.KeepAlive(b.GetReference());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ClrOnly))]
         public void ResizeCompactsAllDead()
         {
             var a = Create("A");


### PR DESCRIPTION
Fixes the Linux mono build.