### PR TITLE
Report uninitialized fields on field if ctor is default

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
@@ -67,8 +67,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void ReportUninitializedNonNullableReferenceTypeFields()
         {
             var thisParameter = MethodThisParameter;
-            var location = thisParameter.ContainingSymbol.Locations.FirstOrDefault() ?? Location.None;
-
             int thisSlot = VariableSlot(thisParameter);
             if (thisSlot == -1)
             {
@@ -105,6 +103,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (fieldSlot == -1 || !this.State.IsAssigned(fieldSlot))
                 {
                     var symbol = (Symbol)(field.AssociatedSymbol as PropertySymbol) ?? field;
+                    var location = (topLevelMethod.DeclaringSyntaxReferences.IsEmpty
+                        ? symbol // default constructor, use the field location
+                        : topLevelMethod).Locations[0];
                     _diagnostics.Add(ErrorCode.WRN_UninitializedNonNullableField, location, symbol.Kind.Localize(), symbol.Name);
                 }
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -128,9 +128,9 @@ public class C
 }", options: WithNonNullTypesTrue());
 
             comp.VerifyDiagnostics(
-                // (6,14): warning CS8618: Non-nullable field 'f' is uninitialized.
-                // public class C
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "f").WithLocation(6, 14)
+                // (8,14): warning CS8618: Non-nullable field 'f' is uninitialized.
+                //     public B f;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "f").WithArguments("field", "f").WithLocation(8, 14)
                 );
         }
 
@@ -2623,9 +2623,9 @@ class C<T>
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "item.Field").WithLocation(9, 13));
 
             verify(fieldType: "string",
-                // (2,7): warning CS8618: Non-nullable field 'Field' is uninitialized.
-                // class C
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "Field").WithLocation(2, 7));
+                // (4,19): warning CS8618: Non-nullable field 'Field' is uninitialized.
+                //     public string Field;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Field").WithArguments("field", "Field").WithLocation(4, 19));
 
             void verify(string fieldType, params DiagnosticDescription[] expected)
             {
@@ -6276,10 +6276,9 @@ public class C<T>
                 // (4,12): error CS8627: A nullable type parameter must be known to be a value type or non-nullable reference type. Consider adding a 'class', 'struct', or type constraint.
                 //     public T? field;
                 Diagnostic(ErrorCode.ERR_NullableUnconstrainedTypeParameter, "T?").WithLocation(4, 12),
-                // (2,14): warning CS8618: Non-nullable field 'field' is uninitialized.
-                // public class C<T>
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "field").WithLocation(2, 14)
-                );
+                // (4,15): warning CS8618: Non-nullable field 'field' is uninitialized.
+                //     public T? field;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "field").WithArguments("field", "field").WithLocation(4, 15));
         }
 
         [Fact]
@@ -8841,9 +8840,9 @@ class C<T>
 
             comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (3,7): warning CS8618: Non-nullable field '_f' is uninitialized.
-                // class C<T>
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "_f").WithLocation(3, 7)
+                // (5,9): warning CS8618: Non-nullable field '_f' is uninitialized.
+                //     T[] _f;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "_f").WithArguments("field", "_f").WithLocation(5, 9)
                 );
         }
 
@@ -23829,9 +23828,9 @@ class C
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
-                // (6,7): warning CS8618: Non-nullable field 'F' is uninitialized.
-                // class B<T>
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "B").WithArguments("field", "F").WithLocation(6, 7),
+                // (8,16): warning CS8618: Non-nullable field 'F' is uninitialized.
+                //     internal T F;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F").WithArguments("field", "F").WithLocation(8, 16),
                 // (14,10): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'B<object?>'.
                 //         (x1 ?? y1)/*T:B<object?>!*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x1").WithArguments("A<object>", "B<object?>").WithLocation(14, 10),
