### PR TITLE
Fix saving naming styles options page

### DIFF
--- a/src/Tools/ILAsm/IlAsmDeploy.csproj
+++ b/src/Tools/ILAsm/IlAsmDeploy.csproj
@@ -12,9 +12,6 @@
     <TargetLatestRuntimePatch>false</TargetLatestRuntimePatch>
     <SelfContained>true</SelfContained>
 
-    <!-- Do not build again when publishing -->
-    <NoBuild>true</NoBuild>
-
     <PublishDir>$(ArtifactsDir)tools\ILAsm\$(Configuration)\</PublishDir>
   </PropertyGroup>
 

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPage.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPage.cs
@@ -12,7 +12,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
     {
         private static IOptionService s_optionService;
         private static OptionStore s_optionStore;
-        private static bool s_needsLoadOnNextActivate = true;
+        private static bool s_needsToUpdateOptionStore = true;
+
+        private bool _needsLoadOnNextActivate = true;
 
         protected abstract AbstractOptionPageControl CreateOptionPage(IServiceProvider serviceProvider, OptionStore optionStore);
 
@@ -50,16 +52,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         {
             EnsureOptionPageCreated();
 
-            if (s_needsLoadOnNextActivate)
+            if (s_needsToUpdateOptionStore)
             {
                 // Reset the option store to the current state of the options.
                 s_optionStore.SetOptions(s_optionService.GetOptions());
                 s_optionStore.SetRegisteredOptions(s_optionService.GetRegisteredOptions());
 
-                s_needsLoadOnNextActivate = false;
+                s_needsToUpdateOptionStore = false;
             }
 
-            pageControl.LoadSettings();
+            if (_needsLoadOnNextActivate)
+            {
+                // For pages that don't use option bindings we need to load setting changes.
+                pageControl.LoadSettings();
+
+                _needsLoadOnNextActivate = false;
+            }
         }
 
         public override void LoadSettingsFromStorage()
@@ -81,19 +89,33 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             // they may have been changed programmatically. Therefore, we'll set a flag so we load
             // next time
 
-            s_needsLoadOnNextActivate = pageControl != null;
+            // If we are being canceled after the pageControl has already been created then
+            // we need to reset the option store on next load.
+            s_needsToUpdateOptionStore = pageControl != null;
+
+            // For pages that don't use option bindings we need to load settings when it is
+            // activated next.
+            _needsLoadOnNextActivate = true;
         }
 
         public override void SaveSettingsToStorage()
         {
             EnsureOptionPageCreated();
 
+            // Allow page controls to perist their settings to the option store before updating the
+            // option service.
+            pageControl.SaveSettings();
+
             // Save the changes that were accumulated in the option store.
             s_optionService.SetOptions(s_optionStore.GetOptions());
 
             // Make sure we load the next time a page is activated, in case that options changed
             // programmatically between now and the next time the page is activated
-            s_needsLoadOnNextActivate = true;
+            s_needsToUpdateOptionStore = true;
+
+            // For pages that don't use option bindings we need to load settings when it is
+            // activated next.
+            _needsLoadOnNextActivate = true;
         }
 
         protected override void OnClosed(EventArgs e)

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
@@ -158,15 +158,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         internal virtual void SaveSettings()
         {
-            foreach (var bindingExpression in _bindingExpressions)
-            {
-                if (!bindingExpression.IsDirty)
-                {
-                    continue;
-                }
-
-                bindingExpression.UpdateSource();
-            }
+            
         }
 
         internal virtual void Close()

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             _bindingExpressions.Add(bindingExpression);
         }
 
-        internal virtual void LoadSettings()
+        internal virtual void OnLoad()
         {
             foreach (var bindingExpression in _bindingExpressions)
             {
@@ -156,9 +156,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             }
         }
 
-        internal virtual void SaveSettings()
+        internal virtual void OnSave()
         {
-            
         }
 
         internal virtual void Close()

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             }
         }
 
