### PR TITLE
made light bulb to check workspace status service

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Editor.Shared;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
@@ -24,12 +25,10 @@ using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
-
 using CodeFixGroupKey = System.Tuple<Microsoft.CodeAnalysis.Diagnostics.DiagnosticData, Microsoft.CodeAnalysis.CodeActions.CodeActionPriority>;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 {
-
     internal partial class SuggestedActionsSourceProvider
     {
         private class SuggestedActionsSource : ForegroundThreadAffinitizedObject, ISuggestedActionsSource2
@@ -44,6 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
             // mutable state
             private Workspace _workspace;
+            private IWorkspaceStatusService _workspaceStatusChangedService;
             private int _lastSolutionVersionReported;
 
             public event EventHandler<EventArgs> SuggestedActionsChanged;
@@ -67,11 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 var updateSource = (IDiagnosticUpdateSource)_owner._diagnosticService;
                 updateSource.DiagnosticsUpdated += OnDiagnosticsUpdated;
 
-                if (_registration.Workspace != null)
-                {
-                    _workspace = _registration.Workspace;
-                    _workspace.DocumentActiveContextChanged += OnActiveContextChanged;
-                }
+                RegisterEventsToWorkspace(_registration.Workspace);
 
                 _registration.WorkspaceChanged += OnWorkspaceChanged;
             }
@@ -82,6 +78,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 {
                     var updateSource = (IDiagnosticUpdateSource)_owner._diagnosticService;
                     updateSource.DiagnosticsUpdated -= OnDiagnosticsUpdated;
+                }
+
+                if (_workspaceStatusChangedService != null)
+                {
+                    _workspaceStatusChangedService.StatusChanged -= OnWorkspaceStatusChanged;
                 }
 
                 if (_workspace != null)
@@ -101,6 +102,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 _owner = null;
                 _workspace = null;
+                _workspaceStatusChangedService = null;
                 _registration = null;
                 _textView = null;
                 _subjectBuffer = null;
@@ -156,6 +158,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 if (IsDisposed)
                 {
                     return null;
+                }
+
+                if (_workspaceStatusChangedService != null)
+                {
+                    // TODO: right now, LightBulb uses IVsThreadedWaitDialog directly rather than new
+                    //       IUIThreadOperationContext. we need to talk to editor team whether we want to
+                    //       update API to pass in OperationContext like any new API, or we use 
+                    //       IWaitIndicator abstraction (which is a thin wrapper on top of IVsThreadedWaitDialog) directly
+                    //       for now, we use the one LB created before calling us. meaning we don't update
+                    //       text on the wait dialog window
+                    _workspaceStatusChangedService.WaitUntilFullyLoadedAsync(cancellationToken).Wait(cancellationToken);
                 }
 
                 using (Logger.LogBlock(FunctionId.SuggestedActions_GetSuggestedActions, cancellationToken))
@@ -878,6 +891,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 // one doesn't need to hold onto workspace in field.
 
                 // remove existing event registration
+                if (_workspaceStatusChangedService != null)
+                {
+                    _workspaceStatusChangedService.StatusChanged -= OnWorkspaceStatusChanged;
+                }
+
                 if (_workspace != null)
                 {
                     _workspace.DocumentActiveContextChanged -= OnActiveContextChanged;
@@ -885,12 +903,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 // REVIEW: why one need to get new workspace from registration? why not just pass in the new workspace?
                 // add new event registration
-                _workspace = _registration.Workspace;
+                RegisterEventsToWorkspace(_registration.Workspace);
+            }
 
-                if (_workspace != null)
+            private void RegisterEventsToWorkspace(Workspace workspace)
+            {
+                _workspace = workspace;
+
+                if (_workspace == null)
                 {
-                    _workspace.DocumentActiveContextChanged += OnActiveContextChanged;
+                    return;
                 }
+
+                _workspace.DocumentActiveContextChanged += OnActiveContextChanged;
+                _workspaceStatusChangedService = workspace.Services.GetService<IWorkspaceStatusService>();
+                _workspaceStatusChangedService.StatusChanged += OnWorkspaceStatusChanged;
             }
 
             private void OnActiveContextChanged(object sender, DocumentActiveContextChangedEventArgs e)
@@ -910,7 +937,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 OnSuggestedActionsChanged(e.Workspace, e.DocumentId, e.Solution.WorkspaceVersion);
             }
 
