### PR TITLE
Require exactly one export of IStreamingFindUsagesPresenter when used

### DIFF
--- a/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToDefinitionService.cs
+++ b/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToDefinitionService.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Composition;
 using Microsoft.CodeAnalysis.Editor.GoToDefinition;
 using Microsoft.CodeAnalysis.Editor.Host;
@@ -14,8 +13,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.GoToDefinition
     {
         [ImportingConstructor]
         public CSharpGoToDefinitionService(
-            [ImportMany]IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters)
-            : base(streamingPresenters)
+            [Import(AllowDefault = true)] Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt)
+            : base(streamingPresenterOpt)
         {
         }
     }

--- a/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToDefinitionService.cs
+++ b/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToDefinitionService.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Editor.GoToDefinition;
 using Microsoft.CodeAnalysis.Editor.Host;
@@ -12,9 +11,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.GoToDefinition
     internal class CSharpGoToDefinitionService : AbstractGoToDefinitionService
     {
         [ImportingConstructor]
-        public CSharpGoToDefinitionService(
-            [Import(AllowDefault = true)] Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt)
-            : base(streamingPresenterOpt)
+        public CSharpGoToDefinitionService(IStreamingFindUsagesPresenter streamingPresenter)
+            : base(streamingPresenter)
         {
         }
     }