-        internal override void LoadSettings()
+        internal override void OnLoad()
         {
             this.ViewModel = _createViewModel(OptionStore, _serviceProvider);
 

--- a/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             }
         }
 
-        internal override void LoadSettings()
+        internal override void OnLoad()
         {
             this.ViewModel = _createViewModel(this.OptionStore, _serviceProvider);
 

--- a/src/VisualStudio/Core/Impl/Options/OptionStore.cs
+++ b/src/VisualStudio/Core/Impl/Options/OptionStore.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Options;
 
@@ -28,27 +30,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         public void SetOption(OptionKey optionKey, object value)
         {
-            var oldOptions = _optionSet;
             _optionSet = _optionSet.WithChangedOption(optionKey, value);
-            OptionLogger.Log(oldOptions, _optionSet);
 
             OnOptionChanged(optionKey);
         }
 
         public void SetOption<T>(Option<T> option, T value)
         {
-            var oldOptions = _optionSet;
             _optionSet = _optionSet.WithChangedOption(option, value);
-            OptionLogger.Log(oldOptions, _optionSet);
 
             OnOptionChanged(new OptionKey(option));
         }
 
         public void SetOption<T>(PerLanguageOption<T> option, string language, T value)
         {
-            var oldOptionSet = _optionSet;
             _optionSet = _optionSet.WithChangedOption(option, language, value);
-            OptionLogger.Log(oldOptionSet, _optionSet);
 
             OnOptionChanged(new OptionKey(option, language));
         }

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
@@ -177,10 +177,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style
                 namingStyles.ToImmutableAndFree(),
                 namingRules.ToImmutableAndFree());
 
-            var oldOptions = OptionStore.GetOptions();
-            var newOptions = oldOptions.WithChangedOption(SimplificationOptions.NamingPreferences, _languageName, info);
-            OptionStore.SetOptions(newOptions);
-            OptionLogger.Log(oldOptions, newOptions);
+            OptionStore.SetOption(SimplificationOptions.NamingPreferences, _languageName, info);
         }
 
         internal override void LoadSettings()

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style
             _notificationService = notificationService;
 
             InitializeComponent();
-            LoadSettings();
+            OnLoad();
         }
 
         private NamingStyleOptionPageViewModel.NamingRuleViewModel CreateItemWithNoSelections()
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style
             }
         }
 
-        internal override void SaveSettings()
+        internal override void OnSave()
         {
             var symbolSpecifications = ArrayBuilder<SymbolSpecification>.GetInstance();
             var namingRules = ArrayBuilder<SerializableNamingRule>.GetInstance();
@@ -180,9 +180,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style
             OptionStore.SetOption(SimplificationOptions.NamingPreferences, _languageName, info);
         }
 
-        internal override void LoadSettings()
+        internal override void OnLoad()
         {
-            base.LoadSettings();
+            base.OnLoad();
 
             var preferences = OptionStore.GetOption(SimplificationOptions.NamingPreferences, _languageName);
             if (preferences == null)


### PR DESCRIPTION
- Allow page controls to store settings to option store before updating service
- Reload page control settings only after a cancel or save

Fixes #34210 which was introduced by https://github.com/dotnet/roslyn/pull/33523

The earlier PR didn't account for the Naming option page having very specialized load and save settings. Other option pages were updated to store their changes immediately into the OptionStore but Naming options still relied on SaveSettings being called to directly update the OptionService. In a related way, Naming service overwrites its view model when LoadSettings is called and because of the earlier change LoadSettings was being called every time the page is activated.


<details><summary>Ask Mode template</summary>

### Customer scenario

User tries to update naming styles for identifiers and changes do not save.

### Bugs this fixes

#34210

### Workarounds, if any

None

### Risk

Low

### Performance impact

Low

### Is this a regression from a previous update?

Yes, regression was introduced by https://github.com/dotnet/roslyn/pull/33523

### Root cause analysis

In Dev16, option saving was rewritten so that all option changes went to a centralized store and were saved to the option service in a single location. This rewrite missed the custom save behavior of the Naming styles option page.

### How was the bug found?

Reported through developer feedback

</details>