### PR TITLE
 Bind T? in cref as Nullable<T>

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -504,8 +504,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var typeSymbol = this.TypeSymbol;
 
-            // It is not safe to check if a type parameter is a reference type right away, this can send us into a cycle.
-            // In this case we delay asking this question as long as possible.
             if (typeSymbol.TypeKind != TypeKind.TypeParameter)
             {
                 if (!typeSymbol.IsValueType && !typeSymbol.IsErrorType())
@@ -514,11 +512,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
-                    return Create(compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(ImmutableArray.Create(typeSymbol)));
+                    return makeNullableT();
                 }
             }
 
+            if (((TypeParameterSymbol)typeSymbol).TypeParameterKind == TypeParameterKind.Cref)
+            {
+                // We always bind annoated type parameters in cref as `Nullable<T>`
+                return makeNullableT();
+            }
+
+            // It is not safe to check if a type parameter is a reference type right away, this can send us into a cycle.
+            // In this case we delay asking this question as long as possible.
             return CreateLazyNullableType(compilation, this);
+
+            TypeSymbolWithAnnotations makeNullableT()
+                => Create(compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(ImmutableArray.Create(typeSymbol)));
         }
 
         private TypeSymbolWithAnnotations AsNullableReferenceType() => _extensions.AsNullableReferenceType(this);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolWithAnnotations.cs
@@ -518,7 +518,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (((TypeParameterSymbol)typeSymbol).TypeParameterKind == TypeParameterKind.Cref)
             {
-                // We always bind annoated type parameters in cref as `Nullable<T>`
+                // We always bind annotated type parameters in cref as `Nullable<T>`
                 return makeNullableT();
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -2349,6 +2349,96 @@ public class C
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics();
         }
 
+        [Fact, WorkItem(33782, "https://github.com/dotnet/roslyn/issues/33782")]
+        public void AnnotationInXmlDoc_TwoDeclarations()
+        {
+            var source = @"
+/// <summary />
+public class C
+{
+    void M<T>(T? t) where T : struct { }
+    void M<T>(T t) where T : class { }
+
+    /// <summary>
+    /// See <see cref=""M{T}(T?)""/>
+    /// </summary>
+    void M2() { }
+}";
+            // In cref, `T?` always binds to `Nullable<T>`
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithDocumentationComments, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
+            var lastCref = tree.GetRoot().DescendantNodes(descendIntoTrivia: true).OfType<NameMemberCrefSyntax>().Last();
+            var lastCrefSymbol = model.GetSymbolInfo(lastCref).Symbol;
+            Assert.Equal("void C.M<T>(T? t)", lastCrefSymbol.ToTestDisplayString());
+        }
+
+        [Fact, WorkItem(33782, "https://github.com/dotnet/roslyn/issues/33782")]
+        public void AnnotationInXmlDoc_DeclaredAsNonNullableReferenceType()
+        {
+            var source = @"
+/// <summary />
+public class C
+{
+    void M<T>(T t) where T : class { }
+
+    /// <summary>
+    /// <see cref=""M{T}(T?)""/> warn 1
+    /// </summary>
+    void M2() { }
+
+    /// <summary>
+    /// <see cref=""M{T}(T)""/>
+    /// </summary>
+    void M3() { }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithDocumentationComments, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (8,20): warning CS1574: XML comment has cref attribute 'M{T}(T?)' that could not be resolved
+                //     /// <see cref="M{T}(T?)"/> warn 1
+                Diagnostic(ErrorCode.WRN_BadXMLRef, "M{T}(T?)").WithArguments("M{T}(T?)").WithLocation(8, 20));
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
+            var lastCref = tree.GetRoot().DescendantNodes(descendIntoTrivia: true).OfType<NameMemberCrefSyntax>().Last();
+            var lastCrefSymbol = model.GetSymbolInfo(lastCref).Symbol;
+            Assert.Equal("void C.M<T>(T t)", lastCrefSymbol.ToTestDisplayString());
+        }
+
+        [Fact, WorkItem(33782, "https://github.com/dotnet/roslyn/issues/33782")]
+        public void AnnotationInXmlDoc_DeclaredAsNullableReferenceType()
+        {
+            var source = @"
+/// <summary />
+public class C
+{
+    void M<T>(T? t) where T : class { }
+
+    /// <summary>
+    /// <see cref=""M{T}(T?)""/> warn 1
+    /// </summary>
+    void M2() { }
+
+    /// <summary>
+    /// <see cref=""M{T}(T)""/>
+    /// </summary>
+    void M3() { }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithDocumentationComments, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (8,20): warning CS1574: XML comment has cref attribute 'M{T}(T?)' that could not be resolved
+                //     /// <see cref="M{T}(T?)"/> warn 1
+                Diagnostic(ErrorCode.WRN_BadXMLRef, "M{T}(T?)").WithArguments("M{T}(T?)").WithLocation(8, 20));
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
+            var lastCref = tree.GetRoot().DescendantNodes(descendIntoTrivia: true).OfType<NameMemberCrefSyntax>().Last();
+            var lastCrefSymbol = model.GetSymbolInfo(lastCref).Symbol;
+            Assert.Equal("void C.M<T>(T? t)", lastCrefSymbol.ToTestDisplayString());
+        }
+
         [Fact, WorkItem(30955, "https://github.com/dotnet/roslyn/issues/30955")]
         public void ArrayTypeInference_Verify30955()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -2363,6 +2363,11 @@ public class C
     /// See <see cref=""M{T}(T?)""/>
     /// </summary>
     void M2() { }
