### PR TITLE
Fix few false positives in unused value assignment analyzer

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -6662,5 +6662,46 @@ class C
     }
 }", PreferUnusedLocal);
         }
+
+        [WorkItem(33949, "https://github.com/dotnet/roslyn/issues/33949")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task UsedInArgumentAfterAnArgumentWithControlFlow(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class A
+{
+    public static void M(int? x)
+    {
+        A [|a|] = new A();
+        a = M2(x ?? 1, a);
+    }
+
+    private static A M2(int? x, A a)
+    {
+        return a;
+    }
+}", optionName);
+        }
+
+        [WorkItem(33949, "https://github.com/dotnet/roslyn/issues/33949")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task ConpoundAssignmentWithControlFlowInValue(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"class A
+{
+    public static void M(int? x)
+    {
+        int [|a|] = 1;
+        a += M2(x ?? 1);
+    }
+
+    private static int M2(int? x) => 0;
+}", optionName);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -6703,5 +6703,101 @@ class C
     private static int M2(int? x) => 0;
 }", optionName);
         }
+
+        [WorkItem(33843, "https://github.com/dotnet/roslyn/issues/33843")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task UsedValueWithUsingStatementAndLocalFunction(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    private class Disposable : IDisposable { public void Dispose() { } }
+    public int M()
+    {
+        var result = 0;
+        void append() => [|result|] += 1; // IDE0059 for 'result'
+        using (var a = new Disposable())
+            append();
+        return result;
+    }
+}", optionName);
+        }
+
+        [WorkItem(33843, "https://github.com/dotnet/roslyn/issues/33843")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task UsedValueWithUsingStatementAndLambda(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    private class Disposable : IDisposable { public void Dispose() { } }
+    public int M()
+    {
+        var result = 0;
+        Action append = () => [|result|] += 1; // IDE0059 for 'result'
+        using (var a = new Disposable())
+            append();
+        return result;
+    }
+}", optionName);
+        }
+
+        [WorkItem(33843, "https://github.com/dotnet/roslyn/issues/33843")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task UsedValueWithUsingStatementAndLambda_02(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    private class Disposable : IDisposable { public void Dispose() { } }
+    public int M()
+    {
+        var result = 0;
+        Action appendLambda = () => [|result|] += 1;
+        void appendLocalFunction() => appendLambda();
+        Action appendDelegate = appendLocalFunction;
+        using (var a = new Disposable())
+            appendDelegate();
+        return result;
+    }
+}", optionName);
+        }
+
+        [WorkItem(33843, "https://github.com/dotnet/roslyn/issues/33843")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task UsedValueWithUsingStatementAndLambda_03(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    private class Disposable : IDisposable { public void Dispose() { } }
+    public int M()
+    {
+        var result = 0;
+        void appendLocalFunction() => [|result|] += 1;
+        Action appendLambda = () => appendLocalFunction();
+        Action appendDelegate = appendLambda;
+        using (var a = new Disposable())
+            appendDelegate();
+        return result;
+    }
+}", optionName);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -6799,5 +6799,69 @@ class C
     }
 }", optionName);
         }
+
+        [WorkItem(33937, "https://github.com/dotnet/roslyn/issues/33937")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task AssignedInCatchUsedInFinally_ThrowInCatch(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+public static class Program
+{
+    public static void Test()
+    {
+        var exceptionThrown = false;
+        try
+        {
+            throw new Exception();
+        }
+        catch
+        {
+            // The `exceptionThrown` token is incorrectly greyed out in the IDE
+            // IDE0059 Value assigned to 'exceptionThrown' is never used
+            [|exceptionThrown|] = true;
+            throw;
+        }
+        finally
+        {
+            // Breakpoint on this line is hit and 'true' is printed
+            Console.WriteLine(exceptionThrown);
+        }
+    }
+}", optionName);
+        }
+
+        [WorkItem(33937, "https://github.com/dotnet/roslyn/issues/33937")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task AssignedInCatchUsedInFinally_NoThrowInCatch(string optionName)
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+public static class Program
+{
+    public static void Test()
+    {
+        var exceptionThrown = false;
+        try
+        {
+            throw new Exception();
+        }
+        catch
+        {
+            [|exceptionThrown|] = true;
+        }
+        finally
+        {
+            Console.WriteLine(exceptionThrown);
+        }
+    }
+}", optionName);
+        }
     }
 }

--- a/src/Test/Utilities/Portable/Compilation/FlowAnalysis/BasicBlockReachabilityDataFlowAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Compilation/FlowAnalysis/BasicBlockReachabilityDataFlowAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
         public override bool AnalyzeBlock(BasicBlock basicBlock, CancellationToken cancellationToken)
         {
-            SetCurrentAnalysisData(basicBlock, isReachable: true);
+            SetCurrentAnalysisData(basicBlock, isReachable: true, cancellationToken);
             return true;
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             return (currentIsReachable, currentIsReachable);
         }
 
