### PR TITLE
Learn from binary operators on non-null constant values

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1873,6 +1873,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         operandComparedToNonNull = SkipReferenceConversions(operandComparedToNonNull);
                         splitAndLearnFromNonNullTest(operandComparedToNonNull, caseToLearn: true);
                         return;
+                    case BinaryOperatorKind.NotEqual:
+                        operandComparedToNonNull = SkipReferenceConversions(operandComparedToNonNull);
+                        splitAndLearnFromNonNullTest(operandComparedToNonNull, caseToLearn: false);
+                        return;
                     default:
                         break;
                 };
@@ -1912,19 +1916,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             static BoundExpression skipImplicitNullableConversions(BoundExpression possiblyConversion)
             {
-                while (possiblyConversion.Kind == BoundKind.Conversion)
+                while (possiblyConversion.Kind == BoundKind.Conversion &&
+                    possiblyConversion is BoundConversion { ConversionKind: ConversionKind.ImplicitNullable, Operand: var operand })
                 {
-                    var conversion = (BoundConversion)possiblyConversion;
-                    switch (conversion.ConversionKind)
-                    {
-                        case ConversionKind.ImplicitNullable:
-                            possiblyConversion = conversion.Operand;
-                            break;
-                        default:
-                            return possiblyConversion;
-                    }
+                    possiblyConversion = operand;
                 }
-
                 return possiblyConversion;
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -5310,8 +5310,6 @@ class C<T> where T : class
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(37, 35)
             };
 
-            // https://github.com/dotnet/roslyn/issues/29839: are annotations on events meaningful/allowed?
-
             var c = CreateCompilation(source);
             c.VerifyDiagnostics(expectedDiagnostics);
 
@@ -17103,6 +17101,9 @@ class C
 ", AssertsTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         c.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9)
                 );
         }
 
@@ -19127,18 +19128,21 @@ class CL2
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                 // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //             z1 = y1;
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y1").WithLocation(16, 18),
-                 // (24,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //             x2 = y2;
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2").WithLocation(24, 18),
-                 // (40,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //             z3 = y3;
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y3").WithLocation(40, 18),
-                 // (48,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //             x4 = y4;
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y4").WithLocation(48, 18)
+                // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             z1 = y1;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y1").WithLocation(16, 18),
+                // (24,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             x2 = y2;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2").WithLocation(24, 18),
+                // (40,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             z3 = y3;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y3").WithLocation(40, 18),
+                // (48,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             x4 = y4;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y4").WithLocation(48, 18),
+                // (64,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             z5 = y5;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y5").WithLocation(64, 18)
                 );
         }
 
@@ -19227,18 +19231,21 @@ class CL2
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                 // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //             z1 = y1;
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y1").WithLocation(16, 18),
-                 // (24,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //             x2 = y2;
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2").WithLocation(24, 18),
-                 // (40,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //             z3 = y3;
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y3").WithLocation(40, 18),
-                 // (48,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                 //             x4 = y4;
-                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y4").WithLocation(48, 18)
+                // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             z1 = y1;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y1").WithLocation(16, 18),
+                // (24,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             x2 = y2;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2").WithLocation(24, 18),
+                // (40,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             z3 = y3;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y3").WithLocation(40, 18),
+                // (48,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             x4 = y4;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y4").WithLocation(48, 18),
+                // (60,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //             x5 = y5;
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y5").WithLocation(60, 18)
                 );
         }
 
@@ -19493,6 +19500,12 @@ class CL1
                 // (20,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z3 = x3 != null ? x3 : y3;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3 != null ? x3 : y3").WithLocation(20, 18),
+                // (26,36): warning CS8602: Possible dereference of a null reference.
+                //         CL1 z4 = x4 != null ? x4 : x4.M1();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x4").WithLocation(26, 36),
+                // (38,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         string z6 = y6 != null ? y6 : x6.M2();
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y6 != null ? y6 : x6.M2()").WithLocation(38, 21),
                 // (44,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         string z7 = y7 != null ? y7 : x7.M2();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y7 != null ? y7 : x7.M2()").WithLocation(44, 21)
