### PR TITLE
Fix race in GetOpenDocumentInCurrentContextWithChanges

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
@@ -33,14 +33,15 @@ namespace Microsoft.CodeAnalysis.Text
         {
             if (Workspace.TryGetWorkspace(text.Container, out var workspace))
             {
+                var solution = workspace.CurrentSolution;
                 var id = workspace.GetDocumentIdInCurrentContext(text.Container);
-                if (id == null || !workspace.CurrentSolution.ContainsDocument(id))
+                if (id == null || !solution.ContainsDocument(id))
                 {
                     return null;
                 }
 
-                var sol = workspace.CurrentSolution.WithDocumentText(id, text, PreservationMode.PreserveIdentity);
-                return sol.GetDocument(id);
+                return solution.WithDocumentText(id, text, PreservationMode.PreserveIdentity)
+                               .GetDocument(id);
             }
 
             return null;


### PR DESCRIPTION
This was reading Workspace.CurrentSolution twice, so if the document was removed between two reads it'd end up throwing exceptions or triggering asserts.

Fixes #33652

<details><summary>Ask Mode template</summary>

### Customer scenario

Sometimes when you're using C# or VB code in Visual Studio and you have code lens on, it'll crash.

### Bugs this fixes

#33652

### Workarounds, if any

Turning off CodeLens will reduce the risk.

### Risk

Zero. Trivial bug fix that closes a race.

### Performance impact

Zero.

### Is this a regression from a previous update?

Yes, ish. The bug has existed for ages, but some changes in 16.0 has probably made it easier to hit.

### Root cause analysis

There's a longstanding race in a common helper function that's used in almost every Roslyn feature. The race can happen if a thread is updating the state of our projects while another thread is calling this function. I suspect we've never really noticed this because usually those were always both the UI thread. But in 16.0, we:

1. Refactored some Code Lens stuff; I haven't checked but this means this function is currently being called on a background thread, and it's possible that moved and is more likely to be hit.
2. Refactored our project system handling, which means our project state can also be updated on a background thread.

### How was the bug found?

Internal automated test runs.

</details>