### PR TITLE
Track nullability across reference and nullable conversions of tuple elements

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -544,6 +544,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 case BoundKind.Conversion:
                     {
+                        int slot = getPlaceholderSlot(node);
+                        if (slot > 0)
+                        {
+                            return slot;
+                        }
                         var conv = (BoundConversion)node;
                         switch (conv.Conversion.Kind)
                         {
@@ -563,18 +568,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         int containingSlot = MakeSlot(operand);
                                         return containingSlot < 0 ? -1 : GetNullableOfTValueSlot(operandType, containingSlot, out _);
                                     }
-                                    else if (AreNullableAndUnderlyingTypes(convertedType, operandType, out _))
-                                    {
-                                        // Explicit conversion of T to Nullable<T> is equivalent to new Nullable<T>(t).
-                                        return getPlaceholderSlot(node);
-                                    }
-                                }
-                                break;
-                            case ConversionKind.ImplicitNullable:
-                                // Implicit conversion of T to Nullable<T> is equivalent to new Nullable<T>(t).
-                                if (AreNullableAndUnderlyingTypes(conv.Type, conv.Operand.Type, out _))
-                                {
-                                    return getPlaceholderSlot(node);
                                 }
                                 break;
                             case ConversionKind.Identity:
@@ -582,17 +575,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                             case ConversionKind.ExplicitReference:
                             case ConversionKind.ImplicitTupleLiteral:
                             case ConversionKind.ExplicitTupleLiteral:
-                            case ConversionKind.ImplicitTuple:
-                            case ConversionKind.ExplicitTuple:
                             case ConversionKind.Boxing:
                             case ConversionKind.Unboxing:
-                                if (isSupportedConversion(conv.Conversion, conv.Operand))
-                                {
-                                    // No need to create a slot for the boxed value (in the Boxing case) since assignment already
-                                    // clones slots and there is not another scenario where creating a slot is observable.
-                                    return MakeSlot(conv.Operand);
-                                }
-                                break;
+                                // No need to create a slot for the boxed value (in the Boxing case) since assignment already
+                                // clones slots and there is not another scenario where creating a slot is observable.
+                                return MakeSlot(conv.Operand);
                         }
                     }
                     break;
@@ -638,58 +625,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     method = container as MethodSymbol;
                 }
                 return null;
-            }
-
-            // Returns true if the nullable state from the operand of the conversion
-            // can be used as is, and we can create a slot from the conversion.
-            static bool isSupportedConversion(Conversion conversion, BoundExpression operandOpt)
-            {
-                // https://github.com/dotnet/roslyn/issues/32599: Allow implicit and explicit
-                // conversions where the nullable state of the operand remains valid.
-                switch (conversion.Kind)
-                {
-                    case ConversionKind.Identity:
-                    case ConversionKind.DefaultOrNullLiteral:
-                    case ConversionKind.ImplicitReference:
-                    case ConversionKind.ExplicitReference:
-                    case ConversionKind.Boxing:
-                    case ConversionKind.Unboxing:
-                        return true;
-                    case ConversionKind.ImplicitTupleLiteral:
-                    case ConversionKind.ExplicitTupleLiteral:
-                        switch (operandOpt?.Kind)
-                        {
-                            case BoundKind.Conversion:
-                                {
-                                    var operandConversion = (BoundConversion)operandOpt;
-                                    return isSupportedConversion(operandConversion.Conversion, operandConversion.Operand);
-                                }
-                            case BoundKind.ConvertedTupleLiteral:
-                                {
-                                    var arguments = ((BoundConvertedTupleLiteral)operandOpt).Arguments;
-                                    var conversions = conversion.UnderlyingConversions;
-                                    for (int i = 0; i < arguments.Length; i++)
-                                    {
-                                        // https://github.com/dotnet/roslyn/issues/32600: Copy nullable
-                                        // state of tuple elements independently.
-                                        if (!isSupportedConversion(conversions[i], (arguments[i] as BoundConversion)?.Operand))
-                                        {
-                                            return false;
-                                        }
-                                    }
-                                    return true;
-                                }
-                            default:
-                                return false;
-                        }
-                    case ConversionKind.ImplicitTuple:
-                    case ConversionKind.ExplicitTuple:
-                        // https://github.com/dotnet/roslyn/issues/32600: Copy nullable
-                        // state of tuple elements independently.
-                        return conversion.UnderlyingConversions.All(c => isSupportedConversion(c, null));
-                    default:
-                        return false;
-                }
             }
         }
 
