### PR TITLE
Restore original behavior of Shift+Enter during completion

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -34,8 +34,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
         [ImportingConstructor]
         public AutomaticLineEnderCommandHandler(
             ITextUndoHistoryRegistry undoRegistry,
-            IEditorOperationsFactoryService editorOperations)
-            : base(undoRegistry, editorOperations)
+            IEditorOperationsFactoryService editorOperations,
+            IAsyncCompletionBroker asyncCompletionBroker)
+            : base(undoRegistry, editorOperations, asyncCompletionBroker)
         {
         }
 

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
@@ -848,9 +849,10 @@ $$
 
         internal override IChainedCommandHandler<AutomaticLineEnderCommandArgs> CreateCommandHandler(
             ITextUndoHistoryRegistry undoRegistry,
-            IEditorOperationsFactoryService editorOperations)
+            IEditorOperationsFactoryService editorOperations,
+            IAsyncCompletionBroker asyncCompletionBroker)
         {
-            return new AutomaticLineEnderCommandHandler(undoRegistry, editorOperations);
+            return new AutomaticLineEnderCommandHandler(undoRegistry, editorOperations, asyncCompletionBroker);
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/AutomaticCompletion/AbstractAutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/AutomaticCompletion/AbstractAutomaticLineEnderCommandHandler.cs
@@ -8,6 +8,8 @@ using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
@@ -20,15 +22,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
     {
         private readonly ITextUndoHistoryRegistry _undoRegistry;
         private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
+        private readonly IAsyncCompletionBroker _asyncCompletionBroker;
 
         public string DisplayName => EditorFeaturesResources.Automatic_Line_Ender;
 
         public AbstractAutomaticLineEnderCommandHandler(
             ITextUndoHistoryRegistry undoRegistry,
-            IEditorOperationsFactoryService editorOperationsFactoryService)
+            IEditorOperationsFactoryService editorOperationsFactoryService,
+            IAsyncCompletionBroker asyncCompletionBroker)
         {
             _undoRegistry = undoRegistry;
             _editorOperationsFactoryService = editorOperationsFactoryService;
+            _asyncCompletionBroker = asyncCompletionBroker;
         }
 
         /// <summary>
@@ -58,6 +63,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
 
         public void ExecuteCommand(AutomaticLineEnderCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
+            // Completion will only be active here if this command wasn't handled by the completion controller itself.
+            if (_asyncCompletionBroker.IsCompletionActive(args.TextView))
+            {
+                var session = _asyncCompletionBroker.GetSession(args.TextView);
+                var computedItems = session.GetComputedItems(context.OperationContext.UserCancellationToken);
+                var softSelection = computedItems.SuggestionItemSelected || computedItems.UsesSoftSelection;
+                var behavior = session.Commit('\n', context.OperationContext.UserCancellationToken);
+                session.Dismiss();
+
+                if (behavior != CommitBehavior.CancelCommit && !softSelection)
+                {
+                    // Skip the automatic line handling in this case for behavior parity with legacy completion.
+                    return;
+                }
+            }
+
             // get editor operation
             var operations = _editorOperationsFactoryService.GetEditorOperations(args.TextView);
             if (operations == null)

--- a/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticLineEnderTests.cs
@@ -1,25 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Commanding;
-using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
-using Moq;
 using Roslyn.Test.Utilities;
-using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
@@ -32,7 +24,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
 
         internal abstract IChainedCommandHandler<AutomaticLineEnderCommandArgs> CreateCommandHandler(
             ITextUndoHistoryRegistry undoRegistry,
-            IEditorOperationsFactoryService editorOperations);
+            IEditorOperationsFactoryService editorOperations,
+            IAsyncCompletionBroker asyncCompletionBroker);
 
         protected void Test(string expected, string code, bool completionActive = false, bool assertNextHandlerInvoked = false)
         {
@@ -46,7 +39,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
 
                 var commandHandler = CreateCommandHandler(
                                         GetExportedValue<ITextUndoHistoryRegistry>(workspace),
-                                        GetExportedValue<IEditorOperationsFactoryService>(workspace));
+                                        GetExportedValue<IEditorOperationsFactoryService>(workspace),
+                                        GetExportedValue<IAsyncCompletionBroker>(workspace));
 
                 commandHandler.ExecuteCommand(new AutomaticLineEnderCommandArgs(view, buffer),
                                                     assertNextHandlerInvoked

--- a/src/EditorFeatures/VisualBasic/AutomaticCompletion/AutomaticLineEnderCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/AutomaticCompletion/AutomaticLineEnderCommandHandler.vb
@@ -24,9 +24,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticCompletion
 
         <ImportingConstructor>
         Friend Sub New(undoRegistry As ITextUndoHistoryRegistry,
-                       editorOperations As IEditorOperationsFactoryService)
+                       editorOperations As IEditorOperationsFactoryService,
+                       asyncCompletionBroker As IAsyncCompletionBroker)
 
-            MyBase.New(undoRegistry, editorOperations)
+            MyBase.New(undoRegistry, editorOperations, asyncCompletionBroker)
         End Sub
 
         Protected Overrides Sub NextAction(editorOperation As IEditorOperations, nextAction As Action)

--- a/src/EditorFeatures/VisualBasicTest/AutomaticCompletion/AutomaticLineEnderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AutomaticCompletion/AutomaticLineEnderTests.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticCompletion
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
 Imports Microsoft.VisualStudio.Commanding
+Imports Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion
 Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 
@@ -245,10 +246,11 @@ End Module
 
         Friend Overrides Function CreateCommandHandler(
             undoRegistry As ITextUndoHistoryRegistry,
-            editorOperations As IEditorOperationsFactoryService
+            editorOperations As IEditorOperationsFactoryService,
+            asyncCompletionBroker As IAsyncCompletionBroker
         ) As IChainedCommandHandler(Of AutomaticLineEnderCommandArgs)
 
-            Return New AutomaticLineEnderCommandHandler(undoRegistry, editorOperations)
+            Return New AutomaticLineEnderCommandHandler(undoRegistry, editorOperations, asyncCompletionBroker)
         End Function
 
         Protected Overrides Function CreateNextHandler(workspace As TestWorkspace) As Action

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpIntelliSense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpIntelliSense.cs
@@ -250,8 +250,7 @@ class Class1
 assertCaretPosition: true);
         }
 
-        // 🐛 This should work with async completion, but currently does not.
-        [ConditionalWpfFact(typeof(LegacyCompletionCondition)), Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         [WorkItem(33823, "https://github.com/dotnet/roslyn/issues/33823")]
         public void CommitOnShiftEnter()
         {


### PR DESCRIPTION
Fixes #33823 

This change is a workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/809579, since we will not be able to fix _and validate_ that from the editor side prior to 16.0 RTM.