### PR TITLE
Complete statement: special handling needed for caret at end of line, outside of delimiters

### DIFF
--- a/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
@@ -79,12 +79,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
 
             var currentNode = token.Parent;
 
-            // If cursor is right before an opening delimiter, start with node outside of delimiters since analysis 
-            // starting with a node containing delimiters assumes the caret is placed inside those delimiters. 
-            // This covers cases like `obj.ToString$()`, where `token` references `(` but the caret isn't actually 
-            // inside the argument list.
-            if (token.IsKind(SyntaxKind.OpenBraceToken, SyntaxKind.OpenBracketToken, SyntaxKind.OpenParenToken)
-                && token.Span.Start >= caretPosition)
+            // If the caret is right before an opening delimiter or right after a closing delimeter,
+            // start analysis with node outside of delimiters.
+            // Examples, 
+            //    `obj.ToString$()` where `token` references `(` but the caret isn't actually inside the argument list.
+            //    `obj.ToString()$` if caret is at the end of the line, `token` references `)` but the caret isn't inside the argument list.
+
+            if (token.IsKind(SyntaxKind.OpenBraceToken, SyntaxKind.OpenBracketToken, SyntaxKind.OpenParenToken) && token.Span.Start >= caretPosition
+                || token.IsKind(SyntaxKind.CloseBraceToken, SyntaxKind.CloseBracketToken, SyntaxKind.CloseParenToken) && token.Span.End <= caretPosition)
             {
                 currentNode = currentNode.Parent;
             }

--- a/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
@@ -83,8 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
             // start analysis with node outside of delimiters.
             // Examples, 
             //    `obj.ToString$()` where `token` references `(` but the caret isn't actually inside the argument list.
-            //    `obj.ToString()$` if caret is at the end of the line, `token` references `)` but the caret isn't inside the argument list.
-
+            //    `obj.ToString()$` or `obj.method()$ .method()` where `token` references `)` but the caret isn't inside the argument list.
             if (token.IsKind(SyntaxKind.OpenBraceToken, SyntaxKind.OpenBracketToken, SyntaxKind.OpenParenToken) && token.Span.Start >= caretPosition
                 || token.IsKind(SyntaxKind.CloseBraceToken, SyntaxKind.CloseBracketToken, SyntaxKind.CloseParenToken) && token.Span.End <= caretPosition)
             {

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -3122,6 +3122,25 @@ using System.$$Linq
             VerifyNoSpecialSemicolonHandling(code);
         }
 
+        [WorkItem(33851, "https://github.com/dotnet/roslyn/issues/33851")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CompleteStatement)]
+        public void AtEndOfLineOutsideParens()
+        {
+            var code = @"
+public class Class1
+{
+    void M()
+    {
+        string s = ""Test"";
+        string t = s.Replace(""T"", ""t"")$$
+            .Trim();
+
+    }
+}
+";
+            VerifyNoSpecialSemicolonHandling(code);
+        }
+
         internal override VSCommanding.ICommandHandler GetCommandHandler(TestWorkspace workspace)
         {
             return workspace.ExportProvider.GetExportedValues<VSCommanding.ICommandHandler>().OfType<CompleteStatementCommandHandler>().Single();

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -3141,6 +3141,24 @@ public class Class1
             VerifyNoSpecialSemicolonHandling(code);
         }
 
+        [WorkItem(33851, "https://github.com/dotnet/roslyn/issues/33851")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CompleteStatement)]
+        public void OutsideParensBeforeSpaceDot()
+        {
+            var code = @"
+public class Class1
+{
+    void M()
+    {
+        string s = ""Test"";
+        string t = s.Replace(""T"", ""t"")$$ .Trim();
+
+    }
+}
+";
+            VerifyNoSpecialSemicolonHandling(code);
+        }
+
         internal override VSCommanding.ICommandHandler GetCommandHandler(TestWorkspace workspace)
         {
             return workspace.ExportProvider.GetExportedValues<VSCommanding.ICommandHandler>().OfType<CompleteStatementCommandHandler>().Single();


### PR DESCRIPTION
Fixes #33851

If caret is at the end of a line, root.FindToken will return the character right before it.  

In this case,

```csharp
obj.method()$
   .method2();
```
Complete statement will incorrectly think it is inside of `method` argument list.  

This PR adds a check for this special case and adjusts the handling of the statement accordingly.