@@ -885,13 +820,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Update tracked value on assignment.
         /// </summary>
         private void TrackNullableStateForAssignment(
-            BoundExpression value,
+            BoundExpression valueOpt,
             TypeWithAnnotations targetType,
             int targetSlot,
             TypeWithState valueType,
             int valueSlot = -1)
         {
-            Debug.Assert(value != null);
             Debug.Assert(!IsConditionalState);
 
             if (this.State.Reachable)
@@ -919,7 +853,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // https://github.com/dotnet/roslyn/issues/31395: We should copy all tracked state from `value` regardless of
                     // BoundNode type but we'll need to handle cycles (see NullableReferenceTypesTests.Members_FieldCycle_07).
                     // For now, we copy a limited set of BoundNode types that shouldn't contain cycles.
-                    if (((targetType.Type.IsReferenceType || targetType.TypeKind == TypeKind.TypeParameter) && (isSupportedReferenceTypeValue(value) || targetType.Type.IsAnonymousType)) ||
+                    if (((targetType.Type.IsReferenceType || targetType.TypeKind == TypeKind.TypeParameter) && (valueOpt is null || isSupportedReferenceTypeValue(valueOpt) || targetType.Type.IsAnonymousType)) ||
                         targetType.IsNullableType())
                     {
                         // Nullable<T> is handled here rather than in InheritNullableStateOfTrackableStruct since that
@@ -932,7 +866,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else if (EmptyStructTypeCache.IsTrackableStructType(targetType.Type))
                     {
-                        InheritNullableStateOfTrackableStruct(targetType.Type, targetSlot, valueSlot, isDefaultValue: IsDefaultValue(value), skipSlot: targetSlot);
+                        InheritNullableStateOfTrackableStruct(targetType.Type, targetSlot, valueSlot, isDefaultValue: !(valueOpt is null) && IsDefaultValue(valueOpt), skipSlot: targetSlot);
                     }
                 }
             }
@@ -1306,7 +1240,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (node.RefKind == RefKind.None)
                 {
-                    VisitOptionalImplicitConversion(expr, returnType, useLegacyWarnings: false, AssignmentKind.Return);
+                    VisitOptionalImplicitConversion(expr, returnType, useLegacyWarnings: false, trackNullability: false, AssignmentKind.Return);
                 }
                 else
                 {
@@ -1410,7 +1344,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 bool inferredType = node.InferredType;
-                valueType = VisitOptionalImplicitConversion(initializer, targetTypeOpt: inferredType ? default : type, useLegacyWarnings: true, AssignmentKind.Assignment);
+                valueType = VisitOptionalImplicitConversion(initializer, targetTypeOpt: inferredType ? default : type, useLegacyWarnings: true, trackNullability: true, AssignmentKind.Assignment);
                 if (inferredType)
                 {
                     if (valueType.HasNullType)
@@ -1522,7 +1456,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (EmptyStructTypeCache.IsTrackableStructType(type))
                     {
-                        this.State[slot] = NullableFlowState.NotNull;
                         var tupleType = constructor?.ContainingType as TupleTypeSymbol;
                         if ((object)tupleType != null && !isDefaultValueTypeConstructor)
                         {
@@ -1555,6 +1488,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
                     }
+
+                    this.State[slot] = resultState;
                 }
             }
 
@@ -1738,7 +1673,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 for (int i = 0; i < n; i++)
                 {
-                    _ = VisitOptionalImplicitConversion(expressions[i], elementType, useLegacyWarnings: false, AssignmentKind.Assignment);
+                    _ = VisitOptionalImplicitConversion(expressions[i], elementType, useLegacyWarnings: false, trackNullability: false, AssignmentKind.Assignment);
                 }
 
                 ResultType = _invalidType;
@@ -1803,6 +1738,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            conversions.Free();
             resultTypes.Free();
             expressions.Free();
 
@@ -2224,7 +2160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var leftState = this.State.Clone();
             LearnFromNonNullTest(leftOperand, ref leftState);
             LearnFromNullTest(leftOperand, ref this.State);
-            TypeWithState rightResult = VisitOptionalImplicitConversion(rightOperand, targetType, UseLegacyWarnings(leftOperand), AssignmentKind.Assignment);
+            TypeWithState rightResult = VisitOptionalImplicitConversion(rightOperand, targetType, useLegacyWarnings: UseLegacyWarnings(leftOperand), trackNullability: false, AssignmentKind.Assignment);
             TrackNullableStateForAssignment(rightOperand, targetType, leftSlot, rightResult, MakeSlot(rightOperand));
             Join(ref this.State, ref leftState);
             TypeWithState resultType = GetNullCoalescingResultType(rightResult, targetType.Type);
@@ -3671,16 +3607,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 useLegacyWarnings: fromExplicitCast && !RequiresSafetyWarningWhenNullIntroduced(explicitType.Type),
                 AssignmentKind.Assignment,
                 reportTopLevelWarnings: fromExplicitCast,
-                reportRemainingWarnings: true);
-
-            switch (node.ConversionKind)
-            {
-                case ConversionKind.ImplicitNullable:
-                case ConversionKind.ExplicitNullable:
-                    TrackNullableStateIfNullableConversion(node);
-                    break;
-            }
-
+                reportRemainingWarnings: true,
+                trackNullability: true);
             return null;
         }
 
