### PR TITLE
hide JsonRpc from partner team

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
@@ -259,7 +259,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             {
                 Event = new ManualResetEvent(false);
 
-                Rpc.StartListening();
+                StartService();
             }
 
             public readonly ManualResetEvent Event;

--- a/src/Workspaces/Remote/Razor/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.csproj
+++ b/src/Workspaces/Remote/Razor/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.csproj
@@ -42,5 +42,14 @@
     <Compile Include="..\ServiceHub\Shared\ServiceHubServiceBase.cs">
       <Link>Shared\ServiceHubServiceBase.cs</Link>
     </Compile>
+    <Compile Include="..\ServiceHub\Shared\Extensions.cs">
+      <Link>Shared\Extensions.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceHub\Shared\ClientDirectStream.cs">
+      <Link>Shared\ClientDirectStream.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceHub\Shared\ServerDirectStream.cs">
+      <Link>Shared\ServerDirectStream.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/Workspaces/Remote/Razor/Shared/WatsonReporter.cs
+++ b/src/Workspaces/Remote/Razor/Shared/WatsonReporter.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Telemetry;
+
+namespace Microsoft.VisualStudio.Telemetry
+{
+    internal interface IFaultUtility
+    {
+        void AddProcessDump(int pid);
+        void AddFile(string fullpathname);
+    }
+}
+
+namespace Microsoft.CodeAnalysis.ErrorReporting
+{
+    /// <summary>
+    /// dummy types just to make linked file work
+    /// </summary>
+    internal class WatsonReporter
+    {
+        public static void Report(string description, Exception exception)
+        {
+            // do nothing
+        }
+
+        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback)
+        {
+            // do nothing
+        }
+    }
+}

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Remote
         public CodeAnalysisService(Stream stream, IServiceProvider serviceProvider) :
             base(serviceProvider, stream)
         {
-            Rpc.StartListening();
+            StartService();
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
@@ -61,8 +61,8 @@ namespace Microsoft.CodeAnalysis.Remote
             public async Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
                 string source, string name, int arity, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<IList<PackageWithTypeResult>>(
-                    nameof(FindPackagesWithTypeAsync), source, name, arity).ConfigureAwait(false);
+                var result = await codeAnalysisService.InvokeAsync<IList<PackageWithTypeResult>>(
+                    nameof(FindPackagesWithTypeAsync), new object[] { source, name, arity }, cancellationToken).ConfigureAwait(false);
 
                 return result;
             }
@@ -70,8 +70,8 @@ namespace Microsoft.CodeAnalysis.Remote
             public async Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
                 string source, string assemblyName, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<IList<PackageWithAssemblyResult>>(
-                    nameof(FindPackagesWithAssemblyAsync), source, assemblyName).ConfigureAwait(false);
+                var result = await codeAnalysisService.InvokeAsync<IList<PackageWithAssemblyResult>>(
+                    nameof(FindPackagesWithAssemblyAsync), new object[] { source, assemblyName }, cancellationToken).ConfigureAwait(false);
 
                 return result;
             }
@@ -79,8 +79,8 @@ namespace Microsoft.CodeAnalysis.Remote
             public async Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
                 string name, int arity, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<IList<ReferenceAssemblyWithTypeResult>>(
-                    nameof(FindReferenceAssembliesWithTypeAsync), name, arity).ConfigureAwait(false);
+                var result = await codeAnalysisService.InvokeAsync<IList<ReferenceAssemblyWithTypeResult>>(
+                    nameof(FindReferenceAssembliesWithTypeAsync), new object[] { name, arity }, cancellationToken).ConfigureAwait(false);
 
                 return result;
             }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
@@ -168,10 +168,10 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
             public Task ReportProgressAsync(int current, int maximum)
-                => _service.Rpc.InvokeAsync(nameof(ReportProgressAsync), current, maximum);
+                => _service.InvokeAsync(nameof(ReportProgressAsync), new object[] { current, maximum }, CancellationToken.None);
 
             public Task OnReferenceFoundAsync(Document document, TextSpan span)
-                => _service.Rpc.InvokeAsync(nameof(OnReferenceFoundAsync), document.Id, span);
+                => _service.InvokeAsync(nameof(OnReferenceFoundAsync), new object[] { document.Id, span }, CancellationToken.None);
         }
 
         private class FindReferencesProgressCallback : IStreamingFindReferencesProgress
@@ -184,30 +184,29 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
             public Task OnStartedAsync()
-                => _service.Rpc.InvokeAsync(nameof(OnStartedAsync));
+                => _service.InvokeAsync(nameof(OnStartedAsync), CancellationToken.None);
 
             public Task OnCompletedAsync()
-                => _service.Rpc.InvokeAsync(nameof(OnCompletedAsync));
+                => _service.InvokeAsync(nameof(OnCompletedAsync), CancellationToken.None);
 
             public Task ReportProgressAsync(int current, int maximum)
-                => _service.Rpc.InvokeAsync(nameof(ReportProgressAsync), current, maximum);
+                => _service.InvokeAsync(nameof(ReportProgressAsync), new object[] { current, maximum }, CancellationToken.None);
 
             public Task OnFindInDocumentStartedAsync(Document document)
-                => _service.Rpc.InvokeAsync(nameof(OnFindInDocumentStartedAsync), document.Id);
+                => _service.InvokeAsync(nameof(OnFindInDocumentStartedAsync), new object[] { document.Id }, CancellationToken.None);
 
             public Task OnFindInDocumentCompletedAsync(Document document)
