### PR TITLE
Undo arcade work arounds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -278,10 +278,10 @@
     <UsingToolXliff>true</UsingToolXliff>
     <UsingToolXUnit>true</UsingToolXUnit>
     <!-- 
-       During the transition period from Microsoft.Net.Compilers to Microsoft.Net.Compilers.Toolset
-       we are always doing custom importing here.
+      When using a bootstrap builder we don't want to use the Microsoft.Net.Compilers.Toolset package but
+      rather explicitly override it. 
     -->
-    <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
+    <UsingToolMicrosoftNetCompilers Condition="'$(BootstrapBuildPath)' == ''">true</UsingToolMicrosoftNetCompilers>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreSources>

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -131,14 +131,6 @@
   <Import Project="Bootstrap.props" Condition="'$(BootstrapBuildPath)' != ''" />
 
   <!--
-     During the transition period from Microsoft.Net.Compilers to Microsoft.Net.Compilers.Toolset
-     we need our own PackageReference
-  -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" Condition="'$(BootstrapBuildPath)' == ''" PrivateAssets="all" IsImplicitlyDefined="true" />
-  </ItemGroup>
-
-  <!--
     Analyzers
   -->
   <ItemGroup>


### PR DESCRIPTION
Now that we have the version of arcade that supports
Microsoft.Net.Compilers.Toolset we can remove a few work arounds.