@@ -3690,7 +3618,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// an implicit conversion, even if that conversion was omitted from the bound tree,
         /// so the conversion can be re-classified with nullability.
         /// </summary>
-        private TypeWithState VisitOptionalImplicitConversion(BoundExpression expr, TypeWithAnnotations targetTypeOpt, bool useLegacyWarnings, AssignmentKind assignmentKind)
+        private TypeWithState VisitOptionalImplicitConversion(BoundExpression expr, TypeWithAnnotations targetTypeOpt, bool useLegacyWarnings, bool trackNullability, AssignmentKind assignmentKind)
         {
             if (!targetTypeOpt.HasType)
             {
@@ -3704,7 +3632,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Cannot implicitly convert type '...' to '...'. An explicit conversion exists ...".
             // Since an error was reported, we don't need to report nested warnings as well.
             bool reportNestedWarnings = !conversion.IsExplicit;
-            var resultType = ApplyConversion(
+            return ApplyConversion(
                 expr,
                 operand,
                 conversion,
@@ -3715,15 +3643,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 useLegacyWarnings: useLegacyWarnings,
                 assignmentKind,
                 reportTopLevelWarnings: true,
-                reportRemainingWarnings: reportNestedWarnings);
-
-            var conv = expr as BoundConversion;
-            if (conv != null && conv.ConversionKind == ConversionKind.ImplicitNullable)
-            {
-                TrackNullableStateIfNullableConversion(conv);
-            }
-
-            return resultType;
+                reportRemainingWarnings: reportNestedWarnings,
+                trackNullability: trackNullability);
         }
 
         private static bool AreNullableAndUnderlyingTypes(TypeSymbol nullableTypeOpt, TypeSymbol underlyingTypeOpt, out TypeWithAnnotations underlyingTypeWithAnnotations)
@@ -3835,7 +3756,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void TrackNullableStateIfNullableConversion(BoundConversion node)
+        private void TrackNullableStateOfNullableConversion(BoundConversion node)
         {
             Debug.Assert(node.ConversionKind == ConversionKind.ImplicitNullable || node.ConversionKind == ConversionKind.ExplicitNullable);
 
@@ -3857,6 +3778,75 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int containingSlot = GetOrCreateObjectCreationPlaceholderSlot(node);
                 Debug.Assert(containingSlot > 0);
                 TrackNullableStateOfNullableValue(containingSlot, convertedType, operand, underlyingType.ToTypeWithState(), valueSlot);
+            }
+        }
+
+        private void TrackNullableStateOfTupleConversion(BoundConversion node)
+        {
+            Debug.Assert(node.ConversionKind == ConversionKind.ImplicitTuple || node.ConversionKind == ConversionKind.ExplicitTuple);
+
+            var operand = node.Operand;
+            var valueTuple = operand.Type as TupleTypeSymbol;
+            if (valueTuple is null)
+            {
+                return;
+            }
+
+            int valueSlot = MakeSlot(operand);
+            if (valueSlot < 0)
+            {
+                return;
+            }
+
+            int slot = GetOrCreateObjectCreationPlaceholderSlot(node);
+            if (slot < 0)
+            {
+                return;
+            }
+
+            var conversions = node.Conversion.UnderlyingConversions;
+            var targetElements = ((TupleTypeSymbol)node.Type).TupleElements;
+            var valueElements = valueTuple.TupleElements;
+            int n = valueElements.Length;
+            for (int i = 0; i < n; i++)
+            {
+                trackConvertedValue(targetElements[i], conversions[i], valueElements[i]);
+            }
+
+            void trackConvertedValue(FieldSymbol targetField, Conversion conversion, FieldSymbol valueField)
+            {
+                switch (conversion.Kind)
+                {
+                    case ConversionKind.Identity:
+                    case ConversionKind.DefaultOrNullLiteral:
+                    case ConversionKind.ImplicitReference:
+                    case ConversionKind.ExplicitReference:
+                    case ConversionKind.Boxing:
+                    case ConversionKind.Unboxing:
+                        InheritNullableStateOfMember(slot, valueSlot, valueField, isDefaultValue: false, skipSlot: slot);
+                        break;
+                    case ConversionKind.ImplicitTupleLiteral:
+                    case ConversionKind.ExplicitTupleLiteral:
+                    case ConversionKind.ImplicitTuple:
+                    case ConversionKind.ExplicitTuple:
+                        // https://github.com/dotnet/roslyn/issues/32599: Track state across conversions of nested tuples.
+                        break;
+                    case ConversionKind.ImplicitNullable:
+                    case ConversionKind.ExplicitNullable:
+                        // Conversion of T to Nullable<T> is equivalent to new Nullable<T>(t).
+                        if (AreNullableAndUnderlyingTypes(targetField.Type, valueField.Type, out _))
+                        {
+                            int targetFieldSlot = GetOrCreateSlot(targetField, slot);
+                            int valueFieldSlot = GetOrCreateSlot(valueField, valueSlot);
+                            Debug.Assert(targetFieldSlot > 0);
+                            Debug.Assert(valueFieldSlot > 0);
+                            this.State[targetFieldSlot] = NullableFlowState.NotNull;
+                            TrackNullableStateOfNullableValue(targetFieldSlot, targetField.Type, null, valueField.TypeWithAnnotations.ToTypeWithState(), valueFieldSlot);
+                        }
+                        break;
+                    default:
+                        break;
+                }
             }
         }
 