@@ -19563,6 +19576,9 @@ class CL1
                 // (20,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z3 = x3 == null ? y3 : x3;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3 == null ? y3 : x3").WithLocation(20, 18),
+                // (26,31): warning CS8602: Possible dereference of a null reference.
+                //         CL1 z4 = x4 == null ? x4.M1() : x4;
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x4").WithLocation(26, 31),
                 // (44,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         string z7 = y7 == null ? x7.M2() : y7;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y7 == null ? x7.M2() : y7").WithLocation(44, 21)
@@ -19573,13 +19589,9 @@ class CL1
         [WorkItem(26624, "https://github.com/dotnet/roslyn/issues/26624")]
         public void ConditionalBranching_08()
         {
-            CSharpCompilation c = CreateCompilation(new[] { @"
+            CSharpCompilation c = CreateCompilation(@"
 class C
 {
-    static void Main()
-    {
-    }
-
     bool Test1(CL1? x1)
     {
         if (x1?.P1 == true)
@@ -19587,7 +19599,7 @@ class C
             return x1.P2;
         }
 
-        return false;
+        return x1.P2; // 1
     }
 }
 
@@ -19596,13 +19608,11 @@ class CL1
     public bool P1 { get { return true;} }
     public bool P2 { get { return true;} }
 }
-" }, options: WithNonNullTypesTrue());
-            // Not tracking state of x?.P == expr
-            // unless expr is `null`. See https://github.com/dotnet/roslyn/issues/26624.
+", options: WithNonNullTypesTrue());
             c.VerifyDiagnostics(
-                // (12,20): warning CS8602: Possible dereference of a null reference.
-                //             return x1.P2;
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(12, 20)
+                // (11,16): warning CS8602: Possible dereference of a null reference.
+                //         return x1.P2; // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(11, 16)
                 );
         }
 
@@ -19651,6 +19661,9 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
+                // (13,9): warning CS8602: Possible dereference of a null reference.
+                //         y1.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(13, 9)
                 );
         }
 
@@ -19702,12 +19715,15 @@ class C
             System.Console.WriteLine(2);
         }
 
-        y1.ToString();
+        y1.ToString(); // 1
     }
 }
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
+                // (22,9): warning CS8602: Possible dereference of a null reference.
+                //         y1.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(22, 9)
                 );
         }
 
@@ -19735,12 +19751,15 @@ class C
             System.Console.WriteLine(2);
         }
 
-        y1.ToString();
+        y1.ToString(); // 1
     }
 }
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
+                // (22,9): warning CS8602: Possible dereference of a null reference.
+                //         y1.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(22, 9)
                 );
         }
 
@@ -34357,6 +34376,99 @@ class C
                 );
         }
 
