### PR TITLE
Update CoreFX dependencies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,7 +71,7 @@
     <MicrosoftNetCompilersToolsetVersion>3.1.0-beta1-19127-06</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNetCoreAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftNetCoreAnalyzersVersion>
     <MicrosoftNetCoreILAsmVersion>2.0.0</MicrosoftNetCoreILAsmVersion>
-    <MicrosoftNETCorePlatformsVersion>2.1.0</MicrosoftNETCorePlatformsVersion>
+    <MicrosoftNETCorePlatformsVersion>2.1.2</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNETCoreRuntimeCoreCLRVersion>2.0.0</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <!-- Using a private build of Microsoft.Net.Test.SDK to work around issue https://github.com/Microsoft/vstest/issues/1764 -->
     <MicrosoftNETTestSdkVersion>15.9.0-dev2</MicrosoftNETTestSdkVersion>
@@ -168,7 +168,7 @@
     <SystemMemoryVersion>4.5.2</SystemMemoryVersion>
     <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>4.5.2</SystemRuntimeCompilerServicesUnsafeVersion>
-    <SystemTextEncodingCodePagesVersion>4.5.0</SystemTextEncodingCodePagesVersion>
+    <SystemTextEncodingCodePagesVersion>4.5.1</SystemTextEncodingCodePagesVersion>
     <SystemTextEncodingExtensionsVersion>4.3.0</SystemTextEncodingExtensionsVersion>
     <SystemThreadingTasksDataflowVersion>4.5.24</SystemThreadingTasksDataflowVersion>
     <!-- We need System.ValueTuple assembly version at least 4.0.3.0 on net47 to make F5 work against Dev15 - see https://github.com/dotnet/roslyn/issues/29705 -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -165,15 +165,15 @@
     <SystemIOFileSystemVersion>4.3.0</SystemIOFileSystemVersion>
     <SystemIOFileSystemPrimitivesVersion>4.3.0</SystemIOFileSystemPrimitivesVersion>
     <SystemIOPipesAccessControlVersion>4.3.0</SystemIOPipesAccessControlVersion>
-    <SystemMemoryVersion>4.5.1</SystemMemoryVersion>
+    <SystemMemoryVersion>4.5.2</SystemMemoryVersion>
     <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>4.5.0</SystemRuntimeCompilerServicesUnsafeVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>4.5.2</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemTextEncodingCodePagesVersion>4.5.0</SystemTextEncodingCodePagesVersion>
     <SystemTextEncodingExtensionsVersion>4.3.0</SystemTextEncodingExtensionsVersion>
     <SystemThreadingTasksDataflowVersion>4.5.24</SystemThreadingTasksDataflowVersion>
     <!-- We need System.ValueTuple assembly version at least 4.0.3.0 on net47 to make F5 work against Dev15 - see https://github.com/dotnet/roslyn/issues/29705 -->
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
-    <SystemThreadingTasksExtensionsVersion>4.5.0</SystemThreadingTasksExtensionsVersion>
+    <SystemThreadingTasksExtensionsVersion>4.5.2</SystemThreadingTasksExtensionsVersion>
     <SQLitePCLRawbundle_greenVersion>1.1.2</SQLitePCLRawbundle_greenVersion>
     <UIAComWrapperVersion>1.1.0.14</UIAComWrapperVersion>
     <MicrosoftVSSDKBuildToolsVersion>15.8.68-develop-g109a00ff</MicrosoftVSSDKBuildToolsVersion>

