### PR TITLE
give CSharpAsAndNullCheckCodeFixProvider more intelligence about removing statements

### DIFF
--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -132,6 +132,43 @@ $@"class C
 }");
         }
 
+        [WorkItem(33345, "https://github.com/dotnet/roslyn/issues/33345")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        public async Task TestRemoveNewLinesInSwitchStatement()
+        {
+            await TestInRegularAndScriptAsync(
+                @"class C
+{
+    void M()
+    {
+        switch (o)
+        {
+            default:
+                [|var|] x = o as string;
+
+                //a comment
+                if (x != null)
+                {
+                }
+        }
+    }
+}",
+                @"class C
+{
+    void M()
+    {
+        switch (o)
+        {
+            default:
+                //a comment
+                if (o is string x)
+                {
+                }
+        }
+    }
+}");
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
         public async Task TestMissingOnNonDeclaration()
         {

--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -343,6 +343,38 @@ $@"class C
     }
 }");
         }
+
+        [WorkItem(33345, "https://github.com/dotnet/roslyn/issues/33345")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        public async Task TestRemoveNewLines2()
+        {
+            await TestInRegularAndScriptAsync(
+                @"class C
+{
+    void M()
+    {
+        int a = 0;
+        [|var|] x = o as string;
+
+        //suffix comment
+        if (x != null)
+        {
+        }
+    }
+}",
+                @"class C
+{
+    void M()
+    {
+        int a = 0;
+        //suffix comment
+        if (o is string x)
+        {
+        }
+    }
+}");
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
         public async Task InlineTypeCheckComplexCondition1()
         {

--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -383,6 +383,35 @@ $@"class C
 
         [WorkItem(33345, "https://github.com/dotnet/roslyn/issues/33345")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        public async Task TestRemoveNewLinesWhereBlankLineIsNotEmpty()
+        {
+            await TestInRegularAndScriptAsync(
+                @"class C
+{
+    void M()
+    {
+        [|var|] x = o as string;
+         
+        //suffix comment
+        if (x != null)
+        {
+        }
+    }
+}",
+                @"class C
+{
+    void M()
+    {
+        //suffix comment
+        if (o is string x)
+        {
+        }
+    }
+}");
+        }
+
+        [WorkItem(33345, "https://github.com/dotnet/roslyn/issues/33345")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
         public async Task TestRemoveNewLines2()
         {
             await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -367,6 +367,7 @@ $@"class C
     void M()
     {
         int a = 0;
+
         //suffix comment
         if (o is string x)
         {

--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -315,6 +315,34 @@ $@"class C
 }");
         }
 
+        [WorkItem(33345, "https://github.com/dotnet/roslyn/issues/33345")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        public async Task TestRemoveNewLines()
+        {
+            await TestInRegularAndScriptAsync(
+                @"class C
+{
+    void M()
+    {
+        [|var|] x = o as string;
+
+        //suffix comment
+        if (x != null)
+        {
+        }
+    }
+}",
+                @"class C
+{
+    void M()
+    {
+        //suffix comment
+        if (o is string x)
+        {
+        }
+    }
+}");
+        }
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
         public async Task InlineTypeCheckComplexCondition1()
         {

--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests_FixAllTests.cs
@@ -201,7 +201,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
 {
     void M()
     {
-
         if (summaryElement.Content[0] is XmlTextSyntax firstTextPartSyntax && summaryElement.Content[1] is XmlEmptyElementSyntax classReferencePart && summaryElement.Content[2] is XmlTextSyntax secondTextPartSyntax)
         {
         }

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
@@ -52,8 +52,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 
             foreach (var firstStatement in firstStatementTracker.FirstStatements)
             {
-                //each statement that is now at the top of its block or switch section
-                //should have no blank lines preceding it
+                // each statement that is now at the top of its block or switch section
+                // should have no blank lines preceding it
                 editor.ReplaceNode(firstStatement, (fs, gen) =>
                     fs.WithLeadingTrivia(fs.GetLeadingTrivia().WithoutLeadingBlankLines()));
             }

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             SyntaxEditor editor, CancellationToken cancellationToken)
         {
             var declaratorLocations = new HashSet<Location>();
-            var firstStatementTracker = new FirstStatementTracker();
+            var firstStatementTracker = new FirstStatementTracker(unused:false);
             foreach (var diagnostic in diagnostics)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -120,10 +120,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             }
         }
 
-        private class FirstStatementTracker
+        private readonly struct FirstStatementTracker
         {
-            private HashSet<StatementSyntax> _removed = new HashSet<StatementSyntax>();
-            public HashSet<StatementSyntax> FirstStatements { get; } = new HashSet<StatementSyntax>();
+            private readonly HashSet<StatementSyntax> _removed ;
+            public readonly HashSet<StatementSyntax> FirstStatements;
+
+            public FirstStatementTracker(bool unused)
+            {
+                _removed = new HashSet<StatementSyntax>();
+                FirstStatements = new HashSet<StatementSyntax>();
+            }
 
             private bool WasFirst(StatementSyntax statementToRemove)
             {

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             foreach (var firstStatement in firstStatementTracker.FirstStatements)
             {
                 editor.ReplaceNode(firstStatement, (fs, gen) =>
-                    fs.WithLeadingTrivia(fs.GetLeadingTrivia().SkipInitialBlankLines()));
+                    fs.WithLeadingTrivia(fs.GetLeadingTrivia().WithoutLeadingBlankLines()));
             }
 
             return Task.CompletedTask;

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 
         private readonly struct FirstStatementTracker
         {
-            private readonly HashSet<StatementSyntax> _removed ;
+            private readonly HashSet<StatementSyntax> _removed;
             public readonly HashSet<StatementSyntax> FirstStatements;
 
             public FirstStatementTracker(bool unused)

--- a/src/Workspaces/CSharp/Portable/Extensions/StatementSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/StatementSyntaxExtensions.cs
@@ -13,11 +13,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 {
     internal static class StatementSyntaxExtensions
     {
-        public static bool IsFirstStatementInEnclosingBlock(this StatementSyntax statement)
-            => statement.Parent is BlockSyntax block && block.Statements.First() == statement;
-
-        public static bool IsFirstStatementInSwitchSection(this StatementSyntax statement)
-            => statement.Parent is SwitchSectionSyntax switchSection && switchSection.Statements.First() == statement;
+        public static StatementSyntax WithoutLeadingBlankLinesInTrivia(this StatementSyntax statement)
+            => statement.WithLeadingTrivia(statement.GetLeadingTrivia().WithoutLeadingBlankLines());
 
         public static StatementSyntax GetPreviousStatement(this StatementSyntax statement)
         {

--- a/src/Workspaces/CSharp/Portable/Extensions/StatementSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/StatementSyntaxExtensions.cs
@@ -13,6 +13,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 {
     internal static class StatementSyntaxExtensions
     {
+        public static bool IsFirstStatementInEnclosingBlock(this StatementSyntax statement)
+        {
+            var enclosingBlock = statement.Ancestors().OfType<BlockSyntax>().FirstOrDefault();
+            if (enclosingBlock == null)
+            {
+                return false;
+            }
+
+            return statement == enclosingBlock.Statements.First();
+        }
+
+        public static bool IsFirstStatementInSwitchSection(this StatementSyntax statement)
+        {
+            var enclosingSwitchSection = statement.Ancestors().OfType<SwitchSectionSyntax>().FirstOrDefault();
+            if (enclosingSwitchSection == null)
+            {
+                return false;
+            }
+
+            return statement == enclosingSwitchSection.Statements.First();
+        }
+
         public static StatementSyntax GetPreviousStatement(this StatementSyntax statement)
         {
             if (statement != null)

--- a/src/Workspaces/CSharp/Portable/Extensions/StatementSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/StatementSyntaxExtensions.cs
@@ -14,24 +14,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
     internal static class StatementSyntaxExtensions
     {
         public static bool IsFirstStatementInEnclosingBlock(this StatementSyntax statement)
-        {
-            if (!(statement.Parent is BlockSyntax enclosingBlock))
-            {
-                return false;
-            }
-
-            return statement == enclosingBlock.Statements.First();
-        }
+            => statement.Parent is BlockSyntax block && block.Statements.First() == statement;
 
         public static bool IsFirstStatementInSwitchSection(this StatementSyntax statement)
-        {
-            if (!(statement.Parent is SwitchSectionSyntax enclosingSwitchSection))
-            {
-                return false;
-            }
-
-            return statement == enclosingSwitchSection.Statements.First();
-        }
+            => statement.Parent is SwitchSectionSyntax block && block.Statements.First() == statement;
 
         public static StatementSyntax GetPreviousStatement(this StatementSyntax statement)
         {

--- a/src/Workspaces/CSharp/Portable/Extensions/StatementSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/StatementSyntaxExtensions.cs
@@ -15,8 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
     {
         public static bool IsFirstStatementInEnclosingBlock(this StatementSyntax statement)
         {
-            var enclosingBlock = statement.Ancestors().OfType<BlockSyntax>().FirstOrDefault();
-            if (enclosingBlock == null)
+            if (!(statement.Parent is BlockSyntax enclosingBlock))
             {
                 return false;
             }
@@ -26,8 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
         public static bool IsFirstStatementInSwitchSection(this StatementSyntax statement)
         {
-            var enclosingSwitchSection = statement.Ancestors().OfType<SwitchSectionSyntax>().FirstOrDefault();
-            if (enclosingSwitchSection == null)
+            if (!(statement.Parent is SwitchSectionSyntax enclosingSwitchSection))
             {
                 return false;
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/StatementSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/StatementSyntaxExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             => statement.Parent is BlockSyntax block && block.Statements.First() == statement;
 
         public static bool IsFirstStatementInSwitchSection(this StatementSyntax statement)
-            => statement.Parent is SwitchSectionSyntax block && block.Statements.First() == statement;
+            => statement.Parent is SwitchSectionSyntax switchSection && switchSection.Statements.First() == statement;
 
         public static StatementSyntax GetPreviousStatement(this StatementSyntax statement)
         {

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaListExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaListExtensions.cs
@@ -52,33 +52,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
         private static ImmutableArray<ImmutableArray<SyntaxTrivia>> BreakIntoLines(this SyntaxTriviaList triviaList)
         {
-            var result = ImmutableArray.Create<ImmutableArray<SyntaxTrivia>>();
-            var currentLine = ImmutableArray.Create<SyntaxTrivia>();
+            var result = ArrayBuilder<ImmutableArray<SyntaxTrivia>>.GetInstance();
+            var currentLine = ArrayBuilder<SyntaxTrivia>.GetInstance();
             foreach (var trivia in triviaList)
             {
-                currentLine = currentLine.Add(trivia);
+                currentLine.Add(trivia);
                 if (trivia.Kind() == SyntaxKind.EndOfLineTrivia)
                 {
-                    result = result.Add(currentLine);
-                    currentLine = ImmutableArray.Create<SyntaxTrivia>();
+                    result.Add(currentLine.ToImmutableAndFree());
+                    currentLine = ArrayBuilder<SyntaxTrivia>.GetInstance();
                 }
             }
 
-            if (currentLine.Length > 0)
+            if (currentLine.Count > 0)
             {
-                result = result.Add(currentLine);
+                result.Add(currentLine.ToImmutableAndFree());
             }
 
-            return result;
+            return result.ToImmutableAndFree();
         }
 
-        public static IEnumerable<SyntaxTrivia> SkipInitialBlankLines(this SyntaxTriviaList triviaList)
+        public static SyntaxTriviaList WithoutLeadingBlankLines(this SyntaxTriviaList triviaList)
         {
-            return triviaList.BreakIntoLines()
+            return new SyntaxTriviaList(triviaList.BreakIntoLines()
                 .SkipWhile(l => l.All(t =>
                     t.Kind() == SyntaxKind.EndOfLineTrivia ||
                     t.Kind() == SyntaxKind.WhitespaceTrivia))
-                .SelectMany(l => l);
+                .SelectMany(l => l));
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes https://github.com/dotnet/roslyn/issues/33345.

There is a `SyntaxNode` extension method called `WithPrependedNonIndentationTriviaFrom`, which takes trivia from one node and prepends them to a node that comes next. But because the node from which they are taken is in the process of being removed, any leading new lines preceding the next node are no longer needed. So the method `WithPrependedNonIndentationTriviaFrom` is changed to take those new lines into account and to do so by making better use of the `SyntaxTriviaListExtensions`.