+        [Theory, WorkItem(31906, "https://github.com/dotnet/roslyn/issues/31906")]
+        [InlineData("==")]
+        [InlineData(">")]
+        [InlineData("<")]
+        [InlineData(">=")]
+        [InlineData("<=")]
+        public void LearnFromNullTest_FromOperatorOnConstant(string op)
+        {
+            var source = @"
+class C
+{
+    static void F(string? s, string? s2)
+    {
+        if (s?.Length OPERATOR 1)
+            s.ToString();
+        else
+            s.ToString(); // 1
+
+        if (1 OPERATOR s2?.Length)
+            s2.ToString();
+        else
+            s2.ToString(); // 2
+    }
+}";
+            var comp = CreateCompilation(source.Replace("OPERATOR", op), options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (9,13): warning CS8602: Possible dereference of a null reference.
+                //             s.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
+                // (14,13): warning CS8602: Possible dereference of a null reference.
+                //             s2.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(14, 13)
+                );
+        }
+
+        [Fact, WorkItem(31906, "https://github.com/dotnet/roslyn/issues/31906")]
+        public void LearnFromNullTest_NotEqualsConstant()
+        {
+            var source = @"
+class C
+{
+    static void F(string? s, string? s2)
+    {
+        if (s?.Length != 1)
+            s.ToString(); // 1
+        else
+            s.ToString(); // 2
+
+        if (1 != s2?.Length)
+            s2.ToString(); // 3
+        else
+            s2.ToString(); // 4
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (7,13): warning CS8602: Possible dereference of a null reference.
+                //             s.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 13),
+                // (9,13): warning CS8602: Possible dereference of a null reference.
+                //             s.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
+                // (12,13): warning CS8602: Possible dereference of a null reference.
+                //             s2.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(12, 13),
+                // (14,13): warning CS8602: Possible dereference of a null reference.
+                //             s2.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(14, 13)
+                );
+        }
+
+        [Fact, WorkItem(31906, "https://github.com/dotnet/roslyn/issues/31906")]
+        public void LearnFromNullTest_FromIsConstant()
+        {
+            var source = @"
+class C
+{
+    static void F(string? s)
+    {
+        if (s?.Length is 1)
+            s.ToString();
+        else
+            s.ToString(); // 1
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (9,13): warning CS8602: Possible dereference of a null reference.
+                //             s.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13)
+                );
+        }
+
         [Fact]
         public void NoPiaObjectCreation_01()
         {
@@ -37708,11 +37820,9 @@ static class Extensions
     }
 }";
 
-            var comp = CreateCompilationWithMscorlib45(
-                new[] { source }, options: WithNonNullTypesTrue(),
-                parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilationWithMscorlib45(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (15,18): error CS8651: It is not legal to use nullable type 'string?' in an as expression; use the underlying type 'string' instead.
+                // (15,18): error CS8651: It is not legal to use nullable reference type 'string?' in an as expression; use the underlying type 'string' instead.
                 //         (null as string?).F();
                 Diagnostic(ErrorCode.ERR_AsNullableType, "string?").WithArguments("string").WithLocation(15, 18),
                 // (12,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -37733,6 +37843,9 @@ static class Extensions
                 // (17,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
                 //         ((p != null) ? p.MiddleName : null).F();
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("s", "void Extensions.F(string s)").WithLocation(17, 10),
+                // (18,10): warning CS8602: Possible dereference of a null reference.
+                //         (p.MiddleName ?? null).F();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "p").WithLocation(18, 10),
                 // (18,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
                 //         (p.MiddleName ?? null).F();
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "p.MiddleName ?? null").WithArguments("s", "void Extensions.F(string s)").WithLocation(18, 10)
@@ -37773,7 +37886,7 @@ class Program
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (16,19): error CS8651: It is not legal to use nullable type 'string?' in an as expression; use the underlying type 'string' instead.
+                // (16,19): error CS8651: It is not legal to use nullable reference type 'string?' in an as expression; use the underlying type 'string' instead.
                 //         G(null as string?);
                 Diagnostic(ErrorCode.ERR_AsNullableType, "string?").WithArguments("string").WithLocation(16, 19),
                 // (12,11): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -37800,6 +37913,9 @@ class Program
                 // (19,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
                 //         G((p != null) ? p.MiddleName : null);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("name", "void Program.G(string name)").WithLocation(19, 11),
+                // (20,11): warning CS8602: Possible dereference of a null reference.
+                //         G(p.MiddleName ?? null);
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "p").WithLocation(20, 11),
                 // (20,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
                 //         G(p.MiddleName ?? null);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "p.MiddleName ?? null").WithArguments("name", "void Program.G(string name)").WithLocation(20, 11)
@@ -44049,19 +44165,21 @@ class Program
         if (x.G != null) return;
         C y = x;
         x.F.ToString();
-        x.G.ToString(); // missing warning; see below
+        x.G.ToString(); // warning
         y.F.ToString();
-        y.G.ToString(); // missing warning; see below
+        y.G.ToString(); // warning
     }
 }";
