### PR TITLE
Delayed failures in integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -35,20 +35,16 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// </summary>
         private static bool _firstLaunch = true;
 
-        static VisualStudioInstanceFactory()
-        {
-            var majorVsProductVersion = VsProductVersion.Split('.')[0];
-
-            if (int.Parse(majorVsProductVersion) < 15)
-            {
-                throw new PlatformNotSupportedException("The Visual Studio Integration Test Framework is only supported on Visual Studio 15.0 and later.");
-            }
-        }
-
         public VisualStudioInstanceFactory()
         {
             AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolveHandler;
             AppDomain.CurrentDomain.FirstChanceException += FirstChanceExceptionHandler;
+
+            var majorVsProductVersion = VsProductVersion.Split('.')[0];
+            if (int.Parse(majorVsProductVersion) < 15)
+            {
+                throw new PlatformNotSupportedException("The Visual Studio Integration Test Framework is only supported on Visual Studio 15.0 and later.");
+            }
         }
 
         private static void FirstChanceExceptionHandler(object sender, FirstChanceExceptionEventArgs eventArgs)

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                     baseFileName = $"{testName}-{eventArgs.Exception.GetType().Name}-{DateTime.Now:HH.mm.ss}";
                 }
 
-                ScreenshotService.TakeScreenshot(Path.Combine(logDir, $"{baseFileName}.png"));
+                Directory.CreateDirectory(logDir);
 
                 var exception = eventArgs.Exception;
                 File.WriteAllText(
@@ -82,6 +82,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
                 EventLogCollector.TryWriteDotNetEntriesToFile(Path.Combine(logDir, $"{baseFileName}.DotNet.log"));
                 EventLogCollector.TryWriteWatsonEntriesToFile(Path.Combine(logDir, $"{baseFileName}.Watson.log"));
+
+                ScreenshotService.TakeScreenshot(Path.Combine(logDir, $"{baseFileName}.png"));
             }
             finally
             {


### PR DESCRIPTION
* Avoid throwing an exception in the `VisualStudioInstanceFactory` static constructor
* Take screenshot _after_ writing logs