### PR TITLE
Nullability for NVT with no constructor argument:

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1280,14 +1280,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             if ((object)type != null)
             {
                 bool isTrackableStructType = EmptyStructTypeCache.IsTrackableStructType(type);
+                var constructor = (node as BoundObjectCreationExpression)?.Constructor;
+                bool isDefaultValueTypeConstructor = constructor?.IsDefaultValueTypeConstructor() == true;
+
                 if (!type.IsValueType || isTrackableStructType)
                 {
                     slot = GetOrCreateObjectCreationPlaceholderSlot(node);
                     if (slot > 0 && isTrackableStructType)
                     {
                         this.State[slot] = NullableAnnotation.NotNullable;
-                        var constructor = (node as BoundObjectCreationExpression)?.Constructor;
-                        bool isDefaultValueTypeConstructor = constructor?.IsDefaultValueTypeConstructor() == true;
                         var tupleType = constructor?.ContainingType as TupleTypeSymbol;
                         if ((object)tupleType != null && !isDefaultValueTypeConstructor)
                         {
@@ -1304,9 +1305,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
-                else if (type.IsNullableType() && arguments.Length == 0)
+                else if (type.IsNullableType() && isDefaultValueTypeConstructor)
                 {
-                    // a nullable value type created with zero arguments is by definition null
+                    // a nullable value type created with its default constructor is by definition null
                     resultAnnotation = NullableAnnotation.Nullable;
                 }
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1276,6 +1276,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             int slot = -1;
             TypeSymbol type = node.Type;
+            NullableAnnotation resultAnnotation = NullableAnnotation.NotNullable;
             if ((object)type != null)
             {
                 bool isTrackableStructType = EmptyStructTypeCache.IsTrackableStructType(type);
@@ -1303,6 +1304,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
+                else if (type.IsNullableType() && arguments.Length == 0)
+                {
+                    // a nullable value type created with zero arguments is by definition null
+                    resultAnnotation = NullableAnnotation.Nullable;
+                }
             }
 
             if (initializerOpt != null)
@@ -1310,7 +1316,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitObjectCreationInitializer(null, slot, initializerOpt);
             }
 
-            ResultType = TypeSymbolWithAnnotations.Create(type, NullableAnnotation.NotNullable);
+            ResultType = TypeSymbolWithAnnotations.Create(type, resultAnnotation);
         }
 
         private void VisitObjectCreationInitializer(Symbol containingSymbol, int containingSlot, BoundExpression node)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -74775,8 +74775,14 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/31502: Recognize Nullable<T> constructors.
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (6,13): warning CS8629: Nullable value type may be null.
+                //         _ = x.Value; // 1
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "x.Value").WithLocation(6, 13),
+                // (10,13): warning CS8629: Nullable value type may be null.
+                //         _ = z.Value; // 2
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "z.Value").WithLocation(10, 13)
+                );
         }
 
         [Fact]


### PR DESCRIPTION
- Explicitly check if an object creation is a nullable value type
- Set its state to nullable when no argument is passed in
- Update tests

Fixes #31502