-                => _service.Rpc.InvokeAsync(nameof(OnFindInDocumentCompletedAsync), document.Id);
+                => _service.InvokeAsync(nameof(OnFindInDocumentCompletedAsync), new object[] { document.Id }, CancellationToken.None);
 
             public Task OnDefinitionFoundAsync(SymbolAndProjectId definition)
-                => _service.Rpc.InvokeAsync(nameof(OnDefinitionFoundAsync),
-                    SerializableSymbolAndProjectId.Dehydrate(definition));
+                => _service.InvokeAsync(nameof(OnDefinitionFoundAsync), new object[] { SerializableSymbolAndProjectId.Dehydrate(definition) }, CancellationToken.None);
 
             public Task OnReferenceFoundAsync(
                 SymbolAndProjectId definition, ReferenceLocation reference)
             {
-                return _service.Rpc.InvokeAsync(nameof(OnReferenceFoundAsync),
-                    SerializableSymbolAndProjectId.Dehydrate(definition),
-                    SerializableReferenceLocation.Dehydrate(reference));
+                return _service.InvokeAsync(nameof(OnReferenceFoundAsync),
+                    new object[] { SerializableSymbolAndProjectId.Dehydrate(definition), SerializableReferenceLocation.Dehydrate(reference) },
+                    CancellationToken.None);
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Remote
             base(serviceProvider, stream)
         {
             // this service provide a way for client to make sure remote host is alive
-            Rpc.StartListening();
+            StartService();
         }
 
         public string Connect(string host, int uiCultureLCID, int cultureLCID, string serializedSession, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Remote
             _updateEngine = new SymbolSearchUpdateEngine(
                 logService: this, progressService: this);
 
-            Rpc.StartListening();
+            StartService();
         }
 
         public Task UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory)
@@ -68,22 +68,22 @@ namespace Microsoft.CodeAnalysis.Remote
         #region Messages to forward from here to VS
 
         public Task LogExceptionAsync(string exception, string text)
-            => this.Rpc.InvokeAsync(nameof(LogExceptionAsync), exception, text);
+            => this.InvokeAsync(nameof(LogExceptionAsync), new object[] { exception, text }, CancellationToken.None);
 
         public Task LogInfoAsync(string text)
-            => this.Rpc.InvokeAsync(nameof(LogInfoAsync), text);
+            => this.InvokeAsync(nameof(LogInfoAsync), new object[] { text }, CancellationToken.None);
 
         public Task OnDownloadFullDatabaseStartedAsync(string title)
-            => this.Rpc.InvokeAsync(nameof(OnDownloadFullDatabaseStartedAsync), title);
+            => this.InvokeAsync(nameof(OnDownloadFullDatabaseStartedAsync), new object[] { title }, CancellationToken.None);
 
         public Task OnDownloadFullDatabaseSucceededAsync()
-            => this.Rpc.InvokeAsync(nameof(OnDownloadFullDatabaseSucceededAsync));
+            => this.InvokeAsync(nameof(OnDownloadFullDatabaseSucceededAsync), CancellationToken.None);
 
         public Task OnDownloadFullDatabaseCanceledAsync()
-            => this.Rpc.InvokeAsync(nameof(OnDownloadFullDatabaseCanceledAsync));
+            => this.InvokeAsync(nameof(OnDownloadFullDatabaseCanceledAsync), CancellationToken.None);
 
         public Task OnDownloadFullDatabaseFailedAsync(string message)
-            => this.Rpc.InvokeAsync(nameof(OnDownloadFullDatabaseFailedAsync), message);
+            => this.InvokeAsync(nameof(OnDownloadFullDatabaseFailedAsync), new object[] { message }, CancellationToken.None);
 
         #endregion
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     {
                         return await _owner.RunServiceAsync(cancellationToken =>
                         {
-                            return _owner.Rpc.InvokeAsync(WellKnownServiceHubServices.AssetService_RequestAssetAsync,
+                            return _owner.InvokeAsync(WellKnownServiceHubServices.AssetService_RequestAssetAsync,
                                 new object[] { scopeId, checksums.ToArray() },
                                 (s, c) => ReadAssets(s, scopeId, checksums, serializerService, c), cancellationToken);
                         }, callerCancellation).ConfigureAwait(false);
@@ -52,8 +52,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
             private bool ReportUnlessCanceled(Exception ex, CancellationToken cancellationToken)
             {
-                if (!cancellationToken.IsCancellationRequested &&
-                    ((IDisposableObservable)_owner.Rpc).IsDisposed)
+                if (!cancellationToken.IsCancellationRequested && _owner.IsDisposed)
                 {
                     // kill OOP if snapshot service got disconnected due to this exception.
                     FailFast.OnFatalException(ex);

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             _source = new JsonRpcAssetSource(this);
 
-            Rpc.StartListening();
+            StartService();
         }
     }
 }


### PR DESCRIPTION
we want to move to newer version of JsonRpc (2.x) from 1.x we use.

but that has some complexity since version 2.x and 1.x is incompatible and we let partner to directly access Rpc exposed from ServiceHubServiceBase type.

this is first step so that partners move to new API that doesn't expose JsonRpc directly.

once they moved, moving us to new versino should be easier since we will not break partner teams.