### PR TITLE
include the correct compiler resources assemblies for pt-BR

### DIFF
--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
@@ -175,7 +175,7 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn\pl
   @(_PlSatellite->'%(_FileEntries)', '%0d%0a  ')
 
 folder InstallDir:\MSBuild\15.0\Bin\Roslyn\pt-BR
-  @(_PlSatellite->'%(_FileEntries)', '%0d%0a  ')
+  @(_PtBrSatellite->'%(_FileEntries)', '%0d%0a  ')
 
 folder InstallDir:\MSBuild\15.0\Bin\Roslyn\ru
   @(_RuSatellite->'%(_FileEntries)', '%0d%0a  ')


### PR DESCRIPTION
The compiler MSBuild package was incorrectly using the Polish resource binaries instead of the Brazilian Portuguese ones.  Confirmed with @tmeschter in current Dev16 preview.