-            // https://github.com/dotnet/roslyn/issues/32703: Not inferring nullability of non-nullable value compared to null
-            // two warnings should appear once 32703 is fixed.
             // https://github.com/dotnet/roslyn/issues/31395: Nullability of class members should be copied on assignment.
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
+                // (16,9): warning CS8602: Possible dereference of a null reference.
+                //         x.G.ToString(); // warning
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.G").WithLocation(16, 9),
                 // (17,9): warning CS8602: Possible dereference of a null reference.
                 //         y.F.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(17, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(17, 9)
+                );
         }
 
         [Fact]
@@ -44089,8 +44207,13 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/32703: Not inferring nullability of non-nullable value compared to null (see // 1, 2).
             comp.VerifyDiagnostics(
+                // (15,9): warning CS8602: Possible dereference of a null reference.
+                //         x.G.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.G").WithLocation(15, 9),
+                // (17,9): warning CS8602: Possible dereference of a null reference.
+                //         y.G.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.G").WithLocation(17, 9)
                 );
         }
 
@@ -44120,7 +44243,157 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/32703: Not inferring nullability of non-nullable value compared to null (see //1, 2).
+            comp.VerifyDiagnostics(
+                // (16,9): warning CS8602: Possible dereference of a null reference.
+                //         x.Value.G.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Value.G").WithLocation(16, 9),
+                // (18,9): warning CS8602: Possible dereference of a null reference.
+                //         y.Value.G.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Value.G").WithLocation(18, 9)
+                );
+        }
+
+        [Fact, WorkItem(33526, "https://github.com/dotnet/roslyn/issues/33526")]
+        public void NullComparisonIsAPureTest()
+        {
+            var source = @"
+class C
+{
+    void F(C x, C y)
+    {
+        if (x == null)
+            x.ToString(); // 1
+        else
+            x.ToString();
+
+        if (null != y)
+            y.ToString();
+        else
+            y.ToString(); // 2
+    }
+    public static bool operator==(C? one, C? two) => throw null!;
+    public static bool operator!=(C? one, C? two) => throw null!;
+    public override bool Equals(object o) => throw null!;
+    public override int GetHashCode() => throw null!;
+}";
+            // `x == null` is a "pure test" even when it binds to a user-defined operator,
+            // so affects both branches
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (7,13): warning CS8602: Possible dereference of a null reference.
+                //             x.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 13),
+                // (14,13): warning CS8602: Possible dereference of a null reference.
+                //             y.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(14, 13)
+                );
+        }
+
+        [Fact, WorkItem(33526, "https://github.com/dotnet/roslyn/issues/33526")]
+        public void NullComparisonIsAPureTest_IntroducesMaybeNull()
+        {
+            var source = @"
+class C
+{
+    void F(C x, C y)
+    {
+        if (x == null) { }
+        x.ToString(); // 1
+
+        if (null != y) { }
+        y.ToString(); // 2
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (7,9): warning CS8602: Possible dereference of a null reference.
+                //         x.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9),
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         y.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(10, 9)
+                );
+        }
+
+        [Fact, WorkItem(33526, "https://github.com/dotnet/roslyn/issues/33526")]
+        public void NullComparisonIsAPureTest_WithCast()
+        {
+            var source = @"
+class C
+{
+    void F(object x, object y)
+    {
+        if ((string)x == null)
+            x.ToString(); // 1
+        else
+            x.ToString();
+
+        if (null != (string)y)
+            y.ToString();
+        else
+            y.ToString(); // 2
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (7,13): warning CS8602: Possible dereference of a null reference.
+                //             x.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 13),
+                // (14,13): warning CS8602: Possible dereference of a null reference.
+                //             y.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(14, 13)
+                );
+        }
+
+        [Fact, WorkItem(33526, "https://github.com/dotnet/roslyn/issues/33526")]
+        public void IsNullIsAPureTest()
+        {
+            var source = @"
+class C
+{
+    void F(C x)
+    {
+        if (x is null)
+            x.ToString(); // 1
+        else
+            x.ToString();
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (7,13): warning CS8602: Possible dereference of a null reference.
+                //             x.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 13)
+                );
+        }
+
+        [Fact, WorkItem(33526, "https://github.com/dotnet/roslyn/issues/33526")]
+        public void OtherComparisonsAreNotPureTest()
+        {
+            var source = @"
+class C
+{
+    void F(C x)
+    {
+        if (x is object) { }
+        x.ToString();
+
+        if (x is object y) { }
+        x.ToString();
+
+        if (x is object _) { }
+        x.ToString();
+
+        if (x is D) { }
+        x.ToString();
+
+        if (x is {}) { }
+        x.ToString();
+    }
+}
+class D : C { }
+";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics();
         }
 
@@ -57450,28 +57723,28 @@ class C
 {
     static void F0<T>()
     {
-        default(T).ToString(); // warn 1
+        default(T).ToString(); // 1
         default(T)?.ToString();
     }
     static void F1<T>()
     {
-        T x1 = default; // warn 2
-        x1.ToString(); // warn 3
+        T x1 = default; // 2
+        x1.ToString(); // 3
         x1!.ToString();
         x1?.ToString();
         if (x1 != null) x1.ToString();
         T y1 = x1;
-        y1.ToString();
+        y1.ToString(); // 4
     }
     static void F2<T>(T x2, T[] a2)
     {
-        x2.ToString(); // warn 4
+        x2.ToString(); // 5
         x2!.ToString();
         x2?.ToString();
         if (x2 != null) x2.ToString();
         T y2 = x2;
-        y2.ToString();
-        a2[0].ToString(); // warn 5
+        y2.ToString(); // 6
+        a2[0].ToString(); // 7
     }
     static void F3<T>() where T : new()
     {
@@ -57479,7 +57752,7 @@ class C
         x3.ToString();
         x3!.ToString();
         var a3 = new[] { new T() };
-        a3[0].ToString(); // warn 6
+        a3[0].ToString(); // 8
     }
     static T F4<T>(T x4)
     {
@@ -57489,29 +57762,35 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,9): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
-                //         default(T).ToString(); // warn 1
+                // (5,9): warning CS8653: A default expression introduces a null value when 'T' is a non-nullable reference type.
+                //         default(T).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default(T)").WithArguments("T").WithLocation(5, 9),
                 // (5,9): warning CS8602: Possible dereference of a null reference.
-                //         default(T).ToString(); // warn 1
+                //         default(T).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "default(T)").WithLocation(5, 9),
-                // (6,9): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
+                // (6,9): warning CS8653: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         default(T)?.ToString();
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default(T)").WithArguments("T").WithLocation(6, 9),
-                // (10,16): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
-                //         T x1 = default; // warn 2
+                // (10,16): warning CS8653: A default expression introduces a null value when 'T' is a non-nullable reference type.
+                //         T x1 = default; // 2
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(10, 16),
                 // (11,9): warning CS8602: Possible dereference of a null reference.
-                //         x1.ToString(); // warn 3
+                //         x1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(11, 9),
+                // (16,9): warning CS8602: Possible dereference of a null reference.
+                //         y1.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(16, 9),
                 // (20,9): warning CS8602: Possible dereference of a null reference.
-                //         x2.ToString(); // warn 4
+                //         x2.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(20, 9),
+                // (25,9): warning CS8602: Possible dereference of a null reference.
+                //         y2.ToString(); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(25, 9),
                 // (26,9): warning CS8602: Possible dereference of a null reference.
-                //         a2[0].ToString(); // warn 5
+                //         a2[0].ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a2[0]").WithLocation(26, 9),
                 // (34,9): warning CS8602: Possible dereference of a null reference.
-                //         a3[0].ToString(); // warn 6
+                //         a3[0].ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a3[0]").WithLocation(34, 9)
                 );
         }
@@ -62504,7 +62783,7 @@ static class E
             x.ToString();
         }
         x.ToString();
-        y.ToString();
+        y.ToString(); // 3
     }
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
@@ -62517,7 +62796,10 @@ static class E
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(7, 9),
                 // (9,9): warning CS8602: Possible dereference of a null reference.
                 //         y.ToString(); // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 9)
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 9),
+                // (18,9): warning CS8602: Possible dereference of a null reference.
+                //         y.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(18, 9)
                 );
         }
 
