### PR TITLE
Move ILASMDeploy to netcoreapp3.0

### DIFF
--- a/src/Tools/ILAsm/IlAsmDeploy.csproj
+++ b/src/Tools/ILAsm/IlAsmDeploy.csproj
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
 
     <!-- 


### PR DESCRIPTION
The deploy project must match the target framework of the binary that is
referenced otherwise `ilasm` on startup will crash with the following
error message:

```
Error: Fail to initialize CoreCLR
Failed to initialize Assembler
```