### PR TITLE
Restore fluent call depth

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -30,16 +30,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
             switch (IntPtr.Size * 8)
             {
                 case 32 when isDebug:
-                    numberFluentCalls = 460;
+                    numberFluentCalls = 510;
                     break;
                 case 32 when !isDebug:
-                    numberFluentCalls = 1300;
+                    numberFluentCalls = 1350;
                     break;
                 case 64 when isDebug:
-                    numberFluentCalls = 175;
+                    numberFluentCalls = 225;
                     break;
                 case 64 when !isDebug:
-                    numberFluentCalls = 570;
+                    numberFluentCalls = 620;
                     break;
                 default:
                     throw new Exception($"unexpected pointer size {IntPtr.Size}");

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
                     numberFluentCalls = 460;
                     break;
                 case 32 when !isDebug:
-                    numberFluentCalls = 1000;
+                    numberFluentCalls = 1300;
                     break;
                 case 64 when isDebug:
                     numberFluentCalls = 175;


### PR DESCRIPTION
The change to move nullable to a two state solution inadverntently
changed how the CLR inlines a number of method calls. The combination of
not-inlining and over-inlining caused us to have a much larger "frame"
for analyzing a fluent call and exceeded our tolerance levels.

This adjusts the inlining so that we get the same results as before.

closes #33775