### PR TITLE
Allow NuGet within the IDE

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,13 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <configuration>
-  <packageRestore>
-    <!-- NuGet Restore was observed to cause performance problems for in-IDE builds,
-         so it has been disabled.
-
-         ⚠ THIS IS A PERFORMANCE-CRITICAL LINE. DO NOT REMOVE. ⚠ -->
-    <add key="enabled" value="false" />
-  </packageRestore>
   <packageSources>
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />

--- a/eng/targets/GenerateCompilerExecutableBindingRedirects.targets
+++ b/eng/targets/GenerateCompilerExecutableBindingRedirects.targets
@@ -14,7 +14,8 @@
           DependsOnTargets="ResolveAssemblyReferences"
           Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ItemGroup>
-      <SuggestedBindingRedirects Include="@(ReferencePath->'%(FusionName)')" MaxVersion="%(ReferencePath.Version)" KeepMetadata="-none-" Condition="'%(ReferencePath.FrameworkFile)' != 'true'" />
+      <!-- Note: ReferencePath.Version can be missing for design time builds prior to the first full build. -->
+      <SuggestedBindingRedirects Include="@(ReferencePath->'%(FusionName)')" MaxVersion="%(ReferencePath.Version)" KeepMetadata="-none-" Condition="'%(ReferencePath.FrameworkFile)' != 'true' and '%(ReferencePath.Version)' != ''" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
As far as I can tell in testing, this change removes the requirement that users run **Restore.cmd** manually before opening **Roslyn.sln**.