### PR TITLE
Use TestRuntimeAdditionalArguments from Arcade:

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -234,19 +234,19 @@ function BuildSolution {
   local test=false
   local test_runtime=""
   local mono_tool=""
+  local test_runtime_args=""
   if [[ "$test_mono" == true ]]; then
-    
-    mono_path="$scriptroot/invoke-mono.sh"
-    # Echo out the mono version to the comamnd line so it's visible in CI logs. It's not fixed
+    mono_path=`command -v mono`
+    # Echo out the mono version to the command line so it's visible in CI logs. It's not fixed
     # as we're using a feed vs. a hard coded package.
     if [[ "$ci" == true ]]; then
       mono --version
-      chmod +x "$mono_path"
     fi
 
     test=true
     test_runtime="/p:TestRuntime=Mono"
     mono_tool="/p:MonoTool=\"$mono_path\""
+    test_runtime_args="--debug"
   elif [[ "$test_core_clr" == true ]]; then
     test=true
     test_runtime="/p:TestRuntime=Core"
@@ -275,6 +275,7 @@ function BuildSolution {
     /p:QuietRestoreBinaryLog="$binary_log" \
     /p:TreatWarningsAsErrors=true \
     /p:RestoreDisableParallel=$disable_parallel_restore \
+    /p:TestRuntimeAdditionalArguments=$test_runtime_args \
     $test_runtime \
     $mono_tool \
     $properties

--- a/eng/invoke-mono.sh
+++ b/eng/invoke-mono.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-#
-# Copyright (c) .NET Foundation and contributors. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
-
-# invoke mono with debug flags
-mono --debug "$@"


### PR DESCRIPTION
 - Remove invoke mono script
 - Pass through debug flag via supported arcade mechanism instead

Related to https://github.com/dotnet/roslyn/pull/32885 and https://github.com/dotnet/arcade/pull/2054