### PR TITLE
Adjust completion for explicit interface implementations

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task ExplicitInterfaceMember()
+        public async Task ExplicitInterfaceMember_01()
         {
             var markup = @"
 interface IGoo
@@ -33,6 +33,69 @@ interface IGoo
 }
 
 class Bar : IGoo
+{
+     void IGoo.$$
+}";
+
+            await VerifyItemExistsAsync(markup, "Goo()");
+            await VerifyItemExistsAsync(markup, "Goo(int x)");
+            await VerifyItemExistsAsync(markup, "Prop");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task ExplicitInterfaceMember_02()
+        {
+            var markup = @"
+interface IGoo
+{
+    void Goo();
+    void Goo(int x);
+    int Prop { get; }
+}
+
+interface IBar : IGoo
+{
+     void IGoo.$$
+}";
+
+            await VerifyItemExistsAsync(markup, "Goo()");
+            await VerifyItemExistsAsync(markup, "Goo(int x)");
+            await VerifyItemExistsAsync(markup, "Prop");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task ExplicitInterfaceMember_03()
+        {
+            var markup = @"
+interface IGoo
+{
+    virtual void Goo() {}
+    virtual void Goo(int x) {}
+    virtual int Prop { get => 0; }
+}
+
+class Bar : IGoo
+{
+     void IGoo.$$
+}";
+
+            await VerifyItemExistsAsync(markup, "Goo()");
+            await VerifyItemExistsAsync(markup, "Goo(int x)");
+            await VerifyItemExistsAsync(markup, "Prop");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task ExplicitInterfaceMember_04()
+        {
+            var markup = @"
+interface IGoo
+{
+    virtual void Goo() {}
+    virtual void Goo(int x) {}
+    virtual int Prop { get => 0; }
+}
+
+interface IBar : IGoo
 {
      void IGoo.$$
 }";
@@ -156,6 +219,190 @@ class Bar : I1
             await VerifyItemExistsAsync(markup, "Foo()");
             await VerifyItemExistsAsync(markup, "Prop");
             await VerifyItemExistsAsync(markup, "TestEvent");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotStaticMember_01()
+        {
+            var markup = @"
+interface IGoo
+{
+    static void Goo() {}
+    static int Prop { get => 0; }
+}
+
+class Bar : IGoo
+{
+     void IGoo.$$
+}";
+
+            await VerifyItemIsAbsentAsync(markup, "Goo()");
+            await VerifyItemIsAbsentAsync(markup, "Prop");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotStaticMember_02()
+        {
+            var markup = @"
+interface IGoo
+{
+    static void Goo() {}
+    static int Prop { get => 0; }
+}
+
+interface IBar : IGoo
+{
+     void IGoo.$$
+}";
+
+            await VerifyItemIsAbsentAsync(markup, "Goo()");
+            await VerifyItemIsAbsentAsync(markup, "Prop");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotSealedMember_01()
+        {
+            var markup = @"
+interface IGoo
+{
+    sealed void Goo() {}
+    sealed int Prop { get => 0; }
+}
+
+class Bar : IGoo
+{
+     void IGoo.$$
+}";
+
+            await VerifyItemIsAbsentAsync(markup, "Goo()");
+            await VerifyItemIsAbsentAsync(markup, "Prop");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotSealedMember_02()
+        {
+            var markup = @"
+interface IGoo
+{
+    sealed void Goo() {}
+    sealed int Prop { get => 0; }
+}
+
+interface IBar : IGoo
+{
+     void IGoo.$$
+}";
+
+            await VerifyItemIsAbsentAsync(markup, "Goo()");
+            await VerifyItemIsAbsentAsync(markup, "Prop");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotNestedType_01()
+        {
+            var markup = @"
+interface IGoo
+{
+    public abstract class Goo
+    {
+    }
+}
+
+class Bar : IGoo
+{
+     void IGoo.$$
+}";
+
+            await VerifyItemIsAbsentAsync(markup, "Goo");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotNestedType_02()
+        {
+            var markup = @"
+interface IGoo
+{
+    public abstract class Goo
+    {
+    }
+}
+
+interface IBar : IGoo
+{
+     void IGoo.$$
+}";
+
+            await VerifyItemIsAbsentAsync(markup, "Goo");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotInaccessibleMember_01()
+        {
+            var markup =
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <ProjectReference>Assembly2</ProjectReference>
+        <Document FilePath=""Test1.cs"">
+<![CDATA[
+class Bar : IGoo
+{
+     void IGoo.$$
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"" LanguageVersion=""Preview"">
+        <Document FilePath=""Test2.cs"">
+interface IGoo
+{
+    internal void Goo1() {}
+    internal int Prop1 { get => 0; }
+    protected void Goo2() {}
+    protected int Prop2 { get => 0; }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await VerifyItemExistsAsync(markup, "Goo1()"); // PROTOTYPE(DefaultInterfaceImplementation): Should use VerifyItemIsAbsentAsync instead after test infrastructure is changed to actually build two distinct projects from the XML 
+            await VerifyItemExistsAsync(markup, "Prop1"); // PROTOTYPE(DefaultInterfaceImplementation): Should use VerifyItemIsAbsentAsync instead after test infrastructure is changed to actually build two distinct projects from the XML 
+            await VerifyItemExistsAsync(markup, "Goo2()");
+            await VerifyItemExistsAsync(markup, "Prop2");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotInaccessibleMember_02()
+        {
+            var markup =
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <ProjectReference>Assembly2</ProjectReference>
+        <Document FilePath=""Test1.cs"">
+<![CDATA[
+interface IBar : IGoo
+{
+     void IGoo.$$
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"" LanguageVersion=""Preview"">
+        <Document FilePath=""Test2.cs"">
+interface IGoo
+{
+    internal void Goo1() {}
+    internal int Prop1 { get => 0; }
+    protected void Goo2() {}
+    protected int Prop2 { get => 0; }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await VerifyItemExistsAsync(markup, "Goo1()"); // PROTOTYPE(DefaultInterfaceImplementation): Should use VerifyItemIsAbsentAsync instead after test infrastructure is changed to actually build two distinct projects from the XML 
+            await VerifyItemExistsAsync(markup, "Prop1"); // PROTOTYPE(DefaultInterfaceImplementation): Should use VerifyItemIsAbsentAsync instead after test infrastructure is changed to actually build two distinct projects from the XML 
+            await VerifyItemExistsAsync(markup, "Goo2()");
+            await VerifyItemExistsAsync(markup, "Prop2");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProviderTests.cs
@@ -88,12 +88,31 @@ class C : IList
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task TestAfterMethod()
+        public async Task TestAfterMethod_01()
         {
             var markup = @"
 using System.Collections;
 
 class C : IList
+{
+    void Goo() { }
+    int $$
+}
+";
+
+            await VerifyAnyItemExistsAsync(markup, hasSuggestionModeItem: true);
+            await VerifyItemExistsAsync(markup, "IEnumerable");
+            await VerifyItemExistsAsync(markup, "ICollection");
+            await VerifyItemExistsAsync(markup, "IList");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestAfterMethod_02()
+        {
+            var markup = @"
+using System.Collections;
+
+interface C : IList
 {
     void Goo() { }
     int $$
@@ -244,7 +263,7 @@ class C : IList
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task NotInInterface()
+        public async Task TestInInterface()
         {
             var markup = @"
 using System.Collections;
@@ -255,7 +274,10 @@ interface I : IList
 }
 ";
 
-            await VerifyNoItemsExistAsync(markup);
+            await VerifyAnyItemExistsAsync(markup, hasSuggestionModeItem: true);
+            await VerifyItemExistsAsync(markup, "IEnumerable");
+            await VerifyItemExistsAsync(markup, "ICollection");
+            await VerifyItemExistsAsync(markup, "IList");
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProvider.cs
@@ -93,7 +93,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 foreach (var member in members)
                 {
-                    if (member.IsAccessor())
+                    if (member.IsAccessor() || member.Kind == SymbolKind.NamedType || !(member.IsAbstract || member.IsVirtual) ||
+                        !semanticModel.IsAccessible(node.SpanStart, member))
                     {
                         continue;
                     }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProvider.cs
@@ -101,8 +101,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return SpecializedTasks.EmptyImmutableArray<ISymbol>();
             }
 
-            // Looks syntactically good.  See what interfaces our containing class/struct has
-            Debug.Assert(IsClassOrStruct(typeDeclaration));
+            // Looks syntactically good.  See what interfaces our containing class/struct/interface has
+            Debug.Assert(IsClassOrStructOrInterface(typeDeclaration));
 
             var semanticModel = context.SemanticModel;
             var namedType = semanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken);
@@ -121,23 +121,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         {
             if (tokenBeforeType.Kind() == SyntaxKind.OpenBraceToken)
             {
-                // Show us after the open brace for a class/struct
-                return IsClassOrStruct(tokenBeforeType.Parent);
+                // Show us after the open brace for a class/struct/interface
+                return IsClassOrStructOrInterface(tokenBeforeType.Parent);
             }
 
             if (tokenBeforeType.Kind() == SyntaxKind.CloseBraceToken ||
                 tokenBeforeType.Kind() == SyntaxKind.SemicolonToken)
             {
-                // Check that we're after a class/struct member.
+                // Check that we're after a class/struct/interface member.
                 var memberDeclaration = tokenBeforeType.GetAncestor<MemberDeclarationSyntax>();
                 return memberDeclaration?.GetLastToken() == tokenBeforeType &&
-                       IsClassOrStruct(memberDeclaration.Parent);
+                       IsClassOrStructOrInterface(memberDeclaration.Parent);
             }
 
             return false;
         }
 
-        private static bool IsClassOrStruct(SyntaxNode node)
-            => node.Kind() == SyntaxKind.ClassDeclaration || node.Kind() == SyntaxKind.StructDeclaration;
+        private static bool IsClassOrStructOrInterface(SyntaxNode node)
+            => node.Kind() == SyntaxKind.ClassDeclaration || node.Kind() == SyntaxKind.StructDeclaration || node.Kind() == SyntaxKind.InterfaceDeclaration;
     }
 }


### PR DESCRIPTION
- Enable type recommendation within interfaces.
- Do not recommend non-implementable members.