### PR TITLE
Enable roll forward in our .NET Core exes

### DIFF
--- a/eng/config/runtimeconfig.template.json
+++ b/eng/config/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+} 

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -18,6 +18,12 @@
 
     <!-- Place VS insertion (CoreXT) packages to a separate directory -->
     <PackageOutputPath Condition="'$(IsVisualStudioInsertionPackage)' == 'true'">$(DevDivPackagesDir)</PackageOutputPath>
+
+    <!-- 
+      When building a .NET Core exe make sure to include the template runtimeconfig.json file 
+      which has all of our global settings 
+    -->
+    <UserRuntimeConfig Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(OutputType)' == 'Exe'">$(RepositoryEngineeringDir)config\runtimeconfig.template.json</UserRuntimeConfig>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(Language)' == 'CSharp' and '$(TargetFramework)' == 'net20'">


### PR DESCRIPTION
This changes our build to mark all of our .NET Core applications as
rolling forward on major / minor versions of the .NET framework.
Presently our tools ship inside both .NET Core 2 and 3 SDKs. This
setting allows our tools to run unmodified in both settings.