### PR TITLE
Simplify VisualStudioWaitIndicator

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Utilities/VisualStudioWaitIndicator.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Utilities/VisualStudioWaitIndicator.cs
@@ -18,7 +18,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
     internal sealed class VisualStudioWaitIndicator : IWaitIndicator
     {
         private readonly SVsServiceProvider _serviceProvider;
-        private readonly bool _isUpdate1;
 
         private static readonly Func<string, string, string> s_messageGetter = (t, m) => string.Format("{0} : {1}", t, m);
 
@@ -26,11 +25,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
         public VisualStudioWaitIndicator(SVsServiceProvider serviceProvider)
         {
             _serviceProvider = serviceProvider;
-
-            var shell = serviceProvider.GetService(typeof(SVsShell)) as IVsShell;
-            shell.GetProperty((int)__VSSPROPID5.VSSPROPID_ReleaseVersion, out var property);
-
-            _isUpdate1 = Equals(property, "14.0.24720.0 D14REL");
         }
 
         public WaitIndicatorResult Wait(
@@ -59,13 +53,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
         private VisualStudioWaitContext StartWait(
             string title, string message, bool allowCancel, bool showProgress)
         {
-            // Update1 has a bug where trying to update hte progress bar will cause a hang.
-            // Check if we're on update1 and turn off 'showProgress' in that case.
-            if (_isUpdate1)
-            {
-                showProgress = false;
-            }
-
             var componentModel = (IComponentModel)_serviceProvider.GetService(typeof(SComponentModel));
             var workspace = componentModel.GetService<VisualStudioWorkspace>();
             Contract.ThrowIfNull(workspace);

--- a/src/VisualStudio/Core/Def/Implementation/Utilities/VisualStudioWaitIndicator.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Utilities/VisualStudioWaitIndicator.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.VisualStudio.ComponentModelHost;
@@ -22,6 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
         private static readonly Func<string, string, string> s_messageGetter = (t, m) => string.Format("{0} : {1}", t, m);
 
         [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public VisualStudioWaitIndicator(SVsServiceProvider serviceProvider)
         {
             _serviceProvider = serviceProvider;


### PR DESCRIPTION
* Remove unnecessary workaround for Visual Studio 2015 Update 1
* Ensure type is constructed properly if/when used in tests