-            private void OnSuggestedActionsChanged(Workspace currentWorkspace, DocumentId currentDocumentId, int solutionVersion, DiagnosticsUpdatedArgs args = null)
+            private void OnWorkspaceStatusChanged(object sender, bool fullyLoaded)
+            {
+                var document = _subjectBuffer.AsTextContainer().GetOpenDocumentInCurrentContext();
+                if (document == null)
+                {
+                    // document is already closed
+                    return;
+                }
+
+                // ask editor to refresh lightbulb when workspace solution status is changed
+                this.SuggestedActionsChanged?.Invoke(this, EventArgs.Empty);
+            }
+
+            private void OnSuggestedActionsChanged(Workspace currentWorkspace, DocumentId currentDocumentId, int solutionVersion)
             {
                 // Explicitly hold onto the _subjectBuffer field in a local and use this local in this function to avoid crashes
                 // if this field happens to be cleared by Dispose() below. This is required since this code path involves code
@@ -934,6 +974,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 {
                     return;
                 }
+
                 this.SuggestedActionsChanged?.Invoke(this, EventArgs.Empty);
 
                 Volatile.Write(ref _lastSolutionVersionReported, solutionVersion);
@@ -941,6 +982,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
             public async Task<ISuggestedActionCategorySet> GetSuggestedActionCategoriesAsync(ISuggestedActionCategorySet requestedActionCategories, SnapshotSpan range, CancellationToken cancellationToken)
             {
+                if (_workspaceStatusChangedService != null && !await _workspaceStatusChangedService.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    // never show light bulb if solution is not fully loaded yet
+                    return null;
+                }
+
                 var provider = _owner;
                 using (var asyncToken = _owner.OperationListener.BeginAsyncOperation(nameof(GetSuggestedActionCategoriesAsync)))
                 {
@@ -959,7 +1006,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                         var selection = await GetSpanAsync(range, linkedToken).ConfigureAwait(false);
 
-                        Task<string> refactoringTask = Task.FromResult((string)null);
+                        var refactoringTask = SpecializedTasks.Default<string>();
                         if (selection != null && requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring))
                         {
                             refactoringTask = Task.Run(

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -917,7 +917,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 _workspace.DocumentActiveContextChanged += OnActiveContextChanged;
                 _workspaceStatusService = workspace.Services.GetService<IWorkspaceStatusService>();
-                _workspaceStatusService.StatusChanged += OnWorkspaceStatusChanged;
+                if (_workspaceStatusService != null)
+                {
+                    _workspaceStatusService.StatusChanged += OnWorkspaceStatusChanged;
+                }
             }
 
             private void OnActiveContextChanged(object sender, DocumentActiveContextChangedEventArgs e)

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServices.Experimentation;
 using Microsoft.VisualStudio.Shell;
 using Roslyn.Utilities;
@@ -84,14 +85,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 if (_workspace.Options.GetOption(ExperimentationOptions.SolutionStatusService_ForceDelay))
                 {
-                    // for testing. 
+                    // this is for prototype/mock for people/teams trying partial solution load prototyping
+                    // it shouldn't concern anyone outside of that group. 
+                    //
+                    // "experimentationService.IsExperimentEnabled(WellKnownExperimentNames.PartialLoadMode)" check above
+                    // make sure this part of code "Service : IWorkspaceStatusService" is not exposed anyone outside of
+                    // the partial solution load group.
+                    //
+                    // for ones that is in the group, one can try lightbulb behavior through internal option page
+                    // such as moving around caret on lines where LB should show up.
+                    //
+                    // it works as below
                     // 1. when this is first called, we return false and start timer to change its status in delayInMS
                     // 2. once delayInMs passed, we clear the delay and return true.
                     // 3. if it is called before the timeout, we reset the timer and return false
                     if (_lastTimeCalled == null)
                     {
                         var delay = _workspace.Options.GetOption(ExperimentationOptions.SolutionStatusService_DelayInMS);
-                        _lastTimeCalled = new ResettableDelay(delayInMilliseconds: delay);
+                        _lastTimeCalled = new ResettableDelay(delayInMilliseconds: delay, AsynchronousOperationListenerProvider.NullListener);
                         _ = _lastTimeCalled.Task.SafeContinueWith(_ => StatusChanged?.Invoke(this, true), TaskScheduler.Default);
 
                         return SpecializedTasks.False;

--- a/src/Workspaces/Core/Portable/Workspace/Host/Status/IWorkspaceStatusService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Status/IWorkspaceStatusService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +11,11 @@ namespace Microsoft.CodeAnalysis.Host
     /// </summary>
     internal interface IWorkspaceStatusService : IWorkspaceService
     {
+        /// <summary>
+        /// Indicate that status has changed
+        /// </summary>
+        event EventHandler<bool> StatusChanged;
+
         /// <summary>
         /// Wait until workspace is fully loaded
         /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Host/Status/IWorkspaceStatusService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Status/IWorkspaceStatusService.cs
@@ -8,11 +8,21 @@ namespace Microsoft.CodeAnalysis.Host
 {
     /// <summary>
     /// Provides workspace status
+    /// 
+    /// this is an work in-progress interface, subject to be changed as we work on prototype.
+    /// 
+    /// it can completely removed at the end or new APIs can added and removed as prototype going on
+    /// no one except one in the prototype group should use this interface.
     /// </summary>
     internal interface IWorkspaceStatusService : IWorkspaceService
     {
         /// <summary>
         /// Indicate that status has changed
+        /// 
+        /// event argument, true, means solution is fully loaded.
+        /// 
+        /// but right now, bool doesn't mean much but having it since platform API we decide to start with bool rather than
+        /// more richer information
         /// </summary>
         event EventHandler<bool> StatusChanged;
 

--- a/src/Workspaces/Core/Portable/Workspace/Host/Status/IWorkspaceStatusService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Status/IWorkspaceStatusService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.CodeAnalysis.Host
     /// 
     /// it can completely removed at the end or new APIs can added and removed as prototype going on
     /// no one except one in the prototype group should use this interface.
+    /// 
+    /// tracking issue - https://github.com/dotnet/roslyn/issues/34415
     /// </summary>
     internal interface IWorkspaceStatusService : IWorkspaceService
     {

--- a/src/Workspaces/Core/Portable/Workspace/Host/Status/WorkspaceStatusService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Status/WorkspaceStatusService.cs
@@ -31,15 +31,5 @@ namespace Microsoft.CodeAnalysis.Host
             // by the default, we are always fully loaded
             return SpecializedTasks.True;
         }
-
-        Task IWorkspaceStatusService.WaitUntilFullyLoadedAsync(CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
-        Task<bool> IWorkspaceStatusService.IsFullyLoadedAsync(CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/Status/WorkspaceStatusService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Status/WorkspaceStatusService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +13,15 @@ namespace Microsoft.CodeAnalysis.Host
     internal sealed class WorkspaceStatusService : IWorkspaceStatusService
     {
         public readonly static WorkspaceStatusService Default = new WorkspaceStatusService();
+
+#pragma warning disable 0067
+        public event EventHandler<bool> StatusChanged
+        {
+            // it never used
+            add { }
+            remove { }
+        }
+#pragma warning restore 0067
 
         public Task WaitUntilFullyLoadedAsync(CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Host/Status/WorkspaceStatusService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Status/WorkspaceStatusService.cs
@@ -14,14 +14,11 @@ namespace Microsoft.CodeAnalysis.Host
     {
         public readonly static WorkspaceStatusService Default = new WorkspaceStatusService();
 
-#pragma warning disable 0067
-        public event EventHandler<bool> StatusChanged
+        event EventHandler<bool> IWorkspaceStatusService.StatusChanged
         {
-            // it never used
             add { }
             remove { }
         }
-#pragma warning restore 0067
 
         public Task WaitUntilFullyLoadedAsync(CancellationToken cancellationToken)
         {
@@ -33,6 +30,16 @@ namespace Microsoft.CodeAnalysis.Host
         {
             // by the default, we are always fully loaded
             return SpecializedTasks.True;
+        }
+
+        Task IWorkspaceStatusService.WaitUntilFullyLoadedAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        Task<bool> IWorkspaceStatusService.IsFullyLoadedAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
with the partial mode, the experience will be

1. no LB until the solution is fully loaded.
2. if LB is explicitly invoked through ctrl+., then wait dialog will show up blocking until the solution is fully loaded.
3. LB will show up automatically if there is one once the solution is fully loaded without user action such as moving caret or modifying the buffer.