### PR TITLE
Record which packages were missing if we skipped an installed instance

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -272,15 +272,17 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 return isMatch;
             });
 
-            var instanceFoundWithInvalidState = false;
+            var messages = new List<string>();
 
             foreach (ISetupInstance2 instance in instances)
             {
-                var packages = instance.GetPackages()
-                                       .Where((package) => requiredPackageIds.Contains(package.GetId()));
+                var instancePackagesIds = instance.GetPackages().Select(p => p.GetId()).ToHashSet();
+                var missingPackageIds = requiredPackageIds.Where(p => !instancePackagesIds.Contains(p)).ToList();
 
-                if (packages.Count() != requiredPackageIds.Count())
+                if (missingPackageIds.Count > 0)
                 {
+                    messages.Add($"An instance of {instance.GetDisplayName()} at {instance.GetInstallationPath()} was found but was missing these packages: " +
+                        string.Join(", ", missingPackageIds));
                     continue;
                 }
 
@@ -288,18 +290,16 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
                 var state = instance.GetState();
 
-                if ((state & minimumRequiredState) == minimumRequiredState)
+                if ((state & minimumRequiredState) != minimumRequiredState)
                 {
-                    return instance;
+                    messages.Add($"An instance of {instance.GetDisplayName()} at {instance.GetInstallationPath()} matched the specified requirements but had an invalid state. (State: {state})");
+                    continue;
                 }
 
-                Debug.WriteLine($"An instance matching the specified requirements but had an invalid state. (State: {state})");
-                instanceFoundWithInvalidState = true;
+                return instance;
             }
 
-            throw new Exception(instanceFoundWithInvalidState ?
-                                "An instance matching the specified requirements was found but it was in an invalid state." :
-                                "There were no instances of Visual Studio found that match the specified requirements.");
+            throw new Exception(string.Join(Environment.NewLine, messages));
         }
 
         private static Process StartNewVisualStudioProcess(string installationPath, int majorVersion)


### PR DESCRIPTION
If you are missing a package in your install, we wouldn't say which one was missing so you got to figure it out the hard way. This will now log it so you can fix your install.