### PR TITLE
Remove IDocumentOperationService.SupportsDiagnostics

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/DiagnosticResultSerializer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticResultSerializer.cs
@@ -146,14 +146,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var document = project.GetDocument(documentId);
 
                 var diagnostics = serializer.ReadFrom(reader, document, cancellationToken);
-
-                if (document?.SupportsDiagnostics() == false)
-                {
-                    // drop diagnostics for non-null document that doesn't support
-                    // diagnostics
-                    continue;
-                }
-
                 map.Add(documentId, GetOrDefault(diagnostics));
             }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -497,11 +497,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 private void Add(ref ImmutableDictionary<DocumentId, ImmutableArray<DiagnosticData>>.Builder locals, DocumentId documentId, ImmutableArray<DiagnosticData> diagnostics)
                 {
-                    if (_project.GetDocument(documentId)?.SupportsDiagnostics() == false)
-                    {
-                        return;
-                    }
-
                     locals = locals ?? ImmutableDictionary.CreateBuilder<DocumentId, ImmutableArray<DiagnosticData>>();
                     locals.Add(documentId, diagnostics);
                 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         {
             // change it to check active file (or visible files), not open files if active file tracking is enabled.
             // otherwise, use open file.
-            return document.IsOpen() && document.SupportsDiagnostics();
+            return document.IsOpen();
         }
 
         private IEnumerable<StateSet> GetStateSetsForFullSolutionAnalysis(IEnumerable<StateSet> stateSets, Project project)

--- a/src/VisualStudio/Core/Test/Venus/DocumentServiceTests.vb
+++ b/src/VisualStudio/Core/Test/Venus/DocumentServiceTests.vb
@@ -90,11 +90,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Venus
                 Dim service = New ContainedDocument.DocumentServiceProvider(projectedDocument.TextBuffer)
                 Dim documentOperations = service.GetService(Of IDocumentOperationService)
 
-                ' contained document supports both document modification and diagnostics
+                ' contained document supports document modification
                 ' soon, contained document will be only used to support old venus and razor but not new razor
                 ' which will use thier own implementation of these services
                 Assert.True(documentOperations.CanApplyChange)
-                Assert.True(documentOperations.SupportDiagnostics)
             End Using
         End Sub
 

--- a/src/VisualStudio/Core/Test/Venus/DocumentService_IntegrationTests.vb
+++ b/src/VisualStudio/Core/Test/Venus/DocumentService_IntegrationTests.vb
@@ -206,15 +206,13 @@ class { }
 
                 Dim diagnosticService = New TestDiagnosticAnalyzerService(DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap())
 
-                ' confirm diagnostic support is off for the document
-                Assert.False(document.SupportsDiagnostics())
-
                 ' register the workspace to the service
                 diagnosticService.CreateIncrementalAnalyzer(workspace)
 
                 ' confirm that IDE doesn't report the diagnostics
                 Dim diagnostics = Await diagnosticService.GetDiagnosticsAsync(workspace.CurrentSolution, documentId:=document.Id)
-                Assert.False(diagnostics.Any())
+                Dim diagnostic = Assert.Single(diagnostics)
+                Assert.Equal("CS1001", diagnostic.Id)
             End Using
         End Function
 
@@ -300,12 +298,6 @@ class { }
                 Public Shared ReadOnly Instance As DocumentOperations = New DocumentOperations()
 
                 Public ReadOnly Property CanApplyChange As Boolean Implements IDocumentOperationService.CanApplyChange
-                    Get
-                        Return False
-                    End Get
-                End Property
-
-                Public ReadOnly Property SupportDiagnostics As Boolean Implements IDocumentOperationService.SupportDiagnostics
                     Get
                         Return False
                     End Get

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResult.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResult.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
 
             // filter out any document that doesn't support diagnostics.
             // g.Key == null means diagnostics on the project which assigned to "others" error category
-            var group = diagnostics.GroupBy(d => d.DocumentId).Where(g => g.Key == null || project.GetDocument(g.Key).SupportsDiagnostics()).ToList();
+            var group = diagnostics.GroupBy(d => d.DocumentId).ToList();
 
             var result = new DiagnosticAnalysisResult(
                 project.Id,
@@ -128,10 +128,6 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             ImmutableArray<DiagnosticData> others,
             ImmutableHashSet<DocumentId> documentIds = null)
         {
-            VerifyDocumentMap(project, syntaxLocalMap);
-            VerifyDocumentMap(project, semanticLocalMap);
-            VerifyDocumentMap(project, nonLocalMap);
-
             return new DiagnosticAnalysisResult(
                 project.Id,
                 version,
@@ -253,15 +249,6 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             }
 
             return ImmutableHashSet.CreateRange(documents);
-        }
-
-        [Conditional("DEBUG")]
-        private static void VerifyDocumentMap(Project project, ImmutableDictionary<DocumentId, ImmutableArray<DiagnosticData>> map)
-        {
-            foreach (var documentId in map.Keys)
-            {
-                Debug.Assert(project.GetDocument(documentId)?.SupportsDiagnostics() == true);
-            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
@@ -118,11 +118,6 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                 return;
             }
 
-            if (!documentOpt.SupportsDiagnostics())
-            {
-                return;
-            }
-
             map = map ?? new Dictionary<DocumentId, List<DiagnosticData>>();
             map.GetOrAdd(documentOpt.Id, _ => new List<DiagnosticData>()).Add(DiagnosticData.Create(documentOpt, diagnostic));
 

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/Extensions.cs
@@ -13,15 +13,5 @@ namespace Microsoft.CodeAnalysis.Host
         {
             return document?.Services.GetService<IDocumentOperationService>().CanApplyChange ?? false;
         }
-
-        public static bool SupportsDiagnostics(this TextDocument document)
-        {
-            return document?.State.SupportsDiagnostics() ?? false;
-        }
-
-        public static bool SupportsDiagnostics(this TextDocumentState document)
-        {
-            return document?.Services.GetService<IDocumentOperationService>().SupportDiagnostics ?? false;
-        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/IDocumentOperationService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/IDocumentOperationService.cs
@@ -13,10 +13,5 @@ namespace Microsoft.CodeAnalysis.Host
         /// document version of <see cref="Workspace.CanApplyChange(ApplyChangesKind)"/>
         /// </summary>
         bool CanApplyChange { get; }
-
-        /// <summary>
-        /// indicates whether this document supports diagnostics or not
-        /// </summary>
-        bool SupportDiagnostics { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DefaultTextDocumentServiceProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DefaultTextDocumentServiceProvider.cs
@@ -40,7 +40,6 @@ namespace Microsoft.CodeAnalysis
             // even support rename through IDynamicFileInfoProvider pattern once we address that in next
             // iteration for razor. for now, we keep existing behavior
             public bool CanApplyChange => true;
-            public bool SupportDiagnostics => true;
         }
     }
 }


### PR DESCRIPTION
All documents can support diagnostics; this property is unnecessary.