### PR TITLE
add "." check in feature name to make RPS happy

### DIFF
--- a/src/VisualStudio/Core/Def/Experimentation/VisualStudioExperimentationService.cs
+++ b/src/VisualStudio/Core/Def/Experimentation/VisualStudioExperimentationService.cs
@@ -57,10 +57,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Experimentation
             {
                 try
                 {
-                    var enabled = _featureFlags.IsFeatureEnabled(experimentName, defaultValue: false);
-                    if (enabled)
+                    // check whether "." exist in the experimentName since it is requirement for featureflag service.
+                    // we do this since RPS complains about resource file being loaded for invalid name exception
+                    // we are not testing all rules but just simple "." check
+                    if (experimentName.IndexOf(".") > 0)
                     {
-                        return enabled;
+                        var enabled = _featureFlags.IsFeatureEnabled(experimentName, defaultValue: false);
+                        if (enabled)
+                        {
+                            return enabled;
+                        }
                     }
                 }
                 catch


### PR DESCRIPTION
new VS feature flag service requires "." in feature name. and we call the service with feature name without dot we use for a/b and other flight. so feature flag service throws and we move to VS experimentation service to ask about the flight.

all good except the exception cause a resource file to be loaded and RPS is not happy about the resource file. so, added a check to not call VS feature flag service if flight name doesn't include "."

"." being the first char is invalid, so it check whether dot is at least not first char, but we don't do any expensive check since we control flight name.