### PR TITLE
publish RoslynDeployment vsix to Roslyn vsix myget feed

### DIFF
--- a/eng/config/PublishVsix.MyGet.config
+++ b/eng/config/PublishVsix.MyGet.config
@@ -10,4 +10,5 @@
   <extension id="ExpressionEvaluatorPackage"/>
   <extension id="Roslyn.VisualStudio.Setup"/>
   <extension id="Roslyn.VisualStudio.InteractiveComponents"/>
+  <extension id="RoslynDeployment"/>
 </extensions>


### PR DESCRIPTION
publish RoslynDeployment vsix to myget feed.

we used to publish roslyn insider vsix but at some point when we changed name, it looks like we stopped publishing the actual vsix people can use to dogfood nightly roslyn.