--- a/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
+++ b/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
@@ -1,21 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
@@ -30,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
     [Name(PredefinedCommandHandlerNames.FindReferences)]
     internal class FindReferencesCommandHandler : VSCommanding.ICommandHandler<FindReferencesCommandArgs>
     {
-        private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _streamingPresenters;
+        private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenterOpt;
 
         private readonly IAsynchronousOperationListener _asyncListener;
 
@@ -38,13 +32,12 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
 
         [ImportingConstructor]
         public FindReferencesCommandHandler(
-            [ImportMany] IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters,
+            [Import(AllowDefault = true)] Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt,
             IAsynchronousOperationListenerProvider listenerProvider)
         {
-            Contract.ThrowIfNull(streamingPresenters);
             Contract.ThrowIfNull(listenerProvider);
 
-            _streamingPresenters = streamingPresenters;
+            _streamingPresenterOpt = streamingPresenterOpt;
             _asyncListener = listenerProvider.GetListener(FeatureAttribute.FindReferences);
         }
 
@@ -102,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
         {
             try
             {
-                return _streamingPresenters.FirstOrDefault()?.Value;
+                return _streamingPresenterOpt?.Value;
             }
             catch
             {

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -16,12 +16,12 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
     // GoToDefinition
     internal abstract class AbstractGoToDefinitionService : IGoToDefinitionService
     {
-        private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _streamingPresenters;
+        private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenterOpt;
 
         protected AbstractGoToDefinitionService(
-            IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters)
+            Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt)
         {
-            _streamingPresenters = streamingPresenters;
+            _streamingPresenterOpt = streamingPresenterOpt;
         }
 
         public async Task<IEnumerable<INavigableItem>> FindDefinitionsAsync(
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
 
             return GoToDefinitionHelpers.TryGoToDefinition(symbol,
                 document.Project,
-                _streamingPresenters,
+                _streamingPresenterOpt,
                 thirdPartyNavigationAllowed: isThirdPartyNavigationAllowed,
                 throwOnHiddenDefinition: true,
                 cancellationToken: cancellationToken);

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -16,12 +15,11 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
     // GoToDefinition
     internal abstract class AbstractGoToDefinitionService : IGoToDefinitionService
     {
-        private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenterOpt;
+        private readonly IStreamingFindUsagesPresenter _streamingPresenter;
 
-        protected AbstractGoToDefinitionService(
-            Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt)
+        protected AbstractGoToDefinitionService(IStreamingFindUsagesPresenter streamingPresenter)
         {
-            _streamingPresenterOpt = streamingPresenterOpt;
+            _streamingPresenter = streamingPresenter;
         }
 
         public async Task<IEnumerable<INavigableItem>> FindDefinitionsAsync(
@@ -54,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
 
             return GoToDefinitionHelpers.TryGoToDefinition(symbol,
                 document.Project,
-                _streamingPresenterOpt,
+                _streamingPresenter,
                 thirdPartyNavigationAllowed: isThirdPartyNavigationAllowed,
                 throwOnHiddenDefinition: true,
                 cancellationToken: cancellationToken);

--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -96,14 +95,14 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
         public static bool TryGoToDefinition(
             ISymbol symbol,
             Project project,
-            IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters,
+            Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt,
             CancellationToken cancellationToken,
             bool thirdPartyNavigationAllowed = true,
             bool throwOnHiddenDefinition = false)
         {
             var definitions = GetDefinitions(symbol, project, thirdPartyNavigationAllowed, cancellationToken);
 
-            var presenter = streamingPresenters.FirstOrDefault()?.Value;
+            var presenter = streamingPresenterOpt?.Value;
             var title = string.Format(EditorFeaturesResources._0_declarations,
                 FindUsagesHelpers.GetDisplayName(symbol));
 
@@ -115,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             ImmutableArray<DefinitionItem> definitions,
             Project project,
             string title,
-            IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters,
+            Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt,
             CancellationToken cancellationToken)
         {
             if (definitions.IsDefaultOrEmpty)
@@ -123,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
                 return false;
             }
 
-            var presenter = streamingPresenters.FirstOrDefault()?.Value;
+            var presenter = streamingPresenterOpt?.Value;
 
             return presenter.TryNavigateToOrPresentItemsAsync(
                 project.Solution.Workspace, title, definitions).WaitAndGetResult(cancellationToken);

--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             ImmutableArray<DefinitionItem> definitions,
             Project project,
             string title,
-            Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt,
+            IStreamingFindUsagesPresenter streamingPresenter,
             CancellationToken cancellationToken)
         {
             if (definitions.IsDefaultOrEmpty)
@@ -122,9 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
                 return false;
             }
 
-            var presenter = streamingPresenterOpt?.Value;
-
-            return presenter.TryNavigateToOrPresentItemsAsync(
+            return streamingPresenter.TryNavigateToOrPresentItemsAsync(
                 project.Solution.Workspace, title, definitions).WaitAndGetResult(cancellationToken);
         }
     }

--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
@@ -95,18 +95,17 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
         public static bool TryGoToDefinition(
             ISymbol symbol,
             Project project,
-            Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt,
+            IStreamingFindUsagesPresenter streamingPresenter,
             CancellationToken cancellationToken,
             bool thirdPartyNavigationAllowed = true,
             bool throwOnHiddenDefinition = false)
         {
             var definitions = GetDefinitions(symbol, project, thirdPartyNavigationAllowed, cancellationToken);
 
-            var presenter = streamingPresenterOpt?.Value;
             var title = string.Format(EditorFeaturesResources._0_declarations,
                 FindUsagesHelpers.GetDisplayName(symbol));
 
-            return presenter.TryNavigateToOrPresentItemsAsync(
+            return streamingPresenter.TryNavigateToOrPresentItemsAsync(
                 project.Solution.Workspace, title, definitions).WaitAndGetResult(cancellationToken);
         }
 

--- a/src/EditorFeatures/Core/GoToImplementation/GoToImplementationCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToImplementation/GoToImplementationCommandHandler.cs
@@ -1,20 +1,18 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Commanding;
-using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
 using VSCommanding = Microsoft.VisualStudio.Commanding;
@@ -26,13 +24,14 @@ namespace Microsoft.CodeAnalysis.Editor.GoToImplementation
     [Name(PredefinedCommandHandlerNames.GoToImplementation)]
     internal partial class GoToImplementationCommandHandler : VSCommanding.ICommandHandler<GoToImplementationCommandArgs>
     {
-        private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _streamingPresenters;
+        private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenterOpt;
 
         [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public GoToImplementationCommandHandler(
-            [ImportMany] IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters)
+            [Import(AllowDefault = true)] Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt)
         {
-            _streamingPresenters = streamingPresenters;
+            _streamingPresenterOpt = streamingPresenterOpt;
         }
 
         public string DisplayName => EditorFeaturesResources.Go_To_Implementation;
@@ -144,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToImplementation
         {
             try
             {
-                return _streamingPresenters.FirstOrDefault()?.Value;
+                return _streamingPresenterOpt?.Value;
             }
             catch
             {

--- a/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
+++ b/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
@@ -19,14 +19,14 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
             private readonly ImmutableArray<DefinitionItem> _definitions;
             private readonly SnapshotSpan _span;
             private readonly Document _document;
-            private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _presenters;
+            private readonly Lazy<IStreamingFindUsagesPresenter> _presenterOpt;
             private readonly IWaitIndicator _waitIndicator;
 
             public NavigableSymbol(
                 ImmutableArray<DefinitionItem> definitions,
                 SnapshotSpan span,
                 Document document,
-                IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters,
+                Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt,
                 IWaitIndicator waitIndicator)
             {
                 Contract.ThrowIfFalse(definitions.Length > 0);
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                 _definitions = definitions;
                 _span = span;
                 _document = document;
-                _presenters = streamingPresenters;
+                _presenterOpt = streamingPresenterOpt;
                 _waitIndicator = waitIndicator;
             }
 
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                         _definitions,
                         _document.Project,
                         _definitions[0].NameDisplayParts.GetFullText(),
-                        _presenters,
+                        _presenterOpt,
                         context.CancellationToken)
                     );
         }

--- a/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
+++ b/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Editor.GoToDefinition;
@@ -19,14 +18,14 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
             private readonly ImmutableArray<DefinitionItem> _definitions;
             private readonly SnapshotSpan _span;
             private readonly Document _document;
-            private readonly Lazy<IStreamingFindUsagesPresenter> _presenterOpt;
+            private readonly IStreamingFindUsagesPresenter _presenter;
             private readonly IWaitIndicator _waitIndicator;
 
             public NavigableSymbol(
                 ImmutableArray<DefinitionItem> definitions,
                 SnapshotSpan span,
                 Document document,
-                Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt,
+                IStreamingFindUsagesPresenter streamingPresenter,
                 IWaitIndicator waitIndicator)
             {
                 Contract.ThrowIfFalse(definitions.Length > 0);
@@ -34,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                 _definitions = definitions;
                 _span = span;
                 _document = document;
-                _presenterOpt = streamingPresenterOpt;
+                _presenter = streamingPresenter;
                 _waitIndicator = waitIndicator;
             }
 
@@ -53,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                         _definitions,
                         _document.Project,
                         _definitions[0].NameDisplayParts.GetFullText(),
-                        _presenterOpt,
+                        _presenter,
                         context.CancellationToken)
                     );
         }

--- a/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.NavigableSymbolSource.cs
+++ b/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.NavigableSymbolSource.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,16 +17,16 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
     {
         private partial class NavigableSymbolSource : INavigableSymbolSource
         {
-            private readonly Lazy<IStreamingFindUsagesPresenter> _presenterOpt;
+            private readonly IStreamingFindUsagesPresenter _presenter;
             private readonly IWaitIndicator _waitIndicator;
 
             private bool _disposed;
 
             public NavigableSymbolSource(
-                Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt,
+                IStreamingFindUsagesPresenter streamingPresenter,
                 IWaitIndicator waitIndicator)
             {
-                _presenterOpt = streamingPresenterOpt;
+                _presenter = streamingPresenter;
                 _waitIndicator = waitIndicator;
             }
 
@@ -67,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                 }
 
                 var snapshotSpan = new SnapshotSpan(snapshot, context.Span.ToSpan());
-                return new NavigableSymbol(definitions.ToImmutableArray(), snapshotSpan, document, _presenterOpt, _waitIndicator);
+                return new NavigableSymbol(definitions.ToImmutableArray(), snapshotSpan, document, _presenter, _waitIndicator);
             }
         }
     }

