### PR TITLE
Specify RuntimeIdentifiers for CompilerBenchmarks

### DIFF
--- a/src/Tools/CompilerBenchmarks/CompilerBenchmarks.csproj
+++ b/src/Tools/CompilerBenchmarks/CompilerBenchmarks.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeIdentifiers>$(RoslynPortableRuntimeIdentifiers)</RuntimeIdentifiers>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes Error NETSDK1047 Assets file 'C:\dev\roslyn\artifacts\obj\CompilerBenchmarks\project.assets.json' doesn't have a target for '.NETCoreApp,Version=v2.1/win-x64'. Ensure that restore has run and that you have included 'netcoreapp2.1' in the TargetFrameworks for your project. You may also need to include 'win-x64' in your project's RuntimeIdentifiers.