### PR TITLE
Fix stack overflow compiling deeply nested generic

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.NamespaceOrTypeOrAliasSymbolWithAnnotations.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class Binder
     {
-        internal struct NamespaceOrTypeOrAliasSymbolWithAnnotations
+        internal readonly struct NamespaceOrTypeOrAliasSymbolWithAnnotations
         {
             private readonly TypeSymbolWithAnnotations _type;
             private readonly Symbol _symbol;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -348,8 +348,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Bind the syntax into a namespace, type or alias symbol. 
         /// </summary>
         /// <remarks>
-        /// This method is used in deeply recursive parts of the compiler. Specifically this and <see cref="BindQualifiedName(ExpressionSyntax, SimpleNameSyntax, DiagnosticBag, ConsList{TypeSymbol}, bool)"/>
-        /// are mutually recursive. The non-recursive parts of this method tend to reserve siginficantly large 
+        /// This method is used in deeply recursive parts of the compiler. Specifically this and
+        /// <see cref="BindQualifiedName(ExpressionSyntax, SimpleNameSyntax, DiagnosticBag, ConsList{TypeSymbol}, bool)"/>
+        /// are mutually recursive. The non-recursive parts of this method tend to reserve significantly large 
         /// stack frames due to their use of large struct like <see cref="TypeSymbolWithAnnotations"/>.
         ///
         /// To keep the stack frame size on recursive paths small the non-recursive parts are factored into local 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -330,6 +331,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return BindNamespaceOrTypeSymbol(syntax, diagnostics, basesBeingResolved, basesBeingResolved != null);
         }
 
+        /// <summary>
+        /// This method is used in deeply recursive parts of the compiler and requires a non-trivial amount of stack
+        /// space to execute. Preventing inlining here to keep recursive frames small.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
         internal NamespaceOrTypeOrAliasSymbolWithAnnotations BindNamespaceOrTypeSymbol(ExpressionSyntax syntax, DiagnosticBag diagnostics, ConsList<TypeSymbol> basesBeingResolved, bool suppressUseSiteDiagnostics)
         {
             var result = BindNamespaceOrTypeOrAliasSymbol(syntax, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics);
@@ -338,44 +344,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             return UnwrapAlias(result, diagnostics, syntax, basesBeingResolved);
         }
 
+        /// <summary>
+        /// Bind the syntax into a namespace, type or alias symbol. 
+        /// </summary>
+        /// <remarks>
+        /// This method is used in deeply recursive parts of the compiler. Specifically this and <see cref="BindQualifiedName(ExpressionSyntax, SimpleNameSyntax, DiagnosticBag, ConsList{TypeSymbol}, bool)"/>
+        /// are mutually recursive. The non-recursive parts of this method tend to reserve siginficantly large 
+        /// stack frames due to their use of large struct like <see cref="TypeSymbolWithAnnotations"/>.
+        ///
+        /// To keep the stack frame size on recursive paths small the non-recursive parts are factored into local 
+        /// functions. This means we pay their stack penalty only when they are used. They are themselves big 
+        /// enough they should be disqualified from inlining. In the future when attributes are allowed on 
+        /// local functions we should explicitly mark them as <see cref="MethodImplOptions.NoInlining"/>
+        /// </remarks>
         internal NamespaceOrTypeOrAliasSymbolWithAnnotations BindNamespaceOrTypeOrAliasSymbol(ExpressionSyntax syntax, DiagnosticBag diagnostics, ConsList<TypeSymbol> basesBeingResolved, bool suppressUseSiteDiagnostics)
         {
             switch (syntax.Kind())
             {
                 case SyntaxKind.NullableType:
-                    {
-                        var nullableSyntax = (NullableTypeSyntax)syntax;
-                        TypeSyntax typeArgumentSyntax = nullableSyntax.ElementType;
-                        TypeSymbolWithAnnotations typeArgument = BindType(typeArgumentSyntax, diagnostics, basesBeingResolved);
-                        TypeSymbolWithAnnotations constructedType = typeArgument.SetIsAnnotated(Compilation);
-
-                        reportNullableReferenceTypesIfNeeded(nullableSyntax.QuestionToken, typeArgument);
-
-                        if (!ShouldCheckConstraints)
-                        {
-                            diagnostics.Add(new LazyUseSiteDiagnosticsInfoForNullableType(constructedType), syntax.GetLocation());
-                        }
-                        else if (constructedType.IsNullableType())
-                        {
-                            ReportUseSiteDiagnostics(constructedType.TypeSymbol.OriginalDefinition, diagnostics, syntax);
-                            var type = (NamedTypeSymbol)constructedType.TypeSymbol;
-                            var location = syntax.Location;
-                            type.CheckConstraints(this.Compilation, this.Conversions, includeNullability: true, location, diagnostics);
-                        }
-                        else if (constructedType.TypeSymbol.IsTypeParameterDisallowingAnnotation())
-                        {
-                            diagnostics.Add(ErrorCode.ERR_NullableUnconstrainedTypeParameter, syntax.Location);
-                        }
-
-                        return constructedType;
-                    }
+                    return bindNullable();
 
                 case SyntaxKind.PredefinedType:
-                    {
-                        var predefinedType = (PredefinedTypeSyntax)syntax;
-                        var type = BindPredefinedTypeSymbol(predefinedType, diagnostics);
-                        return TypeSymbolWithAnnotations.Create(IsNullableEnabled(predefinedType.Keyword), type);
-                    }
+                    return bindPredefined();
 
                 case SyntaxKind.IdentifierName:
                     return BindNonGenericSimpleNamespaceOrTypeOrAliasSymbol((IdentifierNameSyntax)syntax, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics, qualifierOpt: null);
@@ -384,19 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return BindGenericSimpleNamespaceOrTypeOrAliasSymbol((GenericNameSyntax)syntax, diagnostics, basesBeingResolved, qualifierOpt: null);
 
                 case SyntaxKind.AliasQualifiedName:
-                    {
-                        var node = (AliasQualifiedNameSyntax)syntax;
-                        var bindingResult = BindNamespaceAliasSymbol(node.Alias, diagnostics);
-                        var alias = bindingResult as AliasSymbol;
-                        NamespaceOrTypeSymbol left = ((object)alias != null) ? alias.Target : (NamespaceOrTypeSymbol)bindingResult;
-
-                        if (left.Kind == SymbolKind.NamedType)
-                        {
-                            return TypeSymbolWithAnnotations.Create(new ExtendedErrorTypeSymbol(left, LookupResultKind.NotATypeOrNamespace, diagnostics.Add(ErrorCode.ERR_ColColWithTypeAlias, node.Alias.Location, node.Alias.Identifier.Text)));
-                        }
-
-                        return this.BindSimpleNamespaceOrTypeOrAliasSymbol(node.Name, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics, left);
-                    }
+                    return bindAlias();
 
                 case SyntaxKind.QualifiedName:
                     {
@@ -416,24 +394,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                 case SyntaxKind.PointerType:
-                    {
-                        var node = (PointerTypeSyntax)syntax;
-                        var elementType = BindType(node.ElementType, diagnostics, basesBeingResolved);
-                        ReportUnsafeIfNotAllowed(node, diagnostics);
-
-                        // Checking BinderFlags.GenericConstraintsClause to prevent cycles in binding
-                        if (Flags.HasFlag(BinderFlags.GenericConstraintsClause) && elementType.TypeKind == TypeKind.TypeParameter)
-                        {
-                            // Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
-                            Error(diagnostics, ErrorCode.ERR_BadConstraintType, node);
-                        }
-                        else
-                        {
-                            CheckManagedAddr(elementType.TypeSymbol, node, diagnostics);
-                        }
-
-                        return TypeSymbolWithAnnotations.Create(new PointerTypeSymbol(elementType));
-                    }
+                    return bindPointer();
 
                 case SyntaxKind.OmittedTypeArgument:
                     {
@@ -477,6 +438,76 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     LazyMissingNonNullTypesContextDiagnosticInfo.ReportNullableReferenceTypesIfNeeded(isNullableEnabled, typeArgument, location, diagnostics);
                 }
+            }
+
+            NamespaceOrTypeOrAliasSymbolWithAnnotations bindNullable()
+            {
+                var nullableSyntax = (NullableTypeSyntax)syntax;
+                TypeSyntax typeArgumentSyntax = nullableSyntax.ElementType;
+                TypeSymbolWithAnnotations typeArgument = BindType(typeArgumentSyntax, diagnostics, basesBeingResolved);
+                TypeSymbolWithAnnotations constructedType = typeArgument.SetIsAnnotated(Compilation);
+
+                reportNullableReferenceTypesIfNeeded(nullableSyntax.QuestionToken, typeArgument);
+
+                if (!ShouldCheckConstraints)
+                {
+                    diagnostics.Add(new LazyUseSiteDiagnosticsInfoForNullableType(constructedType), syntax.GetLocation());
+                }
+                else if (constructedType.IsNullableType())
+                {
+                    ReportUseSiteDiagnostics(constructedType.TypeSymbol.OriginalDefinition, diagnostics, syntax);
+                    var type = (NamedTypeSymbol)constructedType.TypeSymbol;
+                    var location = syntax.Location;
+                    type.CheckConstraints(this.Compilation, this.Conversions, includeNullability: true, location, diagnostics);
+                }
+                else if (constructedType.TypeSymbol.IsTypeParameterDisallowingAnnotation())
+                {
+                    diagnostics.Add(ErrorCode.ERR_NullableUnconstrainedTypeParameter, syntax.Location);
+                }
+
+                return constructedType;
+            }
+
+            NamespaceOrTypeOrAliasSymbolWithAnnotations bindPredefined()
+            {
+                var predefinedType = (PredefinedTypeSyntax)syntax;
+                var type = BindPredefinedTypeSymbol(predefinedType, diagnostics);
+                return TypeSymbolWithAnnotations.Create(IsNullableEnabled(predefinedType.Keyword), type);
+            }
+
+            NamespaceOrTypeOrAliasSymbolWithAnnotations bindAlias()
+            {
+                var node = (AliasQualifiedNameSyntax)syntax;
+                var bindingResult = BindNamespaceAliasSymbol(node.Alias, diagnostics);
+                var alias = bindingResult as AliasSymbol;
+                NamespaceOrTypeSymbol left = ((object)alias != null) ? alias.Target : (NamespaceOrTypeSymbol)bindingResult;
+
+                if (left.Kind == SymbolKind.NamedType)
+                {
+                    return TypeSymbolWithAnnotations.Create(new ExtendedErrorTypeSymbol(left, LookupResultKind.NotATypeOrNamespace, diagnostics.Add(ErrorCode.ERR_ColColWithTypeAlias, node.Alias.Location, node.Alias.Identifier.Text)));
+                }
+
+                return this.BindSimpleNamespaceOrTypeOrAliasSymbol(node.Name, diagnostics, basesBeingResolved, suppressUseSiteDiagnostics, left);
+            }
+
+            NamespaceOrTypeOrAliasSymbolWithAnnotations bindPointer()
+            {
+                var node = (PointerTypeSyntax)syntax;
+                var elementType = BindType(node.ElementType, diagnostics, basesBeingResolved);
+                ReportUnsafeIfNotAllowed(node, diagnostics);
+
+                // Checking BinderFlags.GenericConstraintsClause to prevent cycles in binding
+                if (Flags.HasFlag(BinderFlags.GenericConstraintsClause) && elementType.TypeKind == TypeKind.TypeParameter)
+                {
+                    // Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                    Error(diagnostics, ErrorCode.ERR_BadConstraintType, node);
+                }
+                else
+                {
+                    CheckManagedAddr(elementType.TypeSymbol, node, diagnostics);
+                }
+
+                return TypeSymbolWithAnnotations.Create(new PointerTypeSymbol(elementType));
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
         }
 
         // This test is a canary attempting to make sure that we don't regress the # of fluent calls that 
-        // the compiler can handle.
+        // the compiler can handle. 
         [WorkItem(16669, "https://github.com/dotnet/roslyn/issues/16669")]
         [Fact]
         public void OverflowOnFluentCall()

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -46,31 +46,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
             // is fixed to determine the bug here
             switch (IntPtr.Size * 8)
             {
-<<<<<<< HEAD
-                case 32 when isDebug:
+                case 32 when IsDebug:
                     numberFluentCalls = 510;
                     break;
-                case 32 when !isDebug:
+                case 32 when !IsDebug:
                     numberFluentCalls = 1350;
                     break;
-                case 64 when isDebug:
+                case 64 when IsDebug:
                     numberFluentCalls = 225;
                     break;
-                case 64 when !isDebug:
-                    numberFluentCalls = 620;
-=======
-                case 32 when IsDebug:
-                    numberFluentCalls = 460;
-                    break;
-                case 32 when !IsDebug:
-                    numberFluentCalls = 1000;
-                    break;
-                case 64 when IsDebug:
-                    numberFluentCalls = 175;
-                    break;
                 case 64 when !IsDebug:
-                    numberFluentCalls = 570;
->>>>>>> PR feedback
+                    numberFluentCalls = 620;
                     break;
                 default:
                     throw new Exception($"unexpected pointer size {IntPtr.Size}");

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -114,13 +114,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
             };
 
             // Un-comment loop below and use above commands to figure out the new limits
-            for (int i = nestingLevel; i < int.MaxValue; i = i + 10)
-            {
-                var start = DateTime.UtcNow;
-                Console.Write($"Depth: {i}");
-                runDeeplyNestedGenericTest(i);
-                Console.WriteLine($" - {DateTime.UtcNow - start}");
-            }
+            // for (int i = nestingLevel; i < int.MaxValue; i = i + 10)
+            // {
+            //     var start = DateTime.UtcNow;
+            //     Console.Write($"Depth: {i}");
+            //     runDeeplyNestedGenericTest(i);
+            //     Console.WriteLine($" - {DateTime.UtcNow - start}");
+            // }
 
             runDeeplyNestedGenericTest(nestingLevel);
 

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -135,6 +135,21 @@ namespace Roslyn.Test.Utilities
 
     public static class ExecutionConditionUtil
     {
+        public static ExecutionArchitecture Architecture => (IntPtr.Size) switch
+        {
+            4 => ExecutionArchitecture.x86,
+            8 => ExecutionArchitecture.x64,
+            _ => throw new InvalidOperationException($"Unrecognized pointer size {IntPtr.Size}")
+        };
+        public static ExecutionConfiguration Configuration =>
+#if DEBUG
+            ExecutionConfiguration.Debug;
+#elif RELEASE
+            ExecutionConfiguration.Release;
+#else
+#error Unsupported Configuration
+#endif
+
         public static bool IsWindows => Path.DirectorySeparatorChar == '\\';
         public static bool IsUnix => !IsWindows;
         public static bool IsDesktop => RuntimeUtilities.IsDesktopRuntime;
@@ -144,9 +159,21 @@ namespace Roslyn.Test.Utilities
         public static bool IsCoreClrUnix => IsCoreClr && IsUnix;
     }
 
+    public enum ExecutionArchitecture
+    {
+        x86,
+        x64,
+    }
+
+    public enum ExecutionConfiguration
+    {
+        Debug,
+        Release,
+    }
+
     public class x86 : ExecutionCondition
     {
-        public override bool ShouldSkip => IntPtr.Size != 4;
+        public override bool ShouldSkip => ExecutionConditionUtil.Architecture != ExecutionArchitecture.x86;
 
         public override string SkipReason => "Target platform is not x86";
     }


### PR DESCRIPTION
As a part of implementing nullable reference types many of our locals
switched from `TypeSymbol` to `TypeSymbolWithAnnotations`. In the vast
majority of cases this doesn't have a meaningful impact on compilation.
They are bigger (about 3X) but it's still a relatively small `struct`
(three words).

The size difference is significant though in
`BindNamespaceOrTypeOrAliasSymbol`. This method is used in recursive
parts of binding and is mutually recursive with `BindQualifiedNam`. This
method defines a large number of locals which contribute to every layer
of recursion. When they moved to `TypeSymbolWithAnnotations` this pushed
us outside our tolerance levels and we hit an overflow in extreme cases.

Virtually none of these locals are used in the recursive case. Factored
their use into local functions so we only pay the stack usage on demand.

closes #33909
fixes https://github.com/dotnet/coreclr/issues/22757