### PR TITLE
Enable C# 8.0 in the code base

### DIFF
--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -11,24 +11,19 @@ Using the command line Roslyn can be developed using the following pattern:
 
 ## Recommended version of .NET Framework
 
-The minimal required version of .NET Framework is 4.6, however 4.7.2 is recommended for best developer experience.
+The minimal required version of .NET Framework is 4.7.2.
 
-The projects in this repository are configured to build with Portable PDBs, which are supported in stack traces starting with .NET Framework 4.7.2.
-If a stack trace is displayed on .NET Framework older than 4.7.2 (e.g. by xUnit when a test fails) it won't contain source and line information.
+## Developing with Visual Studio 2019
 
-.NET Framework 4.7.2 is included in [Windows 10 April 2018 Update](https://blogs.windows.com/windowsexperience/2018/04/30/how-to-get-the-windows-10-april-2018-update/). It can also be installed from the [Microsoft Download Center](https://www.microsoft.com/net/download/dotnet-framework-runtime).
-
-## Developing with Visual Studio 2017
-
-1. [Visual Studio 2017 Version 15.7](https://www.visualstudio.com/vs/preview/)
+1. [Visual Studio 2019 Preview 4](https://www.visualstudio.com/vs/preview/)
     - Ensure C#, VB, MSBuild, .NET Core and Visual Studio Extensibility are included in the selected work loads
-    - Ensure Visual Studio is on Version "15.7" or greater
+    - Ensure Visual Studio is on Version "Preview 4" or greater
 1. [.NET Core SDK 2.1.401](https://www.microsoft.com/net/download/core) (the installers are: [Windows x64 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.401/dotnet-sdk-2.1.401-win-x64.exe), [Windows x86 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.401/dotnet-sdk-2.1.401-win-x86.exe))
 1. [PowerShell 3.0 or newer](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell). If you are on Windows 10, you are fine; you'll only need to upgrade if you're on Windows 7. The download link is under the "upgrading existing Windows PowerShell" heading.
 1. Run Restore.cmd
 1. Open Roslyn.sln
 
-If you already installed Visual Studio and need to add the necessary work loads or move to version 15.7:
+If you already installed Visual Studio and need to add the necessary work loads or move to Preview 4:
 do the following:
 
 - Run the Visual Studio Installer from your start menu. You can just search for "Visual Studio Installer". If you can't find it, it's typically located at "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe"
@@ -44,7 +39,7 @@ There are a number of options for running the core Roslyn unit tests:
 
 The Test.cmd script will run our unit test on already built binaries.  It can be passed the -build arguments to force a new build before running tests.
 
-1. Run the "Developer Command Prompt for VS2017" from your start menu.
+1. Run the "Developer Command Prompt for VS2019" from your start menu.
 2. Navigate to the directory of your Git clone.
 3. Run `msbuild /v:m /m /nodereuse:false BuildAndTest.proj` in the command prompt.
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,10 +73,9 @@
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta1-63011-01</MicrosoftMetadataVisualizerVersion>
     <MicrosoftMSXMLVersion>8.0.0.0-alpha</MicrosoftMSXMLVersion>
     <MicrosoftNetFrameworkReferenceAssembliesVersion>1.0.0-alpha-004</MicrosoftNetFrameworkReferenceAssembliesVersion>
-    <MicrosoftNetCompilersVersion>3.0.0-beta2-19068-12</MicrosoftNetCompilersVersion>
+    <MicrosoftNetCompilersToolsetVersion>3.1.0-beta1-19127-06</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNetCoreAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftNetCoreAnalyzersVersion>
     <MicrosoftNetCoreILAsmVersion>2.0.0</MicrosoftNetCoreILAsmVersion>
-    <MicrosoftNETCoreCompilersVersion>3.0.0-beta2-19068-12</MicrosoftNETCoreCompilersVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.0</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNETCoreRuntimeCoreCLRVersion>2.0.0</MicrosoftNETCoreRuntimeCoreCLRVersion>
      <!-- Using a private build of Microsoft.Net.Test.SDK to work around issue https://github.com/Microsoft/vstest/issues/1764 -->	
@@ -288,10 +287,10 @@
     <UsingToolXUnit>true</UsingToolXUnit>
 
     <!-- 
-      Use compilers in Microsoft.NET.Compilers package unless we are building with bootstrapped compilers.
-      Allows to dogfood the latest compiler features.
+       During the transition period from Microsoft.Net.Compilers to Microsoft.Net.Compilers.Toolset
+       we are always doing custom importing here.
     -->
-    <UsingToolMicrosoftNetCompilers Condition="'$(BootstrapBuildPath)' == ''">true</UsingToolMicrosoftNetCompilers>
+    <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -131,6 +131,14 @@
   <Import Project="Bootstrap.props" Condition="'$(BootstrapBuildPath)' != ''" />
 
   <!--
+     During the transition period from Microsoft.Net.Compilers to Microsoft.Net.Compilers.Toolset
+     we need our own PackageReference
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" Condition="'$(BootstrapBuildPath)' == ''" PrivateAssets="all" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <!--
     Analyzers
   -->
   <ItemGroup>
@@ -188,7 +196,7 @@
     <!-- C# specific settings -->
     <When Condition="'$(Language)' == 'C#'">
       <PropertyGroup>
-        <LangVersion>7.3</LangVersion>
+        <LangVersion>8.0</LangVersion>
         <WarningLevel>4</WarningLevel>
         <ErrorReport>prompt</ErrorReport>
 

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             }
 
             // Returns whether we should proceed to the destination after finallies were taken care of.
-            bool stepThroughFinally(ControlFlowRegion region, BasicBlockBuilder destination)
+            static bool stepThroughFinally(ControlFlowRegion region, BasicBlockBuilder destination)
             {
                 int destinationOrdinal = destination.Ordinal;
                 while (!region.ContainsBlock(destinationOrdinal))


### PR DESCRIPTION
This change enables C# 8.0 use in the code base as well as moving the
recommended Visual Studio version to 2019 Preview 4.  The following
features are now allowed to be used:

- `switch` expressions
- recursive pattern matching
- `using` declarations
- `static` local functions
- local / parameter shadowing in local functions / lambdas
- `null` coalescing assignment
- `async` streams: keep this out of our public API surface for now as we
don't want to block unification with netcoreapp in the future.

Before getting into the features which are off limits I wanted to
outline how compiler toolsets work in this repository. There are three
toolsets we need to consider when adopting new features:

1. The compiler toolset which provides the IDE experience: Intellisense,
syntax highlighting, etc ...
1. The compiler toolset which is used when the solution is built. This
is explicitly different than the compiler toolset which ships with the
MSBuild driving the compilation.
1. The compiler toolset is built from source on every PR and used as the
toolset for the PR (overriding 2 above).

That being said the following features are offlimit for now:

- Index / Range: the API surface area, including the parts the compiler
depends on, underwent significant churn for .NET Core Preview 3. Until
we converge it means toolsets 1 and 2 can be a bit out of sync.
- `unmanaged` generic `struct`: this is not included in VS2019 Preview 4
and hence using it would make the IDE experience poor.
- Nullable Reference Types: this area is under active churn and we could
easily get into a situation where toolsets 2 and 3 disagreed on code
checked into the repository creating unmergeable PRs. As such we're
holding off on this in master for now. Until then please use the branch
[features/NullableDogfood](https://github.com/dotnet/roslyn/tree/features/NullableDogfood)
to dogfood NRT. This will be merged back into master closer to
Dev16.0GA.

Note: This change only affects the C# compiler toolset. There are no
changes to our MSBuild or .NET Core SDK toolsets. Those will be coming
soonish though.