--- a/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.NavigableSymbolSource.cs
+++ b/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.NavigableSymbolSource.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.GoToDefinition;
@@ -13,7 +11,6 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
 {
@@ -21,16 +18,16 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
     {
         private partial class NavigableSymbolSource : INavigableSymbolSource
         {
-            private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _presenters;
+            private readonly Lazy<IStreamingFindUsagesPresenter> _presenterOpt;
             private readonly IWaitIndicator _waitIndicator;
 
             private bool _disposed;
 
             public NavigableSymbolSource(
-                IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters,
+                Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt,
                 IWaitIndicator waitIndicator)
             {
-                _presenters = streamingPresenters;
+                _presenterOpt = streamingPresenterOpt;
                 _waitIndicator = waitIndicator;
             }
 
@@ -70,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                 }
 
                 var snapshotSpan = new SnapshotSpan(snapshot, context.Span.ToSpan());
-                return new NavigableSymbol(definitions.ToImmutableArray(), snapshotSpan, document, _presenters, _waitIndicator);
+                return new NavigableSymbol(definitions.ToImmutableArray(), snapshotSpan, document, _presenterOpt, _waitIndicator);
             }
         }
     }

--- a/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.cs
+++ b/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -18,22 +17,22 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
     internal partial class NavigableSymbolService : INavigableSymbolSourceProvider
     {
         private static readonly object s_key = new object();
-        private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _streamingPresenters;
+        private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenterOpt;
         private readonly IWaitIndicator _waitIndicator;
 
         [ImportingConstructor]
         public NavigableSymbolService(
             IWaitIndicator waitIndicator,
-            [ImportMany] IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters)
+            [Import(AllowDefault = true)] Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt)
         {
             _waitIndicator = waitIndicator;
-            _streamingPresenters = streamingPresenters;
+            _streamingPresenterOpt = streamingPresenterOpt;
         }
 
         public INavigableSymbolSource TryCreateNavigableSymbolSource(ITextView textView, ITextBuffer buffer)
         {
             return textView.GetOrCreatePerSubjectBufferProperty(buffer, s_key,
-                (v, b) => new NavigableSymbolSource(_streamingPresenters, _waitIndicator));
+                (v, b) => new NavigableSymbolSource(_streamingPresenterOpt, _waitIndicator));
         }
     }
 }

--- a/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.cs
+++ b/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -17,22 +16,22 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
     internal partial class NavigableSymbolService : INavigableSymbolSourceProvider
     {
         private static readonly object s_key = new object();
-        private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenterOpt;
+        private readonly IStreamingFindUsagesPresenter _streamingPresenter;
         private readonly IWaitIndicator _waitIndicator;
 
         [ImportingConstructor]
         public NavigableSymbolService(
             IWaitIndicator waitIndicator,
-            [Import(AllowDefault = true)] Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt)
+            IStreamingFindUsagesPresenter streamingPresenter)
         {
             _waitIndicator = waitIndicator;
-            _streamingPresenterOpt = streamingPresenterOpt;
+            _streamingPresenter = streamingPresenter;
         }
 
         public INavigableSymbolSource TryCreateNavigableSymbolSource(ITextView textView, ITextBuffer buffer)
         {
             return textView.GetOrCreatePerSubjectBufferProperty(buffer, s_key,
-                (v, b) => new NavigableSymbolSource(_streamingPresenterOpt, _waitIndicator));
+                (v, b) => new NavigableSymbolSource(_streamingPresenter, _waitIndicator));
         }
     }
 }

