### PR TITLE
Skip test DecimalBinaryOp_03 (#34199)

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -11317,9 +11317,12 @@ class C
 }");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34198")]
         public void DecimalBinaryOp_03()
         {
+            // Test temporarily disabled as it fails CI on Linux in master branch
+            // Tracked by https://github.com/dotnet/roslyn/issues/34198
+
             string source = @"
 class C
 {


### PR DESCRIPTION
Back port https://github.com/dotnet/roslyn/pull/34199 to dev16.0 so CI can pass.

@jaredpar 