### PR TITLE
Move to .NET Core 3.0 SDK

### DIFF
--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -18,7 +18,8 @@ The minimal required version of .NET Framework is 4.7.2.
 1. [Visual Studio 2019 RC](https://visualstudio.microsoft.com/downloads/#2019rc)
     - Ensure C#, VB, MSBuild, .NET Core and Visual Studio Extensibility are included in the selected work loads
     - Ensure Visual Studio is on Version "RC1" or greater
-1. [.NET Core SDK 2.1.401](https://www.microsoft.com/net/download/core) (the installers are: [Windows x64 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.401/dotnet-sdk-2.1.401-win-x64.exe), [Windows x86 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.401/dotnet-sdk-2.1.401-win-x86.exe))
+    - Ensure "Use Previews" is checked in Tools -> Options -> Projects and Solutions -> .NET Core
+1. [.NET Core SDK 3.0 Preview 3](https://dotnet.microsoft.com/download/dotnet-core/3.0) [Windows x64 installer](https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-3.0.100-preview3-windows-x64-installer)
 1. [PowerShell 5.0 or newer](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell). If you are on Windows 10, you are fine; you'll only need to upgrade if you're on Windows 7. The download link is under the "upgrading existing Windows PowerShell" heading.
 1. Run Restore.cmd
 1. Open Roslyn.sln

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,7 +67,7 @@
     <MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>14.3.25407-alpha</MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta1-63011-01</MicrosoftMetadataVisualizerVersion>
     <MicrosoftMSXMLVersion>8.0.0.0-alpha</MicrosoftMSXMLVersion>
-    <MicrosoftNetCompilersToolsetVersion>3.1.0-beta1-19127-06</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>3.1.0-beta1-19164-01</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNetCoreAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftNetCoreAnalyzersVersion>
     <MicrosoftNetCoreILAsmVersion>2.0.0</MicrosoftNetCoreILAsmVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.2</MicrosoftNETCorePlatformsVersion>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -587,7 +587,7 @@ try {
 
         # Make sure a 2.1 runtime is installed so we can run our tests. Most of them still 
         # target netcoreapp2.1.
-        InstallDotNetSdk $global:_DotNetInstallDir "2.1.401"
+        InstallDotNetSdk $global:_DotNetInstallDir "2.1.503"
     }
 
     if ($bootstrap) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -215,8 +215,8 @@ function BuildSolution() {
     $quietRestore = !($ci -or ($bootstrapDir -ne ""))
 
     $testTargetFrameworks = ""
+    $testTargetFrameworks = "netcoreapp2.1" 
     if ($testCoreClr) {
-        $testTargetFrameworks = "netcoreapp2.1" 
 
         # Make sure a 2.1 runtime is installed so we can run our tests. Most of them still 
         # target netcoreapp2.1.
@@ -573,6 +573,15 @@ try {
                 Capture-Screenshot $screenshotPath
             }
         }
+    }
+
+    if ($ci) {
+        $global:_DotNetInstallDir = Join-Path $RepoRoot ".dotnet"
+        InstallDotNetSdk $global:_DotNetInstallDir $GlobalJson.tools.dotnet
+
+        # Make sure a 2.1 runtime is installed so we can run our tests. Most of them still 
+        # target netcoreapp2.1.
+        InstallDotNetSdk $global:_DotNetInstallDir "2.1.401"
     }
 
     if ($bootstrap) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -219,8 +219,11 @@ function BuildSolution() {
     $enableAnalyzers = !$skipAnalyzers
     $toolsetBuildProj = InitializeToolset
 
+    # Have to disable quiet restore during bootstrap builds to work around 
+    # an arcade bug
+    # https://github.com/dotnet/arcade/issues/2220
     $quietRestore = !($ci -or ($bootstrapDir -ne ""))
-    $testTargetFrameworks = if ($testCoreClr) { "netcoreapp2.1" } else { "" } 
+    $testTargetFrameworks = if ($testCoreClr) { "netcoreapp2.1" } else { "" }
     $ibcSourceBranchName = GetIbcSourceBranchName
     $ibcDropId = if ($officialIbcDropId -ne "default") { $officialIbcDropId } else { "" }
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -213,16 +213,7 @@ function BuildSolution() {
     # an arcade bug
     # https://github.com/dotnet/arcade/issues/2220
     $quietRestore = !($ci -or ($bootstrapDir -ne ""))
-
-    $testTargetFrameworks = ""
-    $testTargetFrameworks = "netcoreapp2.1" 
-    if ($testCoreClr) {
-
-        # Make sure a 2.1 runtime is installed so we can run our tests. Most of them still 
-        # target netcoreapp2.1.
-        InstallDotNetSdk ${env:DOTNET_INSTALL_DIR} "2.1.401"
-    }
-
+    $testTargetFrameworks = if ($testCoreClr) { "netcoreapp2.1" } else { "" } 
     $ibcSourceBranchName = GetIbcSourceBranchName
     $ibcDropId = if ($officialIbcDropId -ne "default") { $officialIbcDropId } else { "" }
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -213,7 +213,16 @@ function BuildSolution() {
     # an arcade bug
     # https://github.com/dotnet/arcade/issues/2220
     $quietRestore = !($ci -or ($bootstrapDir -ne ""))
-    $testTargetFrameworks = if ($testCoreClr) { "netcoreapp2.1" } else { "" }
+
+    $testTargetFrameworks = ""
+    if ($testCoreClr) {
+        $testTargetFrameworks = "netcoreapp2.1" 
+
+        # Make sure a 2.1 runtime is installed so we can run our tests. Most of them still 
+        # target netcoreapp2.1.
+        InstallDotNetSdk ${env:DOTNET_INSTALL_DIR} "2.1.401"
+    }
+
     $ibcSourceBranchName = GetIbcSourceBranchName
     $ibcDropId = if ($officialIbcDropId -ne "default") { $officialIbcDropId } else { "" }
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -283,7 +283,7 @@ function BuildSolution {
 InitializeDotNetCli $restore
 
 # Make sure we have a 2.1 runtime available for running our tests
-InstallDotNetSdk $_InitializeDotNetCli 2.1.401
+InstallDotNetSdk $_InitializeDotNetCli 2.1.503
 
 bootstrap_dir=""
 if [[ "$bootstrap" == true ]]; then

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -248,9 +248,6 @@ function BuildSolution {
     test_runtime="/p:TestRuntime=Mono"
     mono_tool="/p:MonoTool=\"$mono_path\""
   elif [[ "$test_core_clr" == true ]]; then
-
-    # Make sure we have a 2.1 runtime available for running our tests
-    InstallDotNetSdk $DOTNET_INSTALL_DIR 2.1.401
     test=true
     test_runtime="/p:TestRuntime=Core"
     mono_tool=""
@@ -284,6 +281,9 @@ function BuildSolution {
 }
 
 InitializeDotNetCli $restore
+
+# Make sure we have a 2.1 runtime available for running our tests
+InstallDotNetSdk $dotnet_root 2.1.401
 
 bootstrap_dir=""
 if [[ "$bootstrap" == true ]]; then

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -283,7 +283,7 @@ function BuildSolution {
 InitializeDotNetCli $restore
 
 # Make sure we have a 2.1 runtime available for running our tests
-InstallDotNetSdk $dotnet_root 2.1.401
+InstallDotNetSdk $_InitializeDotNetCli 2.1.401
 
 bootstrap_dir=""
 if [[ "$bootstrap" == true ]]; then

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -248,6 +248,9 @@ function BuildSolution {
     test_runtime="/p:TestRuntime=Mono"
     mono_tool="/p:MonoTool=\"$mono_path\""
   elif [[ "$test_core_clr" == true ]]; then
+
+    # Make sure we have a 2.1 runtime available for running our tests
+    InstallDotNetSdk $DOTNET_INSTALL_DIR 2.1.401
     test=true
     test_runtime="/p:TestRuntime=Core"
     mono_tool=""

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "2.1.503",
+    "dotnet": "3.0.100-preview3-010431",
     "vs": {
       "version": "16.0"
     },

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <Reference Include="System.Configuration" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
+    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -105,6 +105,7 @@ namespace BuildBoss
 
             // Temporarily inserting Microsoft.DiaSymReader.Native.arm.dll while SDK team tracks down why 
             // it's being inserted into destkop builds.
+            // https://github.com/dotnet/cli/issues/10979
             allGood &= VerifyVsix(
                         textWriter,
                         FindVsix("Roslyn.Compilers.Extension"),

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -103,10 +103,12 @@ namespace BuildBoss
                         string.Empty,
                         assetRelativeNames);
 
+            // Temporarily inserting Microsoft.DiaSymReader.Native.arm.dll while SDK team tracks down why 
+            // it's being inserted into destkop builds.
             allGood &= VerifyVsix(
                         textWriter,
                         FindVsix("Roslyn.Compilers.Extension"),
-                        assetRelativeNames.Concat(new[] { "Roslyn.Compilers.Extension.dll" }));
+                        assetRelativeNames.Concat(new[] { "Roslyn.Compilers.Extension.dll", "Microsoft.DiaSymReader.Native.arm.dll" }));
             return allGood;
         }
 

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -172,6 +172,7 @@ namespace BuildBoss
             // root as well. That copy is unnecessary.
             coreClrAssets.RemoveAll(asset =>
                 PathComparer.Equals("Microsoft.DiaSymReader.Native.amd64.dll", asset.FileRelativeName) ||
+                PathComparer.Equals("Microsoft.DiaSymReader.Native.arm.dll", asset.FileRelativeName) ||
                 PathComparer.Equals("Microsoft.DiaSymReader.Native.x86.dll", asset.FileRelativeName));
 
             // Move all of the assets into bincore as that is where the non-MSBuild task assets will go

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -168,16 +168,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         // TODO: Use PreserveSig instead of throwing these exceptions for common cases.
         public void ReportError2(string bstrErrorMessage, string bstrErrorId, [ComAliasName("VsShell.VSTASKPRIORITY")]VSTASKPRIORITY nPriority, int iStartLine, int iStartColumn, int iEndLine, int iEndColumn, string bstrFileName)
         {
-            // This is showing up in our NetCore tests for brief periods of time due to the following issue
-            // https://github.com/dotnet/cli/issues/10989
-            if (bstrErrorId != "NETSDK1005")
+            // first we check whether given error is something we can take care.
+            if (!CanHandle(bstrErrorId))
             {
-                // first we check whether given error is something we can take care.
-                if (!CanHandle(bstrErrorId))
-                {
-                    // it is not, let project system takes care.
-                    throw new NotImplementedException();
-                }
+                // it is not, let project system takes care.
+                throw new NotImplementedException();
             }
 
             if ((iEndLine >= 0 && iEndColumn >= 0) &&

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -168,11 +168,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         // TODO: Use PreserveSig instead of throwing these exceptions for common cases.
         public void ReportError2(string bstrErrorMessage, string bstrErrorId, [ComAliasName("VsShell.VSTASKPRIORITY")]VSTASKPRIORITY nPriority, int iStartLine, int iStartColumn, int iEndLine, int iEndColumn, string bstrFileName)
         {
-            // first we check whether given error is something we can take care.
-            if (!CanHandle(bstrErrorId))
+            // This is showing up in our NetCore tests for brief periods of time due to the following issue
+            // https://github.com/dotnet/cli/issues/10989
+            if (bstrErrorId != "NETSDK1005")
             {
-                // it is not, let project system takes care.
-                throw new NotImplementedException();
+                // first we check whether given error is something we can take care.
+                if (!CanHandle(bstrErrorId))
+                {
+                    // it is not, let project system takes care.
+                    throw new NotImplementedException();
+                }
             }
 
             if ((iEndLine >= 0 && iEndColumn >= 0) &&

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListNetCore.cs
@@ -30,7 +30,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             base.ErrorLevelWarning();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorList)]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/34211"), Trait(Traits.Feature, Traits.Features.ErrorList)]
         [Trait(Traits.Feature, Traits.Features.NetCore)]
         public override void ErrorsDuringMethodBodyEditing()
         {

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
@@ -26,7 +26,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             base.OpenCSharpThenVBSolution();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        [WpfFact(Skip = "https://github.com/dotnet/cli/issues/10989"), Trait(Traits.Feature, Traits.Features.Workspace)]
         [Trait(Traits.Feature, Traits.Features.NetCore)]
         public override void MetadataReference()
         {


### PR DESCRIPTION
This moves our .NET Core SDK build to be 3.0 Preview 3. Going forward developers will need to install this build in order to work with Roslyn in Visual Studio

https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-3.0.100-preview3-windows-x64-installer