@@ -24066,9 +24065,9 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (2,7): warning CS8618: Non-nullable field 'F' is uninitialized.
-                // class A<T>
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "A").WithArguments("field", "F").WithLocation(2, 7),
+                // (4,16): warning CS8618: Non-nullable field 'F' is uninitialized.
+                //     internal T F;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F").WithArguments("field", "F").WithLocation(4, 16),
                 // (11,15): warning CS8619: Nullability of reference types in value of type 'B<object?>' doesn't match target type 'A<object>'.
                 //         (x ?? y).F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("B<object?>", "A<object>").WithLocation(11, 15),
@@ -36849,7 +36848,7 @@ partial class C
         public void NonNullTypes_02()
         {
             string lib =
-@"#pragma warning disable 8618
+@"
 using System;
 
 " + NonNullTypesOff() + @"
@@ -36859,11 +36858,14 @@ public class CL0
     public class CL1
     {
 " + NonNullTypesOn() + @"
+#pragma warning disable 8618
         public Action F1;
 " + NonNullTypesOn() + @"
+#pragma warning disable 8618
         public Action? F2;
 
 " + NonNullTypesOn() + @"
+#pragma warning disable 8618
         public Action P1 { get; set; }
 " + NonNullTypesOn() + @"
         public Action? P2 { get; set; }
@@ -39586,9 +39588,9 @@ class CL0<T>
                 // (35,9): warning CS8602: Possible dereference of a null reference.
                 //         M1<CL0<string?>?>(x13).P1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1<CL0<string?>?>(x13).P1").WithLocation(35, 9),
-                // (39,7): warning CS8618: Non-nullable property 'P1' is uninitialized.
-                // class CL0<T>
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "CL0").WithArguments("property", "P1").WithLocation(39, 7)
+                // (41,14): warning CS8618: Non-nullable property 'P1' is uninitialized.
+                //     public T P1 {get;set;}
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "P1").WithArguments("property", "P1").WithLocation(41, 14)
                 );
         }
 
@@ -49000,9 +49002,9 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (2,7): warning CS8618: Non-nullable field 'F' is uninitialized.
-                // class A<T>
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "A").WithArguments("field", "F").WithLocation(2, 7),
+                // (4,16): warning CS8618: Non-nullable field 'F' is uninitialized.
+                //     internal T F;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F").WithArguments("field", "F").WithLocation(4, 16),
                 // (12,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         ((A<string>)null).F.ToString();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(A<string>)null").WithLocation(12, 10),
@@ -51810,9 +51812,9 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (1,7): warning CS8618: Non-nullable field 'F' is uninitialized.
-                // class C<T>
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F").WithLocation(1, 7),
+               // (3,16): warning CS8618: Non-nullable field 'F' is uninitialized.
+                //     internal T F;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F").WithArguments("field", "F").WithLocation(3, 16),
                 // (21,27): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //             Create(x).F = null; // warn
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(21, 27),
@@ -63922,9 +63924,9 @@ class A<T1, T2> where T1 : class where T2 : class
             var comp = CreateCompilation(new[] { source });
 
             comp.VerifyDiagnostics(
-                // (5,7): warning CS8618: Non-nullable field 'F' is uninitialized.
-                // class A<T1, T2> where T1 : class where T2 : class
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "A").WithArguments("field", "F").WithLocation(5, 7),
+                // (7,8): warning CS8618: Non-nullable field 'F' is uninitialized.
+                //     T1 F;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F").WithArguments("field", "F").WithLocation(7, 8),
                 // (7,8): warning CS0414: The field 'A<T1, T2>.F' is assigned but its value is never used
                 //     T1 F;
                 Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "F").WithArguments("A<T1, T2>.F").WithLocation(7, 8),