--- a/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                 var listenerProvider = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>();
 
                 var handler = new FindReferencesCommandHandler(
-                    SpecializedCollections.SingletonEnumerable(new Lazy<IStreamingFindUsagesPresenter>(() => presenter)),
+                    new Lazy<IStreamingFindUsagesPresenter>(() => presenter),
                     listenerProvider);
 
                 var textView = workspace.Documents[0].GetTextView();

--- a/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                 var listenerProvider = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>();
 
                 var handler = new FindReferencesCommandHandler(
-                    new Lazy<IStreamingFindUsagesPresenter>(() => presenter),
+                    presenter,
                     listenerProvider);
 
                 var textView = workspace.Documents[0].GetTextView();

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesCommandHandlerTests.vb
@@ -37,7 +37,7 @@ class C
 
                 Dim context = New FindReferencesTests.TestContext()
                 Dim commandHandler = New FindReferencesCommandHandler(
-                    New Lazy(Of IStreamingFindUsagesPresenter)(Function() New MockStreamingFindReferencesPresenter(context)),
+                    New MockStreamingFindReferencesPresenter(context),
                     listenerProvider)
 
                 Dim document = workspace.CurrentSolution.GetDocument(testDocument.Id)

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesCommandHandlerTests.vb
@@ -1,6 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Editor.FindReferences
 Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
@@ -38,7 +37,7 @@ class C
 
                 Dim context = New FindReferencesTests.TestContext()
                 Dim commandHandler = New FindReferencesCommandHandler(
-                    {New Lazy(Of IStreamingFindUsagesPresenter)(Function() New MockStreamingFindReferencesPresenter(context))},
+                    New Lazy(Of IStreamingFindUsagesPresenter)(Function() New MockStreamingFindReferencesPresenter(context)),
                     listenerProvider)
 
                 Dim document = workspace.CurrentSolution.GetDocument(testDocument.Id)

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
@@ -100,7 +100,7 @@ class C
                 Dim cursorBuffer = cursorDocument.TextBuffer
                 Dim document = workspace.CurrentSolution.GetDocument(cursorDocument.Id)
 
-                Dim goToDefService = New CSharpGoToDefinitionService(New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter))
+                Dim goToDefService = New CSharpGoToDefinitionService(presenter)
 
                 Dim waitContext = New TestUIThreadOperationContext(updatesBeforeCancel)
                 Dim commandHandler = New GoToDefinitionCommandHandler()

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
@@ -96,12 +96,11 @@ class C
 
                 Dim navigatedTo = False
                 Dim presenter = New MockStreamingFindUsagesPresenter(Sub() navigatedTo = True)
-                Dim presenters = New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter)
 
                 Dim cursorBuffer = cursorDocument.TextBuffer
                 Dim document = workspace.CurrentSolution.GetDocument(cursorDocument.Id)
 
-                Dim goToDefService = New CSharpGoToDefinitionService(presenters)
+                Dim goToDefService = New CSharpGoToDefinitionService(New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter))
 
                 Dim waitContext = New TestUIThreadOperationContext(updatesBeforeCancel)
                 Dim commandHandler = New GoToDefinitionCommandHandler()

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
@@ -96,7 +96,7 @@ class C
 
                 Dim navigatedTo = False
                 Dim presenter = New MockStreamingFindUsagesPresenter(Sub() navigatedTo = True)
-                Dim presenters = {New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter)}
+                Dim presenters = New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter)
 
                 Dim cursorBuffer = cursorDocument.TextBuffer
                 Dim document = workspace.CurrentSolution.GetDocument(cursorDocument.Id)

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
     Public Class GoToDefinitionTests
         Friend Sub Test(workspaceDefinition As XElement,
                                         expectedResult As Boolean,
-                                        executeOnDocument As Func(Of Document, Integer, Lazy(Of IStreamingFindUsagesPresenter), Boolean))
+                                        executeOnDocument As Func(Of Document, Integer, IStreamingFindUsagesPresenter, Boolean))
             Using workspace = TestWorkspace.Create(
                     workspaceDefinition, exportProvider:=GoToTestHelpers.ExportProviderFactory.CreateExportProvider())
                 Dim solution = workspace.CurrentSolution
@@ -38,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
 
                 Dim presenterCalled As Boolean = False
                 Dim presenter = New MockStreamingFindUsagesPresenter(Sub() presenterCalled = True)
