### PR TITLE
Enable tests expected to pass with recent stabilization work

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
@@ -32,7 +32,7 @@ namespace myNamespace
     }
 }";
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/19816")]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void EncapsulateThroughCommand()
         {

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
@@ -18,6 +19,12 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         public CSharpSendToInteractive(VisualStudioInstanceFactory instanceFactory)
             : base(instanceFactory)
         {
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+
             VisualStudio.SolutionExplorer.CreateSolution(SolutionName);
             var project = new Project(ProjectName);
             VisualStudio.SolutionExplorer.AddProject(project, WellKnownProjectTemplates.ConsoleApplication, Microsoft.CodeAnalysis.LanguageNames.CSharp);
@@ -59,7 +66,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.SubmitText("using System;");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20868")]
+        [WpfFact]
         public void SendSingleLineSubmissionToInteractive()
         {
             VisualStudio.InteractiveWindow.InsertCode("// scenario 1");
@@ -75,7 +82,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutputContains("\"1\"");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20868")]
+        [WpfFact]
         public void SendMultipleLineSubmissionToInteractive()
         {
             VisualStudio.InteractiveWindow.InsertCode("// scenario 2");
@@ -93,7 +100,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutputContains("\"3\"");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20868")]
+        [WpfFact]
         public void SendMultipleLineBlockSelectedSubmissionToInteractive()
         {
             VisualStudio.InteractiveWindow.SubmitText("int x = 1;");
@@ -114,7 +121,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutputContains("4");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20868")]
+        [WpfFact]
         public void SendToInteractiveWithKeyboardShortcut()
         {
             VisualStudio.InteractiveWindow.InsertCode("// scenario 4");
@@ -130,7 +137,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutputContains("\"7\"");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20868")]
+        [WpfFact]
         public void ExecuteSingleLineSubmissionInInteractiveWhilePreservingReplSubmissionBuffer()
         {
             VisualStudio.InteractiveWindow.InsertCode("// scenario 5");
@@ -146,7 +153,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutput("1");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20868")]
+        [WpfFact]
         public void ExecuteMultipleLineSubmissionInInteractiveWhilePreservingReplSubmissionBuffer()
         {
             VisualStudio.InteractiveWindow.InsertCode("// scenario 6");
@@ -164,7 +171,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutput("3");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20868")]
+        [WpfFact]
         public void ExecuteMultipleLineBlockSelectedSubmissionInInteractiveWhilePreservingReplSubmissionBuffer()
         {
             VisualStudio.InteractiveWindow.SubmitText("int x = 1;");
@@ -187,7 +194,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutput("4");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20868")]
+        [WpfFact]
         public void ExecuteInInteractiveWithKeyboardShortcut()
         {
             VisualStudio.InteractiveWindow.InsertCode("// scenario 8");
@@ -203,7 +210,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutput("7");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20868")]
+        [WpfFact]
         public void AddAssemblyReferenceAndTypesToInteractive()
         {
             VisualStudio.InteractiveWindow.ClearReplText();
@@ -217,7 +224,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.SolutionCrawler);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20868")]
+        [WpfFact]
         public void ResetInteractiveFromProjectAndVerify()
         {
             var assembly = new ProjectUtils.AssemblyReference("System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEditAndContinue.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEditAndContinue.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
@@ -15,16 +16,23 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         private const string module1FileName = "Module1.vb";
 
-        public BasicEditAndContinue(VisualStudioInstanceFactory instanceFactory) : base(instanceFactory)
+        public BasicEditAndContinue(VisualStudioInstanceFactory instanceFactory)
+            : base(instanceFactory)
         {
+        }
+
+        protected override string LanguageName => LanguageNames.VisualBasic;
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+
             VisualStudio.SolutionExplorer.CreateSolution(nameof(BasicBuild));
             var testProj = new ProjectUtils.Project("TestProj");
             VisualStudio.SolutionExplorer.AddProject(testProj, WellKnownProjectTemplates.ConsoleApplication, LanguageNames.VisualBasic);
         }
 
-        protected override string LanguageName => LanguageNames.VisualBasic;
-
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/21925")]
+        [WpfFact]
         public void UpdateActiveStatementLeafNode()
         {
             VisualStudio.Editor.SetText(@"
@@ -55,7 +63,7 @@ End Module
             VisualStudio.Debugger.CheckExpression("names(1)", "String", "\"bar\"");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/21925")]
+        [WpfFact]
         public void AddTryCatchAroundActiveStatement()
         {
             VisualStudio.Editor.SetText(@"
@@ -83,7 +91,7 @@ End Try");
             VisualStudio.Editor.Verify.CurrentLineText("End Try");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/21925")]
+        [WpfFact]
         public void EditLambdaExpression()
         {
             VisualStudio.Editor.SetText(@"
@@ -114,7 +122,7 @@ End Module");
             VisualStudio.ErrorList.Verify.NoBuildErrors();
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/21925")]
+        [WpfFact]
         public void EnCWhileDebuggingFromImmediateWindow()
         {
             VisualStudio.Editor.SetText(@"
@@ -137,7 +145,7 @@ End Module");
             VisualStudio.Debugger.ExecuteStatement("Module1.Main()");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/21925")]
+        [WpfFact]
         private void SetupMultiProjectSolution()
         {
             var basicLibrary = new ProjectUtils.Project("BasicLibrary1");
@@ -179,7 +187,7 @@ End Module
             VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/21925")]
+        [WpfFact]
         public void MultiProjectDebuggingWhereNotAllModulesAreLoaded()
         {
             SetupMultiProjectSolution();
@@ -190,7 +198,7 @@ End Module
             VisualStudio.ErrorList.Verify.NoErrors();
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/21925")]
+        [WpfFact]
         public void DocumentStateTrackingReadonlyInRunMode()
         {
             SetupMultiProjectSolution();
@@ -240,7 +248,7 @@ End Module
             VisualStudio.Editor.Verify.IsProjectItemDirty(expectedValue: false);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/21925")]
+        [WpfFact]
         public void LocalsWindowUpdatesAfterLocalGetsItsTypeUpdatedDuringEnC()
         {
             VisualStudio.Editor.SetText(@"
@@ -263,7 +271,7 @@ End Module
             VisualStudio.LocalsWindow.Verify.CheckEntry("goo", "Single", "10");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/21925")]
+        [WpfFact]
         public void LocalsWindowUpdatesCorrectlyDuringEnC()
         {
             VisualStudio.Editor.SetText(@"
@@ -296,7 +304,7 @@ End Module
             VisualStudio.LocalsWindow.Verify.CheckEntry("lLng", "Long", "444");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/21925")]
+        [WpfFact]
         public void WatchWindowUpdatesCorrectlyDuringEnC()
         {
             VisualStudio.Editor.SetText(@"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEncapsulateField.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEncapsulateField.cs
@@ -27,7 +27,7 @@ Module Module1
     End Sub
 End Module";
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/19816")]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void EncapsulateThroughCommand()
         {

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExpressionEvaluator.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExpressionEvaluator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
@@ -13,8 +14,15 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicExpressionEvaluator(VisualStudioInstanceFactory instanceFactory) : base(instanceFactory)
+        public BasicExpressionEvaluator(VisualStudioInstanceFactory instanceFactory)
+            : base(instanceFactory)
         {
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+
             VisualStudio.SolutionExplorer.CreateSolution(nameof(BasicBuild));
             var testProj = new ProjectUtils.Project("TestProj");
             VisualStudio.SolutionExplorer.AddProject(testProj, WellKnownProjectTemplates.ConsoleApplication, LanguageNames.VisualBasic);
@@ -56,7 +64,7 @@ Module Module1
 End Module");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20979")]
+        [WpfFact]
         public void ValidateLocalsWindow()
         {
             VisualStudio.Debugger.Go(waitForBreakMode: true);
@@ -84,7 +92,7 @@ End Module");
             VisualStudio.LocalsWindow.Verify.CheckEntry("myMulticastDelegate", "System.MulticastDelegate", "Nothing");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20979")]
+        [WpfFact]
         public void EvaluatePrimitiveValues()
         {
             VisualStudio.Debugger.Go(waitForBreakMode: true);
@@ -105,14 +113,14 @@ End Module");
             VisualStudio.Debugger.CheckExpression("(Function(val)(val+val))(1)", "Integer", "2");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20979")]
+        [WpfFact]
         public void EvaluateInvalidExpressions()
         {
             VisualStudio.Debugger.Go(waitForBreakMode: true);
             VisualStudio.Debugger.CheckExpression("myNonsense", "", "error BC30451: 'myNonsense' is not declared. It may be inaccessible due to its protection level.");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20979")]
+        [WpfFact]
         public void StateMachineTypeParameters()
         {
             VisualStudio.Editor.SetText(@"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExtractMethod.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExtractMethod.cs
@@ -42,7 +42,7 @@ End Module";
         {
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/33103")]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ExtractMethod)]
         public void SimpleExtractMethod()
         {

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicLineCommit.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicLineCommit.cs
@@ -76,7 +76,7 @@ End Module");
             VisualStudio.Editor.Verify.CaretPosition(16);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/20991"), Trait(Traits.Feature, Traits.Features.LineCommit)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.LineCommit)]
         void CommitOnSave()
         {
             VisualStudio.Editor.SetText(@"Module Module1

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
@@ -99,7 +99,7 @@ End Module");
             Assert.Equal("Sub Program.M(p As Object) (+ 1 overload)", VisualStudio.Editor.GetQuickInfo());
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/30599")]
+        [WpfFact]
         public void RenamingOpenFiles()
         {
             var project = new ProjectUtils.Project(ProjectName);
@@ -109,6 +109,21 @@ End Module");
             Assert.Contains(ProjectName, VisualStudio.Editor.GetProjectNavBarItems());
 
             VisualStudio.SolutionExplorer.RenameFile(project, "BeforeRename.cs", "AfterRename.cs");
+
+            // ...and after.
+            Assert.Contains(ProjectName, VisualStudio.Editor.GetProjectNavBarItems());
+        }
+
+        [WpfFact]
+        public virtual void RenamingOpenFilesViaDTE()
+        {
+            var project = new ProjectUtils.Project(ProjectName);
+            VisualStudio.SolutionExplorer.AddFile(project, "BeforeRename.cs", open: true);
+
+            // Verify we are connected to the project before...
+            Assert.Contains(ProjectName, VisualStudio.Editor.GetProjectNavBarItems());
+
+            VisualStudio.SolutionExplorer.RenameFileViaDTE(project, "BeforeRename.cs", "AfterRename.cs");
 
             // ...and after.
             Assert.Contains(ProjectName, VisualStudio.Editor.GetProjectNavBarItems());

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
@@ -59,5 +59,13 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             VisualStudio.SolutionExplorer.RestoreNuGetPackages(project);
             base.ProjectProperties();
         }
+
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/30599")]
+        [Trait(Traits.Feature, Traits.Features.Workspace)]
+        [Trait(Traits.Feature, Traits.Features.NetCore)]
+        public override void RenamingOpenFilesViaDTE()
+        {
+            base.RenamingOpenFilesViaDTE();
+        }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -133,6 +133,17 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void RenameFile(string projectName, string oldFileName, string newFileName)
         {
+            var project = GetProject(projectName);
+            var projectDirectory = Path.GetDirectoryName(project.FullName);
+
+            VsShellUtilities.RenameDocument(
+                ServiceProvider.GlobalProvider,
+                Path.Combine(projectDirectory, oldFileName),
+                Path.Combine(projectDirectory, newFileName));
+        }
+
+        public void RenameFileViaDTE(string projectName, string oldFileName, string newFileName)
+        {
             var projectItem = GetProjectItem(projectName, oldFileName);
 
             projectItem.Name = newFileName;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
@@ -121,6 +121,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             _instance.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
         }
 
+        public void RenameFileViaDTE(ProjectUtils.Project project, string oldFileName, string newFileName)
+        {
+            // Wireup to open files can happen asynchronously in the case we're being notified of changes on background threads.
+            _inProc.RenameFileViaDTE(project.Name, oldFileName, newFileName);
+            _instance.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
+        }
+
         public void CloseFile(ProjectUtils.Project project, string fileName, bool saveFile)
             => _inProc.CloseFile(project.Name, fileName, saveFile);
 


### PR DESCRIPTION
Closes #19816
Closes #20868
Closes #20979
Closes #20991
Closes #21925
Closes #33103

Mitigates the test gap created by #30599 by creating a second set of tests that passes.