### PR TITLE
Fix local bootstrap build

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -206,7 +206,11 @@ function BuildSolution() {
     $projects = Join-Path $RepoRoot $solution
     $enableAnalyzers = !$skipAnalyzers
     $toolsetBuildProj = InitializeToolset
-    $quietRestore = !$ci
+
+    # Have to disable quiet restore during bootstrap builds to work around 
+    # an arcade bug
+    # https://github.com/dotnet/arcade/issues/2220
+    $quietRestore = !($ci -or ($bootstrapDir -ne ""))
     $testTargetFrameworks = if ($testCoreClr) { "netcoreapp2.1" } else { "" }
     $ibcSourceBranchName = GetIbcSourceBranchName
     $ibcDropId = if ($officialIbcDropId -ne "default") { $officialIbcDropId } else { "" }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1155,7 +1155,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.StateWhenFalse[mainSlot] = whenFalse;
             }
 
-            if (whenTrue.IsNotNull()|| whenFalse.IsNotNull())
+            if (whenTrue.IsNotNull() || whenFalse.IsNotNull())
             {
                 var slotBuilder = ArrayBuilder<int>.GetInstance();
                 GetSlotsToMarkAsNotNullable(expression, slotBuilder);


### PR DESCRIPTION
Have to disable quiet restore explicitly on local dev machines when
doing a bootstrap build to work around this arcade issue:
https://github.com/dotnet/arcade/issues/2220