### PR TITLE
Replace Stack with ArrayBuilder in GreenNode walker

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -643,12 +643,12 @@ namespace Microsoft.CodeAnalysis
 
         protected internal void WriteTo(TextWriter writer, bool leading, bool trailing)
         {
-            // Use an actual Stack so we can write out deeply recursive structures without overflowing.
+            // Use an actual stack so we can write out deeply recursive structures without overflowing.
             var stack = ArrayBuilder<(GreenNode node, bool leading, bool trailing)>.GetInstance();
             stack.Push((this, leading, trailing));
 
             // Separated out stack processing logic so that it does not unintentionally refer to 
-            // "this", "leading" or "trailing.
+            // "this", "leading" or "trailing".
             processStack(writer, stack);
             stack.Free();
             return;

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -644,47 +644,50 @@ namespace Microsoft.CodeAnalysis
         protected internal void WriteTo(TextWriter writer, bool leading, bool trailing)
         {
             // Use an actual Stack so we can write out deeply recursive structures without overflowing.
-            var stack = new Stack<(GreenNode node, bool leading, bool trailing)>();
+            var stack = ArrayBuilder<(GreenNode node, bool leading, bool trailing)>.GetInstance();
             stack.Push((this, leading, trailing));
 
             // Separated out stack processing logic so that it does not unintentionally refer to 
             // "this", "leading" or "trailing.
-            ProcessStack(writer, stack);
-        }
+            processStack(writer, stack);
+            stack.Free();
+            return;
 
-        private static void ProcessStack(TextWriter writer,
-            Stack<(GreenNode node, bool leading, bool trailing)> stack)
-        {
-            while (stack.Count > 0)
+            static void processStack(
+                TextWriter writer,
+                ArrayBuilder<(GreenNode node, bool leading, bool trailing)> stack)
             {
-                var current = stack.Pop();
-                var currentNode = current.node;
-                var currentLeading = current.leading;
-                var currentTrailing = current.trailing;
-
-                if (currentNode.IsToken)
+                while (stack.Count > 0)
                 {
-                    currentNode.WriteTokenTo(writer, currentLeading, currentTrailing);
-                    continue;
-                }
+                    var current = stack.Pop();
+                    var currentNode = current.node;
+                    var currentLeading = current.leading;
+                    var currentTrailing = current.trailing;
 
-                if (currentNode.IsTrivia)
-                {
-                    currentNode.WriteTriviaTo(writer);
-                    continue;
-                }
-
-                var firstIndex = GetFirstNonNullChildIndex(currentNode);
-                var lastIndex = GetLastNonNullChildIndex(currentNode);
-
-                for (var i = lastIndex; i >= firstIndex; i--)
-                {
-                    var child = currentNode.GetSlot(i);
-                    if (child != null)
+                    if (currentNode.IsToken)
                     {
-                        var first = i == firstIndex;
-                        var last = i == lastIndex;
-                        stack.Push((child, currentLeading | !first, currentTrailing | !last));
+                        currentNode.WriteTokenTo(writer, currentLeading, currentTrailing);
+                        continue;
+                    }
+
+                    if (currentNode.IsTrivia)
+                    {
+                        currentNode.WriteTriviaTo(writer);
+                        continue;
+                    }
+
+                    var firstIndex = GetFirstNonNullChildIndex(currentNode);
+                    var lastIndex = GetLastNonNullChildIndex(currentNode);
+
+                    for (var i = lastIndex; i >= firstIndex; i--)
+                    {
+                        var child = currentNode.GetSlot(i);
+                        if (child != null)
+                        {
+                            var first = i == firstIndex;
+                            var last = i == lastIndex;
+                            stack.Push((child, currentLeading | !first, currentTrailing | !last));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This has shown up as a hot allocation path in a few different traces.
This change amortizes the allocations by using a pooled ArrayBuilder
instead of allocating a new Stack every time.

The following benchmarks seem to support the hypothesis:

Before change:

```
BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17134.590 (1803/April2018Update/Redstone4)
AMD Ryzen 7 1800X Eight-Core Processor (Max: 3.60GHz), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=2.2.103
  [Host] : .NET Core 2.1.8 (CoreCLR 4.6.27317.03, CoreFX 4.6.27317.03), 64bit RyuJIT
  Core   : .NET Core 2.1.8 (CoreCLR 4.6.27317.03, CoreFX 4.6.27317.03), 64bit RyuJIT

Job=Core  Runtime=Core  Server=True

                Method |      Mean |     Error |    StdDev |     Gen 0 | Allocated |
---------------------- |----------:|----------:|----------:|----------:|----------:|
               Parsing |  65.25 ms |  1.301 ms |  2.568 ms |         - |   6.57 MB |
 CompileMethodsAndEmit | 634.00 ms | 12.640 ms | 22.468 ms | 1000.0000 |  40.29 MB |
     SerializeMetadata | 200.52 ms |  3.656 ms |  3.241 ms | 1000.0000 |  17.39 MB |
```

After change:

```
BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17134.590 (1803/April2018Update/Redstone4)
AMD Ryzen 7 1800X Eight-Core Processor (Max: 3.60GHz), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=2.2.103
  [Host] : .NET Core 2.1.8 (CoreCLR 4.6.27317.03, CoreFX 4.6.27317.03), 64bit RyuJIT
  Core   : .NET Core 2.1.8 (CoreCLR 4.6.27317.03, CoreFX 4.6.27317.03), 64bit RyuJIT

Job=Core  Runtime=Core  Server=True

                Method |      Mean |     Error |    StdDev |     Gen 0 | Allocated |
---------------------- |----------:|----------:|----------:|----------:|----------:|
               Parsing |  67.26 ms |  1.344 ms |  3.321 ms |         - |   2.59 MB |
 CompileMethodsAndEmit | 627.23 ms | 13.307 ms | 23.995 ms | 1000.0000 |  28.85 MB |
     SerializeMetadata | 206.02 ms |  4.087 ms |  5.991 ms | 1000.0000 |  17.39 MB |
```