-                Dim actualResult = executeOnDocument(document, cursorPosition, New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter))
+                Dim actualResult = executeOnDocument(document, cursorPosition, presenter)
 
                 Assert.Equal(expectedResult, actualResult)
 
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
 
         Private Sub Test(workspaceDefinition As XElement, Optional expectedResult As Boolean = True)
             Test(workspaceDefinition, expectedResult,
-                Function(document As Document, cursorPosition As Integer, presenter As Lazy(Of IStreamingFindUsagesPresenter))
+                Function(document As Document, cursorPosition As Integer, presenter As IStreamingFindUsagesPresenter)
                     Dim goToDefService = If(document.Project.Language = LanguageNames.CSharp,
                         DirectCast(New CSharpGoToDefinitionService(presenter), IGoToDefinitionService),
                         New VisualBasicGoToDefinitionService(presenter))

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
@@ -38,8 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
 
                 Dim presenterCalled As Boolean = False
                 Dim presenter = New MockStreamingFindUsagesPresenter(Sub() presenterCalled = True)
-                Dim presenters = New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter)
-                Dim actualResult = executeOnDocument(document, cursorPosition, presenters)
+                Dim actualResult = executeOnDocument(document, cursorPosition, New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter))
 
                 Assert.Equal(expectedResult, actualResult)
 
@@ -104,10 +103,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
 
         Private Sub Test(workspaceDefinition As XElement, Optional expectedResult As Boolean = True)
             Test(workspaceDefinition, expectedResult,
-                Function(document As Document, cursorPosition As Integer, presenterOpt As Lazy(Of IStreamingFindUsagesPresenter))
+                Function(document As Document, cursorPosition As Integer, presenter As Lazy(Of IStreamingFindUsagesPresenter))
                     Dim goToDefService = If(document.Project.Language = LanguageNames.CSharp,
-                        DirectCast(New CSharpGoToDefinitionService(presenterOpt), IGoToDefinitionService),
-                        New VisualBasicGoToDefinitionService(presenterOpt))
+                        DirectCast(New CSharpGoToDefinitionService(presenter), IGoToDefinitionService),
+                        New VisualBasicGoToDefinitionService(presenter))
 
                     Return goToDefService.TryGoToDefinition(document, cursorPosition, CancellationToken.None)
                 End Function)

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
     Public Class GoToDefinitionTests
         Friend Sub Test(workspaceDefinition As XElement,
                                         expectedResult As Boolean,
-                                        executeOnDocument As Func(Of Document, Integer, IEnumerable(Of Lazy(Of IStreamingFindUsagesPresenter)), Boolean))
+                                        executeOnDocument As Func(Of Document, Integer, Lazy(Of IStreamingFindUsagesPresenter), Boolean))
             Using workspace = TestWorkspace.Create(
                     workspaceDefinition, exportProvider:=GoToTestHelpers.ExportProviderFactory.CreateExportProvider())
                 Dim solution = workspace.CurrentSolution
@@ -38,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
 
                 Dim presenterCalled As Boolean = False
                 Dim presenter = New MockStreamingFindUsagesPresenter(Sub() presenterCalled = True)
-                Dim presenters = {New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter)}
+                Dim presenters = New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter)
                 Dim actualResult = executeOnDocument(document, cursorPosition, presenters)
 
                 Assert.Equal(expectedResult, actualResult)
@@ -104,10 +104,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
 
         Private Sub Test(workspaceDefinition As XElement, Optional expectedResult As Boolean = True)
             Test(workspaceDefinition, expectedResult,
-                Function(document As Document, cursorPosition As Integer, presenters As IEnumerable(Of Lazy(Of IStreamingFindUsagesPresenter)))
+                Function(document As Document, cursorPosition As Integer, presenterOpt As Lazy(Of IStreamingFindUsagesPresenter))
                     Dim goToDefService = If(document.Project.Language = LanguageNames.CSharp,
-                        DirectCast(New CSharpGoToDefinitionService(presenters), IGoToDefinitionService),
-                        New VisualBasicGoToDefinitionService(presenters))
+                        DirectCast(New CSharpGoToDefinitionService(presenterOpt), IGoToDefinitionService),
+                        New VisualBasicGoToDefinitionService(presenterOpt))
 
                     Return goToDefService.TryGoToDefinition(document, cursorPosition, CancellationToken.None)
                 End Function)

--- a/src/EditorFeatures/Test2/NavigableSymbols/NavigableSymbolsTest.vb
+++ b/src/EditorFeatures/Test2/NavigableSymbols/NavigableSymbolsTest.vb
@@ -116,7 +116,7 @@ End Class"
         End Function
 
         Private Function ExtractSymbol(workspace As TestWorkspace, position As Integer, spans As IDictionary(Of String, ImmutableArray(Of TextSpan))) As Task(Of INavigableSymbol)