-        public override void SetCurrentAnalysisData(BasicBlock basicBlock, bool isReachable)
+        public override void SetCurrentAnalysisData(BasicBlock basicBlock, bool isReachable, CancellationToken cancellationToken)
         {
             _visited[basicBlock.Ordinal] = isReachable;
         }

--- a/src/Workspaces/Core/Portable/FlowAnalysis/CustomDataFlowAnalysis.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/CustomDataFlowAnalysis.cs
@@ -212,17 +212,21 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     case ControlFlowBranchSemantics.None:
                     case ControlFlowBranchSemantics.ProgramTermination:
                     case ControlFlowBranchSemantics.StructuredExceptionHandling:
-                    case ControlFlowBranchSemantics.Throw:
-                    case ControlFlowBranchSemantics.Rethrow:
                     case ControlFlowBranchSemantics.Error:
                         Debug.Assert(branch.Destination == null);
+                        return;
+
+                    case ControlFlowBranchSemantics.Throw:
+                    case ControlFlowBranchSemantics.Rethrow:
+                        Debug.Assert(branch.Destination == null);
+                        StepThroughFinally(current.EnclosingRegion, destinationOrdinal: lastBlockOrdinal, ref currentAnalsisData);
                         return;
 
                     case ControlFlowBranchSemantics.Regular:
                     case ControlFlowBranchSemantics.Return:
                         Debug.Assert(branch.Destination != null);
 
-                        if (StepThroughFinally(current.EnclosingRegion, branch.Destination, ref currentAnalsisData))
+                        if (StepThroughFinally(current.EnclosingRegion, branch.Destination.Ordinal, ref currentAnalsisData))
                         {
                             var destination = branch.Destination;
                             var currentDestinationData = analyzer.GetCurrentAnalysisData(destination);
@@ -247,9 +251,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             }
 
             // Returns whether we should proceed to the destination after finallies were taken care of.
-            bool StepThroughFinally(ControlFlowRegion region, BasicBlock destination, ref TBlockAnalysisData currentAnalysisData)
+            bool StepThroughFinally(ControlFlowRegion region, int destinationOrdinal, ref TBlockAnalysisData currentAnalysisData)
             {
-                int destinationOrdinal = destination.Ordinal;
                 while (!region.ContainsBlock(destinationOrdinal))
                 {
                     Debug.Assert(region.Kind != ControlFlowRegionKind.Root);

--- a/src/Workspaces/Core/Portable/FlowAnalysis/CustomDataFlowAnalysis.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/CustomDataFlowAnalysis.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             var toVisit = new SortedSet<int>();
 
             var firstBlock = blocks[firstBlockOrdinal];
-            analyzer.SetCurrentAnalysisData(firstBlock, initialAnalysisData);
+            analyzer.SetCurrentAnalysisData(firstBlock, initialAnalysisData, cancellationToken);
             toVisit.Add(firstBlock.Ordinal);
 
             var processedBlocks = PooledHashSet<BasicBlock>.GetInstance();
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                         continue;
                     }
 
-                    analyzer.SetCurrentAnalysisData(current, analyzer.GetEmptyAnalysisData());
+                    analyzer.SetCurrentAnalysisData(current, analyzer.GetEmptyAnalysisData(), cancellationToken);
                 }
 
                 if (current.Ordinal < firstBlockOrdinal || current.Ordinal > lastBlockOrdinal)
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                             if ((current.IsReachable || !destination.IsReachable) &&
                                 (!analyzer.IsEqual(currentDestinationData, mergedAnalysisData) || !processedBlocks.Contains(destination)))
                             {
-                                analyzer.SetCurrentAnalysisData(destination, mergedAnalysisData);
+                                analyzer.SetCurrentAnalysisData(destination, mergedAnalysisData, cancellationToken);
                                 toVisit.Add(branch.Destination.Ordinal);
                             }
                         }

--- a/src/Workspaces/Core/Portable/FlowAnalysis/DataFlowAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/DataFlowAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// <summary>
         /// Updates the current analysis data for the given basic block.
         /// </summary>
-        public abstract void SetCurrentAnalysisData(BasicBlock basicBlock, TBlockAnalysisData data);
+        public abstract void SetCurrentAnalysisData(BasicBlock basicBlock, TBlockAnalysisData data, CancellationToken cancellationToken);
 
         /// <summary>
         /// Analyze the given basic block and return the block analysis data at the end of the block for its successors.

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                 var isReadFrom = valueUsageInfo.IsReadFrom();
                 var isWrittenTo = valueUsageInfo.IsWrittenTo();
 