@@ -3979,8 +3969,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool reportTopLevelWarnings = true,
             bool reportRemainingWarnings = true,
             bool extensionMethodThisArgument = false,
+            bool trackNullability = false,
             Optional<LocalState> stateForLambda = default)
         {
+            Debug.Assert(!trackNullability || !IsConditionalState);
             Debug.Assert(node != null);
             Debug.Assert(operandOpt != null || !operandType.HasNullType);
             Debug.Assert(targetTypeWithNullability.HasType);
@@ -4164,6 +4156,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case ConversionKind.ImplicitNullable:
+                    if (trackNullability && node.Kind == BoundKind.Conversion)
+                    {
+                        // https://github.com/dotnet/roslyn/issues/34302: Should visit each BoundConversion so node matches conversion.
+                        var conv = (BoundConversion)node;
+                        switch (conv.ConversionKind)
+                        {
+                            case ConversionKind.ImplicitNullable:
+                            case ConversionKind.ExplicitNullable:
+                                TrackNullableStateOfNullableConversion(conv);
+                                break;
+                        }
+                    }
+
                     if (checkConversion)
                     {
                         conversion = GenerateConversion(_conversions, operandOpt, operandType.Type, targetType, fromExplicitCast, extensionMethodThisArgument);
@@ -4195,10 +4200,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     goto case ConversionKind.ImplicitNullable;
 
-                case ConversionKind.ImplicitTupleLiteral:
                 case ConversionKind.ImplicitTuple:
+                case ConversionKind.ImplicitTupleLiteral:
                 case ConversionKind.ExplicitTupleLiteral:
                 case ConversionKind.ExplicitTuple:
+                    if (trackNullability && node.Kind == BoundKind.Conversion)
+                    {
+                        // https://github.com/dotnet/roslyn/issues/34302: Should visit each BoundConversion so node matches conversion.
+                        var conv = (BoundConversion)node;
+                        switch (conv.ConversionKind)
+                        {
+                            case ConversionKind.ImplicitTuple:
+                            case ConversionKind.ExplicitTuple:
+                                TrackNullableStateOfTupleConversion(conv);
+                                break;
+                        }
+                    }
+
                     if (checkConversion)
                     {
                         // https://github.com/dotnet/roslyn/issues/29699: Report warnings for user-defined conversions on tuple elements.
@@ -4432,7 +4450,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TypeWithState rightType;
                 if (!node.IsRef)
                 {
-                    rightType = VisitOptionalImplicitConversion(right, leftLValueType, UseLegacyWarnings(left), AssignmentKind.Assignment);
+                    rightType = VisitOptionalImplicitConversion(right, leftLValueType, UseLegacyWarnings(left), trackNullability: true, AssignmentKind.Assignment);
                 }
                 else
                 {
@@ -4562,7 +4580,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (underlyingConversion.IsIdentity)
                         {
                             operandType = default;
-                            valueType = VisitOptionalImplicitConversion(rightPart, targetType, useLegacyWarnings: true, AssignmentKind.Assignment);
+                            valueType = VisitOptionalImplicitConversion(rightPart, targetType, useLegacyWarnings: true, trackNullability: true, AssignmentKind.Assignment);
                             valueSlot = MakeSlot(rightPart);
                         }
                         else
@@ -4579,7 +4597,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 useLegacyWarnings: true,
                                 AssignmentKind.Assignment,
                                 reportTopLevelWarnings: true,
-                                reportRemainingWarnings: true);
+                                reportRemainingWarnings: true,
+                                trackNullability: false);
                             valueSlot = -1;
                         }
 
@@ -5777,7 +5796,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeWithAnnotations elementType = InMethodBinder.GetIteratorElementTypeFromReturnType(compilation, RefKind.None,
                 method.ReturnType, errorLocationNode: null, diagnostics: null).elementType;
 
-            _ = VisitOptionalImplicitConversion(expr, elementType, useLegacyWarnings: false, AssignmentKind.Return);
+            _ = VisitOptionalImplicitConversion(expr, elementType, useLegacyWarnings: false, trackNullability: false, AssignmentKind.Return);
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3608,7 +3608,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 AssignmentKind.Assignment,
                 reportTopLevelWarnings: fromExplicitCast,
                 reportRemainingWarnings: true,
-                trackNullability: true);
+                trackMembers: true);
             return null;
         }
 
