### PR TITLE
Add a hack to ensure documents are connected to open files

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -482,7 +482,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
 
                 // Check for those files being opened to start wire-up if necessary
-                _workspace.CheckForOpenDocuments(documentFileNamesAdded.ToImmutable());
+                _workspace.QueueCheckForFilesBeingOpen(documentFileNamesAdded.ToImmutable());
             }
         }
 
@@ -1078,7 +1078,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     else
                     {
                         _project._workspace.ApplyChangeToWorkspace(w => _documentAddAction(w, documentInfo));
-                        _project._workspace.CheckForOpenDocuments(ImmutableArray.Create(fullPath));
+                        _project._workspace.QueueCheckForFilesBeingOpen(ImmutableArray.Create(fullPath));
                     }
                 }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
@@ -377,7 +377,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             /// <summary>
             /// Queues a new task to check for files being open for these file names.
             /// </summary>
-            public void CheckForFilesBeingOpen(ImmutableArray<string> newFileNames)
+            public void QueueCheckForFilesBeingOpen(ImmutableArray<string> newFileNames)
             {
                 _foregroundAffinitization.ThisCanBeCalledOnAnyThread();
 
@@ -419,18 +419,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 if (shouldStartTask)
                 {
-                    var asyncToken = _asyncOperationListener.BeginAsyncOperation(nameof(CheckForFilesBeingOpen));
+                    var asyncToken = _asyncOperationListener.BeginAsyncOperation(nameof(QueueCheckForFilesBeingOpen));
 
                     Task.Run(async () =>
                     {
                         await _foregroundAffinitization.ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                        CheckForFilesBeingOpenOnUIThread();
+                        ProcessQueuedWorkOnUIThread();
                     }).CompletesAsyncOperation(asyncToken);
                 }
             }
 
-            private void CheckForFilesBeingOpenOnUIThread()
+            private void ProcessQueuedWorkOnUIThread()
             {
                 _foregroundAffinitization.AssertIsForeground();
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
@@ -42,7 +42,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             /// </summary>
             private readonly object _gate = new object();
             private HashSet<string> _fileNamesToCheckForOpenDocuments;
-            private bool _justEnumerateTheEntireRunningDocumentTable;
+
+            /// <summary>
+            /// Tracks whether we have decided to just scan the entire running document table for files that might already be in the workspace rather than checking
+            /// each file one-by-one. This starts out at true, because we are created asynchronously, and files might have already been added to the workspace
+            /// that we never got a call to <see cref="QueueCheckForFilesBeingOpen(ImmutableArray{string})"/> for.
+            /// </summary>
+            private bool _justEnumerateTheEntireRunningDocumentTable = true;
 
             private bool _taskPending;
 
@@ -101,22 +107,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // hold onto as a field
                 var runningDocumentTable = ((IVsRunningDocumentTable)_runningDocumentTable);
                 runningDocumentTable.AdviseRunningDocTableEvents(new RunningDocumentTableEventSink(this), out var docTableEventsCookie);
-            }
-
-            public void CheckForOpenDocumentsByEnumeratingTheRunningDocumentTable()
-            {
-                _foregroundAffinitization.AssertIsForeground();
-
-                lock (_gate)
-                {
-                    // Since we're scanning the full RDT, we can skip any explicit names we already have queued
-                    ClearPendingFilesForBeingOpen_NoLock();
-                }
-
-                foreach (var cookie in GetInitializedRunningDocumentTableCookies())
-                {
-                    TryOpeningDocumentsForNewCookie(cookie);
-                }
             }
 
             private IEnumerable<uint> GetInitializedRunningDocumentTableCookies()
@@ -430,11 +420,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
             }
 
-            private void ProcessQueuedWorkOnUIThread()
+            public void ProcessQueuedWorkOnUIThread()
             {
                 _foregroundAffinitization.AssertIsForeground();
 
-                // Just pulling off the values from the shared state to the local funtion...
+                // Just pulling off the values from the shared state to the local function.
                 HashSet<string> fileNamesToCheckForOpenDocuments;
                 bool justEnumerateTheEntireRunningDocumentTable;
                 lock (_gate)
@@ -442,14 +432,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     fileNamesToCheckForOpenDocuments = _fileNamesToCheckForOpenDocuments;
                     justEnumerateTheEntireRunningDocumentTable = _justEnumerateTheEntireRunningDocumentTable;
 
-                    ClearPendingFilesForBeingOpen_NoLock();
+                    _fileNamesToCheckForOpenDocuments = null;
+                    _justEnumerateTheEntireRunningDocumentTable = false;
+
+                    _taskPending = false;
                 }
 
                 if (justEnumerateTheEntireRunningDocumentTable)
                 {
-                    CheckForOpenDocumentsByEnumeratingTheRunningDocumentTable();
+                    foreach (var cookie in GetInitializedRunningDocumentTableCookies())
+                    {
+                        TryOpeningDocumentsForNewCookie(cookie);
+                    }
                 }
