### PR TITLE
Fix several outstanding small formatter bugs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -186,6 +186,7 @@
     <xunitVersion>2.4.1-pre.build.4059</xunitVersion>
     <xunitanalyzersVersion>0.10.0</xunitanalyzersVersion>
     <xunitassertVersion>$(xunitVersion)</xunitassertVersion>
+    <XunitCombinatorialVersion>1.2.7</XunitCombinatorialVersion>
     <xunitextensibilitycoreVersion>$(xunitVersion)</xunitextensibilitycoreVersion>
     <xunitrunnerconsoleVersion>2.4.1-pre.build.4059</xunitrunnerconsoleVersion>
     <xunitrunnerwpfVersion>1.0.51</xunitrunnerwpfVersion>

--- a/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
+++ b/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
@@ -151,6 +151,7 @@
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Collections\SimpleIntervalTree.cs" Link="Formatting\SimpleIntervalTree.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Collections\SimpleIntervalTree`1.cs" Link="Formatting\Context\SimpleIntervalTree`1.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Collections\TextSpanIntervalIntrospector.cs" Link="Formatting\TextSpanIntervalIntrospector.cs" />
+    <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Extensions\ChildSyntaxListExtensions.cs" Link="Formatting\ChildSyntaxListExtensions.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Extensions\LinkedListExtensions.cs" Link="Formatting\LinkedListExtensions.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Extensions\SimpleIntervalTreeExtensions.cs" Link="Formatting\SimpleIntervalTreeExtensions.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Shared\Extensions\SourceTextExtensions_SharedWithCodeStyle.cs" Link="Formatting\SourceTextExtensions_SharedWithCodeStyle.cs" />

--- a/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -74,7 +74,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -140,7 +140,7 @@ internal struct NewStruct
         item2 = Item2;
     }
 
-    public static implicit operator (int, int) (NewStruct value)
+    public static implicit operator (int, int)(NewStruct value)
     {
         return (value.Item1, value.Item2);
     }
@@ -206,7 +206,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int, int b) (NewStruct value)
+    public static implicit operator (int, int b)(NewStruct value)
     {
         return (value.Item1, value.b);
     }
@@ -274,7 +274,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -342,7 +342,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -410,7 +410,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -478,7 +478,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -549,7 +549,7 @@ namespace N
             b = this.b;
         }
 
-        public static implicit operator (int a, int b) (NewStruct value)
+        public static implicit operator (int a, int b)(NewStruct value)
         {
             return (value.a, value.b);
         }
@@ -617,7 +617,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (object a, object b) (NewStruct value)
+    public static implicit operator (object a, object b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -683,7 +683,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -751,7 +751,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -831,7 +831,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -903,7 +903,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -975,7 +975,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -1055,7 +1055,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -1121,7 +1121,7 @@ internal struct NewStruct
         item2 = Item2;
     }
 
-    public static implicit operator (int a, object) (NewStruct value)
+    public static implicit operator (int a, object)(NewStruct value)
     {
         return (value.a, value.Item2);
     }
@@ -1203,7 +1203,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, object b) (NewStruct value)
+    public static implicit operator (int a, object b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -1269,7 +1269,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, object b) (NewStruct value)
+    public static implicit operator (int a, object b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -1337,7 +1337,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -1405,7 +1405,7 @@ internal struct NewStruct<X, Y>
         b = this.b;
     }
 
-    public static implicit operator (List<X> a, Y[] b) (NewStruct<X, Y> value)
+    public static implicit operator (List<X> a, Y[] b)(NewStruct<X, Y> value)
     {
         return (value.a, value.b);
     }
@@ -1484,7 +1484,7 @@ internal struct NewStruct1
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct1 value)
+    public static implicit operator (int a, int b)(NewStruct1 value)
     {
         return (value.a, value.b);
     }
@@ -1550,7 +1550,7 @@ internal struct NewStruct
         a = this.a;
     }
 
-    public static implicit operator (int a, int a) (NewStruct value)
+    public static implicit operator (int a, int a)(NewStruct value)
     {
         return (value.a, value.a);
     }
@@ -1628,7 +1628,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -1706,7 +1706,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -1784,7 +1784,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -1862,7 +1862,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -1936,7 +1936,7 @@ internal struct NewStruct
         item2 = Item2;
     }
 
-    public static implicit operator (int, int) (NewStruct value)
+    public static implicit operator (int, int)(NewStruct value)
     {
         return (value.Item1, value.Item2);
     }
@@ -2015,7 +2015,7 @@ internal struct NewStruct
         item2 = Item2;
     }
 
