### PR TITLE
Guard against `string.Concat(object)` returning null

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -717,7 +717,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundExpression Coalesce(BoundExpression left, BoundExpression right)
         {
-            Debug.Assert(left.Type.Equals(right.Type, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
+            Debug.Assert(left.Type.Equals(right.Type, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes) || left.Type.IsErrorType());
             Debug.Assert(left.Type.IsReferenceType);
 
             return new BoundNullCoalescingOperator(Syntax, left, right, Conversion.Identity, BoundNullCoalescingOperatorResultKind.LeftType, left.Type) { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStringConcat.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStringConcat.cs
@@ -406,7 +406,6 @@ Y");
             comp.VerifyDiagnostics();
             comp.VerifyIL("Test.Main", @"
 {
-
   // Code size       97 (0x61)
   .maxstack  2
   IL_0000:  ldsfld     ""object Test.C""
@@ -436,6 +435,50 @@ Y");
   IL_0056:  ldstr      ""Y""
   IL_005b:  call       ""void System.Console.WriteLine(string)""
   IL_0060:  ret
+}
+");
+        }
+
+        [Fact]
+        public void ConcatOneArgWithExplicitConcatCall()
+        {
+            var source = @"
+using System;
+
+public class Test
+{
+    private static object O = ""O"";
+
+    static void Main()
+    {
+        Console.WriteLine(string.Concat(O) + null);
+        Console.WriteLine(string.Concat(O) + null + null);
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: @"O
+O");
+
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("Test.Main", @"
+{
+  // Code size       49 (0x31)
+  .maxstack  2
+  IL_0000:  ldsfld     ""object Test.O""
+  IL_0005:  call       ""string string.Concat(object)""
+  IL_000a:  dup
+  IL_000b:  brtrue.s   IL_0013
+  IL_000d:  pop
+  IL_000e:  ldstr      """"
+  IL_0013:  call       ""void System.Console.WriteLine(string)""
+  IL_0018:  ldsfld     ""object Test.O""
+  IL_001d:  call       ""string string.Concat(object)""
+  IL_0022:  dup
+  IL_0023:  brtrue.s   IL_002b
+  IL_0025:  pop
+  IL_0026:  ldstr      """"
+  IL_002b:  call       ""void System.Console.WriteLine(string)""
+  IL_0030:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStringConcat.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStringConcat.cs
@@ -358,18 +358,84 @@ F");
             comp.VerifyDiagnostics();
             comp.VerifyIL("Test.Main", @"
 {
-  // Code size       35 (0x23)
+  // Code size       44 (0x2c)
   .maxstack  2
   IL_0000:  ldsfld     ""object Test.O""
   IL_0005:  call       ""string string.Concat(object)""
-  IL_000a:  call       ""void System.Console.WriteLine(string)""
-  IL_000f:  ldsfld     ""string Test.S""
-  IL_0014:  dup
-  IL_0015:  brtrue.s   IL_001d
-  IL_0017:  pop
-  IL_0018:  ldstr      """"
-  IL_001d:  call       ""void System.Console.WriteLine(string)""
-  IL_0022:  ret
+  IL_000a:  dup
+  IL_000b:  brtrue.s   IL_0013
+  IL_000d:  pop
+  IL_000e:  ldstr      """"
+  IL_0013:  call       ""void System.Console.WriteLine(string)""
+  IL_0018:  ldsfld     ""string Test.S""
+  IL_001d:  dup
+  IL_001e:  brtrue.s   IL_0026
+  IL_0020:  pop
+  IL_0021:  ldstr      """"
+  IL_0026:  call       ""void System.Console.WriteLine(string)""
+  IL_002b:  ret
+}
+");
+        }
+
+        [Fact]
+        public void ConcatOneArgWithNullToString()
+        {
+            var source = @"
+using System;
+
+public class Test
+{
+    private static object C = new C();
+
+    static void Main()
+    {
+        Console.WriteLine((C + null) == """" ? ""Y"" : ""N"");
+        Console.WriteLine((C + null + null) == """" ? ""Y"" : ""N"");
+    }
+}
+
+public class C
+{
+    public override string ToString() => null;
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: @"Y
+Y");
+
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("Test.Main", @"
+{
+
+  // Code size       97 (0x61)
+  .maxstack  2
+  IL_0000:  ldsfld     ""object Test.C""
+  IL_0005:  call       ""string string.Concat(object)""
+  IL_000a:  dup
+  IL_000b:  brtrue.s   IL_0013
+  IL_000d:  pop
+  IL_000e:  ldstr      """"
+  IL_0013:  ldstr      """"
+  IL_0018:  call       ""bool string.op_Equality(string, string)""
+  IL_001d:  brtrue.s   IL_0026
+  IL_001f:  ldstr      ""N""
+  IL_0024:  br.s       IL_002b
+  IL_0026:  ldstr      ""Y""
+  IL_002b:  call       ""void System.Console.WriteLine(string)""
+  IL_0030:  ldsfld     ""object Test.C""
+  IL_0035:  call       ""string string.Concat(object)""
+  IL_003a:  dup
+  IL_003b:  brtrue.s   IL_0043
+  IL_003d:  pop
+  IL_003e:  ldstr      """"
+  IL_0043:  ldstr      """"
+  IL_0048:  call       ""bool string.op_Equality(string, string)""
+  IL_004d:  brtrue.s   IL_0056
+  IL_004f:  ldstr      ""N""
+  IL_0054:  br.s       IL_005b
+  IL_0056:  ldstr      ""Y""
+  IL_005b:  call       ""void System.Console.WriteLine(string)""
+  IL_0060:  ret
 }
 ");
         }
@@ -398,18 +464,22 @@ F");
             comp.VerifyDiagnostics();
             comp.VerifyIL("Test.Main", @"
 {
-  // Code size       35 (0x23)
+  // Code size       44 (0x2c)
   .maxstack  2
   IL_0000:  ldsfld     ""object Test.O""
   IL_0005:  call       ""string string.Concat(object)""
-  IL_000a:  call       ""void System.Console.WriteLine(string)""
-  IL_000f:  ldsfld     ""string Test.S""
-  IL_0014:  dup
-  IL_0015:  brtrue.s   IL_001d
-  IL_0017:  pop
-  IL_0018:  ldstr      """"
-  IL_001d:  call       ""void System.Console.WriteLine(string)""
-  IL_0022:  ret
+  IL_000a:  dup
+  IL_000b:  brtrue.s   IL_0013
+  IL_000d:  pop
+  IL_000e:  ldstr      """"
+  IL_0013:  call       ""void System.Console.WriteLine(string)""
+  IL_0018:  ldsfld     ""string Test.S""
+  IL_001d:  dup
+  IL_001e:  brtrue.s   IL_0026
+  IL_0020:  pop
+  IL_0021:  ldstr      """"
+  IL_0026:  call       ""void System.Console.WriteLine(string)""
+  IL_002b:  ret
 }
 ");
         }
@@ -537,7 +607,7 @@ A0A0
             comp.VerifyDiagnostics();
             comp.VerifyIL("Test.TestMethod<T>()", @"
 {
-  // Code size      193 (0xc1)
+  // Code size      211 (0xd3)
   .maxstack  4
   .locals init (T V_0)
   IL_0000:  ldstr      ""A""
@@ -585,18 +655,26 @@ A0A0
   IL_0084:  ldloc.0
   IL_0085:  box        ""T""
   IL_008a:  call       ""string string.Concat(object)""
-  IL_008f:  call       ""void System.Console.WriteLine(string)""
-  IL_0094:  ldstr      ""#""
-  IL_0099:  call       ""void System.Console.WriteLine(string)""
-  IL_009e:  ldloca.s   V_0
-  IL_00a0:  initobj    ""T""
-  IL_00a6:  ldloc.0
-  IL_00a7:  box        ""T""
-  IL_00ac:  call       ""string string.Concat(object)""
-  IL_00b1:  call       ""void System.Console.WriteLine(string)""
-  IL_00b6:  ldstr      ""#""
-  IL_00bb:  call       ""void System.Console.WriteLine(string)""
-  IL_00c0:  ret
+  IL_008f:  dup
+  IL_0090:  brtrue.s   IL_0098
+  IL_0092:  pop
+  IL_0093:  ldstr      """"
+  IL_0098:  call       ""void System.Console.WriteLine(string)""
+  IL_009d:  ldstr      ""#""
+  IL_00a2:  call       ""void System.Console.WriteLine(string)""
+  IL_00a7:  ldloca.s   V_0
+  IL_00a9:  initobj    ""T""
+  IL_00af:  ldloc.0
+  IL_00b0:  box        ""T""
+  IL_00b5:  call       ""string string.Concat(object)""
+  IL_00ba:  dup
+  IL_00bb:  brtrue.s   IL_00c3
+  IL_00bd:  pop
+  IL_00be:  ldstr      """"
+  IL_00c3:  call       ""void System.Console.WriteLine(string)""
+  IL_00c8:  ldstr      ""#""
+  IL_00cd:  call       ""void System.Console.WriteLine(string)""
+  IL_00d2:  ret
 }
 ");
         }


### PR DESCRIPTION
This PR is intended as a starting point for any discussion on #34085.

Note that this is a **BREAKING CHANGE** (although it's a correction to align with the spec, it's very niche, and a similar case was inadvertently fixed by Roslyn and I don't believe anyone noticed).

I believe it stands on its own as a working solution (for C# - it doesn't (yet) cover VB), but anticipate that it may need to change, or be rejected entirely because of its breaking nature.

Alternatives to this approach:

1. Change `string.Concat(object)` to never return null (also a breaking change)
2. Use `o?.ToString() ?? ""` instead of `string.Concat(o) ?? ""`
3. Change the spec, or accept and live with the deviation

------------------------------

If you define an object with a ToString method which returns null:

    public class C
    {
        public override string ToString() => null;
    }

And then concatenate that with `null` or "":

    C c = new C();
    c + ""

then the compiler emits:

    string.Concat(c)

However, `string.Concat(object)` will return null if the object's
ToString method returns null. This contradicts section 7.8.4 of the
Specification, which says:

    If ToString returns null, an empty string is substituted.
    ...
    The string concatenation operator never returns a null value

On the other hand, if you write:

    c + "" + ""

then the compiler emits:

    string.Concat(c) ?? ""

This is because it reduces `c + ""` to `string.Concat(c)` as before, but
when it considers the second `+ ""`, it sees `<string> + ""` and simplifies
that to `<string> ?? ""`. This is unnecessary in this case, but
inadvertently fixes this case.

This PR always emits `string.Concat(c) ?? ""`. It enhances the logic
which extracts the arguments to a call to `string.Concat` so it can unwrap
the null coalescing operator, and it enhances the `<string> + ""` logic
so that it only adds `?? ""` if `<string>` is not a call to `string.Concat`
(or `string.Concat(object) ?? ""`), since we know that this can never
result in null.

This introduces one more allocation: a single-element ImmutableArray
in some cases.

It seems that compiled expressions were never affected by this. Their
behaviour now matches that of compiled C#.

This does not change any of the VB code. I haven't looked into what the
VB spec says here, and I want any discussions on this PR to be resolved
before I invest that effort.

Fixes #34085