@@ -62542,7 +62824,7 @@ static class E
             x.ToString();
         }
         x.ToString();
-        y.ToString();
+        y.ToString(); // 3
     }
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
@@ -62553,12 +62835,15 @@ static class E
                 // (7,9): error CS0165: Use of unassigned local variable 'y'
                 //         y.ToString();
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(7, 9),
-                // (8,13): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
+                // (8,13): warning CS8653: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         y = default;
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(8, 13),
                 // (9,9): warning CS8602: Possible dereference of a null reference.
                 //         y.ToString(); // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 9)
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 9),
+                // (18,9): warning CS8602: Possible dereference of a null reference.
+                //         y.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(18, 9)
                 );
         }
 
@@ -63105,25 +63390,16 @@ class Program
     static void F1(object[]? x1, object[]? y1)
     {
         foreach (var x in x1) { } // 1
-    }
-    static void F2(object[]? x1, object[]? y1)
-    {
         foreach (var x in x1) { }
     }
     static void F3(object[]? x1, object[]? y1)
     {
         foreach (var y in y1) { } // 2
-    }
-    static void F4(object[]? x1, object[]? y1)
-    {
         y1.GetEnumerator();
     }
     static void F5(Enumerable? x2, Enumerable? y2)
     {
         foreach (var x in x2) { } // 3
-    }
-    static void F6(Enumerable? x2, Enumerable? y2)
-    {
         foreach (var x in x2) { }
     }
     static void F7(Enumerable? x2, Enumerable? y2)
