### PR TITLE
Report nullability for attribute arguments:

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -182,12 +182,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> boundNamedArguments = analyzedArguments.NamedArguments;
             constructorArguments.Free();
 
-            var attribute = new BoundAttribute(node, attributeConstructor, boundConstructorArguments, boundConstructorArgumentNamesOpt, argsToParamsOpt, expanded,
+            return new BoundAttribute(node, attributeConstructor, boundConstructorArguments, boundConstructorArgumentNamesOpt, argsToParamsOpt, expanded,
                 boundNamedArguments, resultKind, attributeType, hasErrors: resultKind != LookupResultKind.Viable);
-
-            NullableWalker.AnalyzeIfNeeded(Compilation, attribute, diagnostics);
-
-            return attribute;
         }
         private CSharpAttributeData GetAttribute(BoundAttribute boundAttribute, DiagnosticBag diagnostics)
         {
@@ -195,6 +191,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var attributeConstructor = boundAttribute.Constructor;
 
             Debug.Assert((object)attributeType != null);
+
+            NullableWalker.AnalyzeIfNeeded(Compilation, boundAttribute, diagnostics);
 
             bool hasErrors = boundAttribute.HasAnyErrors;
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -242,7 +242,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
                             }
                         }
-
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -185,10 +185,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var attribute = new BoundAttribute(node, attributeConstructor, boundConstructorArguments, boundConstructorArgumentNamesOpt, argsToParamsOpt, expanded,
                 boundNamedArguments, resultKind, attributeType, hasErrors: resultKind != LookupResultKind.Viable);
 
-            if (Compilation.LanguageVersion >= MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion())
-            {
-                NullableWalker.Analyze(Compilation, attribute, diagnostics);
-            }
+            NullableWalker.AnalyzeIfNeeded(Compilation, attribute, diagnostics);
+
             return attribute;
         }
         private CSharpAttributeData GetAttribute(BoundAttribute boundAttribute, DiagnosticBag diagnostics)
@@ -501,7 +499,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return namedArgumentType;
         }
 
-        protected virtual MethodSymbol BindAttributeConstructor(
+        protected MethodSymbol BindAttributeConstructor(
             AttributeSyntax node,
             NamedTypeSymbol attributeType,
             AnalyzedArguments boundConstructorArguments,

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1438,6 +1438,8 @@
     <Field Name="Constructor" Type="MethodSymbol" Null="allow"/>
     <Field Name="ConstructorArguments" Type="ImmutableArray&lt;BoundExpression&gt;"/>
     <Field Name="ConstructorArgumentNamesOpt" Type="ImmutableArray&lt;string&gt;" Null="allow"/>
+    <Field Name="ConstructorArgumentsToParamsOpt" Type="ImmutableArray&lt;int&gt;" Null="allow"/>
+    <Field Name="ConstructorExpanded" Type="bool" />
     <Field Name="NamedArguments" Type ="ImmutableArray&lt;BoundExpression&gt;"/>
     <Field Name="ResultKind" PropertyOverrides="true" Type="LookupResultKind"/>
   </Node>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -423,8 +423,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                var method = _symbol as MethodSymbol;
-                return (object)method == null ? null : method.ThisParameter;
+                ParameterSymbol thisParameter = null;
+                (_symbol as MethodSymbol)?.TryGetThisParameter(out thisParameter);
+                return thisParameter;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -261,11 +261,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _returnTypesOpt.Clear();
             }
             this.Diagnostics.Clear();
-            ((MethodSymbol)_symbol).TryGetThisParameter(out var methodThisParameter);
+            ParameterSymbol methodThisParameter = MethodThisParameter;
             this.State = TopState();                   // entry point is reachable
             this.regionPlace = RegionPlace.Before;
             EnterParameters();                               // with parameters assigned
-            if ((object)methodThisParameter != null)
+            if (!(methodThisParameter is null))
             {
                 EnterParameter(methodThisParameter, methodThisParameter.Type);
             }
@@ -288,12 +288,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             Analyze(compilation, method, node, diagnostics, useMethodSignatureReturnType: false, useMethodSignatureParameterTypes: false, methodSignatureOpt: null, returnTypes: null, initialState: null, callbackOpt);
         }
 
