### PR TITLE
Use threestate to track generated state in CSharpSyntaxTree

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -611,7 +611,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal bool IsGeneratedCode()
         {
-            if (_lazyIsGeneratedCode == -1)
+            if (_lazyIsGeneratedCode == ThreeState.Unknown)
             {
                 // Create the generated code status on demand
                 bool isGenerated = GeneratedCodeUtilities.IsGeneratedCode(
@@ -619,16 +619,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                            isComment: trivia => trivia.Kind() == SyntaxKind.SingleLineCommentTrivia || trivia.Kind() == SyntaxKind.MultiLineCommentTrivia,
                            cancellationToken: default);
 
-                Interlocked.CompareExchange(ref _lazyIsGeneratedCode, isGenerated ? 1 : 0, -1);
+                _lazyIsGeneratedCode = isGenerated.ToThreeState();
             }
 
-            return _lazyIsGeneratedCode == 1;
+            return _lazyIsGeneratedCode == ThreeState.True;
         }
 
         private CSharpLineDirectiveMap _lazyLineDirectiveMap;
         private CSharpPragmaWarningStateMap _lazyPragmaWarningStateMap;
         private NullableDirectiveMap _lazyNullableDirectiveMap;
-        private int _lazyIsGeneratedCode = -1;
+        private ThreeState _lazyIsGeneratedCode = ThreeState.Unknown;
 
         private LinePosition GetLinePosition(int position)
         {


### PR DESCRIPTION
Fixes #33207