### PR TITLE
Store type and slot in VisitResult

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -597,7 +597,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// AssignedWhenFalse.
         /// </summary>
         /// <param name="node"></param>
-        protected BoundNode VisitRvalue(BoundExpression node)
+        protected virtual BoundNode VisitRvalue(BoundExpression node)
         {
             var result = Visit(node);
             Unsplit();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -33927,6 +33927,27 @@ class Awaiter : System.Runtime.CompilerServices.INotifyCompletion
         }
 
         [Fact]
+        public void Await_03()
+        {
+            var source =
+@"using System.Threading.Tasks;
+class Program
+{
+    async void M(Task? x, Task? y)
+    {
+        if (y == null) return;
+        await x; // 1
+        await y;
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (7,15): warning CS8602: Possible dereference of a null reference.
+                //         await x; // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 15));
+        }
+
+        [Fact]
         public void Await_ProduceResultTypeFromTask()
         {
             var source = @"


### PR DESCRIPTION
Change `VisitResult` to `{ Type, Slot }`, representing the inferred type of the visited expression and an optional slot for tracked variables.

If `VisitRvalue(expr)` is called (or `MakeRvalue()` is called after `Visit(expr)`), the top-level nullability of the result type is updated from the tracked state. 