+
+    /// <summary>
+    /// See <see cref=""M{T}(T)""/>
+    /// </summary>
+    void M3() { }
 }";
             // In cref, `T?` always binds to `Nullable<T>`
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularWithDocumentationComments, options: WithNonNullTypesTrue());
@@ -2370,9 +2375,13 @@ public class C
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
+            var firstCref = tree.GetRoot().DescendantNodes(descendIntoTrivia: true).OfType<NameMemberCrefSyntax>().First();
+            var firstCrefSymbol = model.GetSymbolInfo(firstCref).Symbol;
+            Assert.Equal("void C.M<T>(T? t)", firstCrefSymbol.ToTestDisplayString());
+
             var lastCref = tree.GetRoot().DescendantNodes(descendIntoTrivia: true).OfType<NameMemberCrefSyntax>().Last();
             var lastCrefSymbol = model.GetSymbolInfo(lastCref).Symbol;
-            Assert.Equal("void C.M<T>(T? t)", lastCrefSymbol.ToTestDisplayString());
+            Assert.Equal("void C.M<T>(T t)", lastCrefSymbol.ToTestDisplayString());
         }
 
         [Fact, WorkItem(33782, "https://github.com/dotnet/roslyn/issues/33782")]


### PR DESCRIPTION
## Customer scenario
In 16.0, the binding of `T?` in a cref such as `<see cref="M{T}(T?)"/>` regressed. 
This should compile without warning and bind to `M(Nullable<T>)`, but instead produces a warning "CS1580	Invalid type for parameter T? in XML comment cref attribute".

## Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/33782

## Workarounds, if any
None

## Risk, Performance impact
Low. We're making sure that `T?` always binds to `Nullable<T>` in crefs.

## Is this a regression from a previous update?
Yes.

## Root cause analysis
The binding of a `T?` changed due to the nullable feature. 
In common usage (outside of a cref), it can now bind to `Nullable<T>` in some cases, or to an annotated `T` in some others (producing an error for unconstrained type parameters).
But crefs don't include constraints, so this binding change caused `T?` in a cref to bind as an annotated `T` with a unconstrainted `T` (that's an error). The error presented with a specific message for crefs...


## How was the bug found?
Reported by customer.

----

Note: from discussion with Chuck, this fix is correct for the long-term as well. If you want a cref to reference a method with an annotated `T`, you should just use `T`. If you want a cref to reference a method with a `Nullable<T>`, you should use `T?` (as before). We're not planning to extend cref to represent nullable reference type annotations.

Filled https://devdiv.visualstudio.com/DevDiv/_workitems/edit/817666/ for ask-mode approval.