### PR TITLE
Check reachability when looking at uninitialized non-null fields

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var thisParameter = MethodThisParameter;
             int thisSlot = VariableSlot(thisParameter);
-            if (thisSlot == -1)
+            if (thisSlot == -1 || !State.Reachable)
             {
                 return;
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -85,41 +85,6 @@ namespace System
     }
 }";
 
-        [Fact]
-        [WorkItem(25529, "https://github.com/dotnet/roslyn/issues/25529")]
-        public void UnassignedNonNullFieldsUnreachable()
-        {
-            var comp = CreateCompilation(@"
-using System;
-class C
-{
-    private object _f;
-    internal C()
-    {
-        throw new NotImplementedException();
-    }
-
-    internal C(object o) { }
-
-    internal C(string s)
-    {
-        return;
-        throw new NotImplementedException();
-    }
-}
-", options: WithNonNullTypesTrue());
-            comp.VerifyDiagnostics(
-                // (5,20): warning CS0169: The field 'C._f' is never used
-                //     private object _f;
-                Diagnostic(ErrorCode.WRN_UnreferencedField, "_f").WithArguments("C._f").WithLocation(5, 20),
-                // (11,14): warning CS8618: Non-nullable field '_f' is uninitialized.
-                //     internal C(object o) { }
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "_f").WithLocation(11, 14),
-                // (13,14): warning CS8618: Non-nullable field '_f' is uninitialized.
-                //     internal C(string s)
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "_f").WithLocation(13, 14));
-        }
-
         [Fact, WorkItem(32495, "https://github.com/dotnet/roslyn/issues/32495")]
         public void CheckImplicitObjectInitializerReceiver()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
@@ -789,5 +789,60 @@ class C
                 //     C()
                 Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "G").WithLocation(6, 5));
         }
+
+        [Fact]
+        [WorkItem(25529, "https://github.com/dotnet/roslyn/issues/25529")]
+        public void UnassignedNonNullFieldsUnreachable()
+        {
+            var comp = CreateCompilation(@"
+using System;
+class C
+{
+    private object _f;
+    internal C()
+    {
+        throw new NotImplementedException();
+    }
+
+    internal C(object o) { }
+
+    internal C(string s)
+    {
+        return;
+        throw new NotImplementedException();
+    }
+
+    internal C(int x)
+    {
+        if (x == 0)
+        {
+            return;
+        }
+        throw new NotImplementedException();
+    }
+
+    internal C(char c)
+    {
+        return;
+    }
+}
+", options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (5,20): warning CS0169: The field 'C._f' is never used
+                //     private object _f;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "_f").WithArguments("C._f").WithLocation(5, 20),
+                // (11,14): warning CS8618: Non-nullable field '_f' is uninitialized.
+                //     internal C(object o) { }
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "_f").WithLocation(11, 14),
+                // (13,14): warning CS8618: Non-nullable field '_f' is uninitialized.
+                //     internal C(string s)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "_f").WithLocation(13, 14),
+                // (19,14): warning CS8618: Non-nullable field '_f' is uninitialized.
+                //     internal C(int x)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "_f").WithLocation(19, 14),
+                // (28,14): warning CS8618: Non-nullable field '_f' is uninitialized.
+                //     internal C(char c)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "_f").WithLocation(28, 14));
+        }
     }
 }


### PR DESCRIPTION
If the end of a constructor is unreachable we shouldn't warn about
fields which are uninitialized at the end.

Fixes #25529