### PR TITLE
Update async completion and quick info to share BuildClassifiedTextElements

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
@@ -10,7 +11,6 @@ using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.LanguageServices;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -256,7 +256,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             var description = await service.GetDescriptionAsync(document, roslynItem, cancellationToken).ConfigureAwait(false);
 
-            return IntelliSense.Helpers.BuildClassifiedTextElement(description.TaggedParts);
+            var elements = IntelliSense.Helpers.BuildClassifiedTextElements(description.TaggedParts).ToArray();
+            if (elements.Length == 0)
+            {
+                return new ClassifiedTextElement();
+            }
+            else if (elements.Length == 1)
+            {
+                return elements[0];
+            }
+            else
+            {
+                return new ContainerElement(ContainerElementStyle.Stacked | ContainerElementStyle.VerticalPadding, elements);
+            }
         }
 
         private VSCompletionItem Convert(

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Helpers.cs
@@ -2,8 +2,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.VisualStudio.Text.Adornments;
 using Roslyn.Utilities;
 
@@ -11,13 +9,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
 {
     internal static class Helpers
     {
-        internal static ClassifiedTextElement BuildClassifiedTextElement(ImmutableArray<TaggedText> taggedTexts)
-        {
-            return new ClassifiedTextElement(taggedTexts.Select(
-                    part => new ClassifiedTextRun(part.Tag.ToClassificationTypeName(), part.Text)) ?? Enumerable.Empty<ClassifiedTextRun>());
-        }
-
-        internal static IEnumerable<object> BuildClassifiedTextElements(QuickInfoSection section)
+        internal static IEnumerable<object> BuildClassifiedTextElements(ImmutableArray<TaggedText> taggedTexts)
         {
             // This method produces a sequence of zero or more paragraphs
             var paragraphs = new List<object>();
@@ -28,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
             // Each line is constructed from one or more inline elements
             var currentRuns = new List<ClassifiedTextRun>();
 
-            foreach (var part in section.TaggedParts)
+            foreach (var part in taggedTexts)
             {
                 if (part.Tag == TextTags.LineBreak)
                 {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilder.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilder.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Adornments;
-using Roslyn.Utilities;
 
 using CodeAnalysisQuickInfoItem = Microsoft.CodeAnalysis.QuickInfo.QuickInfoItem;
 using IntellisenseQuickInfoItem = Microsoft.VisualStudio.Language.Intellisense.QuickInfoItem;
@@ -47,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             if (descSection != null)
             {
                 var isFirstElement = true;
-                foreach (var element in Helpers.BuildClassifiedTextElements(descSection))
+                foreach (var element in Helpers.BuildClassifiedTextElements(descSection.TaggedParts))
                 {
                     if (isFirstElement)
                     {
@@ -69,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             if (documentationCommentSection != null)
             {
                 var isFirstElement = true;
-                foreach (var element in Helpers.BuildClassifiedTextElements(documentationCommentSection))
+                foreach (var element in Helpers.BuildClassifiedTextElements(documentationCommentSection.TaggedParts))
                 {
                     if (isFirstElement)
                     {
@@ -93,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             // Add the remaining sections as Stacked style
             elements.AddRange(
                 quickInfoItem.Sections.Where(s => s.Kind != QuickInfoSectionKinds.Description && s.Kind != QuickInfoSectionKinds.DocumentationComments)
-                                      .SelectMany(Helpers.BuildClassifiedTextElements));
+                                      .SelectMany(s => Helpers.BuildClassifiedTextElements(s.TaggedParts)));
 
             // build text for RelatedSpan
             if (quickInfoItem.RelatedSpans.Any())


### PR DESCRIPTION
This change fixes a merge of async completion work (originally in **dev16.0-vs-deps**) with Quick Info work (originally in **master**).