### PR TITLE
Write the targets files into the correct directory for VS2019

### DIFF
--- a/src/Compilers/Extension/CompilerPackage.cs
+++ b/src/Compilers/Extension/CompilerPackage.cs
@@ -152,7 +152,18 @@ To reload the Roslyn compiler package, close Visual Studio and any MSBuild proce
                 throw new Exception($"Unrecognized Visual Studio Version: {dte.Version}");
             }
 
-            return parts[0] + ".0";
+            int majorVersion = int.Parse(parts[0]);
+
+            if (majorVersion >= 16)
+            {
+                // Starting in Visual Studio 2019, the folder is just called "Current". See
+                // https://github.com/Microsoft/msbuild/issues/4149 for further commentary.
+                return "Current";
+            }
+            else
+            {
+                return majorVersion + ".0";
+            }
         }
 
         private async Task<string> GetMSBuildPathAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Starting in MSBuild that ships in Visual Studio 2019, the folder to put targets in is just called "Current" to avoid having to revise it for every major version.

This means the compiler extension has some chance of actually working.