-                else
+                else if (fileNamesToCheckForOpenDocuments != null)
                 {
                     foreach (var filename in fileNamesToCheckForOpenDocuments)
                     {
@@ -460,14 +456,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         }
                     }
                 }
-            }
-
-            private void ClearPendingFilesForBeingOpen_NoLock()
-            {
-                _fileNamesToCheckForOpenDocuments = null;
-                _justEnumerateTheEntireRunningDocumentTable = false;
-
-                _taskPending = false;
             }
 
             private class RunningDocumentTableEventSink : IVsRunningDocTableEvents3

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -133,9 +133,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             openFileTracker.CheckForOpenDocumentsByEnumeratingTheRunningDocumentTable();
         }
 
-        public void CheckForOpenDocuments(ImmutableArray<string> newFileNames)
+        public void QueueCheckForFilesBeingOpen(ImmutableArray<string> newFileNames)
         {
-            _openFileTrackerOpt?.CheckForFilesBeingOpen(newFileNames);
+            _openFileTrackerOpt?.QueueCheckForFilesBeingOpen(newFileNames);
         }
 
         internal void AddProjectToInternalMaps(VisualStudioProject project, IVsHierarchy hierarchy, Guid guid, string projectSystemName)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -138,6 +138,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _openFileTrackerOpt?.QueueCheckForFilesBeingOpen(newFileNames);
         }
 
+        public void ProcessQueuedWorkOnUIThread()
+        {
+            _openFileTrackerOpt?.ProcessQueuedWorkOnUIThread();
+        }
+
         internal void AddProjectToInternalMaps(VisualStudioProject project, IVsHierarchy hierarchy, Guid guid, string projectSystemName)
         {
             lock (_gate)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _openFileTrackerOpt = openFileTracker;
             }
 
-            openFileTracker.CheckForOpenDocumentsByEnumeratingTheRunningDocumentTable();
+            openFileTracker.ProcessQueuedWorkOnUIThread();
         }
 
         public void QueueCheckForFilesBeingOpen(ImmutableArray<string> newFileNames)

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -380,6 +380,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
             else
             {
+                // HACK HACK HACK: Ensure we've processed all files being opened before we let designers work further.
+                // In https://devdiv.visualstudio.com/DevDiv/_workitems/edit/728035, a file is opened in an invisible editor and contents are written
+                // to it. The file isn't saved, but it's added to the workspace; we won't have yet hooked up to the open file since that work was deferred.
+                // Since we're on the UI thread here, we can ensure those are all wired up since the analysis of this document may depend on that other file.
+                // We choose to do this here rather than in the project system code when it's added because we don't want to pay the penalty of checking the RDT for
+                // all files being opened on the UI thread if we really don't need it. This uses an 'as' cast, because in unit tests the workspace is a different
+                // derived form of VisualStudioWorkspace, and there we aren't dealing with open files at all so it doesn't matter.
+                (State.Workspace as VisualStudioWorkspaceImpl)?.ProcessQueuedWorkOnUIThread();
+
                 document = Workspace.CurrentSolution.GetDocument(GetDocumentId());
             }
 


### PR DESCRIPTION
In https://devdiv.visualstudio.com/DevDiv/_workitems/edit/728035, a file is opened in an invisible editor and contents are written to it. The file isn't saved, but it's added to the workspace; we won't have yet hooked up to the open file since that work was deferred. Since we're on the UI thread here, we can ensure those are all wired up since the analysis of this document may depend on that other file. We choose to do this here rather than in the project system code when it's added because we don't want to pay the penalty of checking the RDT for all files being opened on the UI thread if we really don't need it.

<details><summary>Ask Mode template</summary>

### Customer scenario

The customer creates a VSTO project like an Excel workbook project. If you add another sheet to the project, you get an error message instead of it working.

### Bugs this fixes

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/728035.

### Workarounds, if any

None.

### Risk

Moderate.

### Performance impact

None.

### Is this a regression from a previous update?

Yes. This was broken in Dev16.0 Preview 1 and onward.

### Root cause analysis

When we refactored a large system to do some performance improvements, we had one specific pattern which an extension could do which would break, but we believed it was very rare. The VSTO templates that add new sheets to projects do this precise pattern, causing them to break. We since have thought of a better way to approach that problem, but that's a larger amount of engineering work and so we're taking this as a targeted fix.

It's possible other extensions or features also do this, but we haven't seen any reports of that so far.

### How was the bug found?

Internal ad-hoc testing.

</details>