### PR TITLE
Mitigation for GetTypeInfo on suppressed expression

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1913,6 +1913,11 @@ done:
                     case SyntaxKind.UncheckedExpression:
                         node = ((CheckedExpressionSyntax)node).Expression;
                         continue;
+
+                    // Simple mitigation to give a result for suppressions. Public API tracked by https://github.com/dotnet/roslyn/issues/26198
+                    case SyntaxKind.SuppressNullableWarningExpression:
+                        node = ((PostfixUnaryExpressionSyntax)node).Operand;
+                        continue;
                 }
 
                 break;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -1045,18 +1045,22 @@ public class C
             var s = model.GetTypeInfo(suppressions[0]);
             Assert.Equal("System.String", s.Type.ToTestDisplayString());
             Assert.Equal("System.String", s.ConvertedType.ToTestDisplayString());
+            Assert.Equal("System.String s", model.GetSymbolInfo(suppressions[0]).Symbol.ToTestDisplayString());
 
             var s2 = model.GetTypeInfo(suppressions[1]);
             Assert.Equal("System.String", s2.Type.ToTestDisplayString());
             Assert.Equal("System.String", s2.ConvertedType.ToTestDisplayString());
+            Assert.Equal("System.String? s2", model.GetSymbolInfo(suppressions[1]).Symbol.ToTestDisplayString());
 
             var c = model.GetTypeInfo(suppressions[2]);
             Assert.Equal("C<System.String>", c.Type.ToTestDisplayString());
             Assert.Equal("C<System.String>", c.ConvertedType.ToTestDisplayString());
+            Assert.Equal("C<System.String> c", model.GetSymbolInfo(suppressions[2]).Symbol.ToTestDisplayString());
 
             var c2 = model.GetTypeInfo(suppressions[3]);
             Assert.Equal("C<System.String?>", c2.Type.ToTestDisplayString());
             Assert.Equal("C<System.String?>", c2.ConvertedType.ToTestDisplayString());
+            Assert.Equal("C<System.String?> c2", model.GetSymbolInfo(suppressions[3]).Symbol.ToTestDisplayString());
         }
 
         [Fact, WorkItem(31370, "https://github.com/dotnet/roslyn/issues/31370")]


### PR DESCRIPTION
Completion in the IDE doesn't work because `GetTypeInfo` returns nothing for suppressed expressions. This PR mitigates this and provides the result from binding (while the deeper public API work is making progress).

FYI @ivanbasov @CyrusNajmabadi 