### PR TITLE
Remove NoBuild from ILAsmDeploy

### DIFF
--- a/src/Tools/ILAsm/IlAsmDeploy.csproj
+++ b/src/Tools/ILAsm/IlAsmDeploy.csproj
@@ -12,9 +12,6 @@
     <TargetLatestRuntimePatch>false</TargetLatestRuntimePatch>
     <SelfContained>true</SelfContained>
 
-    <!-- Do not build again when publishing -->
-    <NoBuild>true</NoBuild>
-
     <PublishDir>$(ArtifactsDir)tools\ILAsm\$(Configuration)\</PublishDir>
   </PropertyGroup>
 


### PR DESCRIPTION
When building roslyn with the core 3.0.0 SDK, one would see errors about ILAsmDeploy build built even though it was flagged as NoBuild. Based on the discussion [here](https://github.com/dotnet/sdk/issues/3001), it was decided to remove the NoBuild flag from the project.