@@ -3644,7 +3644,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 assignmentKind,
                 reportTopLevelWarnings: true,
                 reportRemainingWarnings: reportNestedWarnings,
-                trackNullability: trackNullability);
+                trackMembers: trackNullability);
         }
 
         private static bool AreNullableAndUnderlyingTypes(TypeSymbol nullableTypeOpt, TypeSymbol underlyingTypeOpt, out TypeWithAnnotations underlyingTypeWithAnnotations)
@@ -3952,8 +3952,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// If `checkConversion` is set, the incoming conversion is assumed to be from binding and will be
         /// re-calculated, this time considering nullability. (Note that the conversion calculation considers
         /// nested nullability only. The caller is responsible for checking the top-level nullability of
-        /// the type returned by this method.) `canConvertNestedNullability` is set if the conversion
-        /// considering nested nullability succeeded. `node` is used only for the location of diagnostics.
+        /// the type returned by this method.) `trackMembers` should be set if the nullability of any
+        /// members of the operand should be copied to the converted result when possible.
         /// </summary>
         private TypeWithState ApplyConversion(
             BoundExpression node,
@@ -3969,10 +3969,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool reportTopLevelWarnings = true,
             bool reportRemainingWarnings = true,
             bool extensionMethodThisArgument = false,
-            bool trackNullability = false,
-            Optional<LocalState> stateForLambda = default)
+            Optional<LocalState> stateForLambda = default,
+            bool trackMembers = false)
         {
-            Debug.Assert(!trackNullability || !IsConditionalState);
+            Debug.Assert(!trackMembers || !IsConditionalState);
             Debug.Assert(node != null);
             Debug.Assert(operandOpt != null || !operandType.HasNullType);
             Debug.Assert(targetTypeWithNullability.HasType);
@@ -4156,7 +4156,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case ConversionKind.ImplicitNullable:
-                    if (trackNullability && node.Kind == BoundKind.Conversion)
+                    if (trackMembers && node.Kind == BoundKind.Conversion)
                     {
                         // https://github.com/dotnet/roslyn/issues/34302: Should visit each BoundConversion so node matches conversion.
                         var conv = (BoundConversion)node;
@@ -4204,7 +4204,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ImplicitTupleLiteral:
                 case ConversionKind.ExplicitTupleLiteral:
                 case ConversionKind.ExplicitTuple:
-                    if (trackNullability && node.Kind == BoundKind.Conversion)
+                    if (trackMembers && node.Kind == BoundKind.Conversion)
                     {
                         // https://github.com/dotnet/roslyn/issues/34302: Should visit each BoundConversion so node matches conversion.
                         var conv = (BoundConversion)node;
@@ -4598,7 +4598,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 AssignmentKind.Assignment,
                                 reportTopLevelWarnings: true,
                                 reportRemainingWarnings: true,
-                                trackNullability: false);
+                                trackMembers: false);
                             valueSlot = -1;
                         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -54061,6 +54061,34 @@ class Program
         }
 
         [Fact]
+        [WorkItem(32599, "https://github.com/dotnet/roslyn/issues/32599")]
+        [WorkItem(32600, "https://github.com/dotnet/roslyn/issues/32600")]
+        public void Conversions_TupleConversions_14()
+        {
+            var source =
+@"class A
+{
+    public static implicit operator A?(int i) => new A();
+}
+class B
+{
+    public static implicit operator B(int i) => new B();
+}
+class Program
+{
+    static void F((int, int) t)
+    {
+        (A, B?) u = t; // 1
+        u.Item1.ToString(); // 2
+        u.Item2.ToString();
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            // https://github.com/dotnet/roslyn/issues/32599: Track state across tuple element conversions.
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void Conversions_BoxingConversions_01()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -47200,37 +47200,16 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/32599: Support implicit tuple conversions
-            // (should report warnings for dereferences of F in // 1, 2, 3 only).
             comp.VerifyDiagnostics(
                 // (14,9): warning CS8602: Possible dereference of a null reference.
                 //         t.Item1.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1.F").WithLocation(14, 9),
-                // (16,9): warning CS8629: Nullable value type may be null.
-                //         u.x.Value.F.ToString(); // 2
-                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "u.x").WithLocation(16, 9),
                 // (16,9): warning CS8602: Possible dereference of a null reference.
                 //         u.x.Value.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.x.Value.F").WithLocation(16, 9),
-                // (17,9): warning CS8629: Nullable value type may be null.
-                //         u.y.Value.F.ToString();
-                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "u.y").WithLocation(17, 9),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
-                //         u.y.Value.F.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.y.Value.F").WithLocation(17, 9),
-                // (18,9): warning CS8629: Nullable value type may be null.
-                //         v.Item1.Value.F.ToString(); // 3
-                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "v.Item1").WithLocation(18, 9),
                 // (18,9): warning CS8602: Possible dereference of a null reference.
                 //         v.Item1.Value.F.ToString(); // 3
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v.Item1.Value.F").WithLocation(18, 9),
-                // (19,9): warning CS8629: Nullable value type may be null.
-                //         v.Item2.Value.F.ToString();
-                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "v.Item2").WithLocation(19, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
-                //         v.Item2.Value.F.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v.Item2.Value.F").WithLocation(19, 9)
-                );
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v.Item1.Value.F").WithLocation(18, 9));
         }
 
         [Fact]
