### PR TITLE
The default label is considered reachable in a traditional switch statement

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
@@ -30,7 +30,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var label in section.SwitchLabels)
                 {
-                    if (reachableLabels.Contains(label.Label) || label.HasErrors)
+                    if (reachableLabels.Contains(label.Label) || label.HasErrors ||
+                        label == node.DefaultLabel && node.Expression.ConstantValue == null && IsTraditionalSwitch(node))
                     {
                         SetState(initialState.Clone());
                     }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1155,7 +1155,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.StateWhenFalse[mainSlot] = whenFalse;
             }
 
-            if (whenTrue.IsNotNull()|| whenFalse.IsNotNull())
+            if (whenTrue.IsNotNull() || whenFalse.IsNotNull())
             {
                 var slotBuilder = ArrayBuilder<int>.GetInstance();
                 GetSlotsToMarkAsNotNullable(expression, slotBuilder);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -2918,6 +2918,35 @@ public class TestClass
                 );
         }
 
+        [Fact]
+        [WorkItem(33783, "https://github.com/dotnet/roslyn/issues/33783")]
+        public void UnreachableDefaultInBoolSwitch()
+        {
+            var text = @"
+public class TestClass
+{
+    public static void Main()
+    {
+        bool b = false;
+        switch (b)
+        {
+            case true:
+                break;
+            case false:
+                break;
+            default:
+                break; //1
+        }
+    }
+}";
+            CreateCompilation(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics();
+            CreateCompilation(text, parseOptions: TestOptions.Regular7_3).VerifyDiagnostics();
+            CreateCompilation(text).VerifyDiagnostics(
+                // (14,17): warning CS0162: Unreachable code detected
+                //                 break; //1
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(14, 17));
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
This fixes a compatibility bug (the new compiler complains about unreachable code, but if you remove it the old compiler complains about a switch fall-through).

Fixes #33783