### PR TITLE
Add UseEnhancedColors to FeatureOnOffOptionsProvider

### DIFF
--- a/src/EditorFeatures/Core/Shared/Options/FeatureOnOffOptions.cs
+++ b/src/EditorFeatures/Core/Shared/Options/FeatureOnOffOptions.cs
@@ -115,6 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Options
             FeatureOnOffOptions.RefactoringVerification,
             FeatureOnOffOptions.StreamingGoToImplementation,
             FeatureOnOffOptions.NavigateToDecompiledSources,
-            FeatureOnOffOptions.AcceptedDecompilerDisclaimer);
+            FeatureOnOffOptions.AcceptedDecompilerDisclaimer,
+            FeatureOnOffOptions.UseEnhancedColors);
     }
 }


### PR DESCRIPTION
When adding the UseEnhancedColor Option it was left off the OptionsProvider's list of options.