--- a/eng/targets/GenerateCompilerExecutableBindingRedirects.targets
+++ b/eng/targets/GenerateCompilerExecutableBindingRedirects.targets
@@ -1,56 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
-
-  <!-- The inclusion of this file will cause the resulting .exe.config to contain redirects for our core compiler assemblies,
-       which is needed for things like analyzers to load. -->
-
+<Project>
+  <!--
+    The inclusion of this file will cause the resulting .exe.config to contain redirects for all non-framework dependencies,
+    which is needed for plugins loaded into the compiler (e.g. analyzers) that might target lower versions of these dependencies. 
+  -->
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
-  <Target Name="_GenerateCompilerExecutableBindingRedirects" BeforeTargets="GenerateBindingRedirects" DependsOnTargets="GetAssemblyVersion">
-    <Error Text="AssemblyVersion is not initialized" Condition="'$(AssemblyVersion)' == ''"/>
-    
+  <Target Name="_SuggestBindingRedirectsForNonFrameworkDependencies"
+          BeforeTargets="GenerateBindingRedirects"
+          DependsOnTargets="ResolveAssemblyReferences"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ItemGroup>
-      <!-- The version 0.0.0.0 in these references doesn't actually matter; the generated versions will always generate from 0.0.0.0-->
-      <SuggestedBindingRedirects Include="Microsoft.CodeAnalysis, Version=0.0.0.0, Culture=neutral, PublicKeyToken=$(PublicKeyToken)">
-        <MaxVersion>$(AssemblyVersion)</MaxVersion>
-      </SuggestedBindingRedirects>
-      <SuggestedBindingRedirects Include="Microsoft.CodeAnalysis.CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=$(PublicKeyToken)">
-        <MaxVersion>$(AssemblyVersion)</MaxVersion>
-      </SuggestedBindingRedirects>
-      <SuggestedBindingRedirects Include="Microsoft.CodeAnalysis.VisualBasic, Version=0.0.0.0, Culture=neutral, PublicKeyToken=$(PublicKeyToken)">
-        <MaxVersion>$(AssemblyVersion)</MaxVersion>
-      </SuggestedBindingRedirects>
-      <SuggestedBindingRedirects Include="System.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-        <MaxVersion>4.0.2.0</MaxVersion>
-      </SuggestedBindingRedirects>
-      <SuggestedBindingRedirects Include="System.Collections.Immutable, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-        <MaxVersion>1.2.3.0</MaxVersion>
-      </SuggestedBindingRedirects>
-      <SuggestedBindingRedirects Include="System.Memory, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-        <MaxVersion>4.0.1.0</MaxVersion>
-      </SuggestedBindingRedirects>
-      <SuggestedBindingRedirects Include="System.Numerics.Vectors, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-        <MaxVersion>4.1.3.0</MaxVersion>
-      </SuggestedBindingRedirects>
-      <SuggestedBindingRedirects Include="System.Reflection.Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-        <MaxVersion>1.4.3.0</MaxVersion>
-      </SuggestedBindingRedirects>
-      <SuggestedBindingRedirects Include="System.Runtime.CompilerServices.Unsafe, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-        <MaxVersion>4.0.4.1</MaxVersion>
-      </SuggestedBindingRedirects>
-      <SuggestedBindingRedirects Include="System.Text.Encoding.CodePages, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-        <MaxVersion>4.1.1.0</MaxVersion>
-      </SuggestedBindingRedirects>
-      <SuggestedBindingRedirects Include="System.Threading.Tasks.Extensions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-        <MaxVersion>4.2.0.0</MaxVersion>
-      </SuggestedBindingRedirects>
+      <SuggestedBindingRedirects Include="@(ReferencePath->'%(FusionName)')" MaxVersion="%(ReferencePath.Version)" KeepMetadata="-none-" Condition="'%(ReferencePath.FrameworkFile)' != 'true'" />
     </ItemGroup>
   </Target>
 </Project>

--- a/eng/targets/GenerateCompilerExecutableBindingRedirects.targets
+++ b/eng/targets/GenerateCompilerExecutableBindingRedirects.targets
@@ -34,7 +34,7 @@
         <MaxVersion>1.4.3.0</MaxVersion>
       </SuggestedBindingRedirects>
       <SuggestedBindingRedirects Include="System.Runtime.CompilerServices.Unsafe, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-        <MaxVersion>4.0.4.0</MaxVersion>
+        <MaxVersion>4.0.4.1</MaxVersion>
       </SuggestedBindingRedirects>
       <SuggestedBindingRedirects Include="System.Text.Encoding.CodePages, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
         <MaxVersion>4.1.1.0</MaxVersion>

--- a/eng/targets/GenerateCompilerExecutableBindingRedirects.targets
+++ b/eng/targets/GenerateCompilerExecutableBindingRedirects.targets
@@ -27,8 +27,17 @@
       <SuggestedBindingRedirects Include="Microsoft.CodeAnalysis.VisualBasic, Version=0.0.0.0, Culture=neutral, PublicKeyToken=$(PublicKeyToken)">
         <MaxVersion>$(AssemblyVersion)</MaxVersion>
       </SuggestedBindingRedirects>
+      <SuggestedBindingRedirects Include="System.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+        <MaxVersion>4.0.2.0</MaxVersion>
+      </SuggestedBindingRedirects>
       <SuggestedBindingRedirects Include="System.Collections.Immutable, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
         <MaxVersion>1.2.3.0</MaxVersion>
+      </SuggestedBindingRedirects>
+      <SuggestedBindingRedirects Include="System.Memory, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+        <MaxVersion>4.0.1.0</MaxVersion>
+      </SuggestedBindingRedirects>
+      <SuggestedBindingRedirects Include="System.Numerics.Vectors, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+        <MaxVersion>4.1.3.0</MaxVersion>
       </SuggestedBindingRedirects>
       <SuggestedBindingRedirects Include="System.Reflection.Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
         <MaxVersion>1.4.3.0</MaxVersion>


### PR DESCRIPTION
StreamJsonRpc requires the higher versions of these packages.

Removes hard-coded list of suggested binding redirects and replaces it with a generated list.