@@ -51888,7 +51867,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-               // (3,16): warning CS8618: Non-nullable field 'F' is uninitialized.
+                // (3,16): warning CS8618: Non-nullable field 'F' is uninitialized.
                 //     internal T F;
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "F").WithArguments("field", "F").WithLocation(3, 16),
                 // (21,27): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -53726,21 +53705,15 @@ class Program
                 // (11,10): warning CS8619: Nullability of reference types in value of type '(S?, object?)' doesn't match target type '(S, S)'.
                 //         (((S, S))t).Item1.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "((S, S))t").WithArguments("(S?, object?)", "(S, S)").WithLocation(11, 10),
+                // (12,9): warning CS8602: Possible dereference of a null reference.
+                //         (((S, S))t).Item2.G.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(((S, S))t).Item2.G").WithLocation(12, 9),
                 // (12,10): warning CS8619: Nullability of reference types in value of type '(S?, object?)' doesn't match target type '(S, S)'.
                 //         (((S, S))t).Item2.G.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "((S, S))t").WithArguments("(S?, object?)", "(S, S)").WithLocation(12, 10),
                 // (13,61): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (S?, object?) u = (new S() { F = 2 }, new S() { G = null }); // 3
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 61),
-                // (14,9): warning CS8629: Nullable value type may be null.
-                //         u.Item1.Value.F.ToString();
-                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "u.Item1").WithLocation(14, 9),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
-                //         u.Item1.Value.F.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1.Value.F").WithLocation(14, 9),
-                // (15,10): warning CS8629: Nullable value type may be null.
-                //         ((S?)u.Item2).Value.G.ToString(); // 4
-                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "(S?)u.Item2").WithLocation(15, 10));
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 61));
         }
 
         [Fact]
