### PR TITLE
Fix FindReferencesTests and link to correct issues

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -639,7 +639,8 @@ class C
         End Function
 
         <WorkItem(522786, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/522786")>
-        <WpfFact(Skip:="Bug 522786"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(34107, "https://github.com/dotnet/roslyn/issues/34107")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/34107"), Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestOrdinaryMethodInterfaceDispose1() As Task
             Dim input =
 <Workspace>
@@ -662,7 +663,8 @@ class C
         End Function
 
         <WorkItem(522786, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/522786")>
-        <WpfFact(Skip:="Bug 522786"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(34107, "https://github.com/dotnet/roslyn/issues/34107")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/34107"), Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestOrdinaryMethodInterfaceDispose2() As Task
             Dim input =
 <Workspace>
@@ -847,7 +849,8 @@ class C
         End Function
 
         <WorkItem(634818, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/634818")>
-        <WpfFact(Skip:="636943"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(34106, "https://github.com/dotnet/roslyn/issues/34106")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/34106"), Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestOrdinaryMethodLinqWhere1() As Task
             Dim input =
 <Workspace>
@@ -857,14 +860,18 @@ class C
         using System.Collections.Generic;
         class C
         {
-            public IEnumerable<int> {|Definition:Whe$$re|}(Func<int,bool> pred) { };
-            public IEnumerable<int> Select(Func<int,int> func) { };
             void Zap()
             {
                 var q = from v in this
                         [|where|] v > 21
                         select v;
             }
+        }
+
+        static class Extensions
+        {
+            public static IEnumerable<int> {|Definition:Whe$$re|}(this IEnumerable<int> source, Func<int, bool> predicate) => throw null;
+            public static IEnumerable<int> Select(this IEnumerable<int> source, Func<int, int> func) => throw null;
         }]]>
         </Document>
     </Project>
@@ -873,7 +880,8 @@ class C
         End Function
 
         <WorkItem(636943, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/636943")>
-        <WpfFact(Skip:="636943"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(34106, "https://github.com/dotnet/roslyn/issues/34106")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/34106"), Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestOrdinaryMethodLinqWhere2() As Task
             Dim input =
 <Workspace>
@@ -883,14 +891,18 @@ class C
         using System.Collections.Generic;
         class C
         {
-            public IEnumerable<int> {|Definition:Where|}(Func<int,bool> pred) { };
-            public IEnumerable<int> Select(Func<int,int> func) { };
             void Zap()
             {
                 var q = from v in this
                         [|w$$here|] v > 21
                         select v;
             }
+        }
+
+        static class Extensions
+        {
+            public static IEnumerable<int> {|Definition:Where|}(this IEnumerable<int> source, Func<int, bool> predicate) => throw null;
+            public static IEnumerable<int> Select(this IEnumerable<int> source, Func<int, int> func) => throw null;
         }]]>
         </Document>
     </Project>
@@ -899,7 +911,8 @@ class C
         End Function
 
         <WorkItem(636943, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/636943")>
-        <WpfFact(Skip:="636943"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(34106, "https://github.com/dotnet/roslyn/issues/34106")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/34106"), Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestOrdinaryMethodLinqSelect1() As Task
             Dim input =
 <Workspace>
@@ -909,14 +922,18 @@ class C
         using System.Collections.Generic;
         class C
         {
-            public IEnumerable<int> Where(Func<int,bool> pred) { };
-            public IEnumerable<int> {|Definition:Sel$$ect|}(Func<int,int> func) { };
             void Zap()
             {
                 var q = from v in this
                         where v > 21
                         [|select|] v + 1;
             }
+        }
+
+        static class Extensions
+        {
+            public static IEnumerable<int> Where(this IEnumerable<int> source, Func<int, bool> predicate) => throw null;
+            public static IEnumerable<int> {|Definition:Sel$$ect|}(this IEnumerable<int> source, Func<int, int> func) => throw null;
         }]]>
         </Document>
     </Project>
@@ -925,7 +942,8 @@ class C
         End Function
 
         <WorkItem(636943, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/636943")>
-        <WpfFact(Skip:="636943"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(34106, "https://github.com/dotnet/roslyn/issues/34106")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/34106"), Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestOrdinaryMethodLinqSelect2() As Task
             Dim input =
 <Workspace>
@@ -935,14 +953,18 @@ class C
         using System.Collections.Generic;
         class C
         {
-            public IEnumerable<int> Where(Func<int,bool> pred) { };
-            public IEnumerable<int> {|Definition:Select|}(Func<int,int> func) { };
             void Zap()
             {
                 var q = from v in this
                         where v > 21
                         [|sel$$ect|] v + 1;
             }
+        }
+
+        static class Extensions
+        {
+            public static IEnumerable<int> Where(this IEnumerable<int> source, Func<int, bool> predicate) => throw null;
+            public static IEnumerable<int> {|Definition:Select|}(this IEnumerable<int> source, Func<int, int> func) => throw null;
         }]]>
         </Document>
     </Project>
@@ -951,7 +973,8 @@ class C
         End Function
 
         <WorkItem(528936, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528936")>
-        <WpfFact(Skip:="Bug 528936"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(34105, "https://github.com/dotnet/roslyn/issues/34105")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/34105"), Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestOrdinaryMethodMonitorEnter() As Task
             Dim input =
 <Workspace>
@@ -963,7 +986,8 @@ class C
         {
             void Zap()
             {
-                Monitor.[|En$$ter|](null);
+                bool lockTaken = false;
+                Monitor.[|TryEn$$ter|](null, ref lockTaken);
                 [|lock|] (new C())
                 {
                 }
@@ -976,7 +1000,8 @@ class C
         End Function
 
         <WorkItem(528936, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528936")>
-        <WpfFact(Skip:="Bug 528936"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(34105, "https://github.com/dotnet/roslyn/issues/34105")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/34105"), Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestOrdinaryMethodMonitorExit() As Task
             Dim input =
 <Workspace>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.XmlDocSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.XmlDocSymbols.vb
@@ -317,7 +317,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             Await TestAPIAndFeature(input)
         End Function
 
-        <WpfFact(Skip:="769477"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/34104"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(34104, "https://github.com/dotnet/roslyn/issues/34104")>
         Public Async Function TestCrefConstructor2_VisualBasic() As Task
             Dim input =
 <Workspace>
@@ -444,7 +445,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             Await TestAPIAndFeature(input)
         End Function
 
-        <WpfFact(Skip:="Bug 640274"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestParam3() As Task
             Dim input =
 <Workspace>
@@ -460,7 +461,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                 /// <summary>
                 /// 
                 /// </summary>
-                /// <param name="[|@if|]"></param>
+                /// <param name="[|if|]"></param>
                 static void Goo(int {|Definition:$$@if|}) { }
             }]]>
         </Document>
@@ -469,7 +470,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             Await TestAPIAndFeature(input)
         End Function
 
-        <WpfFact(Skip:="Bug 640274"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestParam3_VisualBasic() As Task
             Dim input =
 <Workspace>
@@ -482,7 +483,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                 ''' <summary>
                 ''' 
                 ''' </summary>
-                ''' <param name="[|@if|]"></param>
+                ''' <param name="[|if|]"></param>
                 Shared Sub Goo({|Definition:$$[if]|} As Integer)
                 End Sub
             End Class]]>
@@ -892,7 +893,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             Await TestAPIAndFeature(input)
         End Function
 
-        <WpfFact(Skip:="Bug 640502"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(640502, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/640502")>
         Public Async Function TestInterfaceInCref1() As Task
             Dim input =
 <Workspace>
@@ -911,7 +913,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             class A : C, I
             {
                 /// <summary>
-                /// <seealso cref="[|Goo|]()"/>
+                /// <seealso cref="I.[|Goo|]()"/>
                 /// </summary>
                 public override void Boo() { [|$$Goo|](); }
             }]]>
@@ -921,7 +923,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             Await TestAPIAndFeature(input)
         End Function
 
-        <WpfFact(Skip:="Bug 640502"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(640502, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/640502")>
         Public Async Function TestInterfaceInCref1_VisualBasic() As Task
             Dim input =
 <Workspace>
@@ -929,18 +932,18 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
         <Document><![CDATA[
             Imports System
             Interface I
-                Sub {|Definition:Goo|}()
+                Sub Goo()
             End Interface
-            Abstract Class C
+            MustInherit Class C
                 Public MustOverride Sub Boo()
                 Public Sub {|Definition:Goo|}() 
                 End Sub
             End Class
             Class A : Inherits C : Implements I
                 ''' <summary>
-                ''' <seealso cref="[|Goo|]()"/>
+                ''' <seealso cref="I.Goo()"/>
                 ''' </summary>
-                Public Overrides Sub Boo() Implements I.[|Goo|]
+                Public Overrides Sub Boo() Implements I.Goo
                     [|$$Goo|]()
                 End Sub
             End Class]]>
@@ -1577,7 +1580,8 @@ End Class]]>
             Await TestAPIAndFeature(input)
         End Function
 
-        <WpfFact(Skip:="783135"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/7288"), Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(7288, "https://github.com/dotnet/roslyn/issues/7288")>
         Public Async Function TestIndexInCref3_VisualBasic() As Task
             Dim input =
 <Workspace>


### PR DESCRIPTION
A few tests were updated to reflect the outcome documented in the old internal bug tracker. Others were relinked to appropriate public-facing issues for disabled tests:

#34104
#34105
#34106
#34107