### PR TITLE
async completion: remove duplicate matching for highlighting

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/FilterResult.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/FilterResult.cs
@@ -9,13 +9,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
     {
         public readonly CompletionItem CompletionItem;
         public readonly bool MatchedFilterText;
-        public readonly string FilterText;
 
-        public FilterResult(CompletionItem completionItem, string filterText, bool matchedFilterText)
+        public FilterResult(CompletionItem completionItem, bool matchedFilterText)
         {
             CompletionItem = completionItem;
             MatchedFilterText = matchedFilterText;
-            FilterText = filterText;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     filterText.Length > 0)
                 {
                     var uniqueItemIndex = itemsInList.IndexOf(i => Equals(i.FilterResult.CompletionItem, deduplicatedList.First()));
-                    uniqueItem = highlightedList[uniqueItemIndex].CompletionItem;
+                    uniqueItem = itemsInList[uniqueItemIndex].CompletionItemWithHighlight.CompletionItem;
                 }
             }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -243,18 +243,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             //     have just typed the character to get completion.  Filtering out items
             //     here is not desirable.
             //
-            //  2. They brough up completion with ctrl-j or through deletion.  In these
+            //  2. They brought up completion with ctrl-j or through deletion.  In these
             //     cases we just always keep all the items in the list.
             if (matchesFilterText ||
                 initialRoslynTriggerKind == CompletionTriggerKind.Deletion ||
                 initialRoslynTriggerKind == CompletionTriggerKind.Invoke ||
                 filterText.Length <= 1)
             {
-                if (matchedSpans.IsEmpty && highlightMatchingPortions)
-                {
-                    matchedSpans = completionHelper.GetHighlightedSpans(item.FilterText, filterText, CultureInfo.CurrentCulture);
-                }
-
                 extendedFilterResult = new ExtendedFilterResult(
                     new CompletionItemWithHighlight(item, matchedSpans.Select(s => s.ToSpan()).ToImmutableArray()),
                     new FilterResult(roslynItem, matchedFilterText: matchesFilterText));
@@ -579,6 +574,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             if (filterReason == CompletionFilterReason.Deletion &&
                 initialTriggerKind == CompletionTriggerKind.Deletion)
             {
+                if (includeMatchSpans)
+                {
+                    matchedSpans = helper.GetHighlightedSpans(item.FilterText, filterText, CultureInfo.CurrentCulture);
+                }
+
                 return item.FilterText.GetCaseInsensitivePrefixLength(filterText) > 0;
             }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -140,12 +140,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     }
 
                     // Check if the item matches the filter text typed so far.
-                    var matchesFilterText = ItemManager.MatchesFilterText(helper, currentItem, filterText, model.Trigger.Kind, filterReason, recentItems);
+                    var matchesFilterText = ItemManager.MatchesFilterText(helper, currentItem, filterText, model.Trigger.Kind, filterReason, recentItems, includeMatchSpans: false, out _);
 
                     if (matchesFilterText)
                     {
-                        filterResults.Add(new FilterResult(
-                            currentItem, filterText, matchedFilterText: true));
+                        filterResults.Add(new FilterResult(currentItem, matchedFilterText: true));
                     }
                     else
                     {
@@ -166,8 +165,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
                         if (shouldKeepItem)
                         {
-                            filterResults.Add(new FilterResult(
-                                currentItem, filterText, matchedFilterText: false));
+                            filterResults.Add(new FilterResult(currentItem, matchedFilterText: false));
                         }
                     }
                 }
@@ -184,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 // ourselves.
                 if (model.Trigger.Kind == CompletionTriggerKind.Deletion)
                 {
-                    return HandleDeletionTrigger(model, filterReason, filterResults);
+                    return HandleDeletionTrigger(model, filterReason, filterResults, filterText);
                 }
 
                 return HandleNormalFiltering(
@@ -285,7 +283,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             }
 
             private Model HandleDeletionTrigger(
-                Model model, CompletionFilterReason filterReason, List<FilterResult> filterResults)
+                Model model, CompletionFilterReason filterReason, List<FilterResult> filterResults, string filterText)
             {
                 if (filterReason == CompletionFilterReason.Insertion &&
                     !filterResults.Any(r => r.MatchedFilterText))
@@ -304,7 +302,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 foreach (var currentFilterResult in filterResults.Where(r => r.MatchedFilterText))
                 {
                     if (bestFilterResult == null ||
-                        ItemManager.IsBetterDeletionMatch(currentFilterResult, bestFilterResult.Value))
+                        ItemManager.IsBetterDeletionMatch(currentFilterResult, bestFilterResult.Value, filterText))
                     {
                         // We had no best result yet, so this is now our best result.
                         bestFilterResult = currentFilterResult;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 foreach (var currentFilterResult in filterResults.Where(r => r.MatchedFilterText))
                 {
                     if (bestFilterResult == null ||
-                        ItemManager.IsBetterDeletionMatch(currentFilterResult, bestFilterResult.Value, filterText))
+                        ItemManager.IsBetterDeletionMatch(currentFilterResult.CompletionItem, bestFilterResult.Value.CompletionItem, filterText))
                     {
                         // We had no best result yet, so this is now our best result.
                         bestFilterResult = currentFilterResult;

--- a/src/EditorFeatures/Test2/IntelliSense/CompletionRulesTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CompletionRulesTests.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Globalization
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
@@ -62,9 +63,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 MarkupTestFile.GetSpan(wordMarkup, word, wordMatchSpan)
 
                 Dim item = CompletionItem.Create(word)
-                Assert.True(helper.MatchesPattern(item.FilterText, pattern, culture), $"Expected item {word} does not match {pattern}")
-
-                Dim highlightedSpans = helper.GetHighlightedSpans(item.FilterText, pattern, culture)
+                Dim highlightedSpans = ImmutableArray(Of TextSpan).Empty
+                Assert.True(helper.MatchesPattern(item.FilterText, pattern, culture, includeMatchSpans:=True, highlightedSpans), $"Expected item {word} does not match {pattern}")
                 Assert.NotEmpty(highlightedSpans)
                 Assert.Equal(1, highlightedSpans.Length)
                 Assert.Equal(wordMatchSpan, highlightedSpans(0))
@@ -77,9 +77,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Dim helper = New CompletionHelper(isCaseSensitive:=True)
             For Each word In wordsToNotMatch
                 Dim item = CompletionItem.Create(word)
-                Assert.False(helper.MatchesPattern(item.FilterText, pattern, culture), $"Unexpected item {word} matches {pattern}")
-
-                Dim highlightedSpans = helper.GetHighlightedSpans(item.FilterText, pattern, culture)
+                Dim highlightedSpans = ImmutableArray(Of TextSpan).Empty
+                Assert.False(helper.MatchesPattern(item.FilterText, pattern, culture, includeMatchSpans:=True, highlightedSpans), $"Unexpected item {word} matches {pattern}")
                 Assert.Empty(highlightedSpans)
             Next
         End Sub


### PR DESCRIPTION
Both completion implementations (old and new) perform duplicate matching for most scenario: (1) to match items and (2) to highlight spans. Let us merge those matching together.