-            Dim presenter = {New Lazy(Of IStreamingFindUsagesPresenter)(Function() New MockStreamingFindUsagesPresenter(Sub() Return))}
+            Dim presenter = New Lazy(Of IStreamingFindUsagesPresenter)(Function() New MockStreamingFindUsagesPresenter(Sub() Return))
             Dim service = New NavigableSymbolService(TestWaitIndicator.Default, presenter)
             Dim view = workspace.Documents.First().GetTextView()
             Dim buffer = workspace.Documents.First().GetTextBuffer()

--- a/src/EditorFeatures/Test2/NavigableSymbols/NavigableSymbolsTest.vb
+++ b/src/EditorFeatures/Test2/NavigableSymbols/NavigableSymbolsTest.vb
@@ -116,7 +116,7 @@ End Class"
         End Function
 
         Private Function ExtractSymbol(workspace As TestWorkspace, position As Integer, spans As IDictionary(Of String, ImmutableArray(Of TextSpan))) As Task(Of INavigableSymbol)
-            Dim presenter = New Lazy(Of IStreamingFindUsagesPresenter)(Function() New MockStreamingFindUsagesPresenter(Sub() Return))
+            Dim presenter = New MockStreamingFindUsagesPresenter(Sub() Return)
             Dim service = New NavigableSymbolService(TestWaitIndicator.Default, presenter)
             Dim view = workspace.Documents.First().GetTextView()
             Dim buffer = workspace.Documents.First().GetTextBuffer()

--- a/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
+++ b/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.SymbolMapping;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities.ExperimentationService;
+using Microsoft.CodeAnalysis.UnitTests.Fakes;
 using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests
@@ -90,6 +89,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
             // Consider removing the internal service from the output: https://github.com/dotnet/roslyn/issues/30249
             return ExportProviderCache.GetOrCreateAssemblyCatalog(assemblies, ExportProviderCache.CreateResolver())
                 .WithPart(typeof(TestExperimentationServiceInternal));
+        }
+
+        public static ComposableCatalog WithDefaultFakes(this ComposableCatalog catalog)
+        {
+            return catalog
+                .WithPart(typeof(StubStreamingFindUsagesPresenter));
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/TestExportProvider.cs
+++ b/src/EditorFeatures/TestUtilities/TestExportProvider.cs
@@ -35,7 +35,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
 
         private static Lazy<ComposableCatalog> s_lazyMinimumCatalogWithCSharpAndVisualBasic =
             new Lazy<ComposableCatalog>(() => ExportProviderCache.CreateTypeCatalog(GetNeutralAndCSharpAndVisualBasicTypes())
-                        .WithParts(MinimalTestExportProvider.GetEditorAssemblyCatalog()));
+                        .WithParts(MinimalTestExportProvider.GetEditorAssemblyCatalog())
+                        .WithDefaultFakes());
 
         private static Lazy<IExportProviderFactory> s_lazyMinimumExportProviderFactoryWithCSharpAndVisualBasic =
             new Lazy<IExportProviderFactory>(() => ExportProviderCache.GetOrCreateExportProviderFactory(MinimumCatalogWithCSharpAndVisualBasic));
@@ -120,7 +121,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
         {
             return ExportProviderCache.GetOrCreateAssemblyCatalog(
                 GetNeutralAndCSharpAndVisualBasicTypes().Select(t => t.Assembly).Distinct(), ExportProviderCache.CreateResolver())
-                .WithParts(MinimalTestExportProvider.GetEditorAssemblyCatalog());
+                .WithParts(MinimalTestExportProvider.GetEditorAssemblyCatalog())
+                .WithDefaultFakes();
         }
     }
 }

--- a/src/EditorFeatures/VisualBasic/GoToDefinition/VisualBasicGoToDefinitionService.vb
+++ b/src/EditorFeatures/VisualBasic/GoToDefinition/VisualBasicGoToDefinitionService.vb
@@ -11,8 +11,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.GoToDefinition
         Inherits AbstractGoToDefinitionService
 
         <ImportingConstructor>
-        Public Sub New(<Import(AllowDefault:=True)> streamingPresenterOpt As Lazy(Of IStreamingFindUsagesPresenter))
-            MyBase.New(streamingPresenterOpt)
+        Public Sub New(streamingPresenter As IStreamingFindUsagesPresenter)
+            MyBase.New(streamingPresenter)
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/GoToDefinition/VisualBasicGoToDefinitionService.vb
+++ b/src/EditorFeatures/VisualBasic/GoToDefinition/VisualBasicGoToDefinitionService.vb
@@ -4,7 +4,6 @@ Imports System.Composition
 Imports Microsoft.CodeAnalysis.Editor.GoToDefinition
 Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
-Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.GoToDefinition
     <ExportLanguageService(GetType(IGoToDefinitionService), LanguageNames.VisualBasic), [Shared]>
@@ -12,8 +11,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.GoToDefinition
         Inherits AbstractGoToDefinitionService
 
         <ImportingConstructor>
