### PR TITLE
16.0 Preview 4. Up and down key do not work for editor if the old completion is turned on

### DIFF
--- a/src/EditorFeatures/Core/CommandHandlers/AbstractCompletionCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/AbstractCompletionCommandHandler.cs
@@ -299,8 +299,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 
         public VSCommanding.CommandState GetCommandState(EscapeKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
-            AssertIsForeground();
-            return GetCommandStateWorker(args, nextHandler);
+            return nextHandler();
         }
 
         public void ExecuteCommand(EscapeKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
@@ -316,8 +315,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 
         public VSCommanding.CommandState GetCommandState(UpKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
-            AssertIsForeground();
-            return GetCommandStateWorker(args, nextHandler);
+            return nextHandler();
         }
 
         public void ExecuteCommand(UpKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
@@ -333,8 +331,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 
         public VSCommanding.CommandState GetCommandState(DownKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
-            AssertIsForeground();
-            return GetCommandStateWorker(args, nextHandler);
+            return nextHandler();
         }
 
         public void ExecuteCommand(DownKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/33744