@@ -63133,29 +63409,19 @@ class Program
     }
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/30562: Should not report second warning in each case.
             comp.VerifyDiagnostics(
                 // (9,27): warning CS8602: Possible dereference of a null reference.
                 //         foreach (var x in x1) { } // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(9, 27),
-                // (13,27): warning CS8602: Possible dereference of a null reference.
-                //         foreach (var x in x1) { }
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(13, 27),
-                // (17,27): warning CS8602: Possible dereference of a null reference.
+                // (14,27): warning CS8602: Possible dereference of a null reference.
                 //         foreach (var y in y1) { } // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(17, 27),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
-                //         y1.GetEnumerator();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(21, 9),
-                // (25,27): warning CS8602: Possible dereference of a null reference.
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(14, 27),
+                // (19,27): warning CS8602: Possible dereference of a null reference.
                 //         foreach (var x in x2) { } // 3
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(25, 27),
-                // (29,27): warning CS8602: Possible dereference of a null reference.
-                //         foreach (var x in x2) { }
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(29, 27),
-                // (33,9): warning CS8602: Possible dereference of a null reference.
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(19, 27),
+                // (24,9): warning CS8602: Possible dereference of a null reference.
                 //         y2.GetEnumerator(); // 4
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(33, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(24, 9));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -19503,9 +19503,6 @@ class CL1
                 // (26,36): warning CS8602: Possible dereference of a null reference.
                 //         CL1 z4 = x4 != null ? x4 : x4.M1();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x4").WithLocation(26, 36),
-                // (38,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         string z6 = y6 != null ? y6 : x6.M2();
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y6 != null ? y6 : x6.M2()").WithLocation(38, 21),
                 // (44,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         string z7 = y7 != null ? y7 : x7.M2();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y7 != null ? y7 : x7.M2()").WithLocation(44, 21)
@@ -34411,6 +34408,49 @@ class C
                 );
         }
 