-        Public Sub New(<ImportMany> streamingPresenters As IEnumerable(Of Lazy(Of IStreamingFindUsagesPresenter)))
-            MyBase.New(streamingPresenters)
+        Public Sub New(<Import(AllowDefault:=True)> streamingPresenterOpt As Lazy(Of IStreamingFindUsagesPresenter))
+            MyBase.New(streamingPresenterOpt)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
@@ -42,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
         private AbstractListItemFactory _listItemFactory;
         private object _classMemberGate = new object();
 
-        private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _streamingPresenters;
+        private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenterOpt;
         private readonly IThreadingContext _threadingContext;
 
         protected AbstractObjectBrowserLibraryManager(
@@ -62,7 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             Workspace.WorkspaceChanged += OnWorkspaceChanged;
 
             _libraryService = new Lazy<ILibraryService>(() => Workspace.Services.GetLanguageServices(_languageName).GetService<ILibraryService>());
-            _streamingPresenters = componentModel.DefaultExportProvider.GetExports<IStreamingFindUsagesPresenter>();
+            _streamingPresenterOpt = componentModel.DefaultExportProvider.GetExports<IStreamingFindUsagesPresenter>().SingleOrDefault();
             _threadingContext = componentModel.DefaultExportProvider.GetExportedValue<IThreadingContext>();
         }
 
