### PR TITLE
Reduce allocations in CanonicallyCompareDiagnostics

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -976,27 +976,9 @@ haveLambdaBodyAndBinders:
             if (codeCompare != 0)
                 return codeCompare;
 
-            // According to a previous comment:
-            //
-            // "ToString fails for a diagnostic with an error code that does not prevent successful delegate conversion.
-            //  Also,the order doesn't matter, since all such diagnostics will be dropped."
-            //
-            // Currently we no longer call Diagnostic.ToString(), but call ToString() on the arguments.
-            // However since we were unable to reproduce this exception, it is possible it came from the arguments.
-            // Besides, the arguments can sometimes be Symbols, for which ToString is an expensive operation, so this is probably an optimization.
-            if (!ErrorFacts.PreventsSuccessfulDelegateConversion(xCode))
-            {
-                return codeCompare;
-            }
-
-            if (x.Arguments is null && y.Arguments is null)
-                return 0;
-            if (x.Arguments is null)
-                return -1;
-            if (y.Arguments is null)
-                return 1;
-
-            for (int i = 0, n = Math.Min(x.Arguments.Count, y.Arguments.Count); i < n; i++)
+            var nx = x.Arguments?.Count ?? 0;
+            var ny = y.Arguments?.Count ?? 0;
+            for (int i = 0, n = Math.Min(nx, ny); i < n; i++)
             {
                 object argx = x.Arguments[i];
                 object argy = y.Arguments[i];
@@ -1006,7 +988,7 @@ haveLambdaBodyAndBinders:
                     return argCompare;
             }
 
-            return x.Arguments.Count - y.Arguments.Count;
+            return nx - ny;
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -976,13 +976,6 @@ haveLambdaBodyAndBinders:
             if (codeCompare != 0)
                 return codeCompare;
 
-            // ToString fails for a diagnostic with an error code that does not prevent successful delegate conversion.
-            // Also, the order doesn't matter, since all such diagnostics will be dropped.
-            if (!ErrorFacts.PreventsSuccessfulDelegateConversion(xCode))
-            {
-                return codeCompare;
-            }
-
             for (int i = 0; i < Math.Min(x.Arguments.Count, y.Arguments.Count); i++)
             {
                 object argx = x.Arguments[i];

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -961,7 +961,7 @@ haveLambdaBodyAndBinders:
 
         /// <summary>
         /// What we need to do is find a *repeatable* arbitrary way to choose between
-        /// two errors; we can for example simply take the one that is lower in alphabetical
+        /// two errors; we can for example simply take the one whose arguments are lower in alphabetical
         /// order when converted to a string.  As an optimization, we compare error codes
         /// first and skip string comparison if they differ.
         /// </summary>
@@ -980,7 +980,20 @@ haveLambdaBodyAndBinders:
             }
 
             // Optimization: don't bother 
-            return codeCompare == 0 ? string.CompareOrdinal(x.ToString(), y.ToString()) : codeCompare;
+            if (codeCompare != 0)
+                return codeCompare;
+
+            for (int i = 0; i < x.Arguments.Count && i < y.Arguments.Count; i++)
+            {
+                object argx = x.Arguments[i];
+                object argy = y.Arguments[i];
+
+                codeCompare = string.CompareOrdinal(argx?.ToString(), argy?.ToString());
+                if (codeCompare != 0)
+                    return codeCompare;
+            }
+
+            return x.Arguments.Count.CompareTo(y.Arguments.Count);
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -976,6 +976,26 @@ haveLambdaBodyAndBinders:
             if (codeCompare != 0)
                 return codeCompare;
 
