### PR TITLE
Immediate Window keyboard navigation with Ctrl+Up has been broken.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
@@ -115,19 +115,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
 
             switch ((VSConstants.VSStd2KCmdID)commandId)
             {
-                // HACK: If you look at EditCtlStatementCompletion.cpp, they translate CANCEL to
-                // SCROLLUP to do some hacking around their own command infrastructure and the
-                // legacy stuff they interfaced with. That means we get SCROLLUP if the user
-                // types escape, so treat SCROLLUP like CANCEL. It's actually a CANCEL.
-                case VSConstants.VSStd2KCmdID.SCROLLUP:
-                    ExecuteCancel(subjectBuffer, contentType, () =>
-                    {
-                        // We cannot just pass executeNextCommandTarget becuase it would execute SCROLLUP
-                        var cancelCmdGroupId = VSConstants.VSStd2K;
-                        NextCommandTarget.Exec(ref cancelCmdGroupId, (uint)VSConstants.VSStd2KCmdID.CANCEL, executeInformation, pvaIn, pvaOut);
-                    });
-                    break;
-
                 // If we see a RETURN, and we're in the immediate window, we'll want to rebuild
                 // spans after all the other command handlers have run.
                 case VSConstants.VSStd2KCmdID.RETURN:


### PR DESCRIPTION
fixes https://developercommunity.visualstudio.com/content/problem/475473/immediate-window-keyboard-navigation-with-ctrlup-h.html