-    public static implicit operator (int Item1, int Item2) (NewStruct value)
+    public static implicit operator (int Item1, int Item2)(NewStruct value)
     {
         return (value.Item1, value.Item2);
     }
@@ -2119,7 +2119,7 @@ internal struct NewStruct<T>
         b = this.b;
     }
 
-    public static implicit operator (T a, int b) (NewStruct<T> value)
+    public static implicit operator (T a, int b)(NewStruct<T> value)
     {
         return (value.a, value.b);
     }
@@ -2221,7 +2221,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -2323,7 +2323,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -2437,7 +2437,7 @@ internal struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -2581,7 +2581,7 @@ namespace N
             b = this.b;
         }
 
-        public static implicit operator (int a, int b) (NewStruct value)
+        public static implicit operator (int a, int b)(NewStruct value)
         {
             return (value.a, value.b);
         }
@@ -2716,7 +2716,7 @@ public struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }
@@ -2839,7 +2839,7 @@ public struct NewStruct
         b = this.b;
     }
 
-    public static implicit operator (int a, int b) (NewStruct value)
+    public static implicit operator (int a, int b)(NewStruct value)
     {
         return (value.a, value.b);
     }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -3,9 +3,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 
@@ -149,6 +151,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     return;
                 case ImplicitArrayCreationExpressionSyntax implicitArrayCreation when implicitArrayCreation.Initializer != null:
                     SetAlignmentBlockOperation(list, implicitArrayCreation.NewKeyword, implicitArrayCreation.Initializer.OpenBraceToken, implicitArrayCreation.Initializer.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
+                    return;
+                case CSharpSyntaxNode syntaxNode when syntaxNode.IsKind(SyntaxKindEx.SwitchExpression):
+                    SetAlignmentBlockOperation(
+                        list,
+                        syntaxNode.GetFirstToken(),
+                        syntaxNode.ChildNodesAndTokens().First(child => child.IsKind(SyntaxKind.OpenBraceToken)).AsToken(),
+                        syntaxNode.ChildNodesAndTokens().Last(child => child.IsKind(SyntaxKind.CloseBraceToken)).AsToken(),
+                        IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
                     return;
             }
         }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -53,7 +53,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             var operation = nextOperation.Invoke();
 
             // } else in the if else context