-        internal static void Analyze(
+        internal static void AnalyzeIfNeeded(
             CSharpCompilation compilation,
             BoundAttribute attribute,
             DiagnosticBag diagnostics)
         {
-            if (attribute.Constructor is null ||
+            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() ||
+                attribute.Constructor is null ||
                 !compilation.SyntaxTrees.Contains(attribute.SyntaxTree))
             {
                 return;
@@ -5741,9 +5742,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Visit(assignment);
             }
 
-            var result = base.VisitAttribute(node);
             SetNotNullResult(node);
-            return result;
+            return null;
         }
 
         protected override string Dump(LocalState state)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() ||
                 attribute.Constructor is null ||
-                !compilation.SyntaxTrees.Contains(attribute.SyntaxTree))
+                !compilation.SyntaxTrees.Contains(attribute.SyntaxTree)) // don't analyze speculative attributes
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _returnTypesOpt.Clear();
             }
             this.Diagnostics.Clear();
-            ParameterSymbol methodThisParameter = MethodThisParameter;
+            ((MethodSymbol)_symbol).TryGetThisParameter(out var methodThisParameter);
             this.State = TopState();                   // entry point is reachable
             this.regionPlace = RegionPlace.Before;
             EnterParameters();                               // with parameters assigned
@@ -293,7 +293,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundAttribute attribute,
             DiagnosticBag diagnostics)
         {
-            if (attribute.Constructor is null)
+            if (attribute.Constructor is null ||
+                !compilation.SyntaxTrees.Contains(attribute.SyntaxTree))
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -294,8 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             DiagnosticBag diagnostics)
         {
             if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() ||
-                attribute.Constructor is null ||
-                !compilation.SyntaxTrees.Contains(attribute.SyntaxTree)) // don't analyze speculative attributes
+                attribute.Constructor is null)
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -293,13 +293,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundAttribute attribute,
             DiagnosticBag diagnostics)
         {
-            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() ||
-                attribute.Constructor is null)
+            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion())
             {
                 return;
             }
 
