### PR TITLE
support feature flag service in IExperimentationService

### DIFF
--- a/src/VisualStudio/Core/Def/Experimentation/VisualStudioExperimentationService.cs
+++ b/src/VisualStudio/Core/Def/Experimentation/VisualStudioExperimentationService.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Experimentation
     {
         private readonly object _experimentationServiceOpt;
         private readonly MethodInfo _isCachedFlightEnabledInfo;
+        private readonly IVsFeatureFlags _featureFlags;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
@@ -25,11 +26,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Experimentation
         {
             object experimentationServiceOpt = null;
             MethodInfo isCachedFlightEnabledInfo = null;
+            IVsFeatureFlags featureFlags = null;
 
             threadingContext.JoinableTaskFactory.Run(async () =>
             {
                 try
                 {
+                    featureFlags = (IVsFeatureFlags)await ((IAsyncServiceProvider)serviceProvider).GetServiceAsync(typeof(SVsFeatureFlags)).ConfigureAwait(false);
                     experimentationServiceOpt = await ((IAsyncServiceProvider)serviceProvider).GetServiceAsync(typeof(SVsExperimentationService)).ConfigureAwait(false);
                     if (experimentationServiceOpt != null)
                     {
@@ -42,6 +45,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Experimentation
                 }
             });
 
+            _featureFlags = featureFlags;
             _experimentationServiceOpt = experimentationServiceOpt;
             _isCachedFlightEnabledInfo = isCachedFlightEnabledInfo;
         }
@@ -51,6 +55,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Experimentation
             ThisCanBeCalledOnAnyThread();
             if (_isCachedFlightEnabledInfo != null)
             {
+                try
+                {
+                    var enabled = _featureFlags.IsFeatureEnabled(experimentName, defaultValue: false);
+                    if (enabled)
+                    {
+                        return enabled;
+                    }
+
+                }
+                catch
+                {
+                    // featureFlags can throw if given name is in incorrect format which can happen for us
+                    // since we use this for experimentation service as well
+                }
+
                 try
                 {
                     return (bool)_isCachedFlightEnabledInfo.Invoke(_experimentationServiceOpt, new object[] { experimentName });

--- a/src/VisualStudio/Core/Def/Experimentation/VisualStudioExperimentationService.cs
+++ b/src/VisualStudio/Core/Def/Experimentation/VisualStudioExperimentationService.cs
@@ -62,7 +62,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Experimentation
                     {
                         return enabled;
                     }
-
                 }
                 catch
                 {


### PR DESCRIPTION
this will let us to create private ring of specific groups for new features until it is ready for bigger group.

once feature is ready for bigger group, this service can support VS experiment flight service which will let us to enable new features for bigger group.

once we are confident on the feature, we will enable it for general public