-                if (isWrittenTo && MakePendingWrite())
+                if (isWrittenTo && MakePendingWrite(operation, symbolOpt: symbol))
                 {
                     // Certain writes are processed at a later visit
                     // and are marked as a pending write for post processing.
@@ -145,50 +145,61 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                 {
                     OnReadReferenceFound(symbol);
                 }
-
-                return;
-
-                // Local functions
-                bool MakePendingWrite()
-                {
-                    Debug.Assert(isWrittenTo);
-
-                    if (operation.Parent is IAssignmentOperation assignmentOperation &&
-                        assignmentOperation.Target == operation)
-                    {
-                        var set = PooledHashSet<(ISymbol, IOperation)>.GetInstance();
-                        set.Add((symbol, operation));
-                        _pendingWritesMap.Add(assignmentOperation, set);
-                        return true;
-                    }
-                    else if (operation.IsInLeftOfDeconstructionAssignment(out var deconstructionAssignment))
-                    {
-                        if (!_pendingWritesMap.TryGetValue(deconstructionAssignment, out var set))
-                        {
-                            set = PooledHashSet<(ISymbol, IOperation)>.GetInstance();
-                            _pendingWritesMap.Add(deconstructionAssignment, set);
-                        }
-
-                        set.Add((symbol, operation));
-                        return true;
-                    }
-
-                    return false;
-                }
             }
 
+            private bool MakePendingWrite(IOperation operation, ISymbol symbolOpt)
+            {
+                Debug.Assert(symbolOpt != null || operation.Kind == OperationKind.FlowCaptureReference);
+
+                if (operation.Parent is IAssignmentOperation assignmentOperation &&
+                    assignmentOperation.Target == operation)
+                {
+                    var set = PooledHashSet<(ISymbol, IOperation)>.GetInstance();
+                    set.Add((symbolOpt, operation));
+                    _pendingWritesMap.Add(assignmentOperation, set);
+                    return true;
+                }
+                else if (operation.IsInLeftOfDeconstructionAssignment(out var deconstructionAssignment))
+                {
+                    if (!_pendingWritesMap.TryGetValue(deconstructionAssignment, out var set))
+                    {
+                        set = PooledHashSet<(ISymbol, IOperation)>.GetInstance();
+                        _pendingWritesMap.Add(deconstructionAssignment, set);
+                    }
+
+                    set.Add((symbolOpt, operation));
+                    return true;
+                }
+
+                return false;
+            }
             private void ProcessPendingWritesForAssignmentTarget(IAssignmentOperation operation)
             {
                 if (_pendingWritesMap.TryGetValue(operation, out var pendingWrites))
                 {
-                    foreach (var (symbol, write) in pendingWrites)
-                    {
-                        OnWriteReferenceFound(symbol, write, maybeWritten: false);
+                    var isUsedCompountAssignment = operation.IsAnyCompoundAssignment() &&
+                        operation.Parent?.Kind != OperationKind.ExpressionStatement;
 
-                        if (operation.IsAnyCompoundAssignment() &&
-                            operation.Parent?.Kind != OperationKind.ExpressionStatement)
+                    foreach (var (symbolOpt, write) in pendingWrites)
+                    {
+                        if (write.Kind != OperationKind.FlowCaptureReference)
                         {
-                            OnReadReferenceFound(symbol);
+                            Debug.Assert(symbolOpt != null);
+                            OnWriteReferenceFound(symbolOpt, write, maybeWritten: false);
+
+                            if (isUsedCompountAssignment)
+                            {
+                                OnReadReferenceFound(symbolOpt);
+                            }
+                        }
+                        else
+                        {
+                            Debug.Assert(symbolOpt == null);
+
+                            var captureReference = (IFlowCaptureReferenceOperation)write;
+                            Debug.Assert(_currentAnalysisData.IsLValueFlowCapture(captureReference.Id));
+
+                            OnLValueDereferenceFound(captureReference.Id);
                         }
                     }
 
@@ -254,7 +265,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
             {
                 base.VisitFlowCaptureReference(operation);
 
-                if (_currentAnalysisData.IsLValueFlowCapture(operation.Id))
+                if (_currentAnalysisData.IsLValueFlowCapture(operation.Id) &&
+                    !MakePendingWrite(operation, symbolOpt: null))
                 {
                     OnLValueDereferenceFound(operation.Id);
                 }

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.Walker.cs
@@ -173,6 +173,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
 
                 return false;
             }
+
             private void ProcessPendingWritesForAssignmentTarget(IAssignmentOperation operation)
             {
                 if (_pendingWritesMap.TryGetValue(operation, out var pendingWrites))


### PR DESCRIPTION
I would recommend reviewing commit by commit for each of the following fixes:

1. https://github.com/dotnet/roslyn/commit/a7e07f77f60663bd952f97135275faee25460c3b: Handle assignment with flow capture reference target similar to the way we handle non-flow capture reference assignment targets in the SymbolUsageAnalysis walker. Fixes #33949
2. https://github.com/dotnet/roslyn/commit/57ca50f3502d060f4be8381afca1ce969b91ac42: Fix logic that computes reachable writes into the finally region. Fixes #33843
3. https://github.com/dotnet/roslyn/commit/3f0b73c076d01799fcff26a6cf4fae4ebf2e5b70: Fix dataflow walker to walk the finally regions from throw/rethrow branches. Fixes #33937