+        [Fact]
+        public void LearnFromNullTest_IncludingConstants()
+        {
+            var source = @"
+class C
+{
+    void F()
+    {
+        const string s1 = """";
+        if (s1 == null)
+            s1.ToString(); // 1
+
+        if (null == s1)
+            s1.ToString(); // 2
+
+        if (s1 != null)
+            s1.ToString();
+        else
+            s1.ToString(); // 3
+
+        if (null != s1)
+            s1.ToString();
+        else
+            s1.ToString(); // 4
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (8,13): warning CS0162: Unreachable code detected
+                //             s1.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "s1").WithLocation(8, 13),
+                // (11,13): warning CS0162: Unreachable code detected
+                //             s1.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "s1").WithLocation(11, 13),
+                // (16,13): warning CS0162: Unreachable code detected
+                //             s1.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "s1").WithLocation(16, 13),
+                // (21,13): warning CS0162: Unreachable code detected
+                //             s1.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "s1").WithLocation(21, 13)
+                );
+        }
+
         [Fact, WorkItem(31906, "https://github.com/dotnet/roslyn/issues/31906")]
         public void LearnFromNullTest_NotEqualsConstant()
         {
@@ -34422,12 +34462,12 @@ class C
         if (s?.Length != 1)
             s.ToString(); // 1
         else
-            s.ToString(); // 2
+            s.ToString();
 
         if (1 != s2?.Length)
-            s2.ToString(); // 3
+            s2.ToString(); // 2
         else
-            s2.ToString(); // 4
+            s2.ToString();
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
@@ -34435,15 +34475,9 @@ class C
                 // (7,13): warning CS8602: Possible dereference of a null reference.
                 //             s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 13),
-                // (9,13): warning CS8602: Possible dereference of a null reference.
-                //             s.ToString(); // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
                 // (12,13): warning CS8602: Possible dereference of a null reference.
-                //             s2.ToString(); // 3
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(12, 13),
-                // (14,13): warning CS8602: Possible dereference of a null reference.
-                //             s2.ToString(); // 4
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(14, 13)
+                //             s2.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(12, 13)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -63426,17 +63426,17 @@ class Program
         foreach (var x in x1) { } // 1
         foreach (var x in x1) { }
     }
-    static void F3(object[]? x1, object[]? y1)
+    static void F2(object[]? x1, object[]? y1)
     {
         foreach (var y in y1) { } // 2
         y1.GetEnumerator();
     }
-    static void F5(Enumerable? x2, Enumerable? y2)
+    static void F3(Enumerable? x2, Enumerable? y2)
     {
         foreach (var x in x2) { } // 3
         foreach (var x in x2) { }
     }
-    static void F7(Enumerable? x2, Enumerable? y2)
+    static void F4(Enumerable? x2, Enumerable? y2)
     {
         y2.GetEnumerator(); // 4
         foreach (var y in y2) { }


### PR DESCRIPTION
Two changes in this PR:
- a comparison (except `!=`) to a non-null constant is a non-null test
- a comparison with `null` (`x == null`, `x != null`, `(Type)x == null`, ...) is a pure null test and therefore affects both branches

Related issues:
- Fixes https://github.com/dotnet/roslyn/issues/31906 (Infer nullability of receiver from `?.` expression compared with non-null)
- Fixes https://github.com/dotnet/roslyn/issues/33526 (Pure null tests should affect both branches)
- Fixes https://github.com/dotnet/roslyn/issues/32703 (Not inferring nullability of non-nullable value compared to null)
- Closes https://github.com/dotnet/roslyn/issues/30562 (Should not warn dereferencing collection after foreach)
