### PR TITLE
PoC: ISymbolicNavigationService to enable C# -> F# GoToDefinition

### DIFF
--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
@@ -101,6 +101,13 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             bool thirdPartyNavigationAllowed = true,
             bool throwOnHiddenDefinition = false)
         {
+            var languageServices = project.Solution.Workspace.Services.GetLanguageServices(LanguageNames.FSharp);
+            var symbolicNavigationService = languageServices?.GetService<ISymbolicNavigationService>();
+            var found = symbolicNavigationService?.TryNavigateToSymbol(symbol, cancellationToken)
+                .WaitAndGetResult(cancellationToken);
+            if (found != null && found == true)
+                return true;
+
             var definitions = GetDefinitions(symbol, project, thirdPartyNavigationAllowed, cancellationToken);
 
             var presenter = streamingPresenters.FirstOrDefault()?.Value;

--- a/src/EditorFeatures/Core/GoToDefinition/ISymbolicNavigationService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/ISymbolicNavigationService.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Editor
+{
+    internal interface ISymbolicNavigationService : ILanguageService
+    {
+        /// <summary>
+        /// Is this a symbol of your language? If it is, tell us and you can take over the navigation however you would like.
+        /// </summary>
+        Task<bool> TryNavigateToSymbol(ISymbol symbol, CancellationToken cancellationToken);
+    }
+}


### PR DESCRIPTION
Defines a new ISymbolicNavigationService interface and uses it in GoToDefinition to enable third parties to navigate if they recognize an ISymbol as their own.

See discussion here: https://github.com/dotnet/roslyn/issues/8105