@@ -63963,6 +63965,7 @@ class A<T1, T2> where T1 : class where T2 : class
 class A<T1, T2> where T1 : class where T2 : class
 {
 " + NonNullTypesOn() + @"
+#pragma warning disable 8618
     T1 F;
 
 " + NonNullTypesOn() + @"
@@ -64010,24 +64013,24 @@ class A<T1, T2> where T1 : class where T2 : class
 ";
             var comp = CreateCompilation(new[] { source });
             comp.VerifyDiagnostics(
-                // (8,8): warning CS0414: The field 'A<T1, T2>.F' is assigned but its value is never used
+                // (9,8): warning CS0414: The field 'A<T1, T2>.F' is assigned but its value is never used
                 //     T1 F;
-                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "F").WithArguments("A<T1, T2>.F").WithLocation(8, 8),
-                // (15,17): warning CS8654: A null literal introduces a null value when 'T1' is a non-nullable reference type.
+                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "F").WithArguments("A<T1, T2>.F").WithLocation(9, 8),
+                // (16,17): warning CS8654: A null literal introduces a null value when 'T1' is a non-nullable reference type.
                 //             F = null; // 1
-                Diagnostic(ErrorCode.WRN_NullLiteralMayIntroduceNullT, "null").WithArguments("T1").WithLocation(15, 17),
-                // (22,13): warning CS8654: A null literal introduces a null value when 'T1' is a non-nullable reference type.
+                Diagnostic(ErrorCode.WRN_NullLiteralMayIntroduceNullT, "null").WithArguments("T1").WithLocation(16, 17),
+                // (23,13): warning CS8654: A null literal introduces a null value when 'T1' is a non-nullable reference type.
                 //         F = null; // 2
-                Diagnostic(ErrorCode.WRN_NullLiteralMayIntroduceNullT, "null").WithArguments("T1").WithLocation(22, 13),
-                // (30,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                Diagnostic(ErrorCode.WRN_NullLiteralMayIntroduceNullT, "null").WithArguments("T1").WithLocation(23, 13),
+                // (31,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //             F = null; // 3
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(30, 17),
-                // (39,17): warning CS8654: A null literal introduces a null value when 'T1' is a non-nullable reference type.
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(31, 17),
+                // (40,17): warning CS8654: A null literal introduces a null value when 'T1' is a non-nullable reference type.
                 //             F = null; // 4
-                Diagnostic(ErrorCode.WRN_NullLiteralMayIntroduceNullT, "null").WithArguments("T1").WithLocation(39, 17),
-                // (48,17): warning CS8654: A null literal introduces a null value when 'T2' is a non-nullable reference type.
+                Diagnostic(ErrorCode.WRN_NullLiteralMayIntroduceNullT, "null").WithArguments("T1").WithLocation(40, 17),
+                // (49,17): warning CS8654: A null literal introduces a null value when 'T2' is a non-nullable reference type.
                 //             F = null; // 5
-                Diagnostic(ErrorCode.WRN_NullLiteralMayIntroduceNullT, "null").WithArguments("T2").WithLocation(48, 17));
+                Diagnostic(ErrorCode.WRN_NullLiteralMayIntroduceNullT, "null").WithArguments("T2").WithLocation(49, 17));
 
             var b = comp.GetTypeByMetadataName("A`2+B");
             Assert.NotNull(b);
@@ -66039,11 +66042,11 @@ class B {}
             var source =
 @"
 #pragma warning disable CS0169
-#pragma warning disable CS8618
 
 class A
 {
 #nullable restore
+#pragma warning disable CS8618
     B F1;
 }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
@@ -36,9 +36,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (1,16): warning CS8618: Non-nullable field 'F1' is uninitialized.
-                // internal class C<T> where T : new()
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(1, 16),
+                // (3,16): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     internal T F1;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F1").WithArguments("field", "F1").WithLocation(3, 16),
                 // (3,16): warning CS0649: Field 'C<T>.F1' is never assigned to, and will always have its default value 
                 //     internal T F1;
                 Diagnostic(ErrorCode.WRN_UnassignedInternalField, "F1").WithArguments("C<T>.F1", "").WithLocation(3, 16),
@@ -65,12 +65,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (1,7): warning CS8618: Non-nullable field 'F3' is uninitialized.
-                // class C
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(1, 7),
-                // (1,7): warning CS8618: Non-nullable field 'F1' is uninitialized.
-                // class C
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(1, 7));
+                // (5,20): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     private object F1;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F1").WithArguments("field", "F1").WithLocation(5, 20),
+                // (7,24): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                //     internal object?[] F3;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F3").WithArguments("field", "F3").WithLocation(7, 24));
         }
 
         [Fact]
