### PR TITLE
[WIP]Bugfix: Settings for using-directives not exported to .editorconfig

### DIFF
--- a/src/VisualStudio/Core/Test/Options/BasicEditorConfigGeneratorTests.vb
+++ b/src/VisualStudio/Core/Test/Options/BasicEditorConfigGeneratorTests.vb
@@ -35,6 +35,10 @@ insert_final_newline = false
 
 #### .NET Coding Conventions ####
 
+# Organize usings
+dotnet_separate_import_directive_groups = true:silent
+dotnet_sort_system_directives_first = true:silent
+
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:silent
 dotnet_style_qualification_for_field = false:silent

--- a/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
+++ b/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
@@ -34,6 +34,10 @@ insert_final_newline = false
 
 #### .NET Coding Conventions ####
 
+# Organize usings
+dotnet_separate_import_directive_groups = true:silent
+dotnet_sort_system_directives_first = true:silent
+
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:silent
 dotnet_style_qualification_for_field = false:silent


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/33766.

At the moment both `dotnet_sort_system_directives_first` and `dotnet_separate_import_directive_groups` rules are not exported when exporting overridden code style from Visual Studio to editorconfig. This PR will ensure both are exported. 