-            Analyze(compilation, attribute.Constructor, attribute, diagnostics);
+            Analyze(compilation, null, attribute, diagnostics, useMethodSignatureReturnType: false, useMethodSignatureParameterTypes: false, methodSignatureOpt: null, returnTypes: null, initialState: null, callbackOpt: null);
         }
 
         internal static void Analyze(
@@ -1102,7 +1101,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void EnterParameters()
         {
-            var methodParameters = ((MethodSymbol)_symbol).Parameters;
+            var methodSymbol = _symbol as MethodSymbol;
+            if (methodSymbol is null)
+            {
+                return;
+            }
+
+            var methodParameters = methodSymbol.Parameters;
             var signatureParameters = _useMethodSignatureParameterTypes ? _methodSignatureOpt.Parameters : methodParameters;
             Debug.Assert(signatureParameters.Length == methodParameters.Length);
             int n = methodParameters.Length;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -5129,8 +5129,8 @@ class C { }
 class MyAttribute : System.Attribute
 {
     public MyAttribute() { }
-	
-	public string MyValue { get; set; } = ""str"";
+    
+    public string MyValue { get; set; } = ""str"";
 }
 
 [MyAttribute(MyValue = null)] //1
@@ -5156,10 +5156,10 @@ class D { }
 class MyAttribute : System.Attribute
 {
     public MyAttribute() { }
-	
-	public string[] PropertyArray { get; set; } = new string[] { };
+    
+    public string[] PropertyArray { get; set; } = new string[] { };
 
-	public string[]? NullablePropertyArray { get; set; } = null;
+    public string[]? NullablePropertyArray { get; set; } = null;
 
 }
 
@@ -5186,11 +5186,10 @@ class D { }
 class MyAttribute : System.Attribute
 {
     public MyAttribute() { }
-	
-	public string[] PropertyArray { get; set; } = new string[] { ""str"" };
 
-	public string[]? PropertyNullableArray { get; set; } = new string[] { ""str"" };
+    public string[] PropertyArray { get; set; } = new string[] { ""str"" };
 
+    public string[]? PropertyNullableArray { get; set; } = new string[] { ""str"" };
 }
 
 [MyAttribute(PropertyArray = new string?[]{ null })] //1
@@ -5216,8 +5215,8 @@ class D { }
 class MyAttribute : System.Attribute
 {
     public MyAttribute() { }
-	
-	public string myValue = ""str"";
+
+    public string myValue = ""str"";
 }
 
 [MyAttribute(myValue = null)] //1
@@ -5243,8 +5242,8 @@ class D { }
 class MyAttribute : System.Attribute
 {
     public MyAttribute() { }
-	
-	public string[] fieldArray = new string[] { };
+
+    public string[] fieldArray = new string[] { };
 
     public string[]? nullableFieldArray = null;
 }
@@ -5272,8 +5271,8 @@ class D { }
 class MyAttribute : System.Attribute
 {
     public MyAttribute() { }
-	
-	public string[] fieldArray = new string[] { };
+
+    public string[] fieldArray = new string[] { };
 
     public string?[] fieldArrayOfNullable = new string?[] { };
 }
@@ -5345,9 +5344,9 @@ class C { }
 #nullable enable
 class MyAttribute : System.Attribute
 {
-	public string[] PropertyArray { get; set; } = new string[] { ""str"" };
+    public string[] PropertyArray { get; set; } = new string[] { ""str"" };
 
-	public string[]? PropertyNullableArray { get; set; } = new string[] { ""str"" };
+    public string[]? PropertyNullableArray { get; set; } = new string[] { ""str"" };
 }
 
 [MyAttribute(  // 1
@@ -5386,7 +5385,7 @@ class C { }
 #nullable enable
 class MyAttribute : System.Attribute
 {
-	public string[] fieldArray = new string[] { };
+    public string[] fieldArray = new string[] { };
 
     public string?[] fieldArrayOfNullable = new string?[] { };
 }
@@ -5429,8 +5428,8 @@ class C { }
 class MyAttribute : System.Attribute
 {
     public MyAttribute(string s, string s2 = ""str"", string s3 = ""str"") { }
-	
-	public string[] fieldArray = new string[] { };
+
+    public string[] fieldArray = new string[] { };
 
     public string?[] fieldArrayOfNullable = new string[] { };
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -5338,15 +5338,13 @@ class C { }
         }
 
         [Fact]
-        public void AttributeArgument_NoMatchingConstructor_PropertyAssignement_NullLiteral()
+        public void AttributeArgument_NoMatchingConstructor_PropertyAssignment_NullLiteral()
         {
             var source =
 @"
 #nullable enable
 class MyAttribute : System.Attribute
 {
-    public MyAttribute() { }
-	
 	public string[] PropertyArray { get; set; } = new string[] { ""str"" };
 
 	public string[]? PropertyNullableArray { get; set; } = new string[] { ""str"" };
@@ -5361,35 +5359,33 @@ class C { }
 ";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (12,2): error CS1729: 'MyAttribute' does not contain a constructor that takes 1 arguments
+                // (10,2): error CS1729: 'MyAttribute' does not contain a constructor that takes 1 arguments
                 // [MyAttribute(  // 1
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"MyAttribute(  // 1
     new string[] { null }, // 2
     PropertyArray = null, // 3
     PropertyNullableArray = new string[] { null } // 4
-)").WithArguments("MyAttribute", "1").WithLocation(12, 2),
-                // (13,20): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+)").WithArguments("MyAttribute", "1").WithLocation(10, 2),
+                // (11,20): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     new string[] { null }, // 2
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 20),
-                // (14,21): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 20),
+                // (12,21): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     PropertyArray = null, // 3
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(14, 21),
-                // (15,44): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 21),
+                // (13,44): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     PropertyNullableArray = new string[] { null } // 4
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(15, 44)
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 44)
                 );
         }
 
         [Fact]
-        public void AttributeArgument_NoMatchingConstructor_FieldAssignement_NullLiteral()
+        public void AttributeArgument_NoMatchingConstructor_FieldAssignment_NullLiteral()
         {
             var source =
 @"
 #nullable enable
 class MyAttribute : System.Attribute
 {
-    public MyAttribute() { }
-
 	public string[] fieldArray = new string[] { };
 
     public string?[] fieldArrayOfNullable = new string?[] { };
@@ -5404,22 +5400,22 @@ class C { }
 ";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (12,2): error CS1729: 'MyAttribute' does not contain a constructor that takes 1 arguments
+                // (10,2): error CS1729: 'MyAttribute' does not contain a constructor that takes 1 arguments
                 // [MyAttribute( // 1
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"MyAttribute( // 1
     new string[] { null }, // 2
     fieldArray = null, // 3
     fieldArrayOfNullable = new string[] { null } // 4
-)").WithArguments("MyAttribute", "1").WithLocation(12, 2),
-                // (13,20): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+)").WithArguments("MyAttribute", "1").WithLocation(10, 2),
+                // (11,20): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     new string[] { null }, // 2
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 20),
-                // (14,18): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 20),
+                // (12,18): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     fieldArray = null, // 3
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(14, 18),
-                // (15,43): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 18),
+                // (13,43): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //     fieldArrayOfNullable = new string[] { null } // 4
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(15, 43)
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 43)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -5200,9 +5200,9 @@ class D { }
 ";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (13,30): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
