### PR TITLE
Completion is not provided inside curly braces settings if the preceeding text contains 'is'

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -4604,6 +4604,26 @@ class C
             End Using
         End Function
 
+        <MemberData(NameOf(AllCompletionImplementations))>
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestVariableNameInCurlyBraces(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+                              <Document>
+class C
+{
+    public static void M() 
+    {
+        var a = 1;
+        if (a is { $$})
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="a")
+            End Using
+        End Function
+
         Private Class MultipleChangeCompletionProvider
             Inherits CompletionProvider
 

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2024,6 +2024,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 return true;
             }
 
+            // { |
+            if (token.IsKind(SyntaxKind.OpenBraceToken) &&
+                token.Parent.IsKind(SyntaxKind.PropertyPatternClause))
+            {
+                return true;
+            }
+
             // - |
             // + |
             // ~ |


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/815109