### PR TITLE
IDE benchmarks

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -416,6 +416,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Exte
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.ExternalAccess.ProjectSystem", "src\Tools\ExternalAccess\ProjectSystem\Microsoft.CodeAnalysis.ExternalAccess.ProjectSystem.csproj", "{620EA38F-F039-41B9-9003-5EBF5EC19D85}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IdeBenchmarks", "src\Tools\IdeBenchmarks\IdeBenchmarks.csproj", "{FF38E9C9-7A25-44F0-B2C4-24C9BFD6A8F6}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
@@ -1105,6 +1107,10 @@ Global
 		{620EA38F-F039-41B9-9003-5EBF5EC19D85}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{620EA38F-F039-41B9-9003-5EBF5EC19D85}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{620EA38F-F039-41B9-9003-5EBF5EC19D85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF38E9C9-7A25-44F0-B2C4-24C9BFD6A8F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF38E9C9-7A25-44F0-B2C4-24C9BFD6A8F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF38E9C9-7A25-44F0-B2C4-24C9BFD6A8F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF38E9C9-7A25-44F0-B2C4-24C9BFD6A8F6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1300,6 +1306,7 @@ Global
 		{0ED8E92D-3781-43B5-A7AD-43A92F91C243} = {8977A560-45C2-4EC2-A849-97335B382C74}
 		{D3AA159B-5DC6-420A-BD9B-1BB6BCD3DDB2} = {8977A560-45C2-4EC2-A849-97335B382C74}
 		{620EA38F-F039-41B9-9003-5EBF5EC19D85} = {8977A560-45C2-4EC2-A849-97335B382C74}
+		{FF38E9C9-7A25-44F0-B2C4-24C9BFD6A8F6} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {604E6B91-7BC0-4126-AE07-D4D2FEFC3D29}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,7 +25,7 @@
     <MicrosoftCodeAnalysisTestingVersion>1.0.0-beta1-63310-01</MicrosoftCodeAnalysisTestingVersion>
     <CodeStyleAnalyzerVersion>3.1.0-beta1-19113-04</CodeStyleAnalyzerVersion>
     <BasicUndoVersion>0.9.3</BasicUndoVersion>
-    <BenchmarkDotNetVersion>0.11.1</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.11.4</BenchmarkDotNetVersion>
     <CommandLineParserVersion>2.0.273-beta</CommandLineParserVersion>
     <DiffPlexVersion>1.4.4</DiffPlexVersion>
     <DropAppVersion>17.144.28413-buildid7983345</DropAppVersion>

--- a/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
+++ b/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepositoryEngineeringDir)targets\GenerateCompilerExecutableBindingRedirects.targets" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <!-- Automatically generate the necessary assembly binding redirects -->
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <NoWarn>$(NoWarn),CA2007</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
+  </ItemGroup>
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
+    <ProjectReference Include="..\..\Compilers\Test\Resources\Core\Microsoft.CodeAnalysis.Compiler.Test.Resources.csproj" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.vbproj" />
+    <ProjectReference Include="..\..\EditorFeatures\Core.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj" />
+    <ProjectReference Include="..\..\EditorFeatures\CSharp.Wpf\Microsoft.CodeAnalysis.CSharp.EditorFeatures.Wpf.csproj" />
+    <ProjectReference Include="..\..\EditorFeatures\TestUtilities\Roslyn.Services.Test.Utilities.csproj" />
+    <ProjectReference Include="..\..\Interactive\Host\Microsoft.CodeAnalysis.InteractiveHost.csproj" />
+    <ProjectReference Include="..\..\Scripting\Core\Microsoft.CodeAnalysis.Scripting.csproj" />
+    <ProjectReference Include="..\..\Scripting\CSharp\Microsoft.CodeAnalysis.CSharp.Scripting.csproj" />
+    <ProjectReference Include="..\..\Test\Utilities\Portable\Roslyn.Test.Utilities.csproj" />
+    <ProjectReference Include="..\..\Workspaces\CoreTestUtilities\Roslyn.Services.UnitTests.Utilities.csproj" />
+    <ProjectReference Include="..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
+    <ProjectReference Include="..\..\Workspaces\Core\MSBuild\Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj" />
+    <ProjectReference Include="..\..\Workspaces\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Workspaces.csproj" />
+    <ProjectReference Include="..\..\Workspaces\Remote\Core\Microsoft.CodeAnalysis.Remote.Workspaces.csproj" />
+    <ProjectReference Include="..\..\Workspaces\Remote\ServiceHub\Microsoft.CodeAnalysis.Remote.ServiceHub.csproj" />
+    <ProjectReference Include="..\..\Workspaces\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Workspaces.vbproj" />
+    <ProjectReference Include="..\..\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj" />
+    <ProjectReference Include="..\..\EditorFeatures\Text\Microsoft.CodeAnalysis.EditorFeatures.Text.csproj" />
+    <!-- These aren't used by the build, but it allows the tool to locate dependencies of the built-in analyzers. -->
+    <ProjectReference Include="..\..\EditorFeatures\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj" />
+    <ProjectReference Include="..\..\EditorFeatures\CSharp\Microsoft.CodeAnalysis.CSharp.EditorFeatures.csproj" />
+    <ProjectReference Include="..\..\EditorFeatures\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.vbproj" />
+    <ProjectReference Include="..\..\Features\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj" />
+    <ProjectReference Include="..\..\Features\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Features.vbproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+</Project>