-            if (previousToken.IsKind(SyntaxKind.CloseBraceToken) && currentToken.IsKind(SyntaxKind.ElseKeyword))
+            if (previousToken.IsKind(SyntaxKind.CloseBraceToken)
+                && currentToken.IsKind(SyntaxKind.ElseKeyword)
+                && previousToken.Parent.Parent == currentToken.Parent.Parent)
             {
                 if (!optionSet.GetOption(CSharpFormattingOptions.NewLineForElse))
                 {
@@ -206,7 +208,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // } else in the if else context
             if (previousToken.IsKind(SyntaxKind.CloseBraceToken) && currentToken.IsKind(SyntaxKind.ElseKeyword))
             {
-                if (optionSet.GetOption(CSharpFormattingOptions.NewLineForElse))
+                if (optionSet.GetOption(CSharpFormattingOptions.NewLineForElse)
+                    || previousToken.Parent.Parent != currentToken.Parent.Parent)
                 {
                     return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
                 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SpacingFormattingRule.cs
@@ -38,7 +38,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             // Case: public static implicit operator string(Program p) { return null; }
-            if (previousToken.IsKeyword() && currentToken.IsOpenParenInParameterListOfAConversionOperatorDeclaration())
+            // Case: public static implicit operator int?(Program p) { return null; }
+            // Case: public static implicit operator int*(Program p) { return null; }
+            // Case: public static implicit operator int[](Program p) { return null; }
+            // Case: public static implicit operator (int, int)(Program p) { return null; }
+            // Case: public static implicit operator Action<int>(Program p) { return null; }
+            if ((previousToken.IsKeyword() || previousToken.IsKind(SyntaxKind.QuestionToken, SyntaxKind.AsteriskToken, SyntaxKind.CloseBracketToken, SyntaxKind.CloseParenToken, SyntaxKind.GreaterThanToken))
+                && currentToken.IsOpenParenInParameterListOfAConversionOperatorDeclaration())
             {
                 return AdjustSpacesOperationZeroOrOne(optionSet, CSharpFormattingOptions.SpacingAfterMethodDeclarationName);
             }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -2125,6 +2125,40 @@ else
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(33458, "https://github.com/dotnet/roslyn/issues/33458")]
+        public async Task NoNewLineForElseChecksBraceOwner()
+        {
+            var changingOptions = new Dictionary<OptionKey, object>
+            {
+                { NewLineForElse, false },
+                { NewLinesForBracesInControlBlocks, false },
+            };
+
+            await AssertFormatAsync(@"class Class
+{
+    void Method()
+    {
+        if (true)
+            for (int i = 0; i < 10; i++) {
+                Method();
+            }
+        else
+            return;
+    }
+}", @"class Class
+{
+    void Method()
+    {
+        if (true)
+            for (int i = 0; i < 10; i++) {
+                Method();
+            } else
+            return;
+    }
+}", changedOptionSet: changingOptions);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task NewLineForExpressionDefault()
         {
             await AssertFormatAsync(@"class f00

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -9038,5 +9038,31 @@ public class Test
     }
 }");
         }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(31571, "https://github.com/dotnet/roslyn/issues/31571")]
+        [WorkItem(33910, "https://github.com/dotnet/roslyn/issues/33910")]
+        [CombinatorialData]
+        public async Task ConversionOperator_CorrectlySpaceArgumentList(
+            [CombinatorialValues("implicit", "explicit")] string operatorType,
+            [CombinatorialValues("string", "string[]", "System.Action<int>", "int?", "int*", "(int, int)")] string targetType,
+            bool spacingAfterMethodDeclarationName)
+        {
+            var expectedSpacing = spacingAfterMethodDeclarationName ? " " : "";
+            var initialSpacing = spacingAfterMethodDeclarationName ? "" : " ";
+            var changedOptionSet = new Dictionary<OptionKey, object> { { SpacingAfterMethodDeclarationName, spacingAfterMethodDeclarationName } };
+            await AssertFormatAsync(
+                $@"
+public unsafe class Test
+{{
+    public static {operatorType} operator {targetType}{expectedSpacing}() => throw null;
+}}",
+                $@"
+public unsafe class Test
+{{
+    public static {operatorType} operator {targetType}{initialSpacing}() => throw null;
+}}",
+                changedOptionSet: changedOptionSet);
+        }
     }
 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5512,6 +5512,36 @@ _ = this switch
             await AssertFormatAsync(expectedCode, code);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(33839, "https://github.com/dotnet/roslyn/issues/33839")]
+        public async Task FormatSwitchExpression_ExpressionBody()
+        {
+            var code = @"
+public class Test
+{
+    public object Method(int i)
+        => i switch
+{
+1 => 'a',
+2 => 'b',
+_ => null,
+};
+}";
+            var expectedCode = @"
+public class Test
+{
+    public object Method(int i)
+        => i switch
+        {
+            1 => 'a',
+            2 => 'b',
+            _ => null,
+        };
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task FormatSwitchWithPropertyPattern()

--- a/src/Workspaces/CSharpTest/Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.csproj
+++ b/src/Workspaces/CSharpTest/Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.csproj
@@ -26,6 +26,9 @@
     <ProjectReference Include="..\..\Test\PdbUtilities\Roslyn.Test.PdbUtilities.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ChildSyntaxListExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ChildSyntaxListExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Shared.Extensions
+{
+    internal static class ChildSyntaxListExtensions
+    {
+        public static SyntaxNodeOrToken First(this ChildSyntaxList childSyntaxList, Func<SyntaxNodeOrToken, bool> predicate)
+        {
+            foreach (var syntaxNodeOrToken in childSyntaxList)
+            {
+                if (predicate(syntaxNodeOrToken))
+                    return syntaxNodeOrToken;
+            }
+
+            // Delegate to Enumerable.Last which will throw the exception.
+            return Enumerable.First(childSyntaxList, predicate);
+        }
+
+        public static SyntaxNodeOrToken Last(this ChildSyntaxList childSyntaxList, Func<SyntaxNodeOrToken, bool> predicate)
+        {
+            foreach (var syntaxNodeOrToken in childSyntaxList.Reverse())
+            {
+                if (predicate(syntaxNodeOrToken))
+                    return syntaxNodeOrToken;
+            }
+
+            // Delegate to Enumerable.Last which will throw the exception.
+            return Enumerable.Last(childSyntaxList, predicate);
+        }
+    }
+}


### PR DESCRIPTION
📝 I can break this pull request up on request.

* `NewLineForElse` must check parent of preceding brace (fixes #33458)
* Fix spacing before parameter list for conversion operators (fixes #31571, fixes #33910)
* Fix formatting of switch expression blocks (fixes #33839)