### PR TITLE
Only skip test on mono

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -11317,10 +11317,11 @@ class C
 }");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34198")]
+        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/34198")]
         public void DecimalBinaryOp_03()
         {
-            // Test temporarily disabled as it fails CI on Linux in master branch
+            // Test temporarily disabled on Mono as it fails on nightlies due to System.Decimal changes
+            // We'll need to update / disable for CoreCLR 3.0 too as it has the same change
             // Tracked by https://github.com/dotnet/roslyn/issues/34198
 
             string source = @"


### PR DESCRIPTION
Re-enable DecimalBinaryOp_03 test for platforms other than mono
Update comment to to track status