--- a/src/Tools/IdeBenchmarks/MemoryDiagnoserConfig.cs
+++ b/src/Tools/IdeBenchmarks/MemoryDiagnoserConfig.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace IdeBenchmarks
+{
+    public class MemoryDiagnoserConfig : ManualConfig
+    {
+        public MemoryDiagnoserConfig()
+        {
+            Add(MemoryDiagnoser.Default);
+        }
+    }
+}

--- a/src/Tools/IdeBenchmarks/Program.cs
+++ b/src/Tools/IdeBenchmarks/Program.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Running;
+
+namespace IdeBenchmarks
+{
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            new BenchmarkSwitcher(typeof(Program).Assembly).Run(args);
+        }
+    }
+}

--- a/src/Tools/IdeBenchmarks/Program.cs
+++ b/src/Tools/IdeBenchmarks/Program.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
 namespace IdeBenchmarks
@@ -8,7 +9,13 @@ namespace IdeBenchmarks
     {
         private static void Main(string[] args)
         {
-            new BenchmarkSwitcher(typeof(Program).Assembly).Run(args);
+#if DEBUG
+            var config = new DebugInProcessConfig();
+#else
+            IConfig config = null;
+#endif
+
+            new BenchmarkSwitcher(typeof(Program).Assembly).Run(args, config);
         }
     }
 }

--- a/src/Tools/IdeBenchmarks/Properties/AssemblyInfo.cs
+++ b/src/Tools/IdeBenchmarks/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Attributes;
+using IdeBenchmarks;
+
+[assembly: Config(typeof(MemoryDiagnoserConfig))]

--- a/src/Tools/IdeBenchmarks/RegexClassifierBenchmarks.cs
+++ b/src/Tools/IdeBenchmarks/RegexClassifierBenchmarks.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Extensions;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace IdeBenchmarks
+{
+    [ShortRunJob]
+    public class RegexClassifierBenchmarks
+    {
+        [Benchmark(Baseline = true, Description = "String literal")]
+        public object TestStringLiteral()
+        {
+            var code = @"
+class Program
+{
+    void Method()
+    {
+        // xanguage=regex
+        _ = @""aaaaaaaaaaaa"";
+    }
+}
+";
+
+            return GetClassificationSpansAsync(code, new TextSpan(0, code.Length), parseOptions: null).Result;
+        }
+
+        [Benchmark(Description = "Regular expression literal")]
+        public object TestRegexStringLiteral()
+        {
+            var code = @"
+class Program
+{
+    void Method()
+    {
+        // language=regex
+        _ = @""aaaaaaaaaaaa"";
+    }
+}
+";
+
+            return GetClassificationSpansAsync(code, new TextSpan(0, code.Length), parseOptions: null).Result;
+        }
+
+        protected Task<ImmutableArray<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions parseOptions)
+        {
+            using (var workspace = TestWorkspace.CreateCSharp(code, parseOptions))
+            {
+                var document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id);
+                return GetSemanticClassificationsAsync(document, span);
+            }
+        }
+
+        protected static async Task<ImmutableArray<ClassifiedSpan>> GetSemanticClassificationsAsync(Document document, TextSpan span)
+        {
+            var tree = await document.GetSyntaxTreeAsync();
+
+            var service = document.GetLanguageService<ISyntaxClassificationService>();
+            var classifiers = service.GetDefaultSyntaxClassifiers();
+            var extensionManager = document.Project.Solution.Workspace.Services.GetService<IExtensionManager>();
+
+            var results = ArrayBuilder<ClassifiedSpan>.GetInstance();
+
+            await service.AddSemanticClassificationsAsync(document, span,
+                extensionManager.CreateNodeExtensionGetter(classifiers, c => c.SyntaxNodeTypes),
+                extensionManager.CreateTokenExtensionGetter(classifiers, c => c.SyntaxTokenKinds),
+                results,
+                CancellationToken.None);
+
+            return results.ToImmutableAndFree();
+        }
+    }
+}

