### PR TITLE
Hide obsolete member from the IDE for improved usability

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 
@@ -169,6 +170,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <param name="rules">The rules that declare how this item should behave.</param>
         /// <returns></returns>
         [Obsolete("Use the Create overload that does not take a span", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static CompletionItem Create(
             string displayText,
             string filterText,
@@ -245,6 +247,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// Creates a copy of this <see cref="CompletionItem"/> with the <see cref="Span"/> property changed.
         /// </summary>
         [Obsolete("Not used anymore.  CompletionList.Span is used to control the span used for filtering.", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public CompletionItem WithSpan(TextSpan span)
         {
             return this;


### PR DESCRIPTION
Since the given members are obsolete and will cause a build error if used, 
it's just better if they aren't shown at all.