@@ -502,7 +501,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                 switch (commandId)
                 {
                     case (uint)VSConstants.VSStd97CmdID.FindReferences:
-                        var streamingPresenter = _streamingPresenters.FirstOrDefault()?.Value;
+                        var streamingPresenter = _streamingPresenterOpt?.Value;
                         var symbolListItem = _activeListItem as SymbolListItem;
 
                         if (streamingPresenter != null && symbolListItem?.ProjectId != null)

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -28,6 +28,10 @@ namespace Microsoft.VisualStudio.LanguageServices
     [Export(typeof(VisualStudioWorkspaceImpl))]
     internal class RoslynVisualStudioWorkspace : VisualStudioWorkspaceImpl
     {
+        /// <remarks>
+        /// Must be lazily constructed since the <see cref="IStreamingFindUsagesPresenter"/> implementation imports a
+        /// backreference to <see cref="VisualStudioWorkspace"/>.
+        /// </remarks>
         private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenter;
 
         [ImportingConstructor]
@@ -116,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices
 
             return GoToDefinitionHelpers.TryGoToDefinition(
                 searchSymbol, searchProject,
-                _streamingPresenter, cancellationToken);
+                _streamingPresenter.Value, cancellationToken);
         }
 
         public override bool TryFindAllReferences(ISymbol symbol, Project project, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -28,18 +28,18 @@ namespace Microsoft.VisualStudio.LanguageServices
     [Export(typeof(VisualStudioWorkspaceImpl))]
     internal class RoslynVisualStudioWorkspace : VisualStudioWorkspaceImpl
     {
-        private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenterOpt;
+        private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenter;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public RoslynVisualStudioWorkspace(
             ExportProvider exportProvider,
-            [Import(AllowDefault = true)] Lazy<IStreamingFindUsagesPresenter> streamingPresenterOpt,
+            Lazy<IStreamingFindUsagesPresenter> streamingPresenter,
             [ImportMany] IEnumerable<IDocumentOptionsProviderFactory> documentOptionsProviderFactories,
             [Import(typeof(SVsServiceProvider))] IAsyncServiceProvider asyncServiceProvider)
             : base(exportProvider, asyncServiceProvider)
         {
-            _streamingPresenterOpt = streamingPresenterOpt;
+            _streamingPresenter = streamingPresenter;
 
             foreach (var providerFactory in documentOptionsProviderFactories)
             {
@@ -108,11 +108,6 @@ namespace Microsoft.VisualStudio.LanguageServices
         public override bool TryGoToDefinition(
             ISymbol symbol, Project project, CancellationToken cancellationToken)
         {
-            if (_streamingPresenterOpt == null)
-            {
-                return false;
-            }
-
             if (!TryResolveSymbol(symbol, project, cancellationToken,
                     out var searchSymbol, out var searchProject))
             {
@@ -121,7 +116,7 @@ namespace Microsoft.VisualStudio.LanguageServices
 
             return GoToDefinitionHelpers.TryGoToDefinition(
                 searchSymbol, searchProject,
-                _streamingPresenterOpt, cancellationToken);
+                _streamingPresenter, cancellationToken);
         }
 
         public override bool TryFindAllReferences(ISymbol symbol, Project project, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Test/GoToDefinition/GoToDefinitionApiTests.vb
+++ b/src/VisualStudio/Core/Test/GoToDefinition/GoToDefinitionApiTests.vb
@@ -3,7 +3,6 @@
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.GoToDefinition
-Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Test.Utilities
@@ -42,7 +41,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.GoToDefinition
                 WpfTestRunner.RequireWpfFact($"{NameOf(GoToDefinitionHelpers)}.{NameOf(GoToDefinitionHelpers.TryGoToDefinition)} assumes it's on the UI thread with a {NameOf(TaskExtensions.WaitAndGetResult)} call")
                 Dim success = GoToDefinitionHelpers.TryGoToDefinition(
                     symbolInfo.Symbol, document.Project,
-                    New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter),
+                    presenter,
                     thirdPartyNavigationAllowed:=True, throwOnHiddenDefinition:=False,
                     cancellationToken:=CancellationToken.None)
 

--- a/src/VisualStudio/Core/Test/GoToDefinition/GoToDefinitionApiTests.vb
+++ b/src/VisualStudio/Core/Test/GoToDefinition/GoToDefinitionApiTests.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.GoToDefinition
                 WpfTestRunner.RequireWpfFact($"{NameOf(GoToDefinitionHelpers)}.{NameOf(GoToDefinitionHelpers.TryGoToDefinition)} assumes it's on the UI thread with a {NameOf(TaskExtensions.WaitAndGetResult)} call")
                 Dim success = GoToDefinitionHelpers.TryGoToDefinition(
                     symbolInfo.Symbol, document.Project,
-                    {New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter)},
+                    New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter),
                     thirdPartyNavigationAllowed:=True, throwOnHiddenDefinition:=False,
                     cancellationToken:=CancellationToken.None)
 

--- a/src/Workspaces/CoreTestUtilities/Fakes/StubStreamingFindUsagesPresenter.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/StubStreamingFindUsagesPresenter.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using Microsoft.CodeAnalysis.Editor.FindUsages;
+using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.FindUsages;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Fakes
+{
+    [Export(typeof(IStreamingFindUsagesPresenter))]
+    [Shared]
+    [PartNotDiscoverable]
+    internal class StubStreamingFindUsagesPresenter : IStreamingFindUsagesPresenter
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public StubStreamingFindUsagesPresenter()
+        {
+        }
+
+        public virtual void ClearAll()
+        {
+        }
+
+        public virtual FindUsagesContext StartSearch(string title, bool supportsReferences)
+        {
+            return new SimpleFindUsagesContext(CancellationToken.None);
+        }
+    }
+}

--- a/src/Workspaces/CoreTestUtilities/MEF/ExportProviderCache.cs
+++ b/src/Workspaces/CoreTestUtilities/MEF/ExportProviderCache.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.VisualStudio.Composition;
 using Roslyn.Utilities;
+using Xunit;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
@@ -171,17 +172,19 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var configuration = CompositionConfiguration.Create(catalog.WithCompositionService());
             var runtimeComposition = RuntimeComposition.CreateRuntimeComposition(configuration);
             var exportProviderFactory = runtimeComposition.CreateExportProviderFactory();
-            return new SingleExportProviderFactory(catalog, exportProviderFactory);
+            return new SingleExportProviderFactory(catalog, configuration, exportProviderFactory);
         }
 
         private class SingleExportProviderFactory : IExportProviderFactory
         {
             private readonly ComposableCatalog _catalog;
+            private readonly CompositionConfiguration _configuration;
             private readonly IExportProviderFactory _exportProviderFactory;
 
-            public SingleExportProviderFactory(ComposableCatalog catalog, IExportProviderFactory exportProviderFactory)
+            public SingleExportProviderFactory(ComposableCatalog catalog, CompositionConfiguration configuration, IExportProviderFactory exportProviderFactory)
             {
                 _catalog = catalog;
+                _configuration = configuration;
                 _exportProviderFactory = exportProviderFactory;
             }
 
@@ -200,6 +203,35 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 var expected = _expectedProviderForCatalog;
                 if (expected == null)
                 {
+                    foreach (var errorCollection in _configuration.CompositionErrors)
+                    {
+                        foreach (var error in errorCollection)
+                        {
+                            foreach (var part in error.Parts)
+                            {
+                                foreach (var (importBinding, exportBindings) in part.SatisfyingExports)
+                                {
+                                    if (exportBindings.Count <= 1)
+                                    {
+                                        // Ignore composition errors for missing parts
+                                        continue;
+                                    }
+
+                                    if (importBinding.ImportDefinition.Cardinality != ImportCardinality.ZeroOrMore)
+                                    {
+                                        // This failure occurs when a binding fails because multiple exports were
+                                        // provided but only a single one (at most) is expected. This typically occurs
+                                        // when a test ExportProvider is created with a mock implementation without
+                                        // first removing a value provided by default.
+                                        throw new InvalidOperationException(
+                                            "Failed to construct the MEF catalog for testing. Multiple exports were found for a part for which only one export is expected:" + Environment.NewLine
+                                            + error.Message);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     expected = _exportProviderFactory.CreateExportProvider();
                     expected = Interlocked.CompareExchange(ref _expectedProviderForCatalog, expected, null) ?? expected;
                     Interlocked.CompareExchange(ref _currentExportProvider, expected, null);


### PR DESCRIPTION
Closes #24794 (not necessarily related, but I couldn't find any evidence of ongoing flakiness in the test and multiple stabilization passes have occurred since it was filed)