--- a/src/Tools/IdeBenchmarks/app.config
+++ b/src/Tools/IdeBenchmarks/app.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <gcServer enabled="true" />
+  </runtime>
+</configuration>

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -286,6 +286,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures2.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.UnitTests" />
     <InternalsVisibleTo Include="Roslyn.Services.Test.Utilities" />
+    <InternalsVisibleTo Include="IdeBenchmarks" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Workspaces.UnitTests" />
     <InternalsVisibleTo Include="Roslyn.Services.UnitTests.Utilities" />


### PR DESCRIPTION
Here's the results from RegexClassifierBanchmarks:

|               Method | StringLength | RepeatElement |      Mean |     Error |    StdDev |    Median | Scaled | ScaledSD |     Gen 0 |  Allocated |
|--------------------- |------------- |-------------- |----------:|----------:|----------:|----------:|-------:|---------:|----------:|-----------:|
|     'String literal' |            0 |             \ |  4.615 ms | 0.1496 ms | 0.4388 ms |  4.737 ms |   1.00 |     0.00 |         - |     616 KB |
| 'Regular expression' |            0 |             \ |  7.236 ms | 0.4300 ms | 1.2680 ms |  6.437 ms |   1.58 |     0.32 | 1000.0000 |   832.1 KB |
|                      |              |               |           |           |           |           |        |          |           |            |
|     'String literal' |            0 |             a |  4.712 ms | 0.1480 ms | 0.4248 ms |  4.765 ms |   1.00 |     0.00 |         - |     608 KB |
| 'Regular expression' |            0 |             a |  7.990 ms | 0.4173 ms | 1.2304 ms |  7.274 ms |   1.71 |     0.31 | 1000.0000 |  832.54 KB |
|                      |              |               |           |           |           |           |        |          |           |            |
|     'String literal' |         1000 |             \ |  6.815 ms | 0.3909 ms | 1.1526 ms |  6.133 ms |   1.00 |     0.00 | 1000.0000 |  835.71 KB |
| 'Regular expression' |         1000 |             \ | 10.973 ms | 0.7669 ms | 2.2613 ms | 10.601 ms |   1.65 |     0.43 | 1000.0000 | 1139.77 KB |
|                      |              |               |           |           |           |           |        |          |           |            |
|     'String literal' |         1000 |             a |  4.503 ms | 0.1523 ms | 0.4466 ms |  4.280 ms |   1.00 |     0.00 |         - |  668.02 KB |
| 'Regular expression' |         1000 |             a |  8.417 ms | 0.5412 ms | 1.5957 ms |  7.455 ms |   1.89 |     0.40 | 1000.0000 |  988.09 KB |
|                      |              |               |           |           |           |           |        |          |           |            |
|     'String literal' |        10000 |             \ |  7.561 ms | 0.1443 ms | 0.1350 ms |  7.538 ms |   1.00 |     0.00 | 1000.0000 | 3165.84 KB |
| 'Regular expression' |        10000 |             \ | 30.495 ms | 1.1173 ms | 3.1330 ms | 29.072 ms |   4.03 |     0.42 | 1000.0000 | 4413.26 KB |
|                      |              |               |           |           |           |           |        |          |           |            |
|     'String literal' |        10000 |             a |  7.767 ms | 0.3726 ms | 1.0985 ms |  7.022 ms |   1.00 |     0.00 | 1000.0000 | 1196.38 KB |
| 'Regular expression' |        10000 |             a | 19.597 ms | 1.3913 ms | 4.1021 ms | 16.807 ms |   2.57 |     0.65 | 1000.0000 | 2524.56 KB |