### PR TITLE
Fix result and slot of conditional receiver

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -88,6 +88,161 @@ namespace System
     }
 }";
 
+        [Fact, WorkItem(33289, "https://github.com/dotnet/roslyn/issues/33289")]
+        public void ConditionalReceiver()
+        {
+            var comp = CreateCompilation(@"
+public class Container<T>
+{
+    public T Field = default!;
+}
+
+class C
+{
+    static void M(string? s)
+    {
+        var x = Create(s);
+        _ = x /*T:Container<string?>?*/;
+        x?.Field.ToString(); // 1
+    }
+
+    public static Container<U>? Create<U>(U u) => new Container<U>();
+}", options: WithNonNullTypesTrue());
+            comp.VerifyTypes();
+            comp.VerifyDiagnostics(
+                // (13,11): warning CS8602: Possible dereference of a null reference.
+                //         x?.Field.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".Field").WithLocation(13, 11)
+                );
+        }
+
+        [Fact, WorkItem(33289, "https://github.com/dotnet/roslyn/issues/33289")]
+        public void ConditionalReceiver_Chained()
+        {
+            var comp = CreateCompilation(@"
+public class Container<T>
+{
+    public T Field = default!;
+}
+
+class C
+{
+    static void M(string? s)
+    {
+        var x = Create(s);
+        if (x is null) return;
+        _ = x /*T:Container<string?>!*/;
+        x?.Field.ToString(); // 1
+
+        x = Create(s);
+        if (x is null) return;
+        x.Field?.ToString();
+    }
+
+    public static Container<U>? Create<U>(U u) => new Container<U>();
+}", options: WithNonNullTypesTrue());
+            comp.VerifyTypes();
+            comp.VerifyDiagnostics(
+                // (14,11): warning CS8602: Possible dereference of a null reference.
+                //         x?.Field.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".Field").WithLocation(14, 11)
+                );
+        }
+
+        [Fact, WorkItem(33289, "https://github.com/dotnet/roslyn/issues/33289")]
+        public void ConditionalReceiver_Chained_Inversed()
+        {
+            var comp = CreateCompilation(@"
+public class Container<T>
+{
+    public T Field = default!;
+}
+
+class C
+{
+    static void M(string s)
+    {
+        var x = Create(s);
+        _ = x /*T:Container<string!>?*/;
+        x?.Field.ToString();
+
+        x = Create(s);
+        x.Field?.ToString(); // 1
+    }
+
+    public static Container<U>? Create<U>(U u) => new Container<U>();
+}", options: WithNonNullTypesTrue());
+            comp.VerifyTypes();
+            comp.VerifyDiagnostics(
+                // (16,9): warning CS8602: Possible dereference of a null reference.
+                //         x.Field?.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(16, 9)
+                );
+        }
+
+        [Fact, WorkItem(33289, "https://github.com/dotnet/roslyn/issues/33289")]
+        public void ConditionalReceiver_Nested()
+        {
+            var comp = CreateCompilation(@"
+public class Container<T>
+{
+    public T Field = default!;
+}
+
+class C
+{
+    static void M(string? s1, string s2)
+    {
+        var x = Create(s1);
+        var y = Create(s2);
+        x?.Field /*1*/
+            .Extension(y?.Field.ToString());
+    }
+
+    public static Container<U>? Create<U>(U u) => new Container<U>();
+}
+public static class Extensions
+{
+    public static void Extension(this string s, object? o) => throw null!;
+}", options: WithNonNullTypesTrue());
+            comp.VerifyTypes();
+            comp.VerifyDiagnostics(
+                // (13,11): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.Extension(string s, object? o)'.
+                //         x?.Field /*1*/
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, ".Field").WithArguments("s", "void Extensions.Extension(string s, object? o)").WithLocation(13, 11)
+                );
+        }
+
+        [Fact, WorkItem(33289, "https://github.com/dotnet/roslyn/issues/33289")]
+        public void ConditionalReceiver_MiscTypes()
+        {
+            var comp = CreateCompilation(@"
+public class Container<T>
+{
+    public T M() => default!;
+}
+class C
+{
+    static void M<T>(int i, Missing m, string s, T t)
+    {
+        Create(i)?.M().ToString();
+        Create(m)?.M().ToString();
+        Create(s)?.M().ToString();
+        Create(t)?.M().ToString(); // 1
+    }
+
+    public static Container<U>? Create<U>(U u) => new Container<U>();
+}", options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (8,29): error CS0246: The type or namespace name 'Missing' could not be found (are you missing a using directive or an assembly reference?)
+                //     static void M<T>(int i, Missing m, string s, T t)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Missing").WithArguments("Missing").WithLocation(8, 29),
+                // (13,19): warning CS8602: Possible dereference of a null reference.
+                //         Create(t)?.M().ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".M()").WithLocation(13, 19)
+                );
+        }
+
         [Fact, WorkItem(33537, "https://github.com/dotnet/roslyn/issues/33537")]
         public void SuppressOnNullLiteralInAs()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -82588,20 +82588,20 @@ class Node
 public class C
 {
     public C? f;
-    int? Test1(C? c) => c?.f.M(c.f.ToString()); // nested use of `c.f` is safe
-    int? Test2(C? c) => c.f.M(c.f.ToString());
-    int M(string s) => s.Length;
+    void Test1(C? c) => c?.f.M(c.f.ToString()); // nested use of `c.f` is safe
+    void Test2(C? c) => c.f.M(c.f.ToString());
+    void M(string s) => throw null!;
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (5,27): warning CS8602: Possible dereference of a null reference.
-                //     int? Test1(C? c) => c?.f.M(c.f.ToString()); // nested use of `c.f` is safe
+                //     void Test1(C? c) => c?.f.M(c.f.ToString()); // nested use of `c.f` is safe
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".f").WithLocation(5, 27),
                 // (6,25): warning CS8602: Possible dereference of a null reference.
-                //     int? Test2(C? c) => c.f.M(c.f.ToString());
+                //     void Test2(C? c) => c.f.M(c.f.ToString());
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(6, 25),
                 // (6,25): warning CS8602: Possible dereference of a null reference.
-                //     int? Test2(C? c) => c.f.M(c.f.ToString());
+                //     void Test2(C? c) => c.f.M(c.f.ToString());
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.f").WithLocation(6, 25)
                 );
         }


### PR DESCRIPTION
As the `Dump()` for a conditional access (excerpted below) shows, the call or member access uses a placeholder ("conditional receiver") in place of the actual receiver.

There are two parts of this PR:
- we ensure that visiting a conditional receiver produces the correct result type,
- we ensure that asking for a slot for a conditional receiver produces the correct slot.

To do that, we store some information (the result and the slot) about the real receiver when we visit a conditional access. 

- Fixes https://github.com/dotnet/roslyn/issues/33289 (fails to apply inferred type arguments' nullability after `?.` access)
- Fixes https://github.com/dotnet/roslyn/issues/31909 (Dereference doesn't update null state if there's an unrelated conditional qualifier)
- Fixes https://github.com/dotnet/roslyn/issues/33347 (Variables known to be non-null sometimes artifically restricted to one variable)
- Fixes https://github.com/dotnet/roslyn/issues/31905 (Nullable flow analysis works incorrectly with nested conditional accesses)
- Fixes https://github.com/dotnet/roslyn/issues/29956 (PROTOTYPE markers in VisitConditionalAccess and VisitConditionalReceiver)

```
conditionalAccess
    ├─receiver
    │ └─local
    │   ├─localSymbol: Container<System.String> x
    │   ├─type: Container<System.String>
    │   └─isSuppressed: False
    ├─accessExpression
    │ └─call
    │   ├─receiverOpt
    │   │ └─fieldAccess
    │   │   ├─receiverOpt
    │   │   │ └─conditionalReceiver
    │   │   │   ├─id: 0
    │   │   │   ├─type: Container<System.String>
    │   │   │   └─isSuppressed: False
    │   │   ├─fieldSymbol: System.String Container<System.String>.Field
    │   │   └─isSuppressed: False
    │   ├─method: System.String System.String.ToString()
    │   ├─type: System.String
    │   └─isSuppressed: False
    ├─type: System.String
    └─isSuppressed: False
```