### PR TITLE
Move to BYOC pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,9 @@ pr:
 
 jobs:
 - job: Windows_Desktop_Unit_Tests
-  pool: dotnet-external-temp
+  pool:
+    name: NetCorePublic-Int-Pool
+    queue: BuildPool.Windows.10.Amd64.VS2017.Open
   strategy:
     maxParallel: 4
     matrix:
@@ -88,7 +90,9 @@ jobs:
       condition: not(succeeded())
 
 - job: Windows_CoreClr_Unit_Tests
-  pool: dotnet-external-temp
+  pool:
+    name: NetCorePublic-Int-Pool
+    queue: BuildPool.Windows.10.Amd64.VS2017.Open
   strategy:
     maxParallel: 2
     matrix:
@@ -121,7 +125,9 @@ jobs:
       condition: not(succeeded())
            
 - job: Windows_Determinism_Test
-  pool: dotnet-external-temp
+  pool:
+    name: NetCorePublic-Int-Pool
+    queue: BuildPool.Windows.10.Amd64.VS2017.Open
   timeoutInMinutes: 90
   steps:
     - script: eng/test-determinism.cmd -configuration Debug
@@ -137,7 +143,9 @@ jobs:
       condition: not(succeeded())
 
 - job: Windows_Correctness_Test
-  pool: dotnet-external-temp
+  pool:
+    name: NetCorePublic-Int-Pool
+    queue: BuildPool.Windows.10.Amd64.VS2017.Open
   timeoutInMinutes: 90
   steps:
     - script: eng/test-build-correctness.cmd -configuration Release
@@ -169,7 +177,9 @@ jobs:
       condition: succeeded()
 
 - job: Linux_Test
-  pool: DotNetCore-Linux
+  pool: 
+   name: NetCorePublic-Int-Pool
+   queue: BuildPool.Ubuntu.1604.amd64.Open
   strategy:
     maxParallel: 2
     matrix:


### PR DESCRIPTION
This changes our pipelines to use the BYOC (Bring Your Own Cloud) pools
hosed by the core engineering team. This is a dynamic queue which should
scale better for our uses than the static pools we are using today.