### PR TITLE
Copy nullable state from a limited set of BoundExpression types only

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (object)receiverType != null && receiverType.Kind == SymbolKind.NamedType && ((NamedTypeSymbol)receiverType).IsComImport;
         }
 
-        // https://github.com/dotnet/roslyn/issues/29618 Remove this method. Initial binding should not infer nullability.
+        // https://github.com/dotnet/roslyn/issues/33941: Remove this method. Initial binding should not infer nullability.
         internal static TypeSymbolWithAnnotations GetTypeAndNullability(this BoundExpression expr)
         {
             var type = expr.Type;
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return TypeSymbolWithAnnotations.Create(type, annotation);
         }
 
-        // https://github.com/dotnet/roslyn/issues/29618 Remove this method. Initial binding should not infer nullability.
+        // https://github.com/dotnet/roslyn/issues/33941: Remove this method. Initial binding should not infer nullability.
         /// <summary>
         /// Returns the top-level nullability of the expression if the nullability can be determined statically,
         /// and returns null otherwise. (May return null even in cases where the nullability is explicit,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -834,7 +834,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // if InheritNullableStateOfMember asserts the member is valid for target and value?
                 if (areEquivalentTypes(targetType, valueType)) // https://github.com/dotnet/roslyn/issues/29968 Allow assignment to base type.
                 {
-                    if (targetType.IsReferenceType || targetType.IsNullableType())
+                    // https://github.com/dotnet/roslyn/issues/31395: We should copy all tracked state from `value` regardless of
+                    // BoundNode type but we'll need to handle cycles (see NullableReferenceTypesTests.Members_FieldCycle_07).
+                    // For now, we copy a limited set of BoundNode types that shouldn't contain cycles.
+                    if ((targetType.IsReferenceType && (value.Kind == BoundKind.ObjectCreationExpression || value.Kind == BoundKind.AnonymousObjectCreationExpression || value.Kind == BoundKind.DynamicObjectCreationExpression || targetType.TypeSymbol.IsAnonymousType)) ||
+                        targetType.IsNullableType())
                     {
                         // Nullable<T> is handled here rather than in InheritNullableStateOfTrackableStruct since that
                         // method only clones auto-properties (see https://github.com/dotnet/roslyn/issues/29619).


### PR DESCRIPTION
Reverts fix for #31395 for now.

Fixes #33908.