### PR TITLE
added ability to clear all diagnostics reproted from a IDiagnosticUpd…

### DIFF
--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
         public bool SupportGetDiagnostics => false;
 
         public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
-        public event EventHandler Cleared { add { } remove { } }
+        public event EventHandler DiagnosticsCleared { add { } remove { } }
 
         public ImmutableArray<DiagnosticData> GetDiagnostics(Workspace workspace, ProjectId projectId, DocumentId documentId, object id, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
         {

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
         public bool SupportGetDiagnostics => false;
 
         public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
+        public event EventHandler Cleared { add { } remove { } }
 
         public ImmutableArray<DiagnosticData> GetDiagnostics(Workspace workspace, ProjectId projectId, DocumentId documentId, object id, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
         {

--- a/src/EditorFeatures/TestUtilities/Squiggles/AbstractSquiggleProducerTests.cs
+++ b/src/EditorFeatures/TestUtilities/Squiggles/AbstractSquiggleProducerTests.cs
@@ -89,6 +89,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Squiggles
             }
 
             public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
+            public event EventHandler Cleared { add { } remove { } }
 
             public bool SupportGetDiagnostics => false;
 

--- a/src/EditorFeatures/TestUtilities/Squiggles/AbstractSquiggleProducerTests.cs
+++ b/src/EditorFeatures/TestUtilities/Squiggles/AbstractSquiggleProducerTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Squiggles
             }
 
             public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
-            public event EventHandler Cleared { add { } remove { } }
+            public event EventHandler DiagnosticsCleared { add { } remove { } }
 
             public bool SupportGetDiagnostics => false;
 

--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
-        public event EventHandler Cleared { add { } remove { } }
+        public event EventHandler DiagnosticsCleared { add { } remove { } }
 
         public void RaiseDiagnosticsUpdated(DiagnosticsUpdatedArgs args)
         {

--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
+        public event EventHandler Cleared { add { } remove { } }
 
         public void RaiseDiagnosticsUpdated(DiagnosticsUpdatedArgs args)
         {

--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
+        public event EventHandler Cleared { add { } remove { } }
 
         // this only support push model, pull model will be provided by DiagnosticService by caching everything this one pushed
         public bool SupportGetDiagnostics => false;

--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
-        public event EventHandler Cleared { add { } remove { } }
+        public event EventHandler DiagnosticsCleared { add { } remove { } }
 
         // this only support push model, pull model will be provided by DiagnosticService by caching everything this one pushed
         public bool SupportGetDiagnostics => false;

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        public event EventHandler Cleared
+        public event EventHandler DiagnosticsCleared
         {
             add
             {

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
@@ -43,6 +43,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
+        public event EventHandler Cleared
+        {
+            add
+            {
+                // don't do anything. this update source doesn't use cleared event
+            }
+
+            remove
+            {
+                // don't do anything. this update source doesn't use cleared event
+            }
+        }
+
         internal void RaiseDiagnosticsUpdated(DiagnosticsUpdatedArgs args)
         {
             // all diagnostics events are serialized.

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticService_UpdateSourceRegistrationService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticService_UpdateSourceRegistrationService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 _updateSources = _updateSources.Add(source);
 
                 source.DiagnosticsUpdated += OnDiagnosticsUpdated;
-                source.Cleared += OnCleared;
+                source.DiagnosticsCleared += OnCleared;
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticService_UpdateSourceRegistrationService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticService_UpdateSourceRegistrationService.cs
@@ -28,7 +28,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
 
                 _updateSources = _updateSources.Add(source);
+
                 source.DiagnosticsUpdated += OnDiagnosticsUpdated;
+                source.Cleared += OnCleared;
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticUpdateSource.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// Raise this when all diagnostics reported from this update source has cleared
         /// </summary>
-        event EventHandler Cleared;
+        event EventHandler DiagnosticsCleared;
 
         /// <summary>
         /// Return true if the source supports GetDiagnostics API otherwise, return false so that the engine can cache data from DiagnosticsUpdated in memory

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticUpdateSource.cs
@@ -17,6 +17,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
 
         /// <summary>
+        /// Raise this when all diagnostics reported from this update source has cleared
+        /// </summary>
+        event EventHandler Cleared;
+
+        /// <summary>
         /// Return true if the source supports GetDiagnostics API otherwise, return false so that the engine can cache data from DiagnosticsUpdated in memory
         /// </summary>
         bool SupportGetDiagnostics { get; }

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
         public event EventHandler<bool> BuildStarted;
         public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
-        public event EventHandler Cleared { add { } remove { } }
+        public event EventHandler DiagnosticsCleared { add { } remove { } }
 
         public bool IsInProgress => BuildInprogressState != null;
 

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -76,6 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
         public event EventHandler<bool> BuildStarted;
         public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
+        public event EventHandler Cleared { add { } remove { } }
 
         public bool IsInProgress => BuildInprogressState != null;
 

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -346,7 +346,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             End Property
 
             Public Event DiagnosticsUpdated As EventHandler(Of DiagnosticsUpdatedArgs) Implements IDiagnosticUpdateSource.DiagnosticsUpdated
-            Public Event Cleared As EventHandler Implements IDiagnosticUpdateSource.Cleared
+            Public Event DiagnosticsCleared As EventHandler Implements IDiagnosticUpdateSource.DiagnosticsCleared
 
             Public Function GetDiagnostics(workspace As Microsoft.CodeAnalysis.Workspace, projectId As ProjectId, documentId As DocumentId, id As Object, includeSuppressedDiagnostics As Boolean, cancellationToken As CancellationToken) As ImmutableArray(Of DiagnosticData) Implements IDiagnosticUpdateSource.GetDiagnostics
                 Return If(includeSuppressedDiagnostics, _data, _data.WhereAsArray(Function(d) Not d.IsSuppressed))

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -346,6 +346,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             End Property
 
             Public Event DiagnosticsUpdated As EventHandler(Of DiagnosticsUpdatedArgs) Implements IDiagnosticUpdateSource.DiagnosticsUpdated
+            Public Event Cleared As EventHandler Implements IDiagnosticUpdateSource.Cleared
 
             Public Function GetDiagnostics(workspace As Microsoft.CodeAnalysis.Workspace, projectId As ProjectId, documentId As DocumentId, id As Object, includeSuppressedDiagnostics As Boolean, cancellationToken As CancellationToken) As ImmutableArray(Of DiagnosticData) Implements IDiagnosticUpdateSource.GetDiagnostics
                 Return If(includeSuppressedDiagnostics, _data, _data.WhereAsArray(Function(d) Not d.IsSuppressed))

--- a/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
+++ b/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
             End Property
 
             Public Event DiagnosticsUpdated As EventHandler(Of DiagnosticsUpdatedArgs) Implements IDiagnosticUpdateSource.DiagnosticsUpdated
-            Public Event Cleared As EventHandler Implements IDiagnosticUpdateSource.Cleared
+            Public Event DiagnosticsCleared As EventHandler Implements IDiagnosticUpdateSource.DiagnosticsCleared
 
             Public Function GetDiagnostics(workspace As Microsoft.CodeAnalysis.Workspace, projectId As ProjectId, documentId As DocumentId, id As Object, includeSuppressedDiagnostics As Boolean, cancellationToken As CancellationToken) As ImmutableArray(Of DiagnosticData) Implements IDiagnosticUpdateSource.GetDiagnostics
                 Return If(includeSuppressedDiagnostics, _data, _data.WhereAsArray(Function(d) Not d.IsSuppressed))

--- a/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
+++ b/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
@@ -43,6 +43,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
             End Property
 
             Public Event DiagnosticsUpdated As EventHandler(Of DiagnosticsUpdatedArgs) Implements IDiagnosticUpdateSource.DiagnosticsUpdated
+            Public Event Cleared As EventHandler Implements IDiagnosticUpdateSource.Cleared
 
             Public Function GetDiagnostics(workspace As Microsoft.CodeAnalysis.Workspace, projectId As ProjectId, documentId As DocumentId, id As Object, includeSuppressedDiagnostics As Boolean, cancellationToken As CancellationToken) As ImmutableArray(Of DiagnosticData) Implements IDiagnosticUpdateSource.GetDiagnostics
                 Return If(includeSuppressedDiagnostics, _data, _data.WhereAsArray(Function(d) Not d.IsSuppressed))

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -444,7 +444,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return additionalProperties == null
                 ? properties
                 : properties.AddRange(additionalProperties);
-            throw new NotImplementedException();
         }
 
         /// <summary>


### PR DESCRIPTION
…ateSource

previously IDiagnosticUpdateSource has to clear each diagnostics it reported group by group. that was fine for IDiagnosticUpdateSource that supports incremental update, but some source such as EditAndContinue doesn't support incremental update since their errors (emit errors) come and go as a bulk (whole project). when they update, they need to update everything. so tracking things in group for incremental update is unnecessary for such source.

the new API (Source.Cleared) make it easy for source to clear all diagnostics at once it produced.