@@ -128,12 +128,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (1,7): warning CS8618: Non-nullable field 'F3' is uninitialized.
-                // class C
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(1, 7),
-                // (1,7): warning CS8618: Non-nullable field 'F1' is uninitialized.
-                // class C
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(1, 7));
+                // (5,29): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     private readonly object F1;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F1").WithArguments("field", "F1").WithLocation(5, 29),
+                // (7,33): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                //     internal readonly object?[] F3;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F3").WithArguments("field", "F3").WithLocation(7, 33));
         }
 
         [Fact]
@@ -598,30 +598,30 @@ class C5<T, U> where T : A where U : T
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (4,7): warning CS8618: Non-nullable field 'G1' is uninitialized.
-                // class C1<T, U> where U : T
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C1").WithArguments("field", "G1").WithLocation(4, 7),
-                // (4,7): warning CS8618: Non-nullable field 'F1' is uninitialized.
-                // class C1<T, U> where U : T
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C1").WithArguments("field", "F1").WithLocation(4, 7),
-                // (13,7): warning CS8618: Non-nullable field 'G3' is uninitialized.
-                // class C3<T, U> where T : class where U : T
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C3").WithArguments("field", "G3").WithLocation(13, 7),
-                // (13,7): warning CS8618: Non-nullable field 'F3' is uninitialized.
-                // class C3<T, U> where T : class where U : T
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C3").WithArguments("field", "F3").WithLocation(13, 7),
-                // (18,7): warning CS8618: Non-nullable field 'G4' is uninitialized.
-                // class C4<T, U> where T : I where U : T
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C4").WithArguments("field", "G4").WithLocation(18, 7),
-                // (18,7): warning CS8618: Non-nullable field 'F4' is uninitialized.
-                // class C4<T, U> where T : I where U : T
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C4").WithArguments("field", "F4").WithLocation(18, 7),
-                // (23,7): warning CS8618: Non-nullable field 'G5' is uninitialized.
-                // class C5<T, U> where T : A where U : T
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C5").WithArguments("field", "G5").WithLocation(23, 7),
-                // (23,7): warning CS8618: Non-nullable field 'F5' is uninitialized.
-                // class C5<T, U> where T : A where U : T
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C5").WithArguments("field", "F5").WithLocation(23, 7));
+                // (6,7): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     T F1;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F1").WithArguments("field", "F1").WithLocation(6, 7),
+                // (7,7): warning CS8618: Non-nullable field 'G1' is uninitialized.
+                //     U G1;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "G1").WithArguments("field", "G1").WithLocation(7, 7),
+                // (15,7): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                //     T F3;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F3").WithArguments("field", "F3").WithLocation(15, 7),
+                // (16,7): warning CS8618: Non-nullable field 'G3' is uninitialized.
+                //     U G3;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "G3").WithArguments("field", "G3").WithLocation(16, 7),
+                // (20,7): warning CS8618: Non-nullable field 'F4' is uninitialized.
+                //     T F4;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F4").WithArguments("field", "F4").WithLocation(20, 7),
+                // (21,7): warning CS8618: Non-nullable field 'G4' is uninitialized.
+                //     U G4;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "G4").WithArguments("field", "G4").WithLocation(21, 7),
+                // (25,7): warning CS8618: Non-nullable field 'F5' is uninitialized.
+                //     T F5;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F5").WithArguments("field", "F5").WithLocation(25, 7),
+                // (26,7): warning CS8618: Non-nullable field 'G5' is uninitialized.
+                //     U G5;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "G5").WithArguments("field", "G5").WithLocation(26, 7));
         }
 
         [Fact]


### PR DESCRIPTION
It's not clear that reporting warnings for unitialized non-null fields
on the field location is better in all cases (instead of the ctor) but
it seems a Pareto improvement for default constructors, specifically.

Fixes #32444