+            // According to a previous comment:
+            //
+            // "ToString fails for a diagnostic with an error code that does not prevent successful delegate conversion.
+            //  Also,the order doesn't matter, since all such diagnostics will be dropped."
+            //
+            // Currently we no longer call Diagnostic.ToString(), but call ToString() on the arguments.
+            // However since we were unable to reproduce this exception, it is possible it came from the arguments.
+            // Besides, the arguments can sometimes be Symbols, for which ToString is an expensive operation, so this is probably an optimization.
+            if (!ErrorFacts.PreventsSuccessfulDelegateConversion(xCode))
+            {
+                return codeCompare;
+            }
+
+            if (x.Arguments is null && y.Arguments is null)
+                return 0;
+            if (x.Arguments is null)
+                return -1;
+            if (y.Arguments is null)
+                return 1;
+
             for (int i = 0, n = Math.Min(x.Arguments.Count, y.Arguments.Count); i < n; i++)
             {
                 object argx = x.Arguments[i];

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -967,14 +967,9 @@ haveLambdaBodyAndBinders:
         /// </summary>
         private static int CanonicallyCompareDiagnostics(Diagnostic x, Diagnostic y)
         {
-            ErrorCode xCode = (ErrorCode)x.Code;
-            ErrorCode yCode = (ErrorCode)y.Code;
-
-            int codeCompare = xCode.CompareTo(yCode);
-
             // Optimization: don't bother 
-            if (codeCompare != 0)
-                return codeCompare;
+            if (x.Code != y.Code)
+                return x.Code - y.Code;
 
             var nx = x.Arguments?.Count ?? 0;
             var ny = y.Arguments?.Count ?? 0;

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -976,17 +976,17 @@ haveLambdaBodyAndBinders:
             if (codeCompare != 0)
                 return codeCompare;
 
-            for (int i = 0; i < Math.Min(x.Arguments.Count, y.Arguments.Count); i++)
+            for (int i = 0, n = Math.Min(x.Arguments.Count, y.Arguments.Count); i < n; i++)
             {
                 object argx = x.Arguments[i];
                 object argy = y.Arguments[i];
 
-                codeCompare = string.CompareOrdinal(argx?.ToString(), argy?.ToString());
-                if (codeCompare != 0)
-                    return codeCompare;
+                int argCompare = string.CompareOrdinal(argx?.ToString(), argy?.ToString());
+                if (argCompare != 0)
+                    return argCompare;
             }
 
-            return x.Arguments.Count.CompareTo(y.Arguments.Count);
+            return x.Arguments.Count - y.Arguments.Count;
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -972,18 +972,18 @@ haveLambdaBodyAndBinders:
 
             int codeCompare = xCode.CompareTo(yCode);
 
-            // ToString fails for a diagnostic with an error code that does not prevent successful delegate conversion.
-            // Also, the order doesn't matter, since all such diagnostics will be dropped.
-            if (!ErrorFacts.PreventsSuccessfulDelegateConversion(xCode) || !ErrorFacts.PreventsSuccessfulDelegateConversion(yCode))
-            {
-                return codeCompare;
-            }
-
             // Optimization: don't bother 
             if (codeCompare != 0)
                 return codeCompare;
 
-            for (int i = 0; i < x.Arguments.Count && i < y.Arguments.Count; i++)
+            // ToString fails for a diagnostic with an error code that does not prevent successful delegate conversion.
+            // Also, the order doesn't matter, since all such diagnostics will be dropped.
+            if (!ErrorFacts.PreventsSuccessfulDelegateConversion(xCode))
+            {
+                return codeCompare;
+            }
+
+            for (int i = 0; i < Math.Min(x.Arguments.Count, y.Arguments.Count); i++)
             {
                 object argx = x.Arguments[i];
                 object argy = y.Arguments[i];


### PR DESCRIPTION
In UnboundLambda.CanonicallyCompareDiagnostics, we currently have this code:
```csharp
     return codeCompare == 0 ? string.CompareOrdinal(x.ToString(), y.ToString()) : codeCompare;
```
Both `x` and `y` are diagnostics, and Diagnostic.ToString() is quite an expensive operation, involving numerous allocations.

In a pathological case, this was responsible for nearly 8GB of allocations! See #33846 .

The ironic thing is, the diagnostic message is utterly irrelevant here. The purpose of calling ToString is just to have some repeatable way of selecting a diagnostic to display, so that the tests for roslyn don't keep on having to be updated.

See this comment for example in UnboundLambda.GenerateSummaryErrors:
```csharp
            // It is highly likely that "the same" error will be given for two different
            // bindings of the same lambda but with different values for the parameters
            // of the error. For example, if we have x=>x.Blah() where x could be int
            // or string, then the two errors will be "int does not have member Blah" and 
            // "string does not have member Blah", but the locations and errors numbers
            // will be the same.
            //
            // We should first see if there is a set of errors that are "the same" by
            // this definition that occur in every lambda binding; if there are then
            // those are the errors we should report.
            //
            // If there are no errors that are common to *every* binding then we
            // can report the complete set of errors produced by every binding. However,
            // we still wish to avoid duplicates, so we will use the same logic for
            // building the union as the intersection; two errors with the same code
            // and location are to be treated as the same error and only reported once,
            // regardless of how that error is parameterized.
            //
            // The question then rears its head: when given two of "the same" error
            // to report that are nevertheless different in their arguments, which one
            // do we choose? To the user it hardly matters; either one points to the
            // right location in source code. But it surely matters to our testing team;
            // we do not want to be in a position where some small change to our internal
            // representation of lambdas causes tests to break because errors are reported
            // differently.
            //
            // What we need to do is find a *repeatable* arbitrary way to choose between
            // two errors; we can for example simply take the one that is lower in alphabetical
            // order when converted to a string.
```

Replacing the above code with this code which tests each argument individually:

```csharp
            if (codeCompare != 0)
                return codeCompare;

            for (int i = 0; i < x.Arguments.Count && i < y.Arguments.Count; i++)
            {
                object argx = x.Arguments[i];
                object argy = y.Arguments[i];

                codeCompare = string.CompareOrdinal(argx?.ToString(), argy?.ToString());
                if (codeCompare != 0)
                    return codeCompare;
            }

            return x.Arguments.Count.CompareTo(y.Arguments.Count);
```

all the tests still pass, but allocations should be significantly reduced.