+                // (12,30): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
                 // [MyAttribute(PropertyArray = new string?[]{ null })] //1
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new string?[]{ null }").WithArguments("string?[]", "string[]").WithLocation(13, 30)
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new string?[]{ null }").WithArguments("string?[]", "string[]").WithLocation(12, 30)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -4755,7 +4755,7 @@ class E { }
                 //     public MyAttribute(string s, string s2 = null) { } //1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(4, 46),
                 // (10,21): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-                // [MyAttribute("str", null)] // 3
+                // [MyAttribute("str", null)] // 2
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 21)
                 );
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -4578,8 +4578,11 @@ public class MyAttribute : System.Attribute
 class C { }
 ";
             var comp = CreateCompilation(source, options: TestOptions.DebugDll);
-            comp.VerifyDiagnostics();
-            // Expecting a warning. Issue tracked by https://github.com/dotnet/roslyn/issues/23697
+            comp.VerifyDiagnostics(
+                // (7,20): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [My(new string[] { null })]
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 20)
+                );
         }
 
         [Fact, WorkItem(31740, "https://github.com/dotnet/roslyn/issues/31740")]
@@ -83689,6 +83692,451 @@ namespace System
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void AttributeArgument_Constructor_NullLiteral()
+        {
+            var source =
+@"
+#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute(string s) { }
+}
+
+[MyAttribute(null)] //1
+class C {}
+
+[MyAttribute(""foo"")]
+class D {}
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (2,14): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(null)]
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 14)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_Constructor_NullLiteral_WithDefaultArgument()
+        {
+            var source =
+@"#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute(string s, string s2 = ""foo"") { }
+}
+
+[MyAttribute(null)] //1
+class C {} 
+
+[MyAttribute(null, null)] // 2, 3
+class D {}
+
+[MyAttribute(null, ""foo"")] // 4
+class E {}
+
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (7,14): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(null)] //1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 14),
+                // (10,14): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(null, null)] // 2, 3
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 14),
+                // (10,20): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(null, null)] // 2, 3
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 20),
+                // (13,14): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(null, "foo")] // 4
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 14)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_Constructor_NullLiteral_WithNamedArguments()
+        {
+            var source =
+@"#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute(string s, string s2 = ""bar"") { }
+}
+
+[MyAttribute(""foo"", s2: null)] //1
+class C {}
+
+[MyAttribute(s2: null, s: ""foo"")] // 2
+class D {}
+
+[MyAttribute(s2: ""bar"", s: ""foo"")]
+class E {}
+
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (7,25): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute("foo", s2: null)] //1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 25),
+                // (10,18): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(s2: null, s: "foo")] // 2
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 18)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_Constructor_NullLiteral_DisabledEnabled()
+        {
+            var source =
+@"
+#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute(string s, string s2) { }
+}
+
+[MyAttribute(null, //1
+#nullable disable
+null
+#nullable enable
+)] 
+class C {}
+
+[MyAttribute(
+#nullable disable
+null, 
+#nullable enable
+null //2
+)] 
+class D {}
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (8,14): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(null, //1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 14),
+                // (19,1): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // null //2
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(19, 1)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_Constructor_Array_LiteralNull()
+        {
+            var source =
+@"
+#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute(string[] s) { }
+}
+
+[MyAttribute(null)] //1
+class C {}
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (2,14): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(null)] //1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 14)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_Constructor_Array_ArrayOfNullable()
+        {
+            var source =
+@"
+#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute(string[] s) { }
+}
+
+[MyAttribute(new string?[]{ null })] //1
+class C {}
+";
+            //TODO: fix this
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (8,14): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
+                // [MyAttribute(new string?[]{ null })] //1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new string?[]{ null }").WithArguments("string?[]", "string[]").WithLocation(8, 14)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_PropertyAssignment_NullLiteral()
+        {
+            var source =
+@"
+#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute() { }
+	
+	public string MyValue {get; set; } = ""foo"";
+}
+
+[MyAttribute(MyValue = null)] //1
+class C {}
+
+[MyAttribute(MyValue = ""foo"")]
+class D {}
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (10,24): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(MyValue = null)] //1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 24)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_PropertyAssignment_Array_NullLiteral()
+        {
+            var source =
+@"
+#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute() { }
+	
+	public string[] PropertyArray {get; set; } = new string[]{};
+
+	public string[]? NullablePropertyArray {get; set; } = null;
+
+}
+
+[MyAttribute(PropertyArray = null)] //1
+class C {}
+
+[MyAttribute(NullablePropertyArray = null)] 
+class D {}
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (13,30): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(MyValue = null)] //1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 30)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_PropertyAssignment_Array_ArrayOfNullable()
+        {
+            var source =
+@"
+#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute() { }
+	
+	public string[] PropertyArray {get; set; } = new string[]{ ""foo"" };
+
+	public string[]? PropertyArrayOfNullable {get; set; } = new string[]{ ""foo"" };
+
+}
+
+[MyAttribute(PropertyArray = new string?[]{ null })] //1
+class C {}
+
+[MyAttribute(PropertyArrayOfNullable = null)] //1
+class D {}
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (13,30): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
+                // [MyAttribute(MyValue = new string?[]{ null })] //1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new string?[]{ null }").WithArguments("string?[]", "string[]").WithLocation(13, 30)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_FieldAssignment_NullLiteral()
+        {
+            var source =
+@"
+#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute() { }
+	
+	public string myValue = ""foo"";
+}
+
+[MyAttribute(myValue = null)] //1
+class C {}
+
+[MyAttribute(myValue = ""foo"")]
+class D {}
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (10,24): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(myValue = null)] //1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 24)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_FieldAssignment_Array_NullLiteral()
+        {
+            var source =
+@"
+#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute() { }
+	
+	public string[] fieldArray = new string[]{};
+
+    public string[]? nullableFieldArray = null;
+}
+
+[MyAttribute(fieldArray = null)] //1
+class C {}
+
+[MyAttribute(nullableFieldArray = null)] //1
+class D {}
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (12,27): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(myValue = null)] //1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 27)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_FieldAssignment_Array_ArrayOfNullable()
+        {
+            var source =
+@"
+#nullable enable
+class MyAttribute : System.Attribute
+{
+    public MyAttribute() { }
+	
+	public string[] fieldArray = new string[]{};
+
+    public string?[] fieldArrayOfNullable = new string?[] {};
+}
+
+[MyAttribute(fieldArray = new string?[]{ null })] //1
+class C {}
+
+[MyAttribute(fieldArrayOfNullable = new string?[]{ null })] 
+class D {}
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (12,27): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
+                // [MyAttribute(MyValue = new string?[]{ null })] //1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new string?[]{ null }").WithArguments("string?[]", "string[]").WithLocation(12, 27)
+                );
+        }
+
+        [Fact]
+        public void AttributeArgument_ComplexAssignment()
+        {
+            var source =
+@"
+#nullable enable
+[System.AttributeUsage(System.AttributeTargets.All, AllowMultiple = true)]
+class MyAttribute : System.Attribute
+{
+    public MyAttribute(string s, string s2 = ""foo"", string s3 = ""bar"") { }
+	
+	public string[] fieldArray = new string[]{};
+
+    public string?[] fieldArrayOfNullable = new string[]{};
+
+    public string[]? nullableFieldArray = null;
+
+    public string[] PropertyArray {get; set; } = new string[]{};
+
+    public string?[] PropertyArrayOfNullable {get; set; } = new string[]{};
+
+    public string[]? NullablePropertyArray {get; set; } = null;
+
+}
+
+[MyAttribute(""s1"")]
+[MyAttribute(""s1"", s3: ""s3"", fieldArray = new string[]{})]
+[MyAttribute(""s1"", s2: ""s2"", fieldArray = new string[]{}, PropertyArray = new string[]{})]
+[MyAttribute(""s1"", fieldArrayOfNullable = new string?[]{ null }, NullablePropertyArray = null)]
+[MyAttribute(null)] // 1
+[MyAttribute(""s1"", s3: null, fieldArray = new string[]{})] // 2
+[MyAttribute(""s1"", s2: ""s2"", fieldArray = new string?[]{ null }, PropertyArray = new string[]{})] // 3
+[MyAttribute(""s1"", PropertyArrayOfNullable = null)] // 4
+[MyAttribute(""s1"", NullablePropertyArray = new string?[]{ null })] // 5
+[MyAttribute(""s1"", fieldArrayOfNullable = null)] // 6
+[MyAttribute(""s1"", nullableFieldArray = new string[]{ null })] // 7
+[MyAttribute(null, //8
+            s2: null, //9
+            fieldArrayOfNullable = null, //10
+            NullablePropertyArray = new string?[]{ null })] // 11
+[MyAttribute(null, // 12
+#nullable disable
+            s2: null,
+#nullable enable
+            fieldArrayOfNullable = null, //13
+#pragma warning disable nullable
+            NullablePropertyArray = new string?[]{ null },
+#pragma warning enable nullable
+            nullableFieldArray = new string?[]{ null })] //14
+class C { }
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (26,14): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(null)] // 1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(26, 14),
+                // (27,24): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute("s1", s3: null, fieldArray = new string[]{})] // 2
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(27, 24),
+                // (28,43): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
+                // [MyAttribute("s1", s2: "s2", fieldArray = new string?[]{ null }, PropertyArray = new string[]{})] // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new string?[]{ null }").WithArguments("string?[]", "string[]").WithLocation(28, 43),
+                // (29,46): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute("s1", PropertyArrayOfNullable = null)] // 4
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(29, 46),
+                // (30,44): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
+                // [MyAttribute("s1", NullablePropertyArray = new string?[]{ null })] // 5
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new string?[]{ null }").WithArguments("string?[]", "string[]").WithLocation(30, 44),
+                // (31,43): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute("s1", fieldArrayOfNullable = null)] // 6
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(31, 43),
+                // (32,55): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute("s1", nullableFieldArray = new string[]{ null })] // 7
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(32, 55),
+                // (33,14): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(null, //8
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(33, 14),
+                // (34,17): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //             s2: null, //9
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(34, 17),
+                // (35,36): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //             fieldArrayOfNullable = null, //10
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(35, 36),
+                // (36,37): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
+                //             NullablePropertyArray = new string?[]{ null })] // 11
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new string?[]{ null }").WithArguments("string?[]", "string[]").WithLocation(36, 37),
+                // (37,14): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                // [MyAttribute(null, // 12
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(37, 14),
+                // (41,36): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
+                //             fieldArrayOfNullable = null, //13
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(41, 36),
+                // (45,34): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
+                //             nullableFieldArray = new string?[]{ null })] //14
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new string?[]{ null }").WithArguments("string?[]", "string[]").WithLocation(45, 34)
+                );
         }
 
         [Fact, WorkItem(33905, "https://github.com/dotnet/roslyn/issues/33905")]


### PR DESCRIPTION
- Add an entry point to nullable walker for attribute analysis
- Implement analyze attribute in the walker
- Remove the analysis from binder_attributes and call nullable walker instead
- Add extra fields to BoundAttribute that are needed for nullable analysis
- Add tests

Fixes #23697