@@ -53798,11 +53771,293 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/32599: Support implicit tuple conversions: see // 2.
             comp.VerifyDiagnostics(
                 // (12,20): warning CS8619: Nullability of reference types in value of type '(B? a, B b)' doesn't match target type '(B, B)'.
                 //         (B, B) t = (a, b); // 1
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(a, b)").WithArguments("(B? a, B b)", "(B, B)").WithLocation(12, 20));
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(a, b)").WithArguments("(B? a, B b)", "(B, B)").WithLocation(12, 20),
+                // (13,9): warning CS8602: Possible dereference of a null reference.
+                //         t.Item1.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1").WithLocation(13, 9));
+        }
+
+        [Fact]
+        [WorkItem(32599, "https://github.com/dotnet/roslyn/issues/32599")]
+        public void Conversions_TupleConversions_08()
+        {
+            var source =
+@"class A
+{
+    public static implicit operator B?(A a) => null;
+}
+class B
+{
+}
+class Program
+{
+    static void F(A a, B b)
+    {
+        var t = ((B, B))(b, a); // 1, 2
+        t.Item1.ToString();
+        t.Item2.ToString(); // 3
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (12,17): warning CS8619: Nullability of reference types in value of type '(B b, B? a)' doesn't match target type '(B, B)'.
+                //         var t = ((B, B))(b, a); // 1, 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "((B, B))(b, a)").WithArguments("(B b, B? a)", "(B, B)").WithLocation(12, 17),
+                // (12,29): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         var t = ((B, B))(b, a); // 1, 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "a").WithLocation(12, 29),
+                // (14,9): warning CS8602: Possible dereference of a null reference.
+                //         t.Item2.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2").WithLocation(14, 9));
+        }
+
+        [Fact]
+        [WorkItem(32599, "https://github.com/dotnet/roslyn/issues/32599")]
+        [WorkItem(32600, "https://github.com/dotnet/roslyn/issues/32600")]
+        public void Conversions_TupleConversions_09()
+        {
+            var source =
+@"class A
+{
+    public static implicit operator B?(A a) => null;
+}
+class B
+{
+}
+struct S
+{
+    internal object? F;
+}
+class Program
+{
+    static void F1()
+    {
+        (B, S) t1 = (new A(), new S() { F = 1 }); // 1
+        t1.Item1.ToString(); // 2
+        t1.Item2.F.ToString();
+    }
+    static void F2()
+    {
+        (A, S?) t2 = (new A(), new S() { F = 2 });
+        t2.Item1.ToString();
+        t2.Item2.Value.F.ToString();
+    }
+    static void F3()
+    {
+        (B, S?) t3 = (new A(), new S() { F = 3 }); // 3
+        t3.Item1.ToString(); // 4
+        t3.Item2.Value.F.ToString();
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (16,21): warning CS8619: Nullability of reference types in value of type '(B?, S)' doesn't match target type '(B, S)'.
+                //         (B, S) t1 = (new A(), new S() { F = 1 }); // 1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(new A(), new S() { F = 1 })").WithArguments("(B?, S)", "(B, S)").WithLocation(16, 21),
+                // (17,9): warning CS8602: Possible dereference of a null reference.
+                //         t1.Item1.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1.Item1").WithLocation(17, 9),
+                // (28,22): warning CS8619: Nullability of reference types in value of type '(B?, S?)' doesn't match target type '(B, S?)'.
+                //         (B, S?) t3 = (new A(), new S() { F = 3 }); // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(new A(), new S() { F = 3 })").WithArguments("(B?, S?)", "(B, S?)").WithLocation(28, 22),
+                // (29,9): warning CS8602: Possible dereference of a null reference.
+                //         t3.Item1.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t3.Item1").WithLocation(29, 9));
+        }
+
+        [Fact]
+        [WorkItem(32599, "https://github.com/dotnet/roslyn/issues/32599")]
+        [WorkItem(32600, "https://github.com/dotnet/roslyn/issues/32600")]
+        public void Conversions_TupleConversions_10()
+        {
+            var source =
+@"class A
+{
+    public static implicit operator B?(A a) => null;
+}
+class B
+{
+}
+struct S
+{
+    internal object? F;
+}
+class Program
+{
+    static void F1()
+    {
+        var t1 = ((S, B))(new S() { F = 1 }, new A()); // 1, 2
+        t1.Item1.F.ToString();
+        t1.Item2.ToString(); // 3
+    }
+    static void F2()
+    {
+        var t2 = ((S?, A))(new S() { F = 2 }, new A());
+        t2.Item1.Value.F.ToString();
+        t2.Item2.ToString();
+    }
+    static void F3()
+    {
+        var t3 = ((S?, B))(new S() { F = 3 }, new A()); // 4, 5
+        t3.Item1.Value.F.ToString();
+        t3.Item2.ToString(); // 6
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (16,18): warning CS8619: Nullability of reference types in value of type '(S, B?)' doesn't match target type '(S, B)'.
+                //         var t1 = ((S, B))(new S() { F = 1 }, new A()); // 1, 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "((S, B))(new S() { F = 1 }, new A())").WithArguments("(S, B?)", "(S, B)").WithLocation(16, 18),
+                // (16,46): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         var t1 = ((S, B))(new S() { F = 1 }, new A()); // 1, 2
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "new A()").WithLocation(16, 46),
+                // (18,9): warning CS8602: Possible dereference of a null reference.
+                //         t1.Item2.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1.Item2").WithLocation(18, 9),
+                // (28,18): warning CS8619: Nullability of reference types in value of type '(S?, B?)' doesn't match target type '(S?, B)'.
+                //         var t3 = ((S?, B))(new S() { F = 3 }, new A()); // 4, 5
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "((S?, B))(new S() { F = 3 }, new A())").WithArguments("(S?, B?)", "(S?, B)").WithLocation(28, 18),
+                // (28,47): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         var t3 = ((S?, B))(new S() { F = 3 }, new A()); // 4, 5
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "new A()").WithLocation(28, 47),
+                // (30,9): warning CS8602: Possible dereference of a null reference.
+                //         t3.Item2.ToString(); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t3.Item2").WithLocation(30, 9));
+        }
+
+        [Fact]
+        [WorkItem(32599, "https://github.com/dotnet/roslyn/issues/32599")]
+        [WorkItem(32600, "https://github.com/dotnet/roslyn/issues/32600")]
+        public void Conversions_TupleConversions_11()
+        {
+            var source =
+@"class A
+{
+    public static implicit operator B?(A a) => null;
+}
+class B
+{
+}
+struct S
+{
+    internal object? F;
+}
+class Program
+{
+    static void F1()
+    {
+        (A, S) t1 = (new A(), new S() { F = 1 });
+        (B, S?) u1 = t1; // 1
+        u1.Item1.ToString(); // 2
+        u1.Item2.Value.F.ToString();
+    }
+    static void F2()
+    {
+        (A, S) t2 = (new A(), new S() { F = 2 });
+        var u2 = ((B, S?))t2; // 3, 4
+        u2.Item1.ToString(); // 5
+        u2.Item2.Value.F.ToString();
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            // https://github.com/dotnet/roslyn/issues/32599: Track state across tuple element conversions.
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(32599, "https://github.com/dotnet/roslyn/issues/32599")]
+        [WorkItem(32600, "https://github.com/dotnet/roslyn/issues/32600")]
+        public void Conversions_TupleConversions_12()
+        {
+            var source =
+@"#pragma warning disable 0649
+class A
+{
+    public static implicit operator B?(A a) => null;
+}
+class B
+{
+}
+struct S
+{
+    internal object? F;
+}
+class Program
+{
+    static void F1()
+    {
+        (int, (A, S)) t1 = (1, (new A(), new S() { F = 1 }));
+        (object x, (B, S?) y) u1 = t1; // 1
+        u1.y.Item1.ToString(); // 2
+        u1.y.Item2.Value.F.ToString();
+    }
+    static void F2()
+    {
+        (int, (A, S)) t2 = (2, (new A(), new S() { F = 2 }));
+        var u2 = ((object x, (B, S?) y))t2; // 3
+        u2.y.Item1.ToString(); // 4
+        u2.y.Item2.Value.F.ToString();
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            // https://github.com/dotnet/roslyn/issues/32599: Track state across tuple element conversions.
+            comp.VerifyDiagnostics(
+                // (20,9): warning CS8602: Possible dereference of a null reference.
+                //         u1.y.Item2.Value.F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u1.y.Item2.Value.F").WithLocation(20, 9),
+                // (27,9): warning CS8602: Possible dereference of a null reference.
+                //         u2.y.Item2.Value.F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u2.y.Item2.Value.F").WithLocation(27, 9));
+        }
+
+        [Fact]
+        [WorkItem(32599, "https://github.com/dotnet/roslyn/issues/32599")]
+        [WorkItem(32600, "https://github.com/dotnet/roslyn/issues/32600")]
+        public void Conversions_TupleConversions_13()
+        {
+            var source =
+@"class A
+{
+    public static implicit operator B(A a) => throw null!;
+}
+class B
+{
+}
+struct S
+{
+    internal object? F;
+    internal object G;
+}
+class Program
+{
+    static void F()
+    {
+        A x = new A();
+        S y = new S() { F = 1, G = null }; // 1
+        var t = (x, y, x, y, x, y, x, y, x, y);
+        (B?, S?, B?, S?, B?, S?, B?, S?, B?, S?) u = t;
+        u.Item1.ToString();
+        u.Item2.Value.F.ToString();
+        u.Item2.Value.G.ToString(); // 2
+        u.Item9.ToString();
+        u.Item10.Value.F.ToString();
+        u.Item10.Value.G.ToString(); // 3
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (18,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         S y = new S() { F = 1, G = null }; // 1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(18, 36),
+                // (23,9): warning CS8602: Possible dereference of a null reference.
+                //         u.Item2.Value.G.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item2.Value.G").WithLocation(23, 9),
+                // (26,9): warning CS8602: Possible dereference of a null reference.
+                //         u.Item10.Value.G.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item10.Value.G").WithLocation(26, 9));
         }
 
         [Fact]
@@ -54094,7 +54349,6 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/34086: Track state across Nullable<T> conversions with nested conversions.
             comp.VerifyDiagnostics(
                 // (10,30): warning CS8619: Nullability of reference types in value of type '(T?, T?)' doesn't match target type '(object, object)'.
                 //         (object, object) t = ((T?, T?))(new T() { P = 1 }, new T() { Q = null }); // 1
@@ -54102,9 +54356,9 @@ class Program
                 // (10,74): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (object, object) t = ((T?, T?))(new T() { P = 1 }, new T() { Q = null }); // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 74),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
-                //         ((T?)t.Item1).Value.P.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((T?)t.Item1).Value.P").WithLocation(11, 9));
+                // (12,9): warning CS8602: Possible dereference of a null reference.
+                //         (((T?, T?))t).Item2.Value.Q.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(((T?, T?))t).Item2.Value.Q").WithLocation(12, 9));
         }
 
         [Fact]
@@ -84755,11 +85009,7 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/33011: Should warn for `b` only.
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
-                //         a.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(7, 9),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         b.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b").WithLocation(8, 9));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -54004,13 +54004,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/32599: Track state across tuple element conversions.
-            comp.VerifyDiagnostics(
-                // (20,9): warning CS8602: Possible dereference of a null reference.
-                //         u1.y.Item2.Value.F.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u1.y.Item2.Value.F").WithLocation(20, 9),
-                // (27,9): warning CS8602: Possible dereference of a null reference.
-                //         u2.y.Item2.Value.F.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u2.y.Item2.Value.F").WithLocation(27, 9));
+            comp.VerifyDiagnostics();
         }
 
         [Fact]


### PR DESCRIPTION
Moves tracking of nullability across conversions into `ApplyConversion` and adds support for reference and nullable conversions of tuple elements.

There are a couple of cases that will be handled next (nested tuple conversions, and conversion groups where the top-most conversion is not the interesting conversion), but those are likely to involve more significant changes.