### PR TITLE
Change verification default based on framework

### DIFF
--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -637,8 +637,8 @@ namespace System.Runtime.CompilerServices
             TargetFramework targetFramework = TargetFramework.Standard,
             Verification? verify = null)
         {
-            options = options ?? TestOptions.ReleaseDll.WithOutputKind((expectedOutput != null) ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary);
-            verify = verify ?? TargetFrameworkUtil.GetVerification(targetFramework, references);
+            options ??= TestOptions.ReleaseDll.WithOutputKind((expectedOutput != null) ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary);
+            verify ??= TargetFrameworkUtil.GetVerification(targetFramework, references);
             var compilation = CreateCompilation(source, references, options, parseOptions, targetFramework, assemblyName: GetUniqueName());
             return CompileAndVerify(
                 compilation,

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -30,6 +30,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 {
     public abstract class CSharpTestBase : CommonTestBase
     {
+        #region Source Definitions Helpers 
+
         protected const string NullableAttributeDefinition = @"
 namespace System.Runtime.CompilerServices
 {
@@ -409,6 +411,8 @@ namespace System.Runtime.CompilerServices
 }
 ";
 
+        #endregion
+
         protected static CSharpCompilationOptions WithNonNullTypesTrue(CSharpCompilationOptions options = null)
         {
             return WithNonNullTypes(options, NullableContextOptions.Enable);
@@ -454,7 +458,7 @@ namespace System.Runtime.CompilerServices
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes) =>
+            Verification? verify = null) =>
             CompileAndVerify(
                 source,
                 references,
@@ -488,7 +492,7 @@ namespace System.Runtime.CompilerServices
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes) =>
+            Verification? verify = null) =>
             CompileAndVerify(
                 source,
                 references,
@@ -523,7 +527,7 @@ namespace System.Runtime.CompilerServices
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes)
+            Verification? verify = null)
         {
             options = options ?? TestOptions.ReleaseDll.WithOutputKind((expectedOutput != null) ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary);
             var compilation = CreateExperimentalCompilationWithMscorlib45(source, feature, references, options, parseOptions, assemblyName: GetUniqueName());
@@ -562,7 +566,7 @@ namespace System.Runtime.CompilerServices
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes) =>
+            Verification? verify = null) =>
             CompileAndVerify(
                 source,
                 references,
@@ -596,7 +600,7 @@ namespace System.Runtime.CompilerServices
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes) =>
+            Verification? verify = null) =>
             CompileAndVerify(
                 source,
                 references,
@@ -631,9 +635,10 @@ namespace System.Runtime.CompilerServices
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
             TargetFramework targetFramework = TargetFramework.Standard,
-            Verification verify = Verification.Passes)
+            Verification? verify = null)
         {
             options = options ?? TestOptions.ReleaseDll.WithOutputKind((expectedOutput != null) ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary);
+            verify = verify ?? TargetFrameworkUtil.GetVerification(targetFramework, references);
             var compilation = CreateCompilation(source, references, options, parseOptions, targetFramework, assemblyName: GetUniqueName());
             return CompileAndVerify(
                 compilation,
@@ -647,7 +652,7 @@ namespace System.Runtime.CompilerServices
                 expectedReturnCode,
                 args,
                 emitOptions,
-                verify);
+                verify.Value);
         }
 
         internal CompilationVerifier CompileAndVerify(

--- a/src/Test/Utilities/Portable/CommonTestBase.cs
+++ b/src/Test/Utilities/Portable/CommonTestBase.cs
@@ -150,7 +150,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Verification verify)
         {
             var verifier = new CompilationVerifier(compilation, VisualizeRealIL, dependencies);
-
             verifier.Emit(expectedOutput, expectedReturnCode, args, manifestResources, emitOptions, verify, expectedSignatures);
 
             if (assemblyValidator != null || symbolValidator != null)

--- a/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
+++ b/src/Test/Utilities/Portable/TargetFrameworkUtil.cs
@@ -186,15 +186,20 @@ namespace Roslyn.Test.Utilities
                 case TargetFramework.Mscorlib46Extended:
                 case TargetFramework.Mscorlib461:
                 case TargetFramework.Mscorlib461Extended:
-                case TargetFramework.NetStandard20:
                 case TargetFramework.WinRT:
                 case TargetFramework.DefaultVb:
+                    // Verification is fully supported on desktop and hence these should pass unless explicitly marked
+                    // otherwise.
                     return Verification.Passes;
+                case TargetFramework.NetStandard20:
+                    // On CoreCLR and NetStandard PEVerify will often fail because it's not supported. Hence it is 
+                    // skipped.
+                    return Verification.Skipped;
                 case TargetFramework.Standard:
                 case TargetFramework.StandardAndCSharp:
                 case TargetFramework.StandardAndVBRuntime:
                 case TargetFramework.StandardCompat:
-                    return Verification.Fails;
+                    return RuntimeUtilities.IsDesktopRuntime ? Verification.Passes : Verification.Skipped;
                 default: throw new InvalidOperationException($"Unexpected target framework {tf}");
             }
         }


### PR DESCRIPTION
This changes our core compiler helpers to default verification off of
the target framework and references. This should remove some confusion
about verification in the test suites and make it more correct by
default.