### PR TITLE
Invoke new document API for fully load in code broom.

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
@@ -313,7 +313,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 var buffer = textBufferScope.SubjectBuffer;
 
                 // Load document here so that the partial load message actually shows up before the next scope kicks in.
-                var document = await buffer.CurrentSnapshot.GetFullyLoadedOpenDocumentInCurrentContextWithChangesAsync(context.OperationContext).ConfigureAwait(false);
+                var document = await buffer.CurrentSnapshot.GetFullyLoadedOpenDocumentInCurrentContextWithChangesAsync(context.OperationContext).ConfigureAwait(true);
 
                 using (var scope = context.OperationContext.AddScope(allowCancellation: true, description: EditorFeaturesResources.Applying_changes))
                 {

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
@@ -313,8 +313,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 var buffer = textBufferScope.SubjectBuffer;
 
                 // Load document here so that the partial load message actually shows up before the next scope kicks in.
-                var document = buffer.CurrentSnapshot.GetFullyLoadedOpenDocumentInCurrentContextWithChangesAsync(
-                        context.OperationContext).WaitAndGetResult(cancellationToken);
+                var document = await buffer.CurrentSnapshot.GetFullyLoadedOpenDocumentInCurrentContextWithChangesAsync(context.OperationContext).ConfigureAwait(false);
 
                 using (var scope = context.OperationContext.AddScope(allowCancellation: true, description: EditorFeaturesResources.Applying_changes))
                 {

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnusedVariable;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -21,6 +22,7 @@ using Microsoft.VisualStudio.Editor.CodeCleanup;
 using Microsoft.VisualStudio.Language.CodeCleanUp;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup;
 using Microsoft.VisualStudio.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 {
@@ -309,6 +311,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 cancellationToken = cancellationTokenSource.Token;
 
                 var buffer = textBufferScope.SubjectBuffer;
+                var document = buffer.CurrentSnapshot.GetFullyLoadedOpenDocumentInCurrentContextWithChangesAsync(
+                        context.OperationContext).WaitAndGetResult(cancellationToken);
+
                 using (var scope = context.OperationContext.AddScope(allowCancellation: true, description: EditorFeaturesResources.Applying_changes))
                 {
                     var progressTracker = new ProgressTracker((description, completed, total) =>
@@ -320,7 +325,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                         }
                     });
 
-                    var document = buffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
                     var codeCleanupService = document.GetLanguageService<ICodeCleanupService>();
 
                     var allDiagnostics = codeCleanupService.GetAllDiagnostics();

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
@@ -311,6 +311,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 cancellationToken = cancellationTokenSource.Token;
 
                 var buffer = textBufferScope.SubjectBuffer;
+
+                // Load document here so that the partial load message actually shows up before the next scope kicks in.
                 var document = buffer.CurrentSnapshot.GetFullyLoadedOpenDocumentInCurrentContextWithChangesAsync(
                         context.OperationContext).WaitAndGetResult(cancellationToken);
 


### PR DESCRIPTION
Related to #34133

Wait until solution is fully loaded when the user hits the code broom.
![code_broom_wait](https://user-images.githubusercontent.com/5749229/54462191-18b29280-472c-11e9-97e8-d366640cc1d3.gif)
