### PR TITLE
Include source branch in container name

### DIFF
--- a/eng/docker/mono.sh
+++ b/eng/docker/mono.sh
@@ -11,6 +11,7 @@ dockerfile="$dir"/Mono
 
 [ -z "$CONTAINER_TAG" ] && CONTAINER_TAG="roslyn-build"
 [ -z "$CONTAINER_NAME" ] && CONTAINER_NAME="roslyn-build-container-mono-nightly"
+[ -z "$BUILD_SOURCEBRANCHNAME" ] && CONTAINER_NAME="roslyn-build-container-mono-nightly-$BUILD_SOURCEBRANCHNAME"
 [ -z "$DOCKER_HOST_SHARE_dir" ] && DOCKER_HOST_SHARE_DIR="$dir"/../..
 
 # Ensure the container isn't already running. Can happened for cancelled jobs in CI


### PR DESCRIPTION
This ensures we have proper isolation between branches. Given different
branches may have vastly different setups, including dotnet
installations, this can be necessary.

closes #34198