### PR TITLE
Remove the use of forced GC in production code

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/GCManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/GCManager.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Runtime;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -57,28 +56,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         /// </summary>
         internal static void TurnOffLowLatencyMode()
         {
-            if (s_delayMilliseconds <= 0)
-            {
-                // if it is already turned off, we don't do anything.
-                return;
-            }
-
-            // first set delay to 0 to turn it off
+            // set delay to 0 to turn off the use of sustained low latency
             s_delayMilliseconds = 0;
-
-            // explictly call Full GC to remove impact of SustainedLowLatency
-            // this is based on finding on https://github.com/dotnet/roslyn/issues/6802
-            // one of reason we do this here is so that GC do compact on fragmented memory.
-            // which will in return let us have bigger continuous free memory chunk.
-            //
-            // we do this 5 times to make sure we release all pending memories. something
-            // most of our tests do. previous collect can put objects in finalizer and running
-            // finalizer can release even more memory so we repeat this 5 times.
-            for (var i = 0; i < 5; i++)
-            {
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-            }
         }
 
         /// <summary>
@@ -116,14 +95,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.GC.Collect", Justification = "We are using GCCollectionMode.Optimized and this is called on a threadpool thread.")]
         private static void RestoreGCLatencyMode(GCLatencyMode originalMode)
         {
             GCSettings.LatencyMode = originalMode;
             s_delay = null;
-
-            // hint to the GC that if it postponed a gen 2 collection, now might be a good time to do it.
-            GC.Collect(2, GCCollectionMode.Optimized);
         }
     }
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/588288 (performance reports saying many users experienced UI delays which are blamed to Roslyn).

I have requested the platform perform a forced GC in response to the same internal notification that we were handling originally. This change should also land in 16.1, with the following impact:

1. The platform implementation is slightly more efficient (it only loops until the forced GC fails to make "substantial progress"
2. UI delays will get blamed to the platform, where they belong for this in the first place