### PR TITLE
Fix Mono tests

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -35852,7 +35852,7 @@ I2.+2
             CompileAndVerify(compilation3, expectedOutput: expectedOutput);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly), Reason = ConditionalSkipReason.MonoDefaultInterfaceMethods)]
         public void Operators_16()
         {
             var source1 =
@@ -36073,7 +36073,7 @@ I1.+
             CompileAndVerify(compilation3, expectedOutput: expectedOutput);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly), Reason = ConditionalSkipReason.MonoDefaultInterfaceMethods)]
         public void Operators_19()
         {
             var source1 =

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -45,6 +45,11 @@ namespace Roslyn.Test.Utilities
         /// Edit and continue is only supported on desktop at the moment.
         /// </summary>
         public const string EditAndContinueRequiresDesktop = "Edit and continue is only supported on desktop";
+
+        /// <summary>
+        /// Mono issues around Default Interface Methods
+        /// </summary>
+        public const string MonoDefaultInterfaceMethods = "Mono can't execute this default interface method test yet";
     }
 
     public class ConditionalFactAttribute : FactAttribute


### PR DESCRIPTION
Mono was crashing when invoking a `static` member on an `interface`.
Disabled the tests on Mono and filed a follow up issue

https://github.com/mono/mono/issues/13319