### PR TITLE
Move EnC debug information reading to Features.

### DIFF
--- a/src/Compilers/Test/Utilities/CSharp/EditAndContinueTestUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/EditAndContinueTestUtilities.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.Emit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public static class EditAndContinueTestUtilities
+    {
+        #region EditAndContinueMethodDebugInformation inspection
+
+        // Helpers that allow tests in IDE layers to inspect internals of EditAndContinueMethodDebugInformation without having IVT to the compiler.
+
+        public static int GetMethodOrdinal(this EditAndContinueMethodDebugInformation debugInfo)
+            => debugInfo.MethodOrdinal;
+
+        public static IEnumerable<string> InspectLocalSlots(this EditAndContinueMethodDebugInformation debugInfo)
+            => debugInfo.LocalSlots.IsDefault ? null : debugInfo.LocalSlots.Select(s => $"Offset={s.Id.SyntaxOffset} Ordinal={s.Id.Ordinal} Kind={s.SynthesizedKind}");
+
+        public static IEnumerable<string> InspectLambdas(this EditAndContinueMethodDebugInformation debugInfo)
+            => debugInfo.Lambdas.IsDefault ? null : debugInfo.Lambdas.Select(l => $"Offset={l.SyntaxOffset} Id={l.LambdaId.Generation}#{l.LambdaId.Ordinal} Closure={l.ClosureOrdinal}");
+
+        public static IEnumerable<string> InspectClosures(this EditAndContinueMethodDebugInformation debugInfo)
+            => debugInfo.Closures.IsDefault ? null : debugInfo.Closures.Select(c => $"Offset={c.SyntaxOffset} Id={c.ClosureId.Generation}#{c.ClosureId.Ordinal}");
+
+        #endregion
+    }
+}

--- a/src/Compilers/Test/Utilities/CSharp/EditAndContinueTestUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/EditAndContinueTestUtilities.cs
@@ -16,13 +16,16 @@ namespace Microsoft.CodeAnalysis.UnitTests
             => debugInfo.MethodOrdinal;
 
         public static IEnumerable<string> InspectLocalSlots(this EditAndContinueMethodDebugInformation debugInfo)
-            => debugInfo.LocalSlots.IsDefault ? null : debugInfo.LocalSlots.Select(s => $"Offset={s.Id.SyntaxOffset} Ordinal={s.Id.Ordinal} Kind={s.SynthesizedKind}");
+            => debugInfo.LocalSlots.IsDefault ? null :
+               debugInfo.LocalSlots.Select(s => $"Offset={s.Id.SyntaxOffset} Ordinal={s.Id.Ordinal} Kind={s.SynthesizedKind}");
 
         public static IEnumerable<string> InspectLambdas(this EditAndContinueMethodDebugInformation debugInfo)
-            => debugInfo.Lambdas.IsDefault ? null : debugInfo.Lambdas.Select(l => $"Offset={l.SyntaxOffset} Id={l.LambdaId.Generation}#{l.LambdaId.Ordinal} Closure={l.ClosureOrdinal}");
+            => debugInfo.Lambdas.IsDefault ? null :
+               debugInfo.Lambdas.Select(l => $"Offset={l.SyntaxOffset} Id={l.LambdaId.Generation}#{l.LambdaId.Ordinal} Closure={l.ClosureOrdinal}");
 
         public static IEnumerable<string> InspectClosures(this EditAndContinueMethodDebugInformation debugInfo)
-            => debugInfo.Closures.IsDefault ? null : debugInfo.Closures.Select(c => $"Offset={c.SyntaxOffset} Id={c.ClosureId.Generation}#{c.ClosureId.Ordinal}");
+            => debugInfo.Closures.IsDefault ? null :
+               debugInfo.Closures.Select(c => $"Offset={c.SyntaxOffset} Id={c.ClosureId.Generation}#{c.ClosureId.Ordinal}");
 
         #endregion
     }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/EditAndContinueMethodDebugInfoReaderTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/EditAndContinueMethodDebugInfoReaderTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+using System;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata.Ecma335;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.UnitTests;
+using Microsoft.DiaSymReader;
+using Microsoft.DiaSymReader.PortablePdb;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditAndContinue
+{
+    public class EditAndContinueMethodDebugInfoReaderTests
+    {
+        private class DummyMetadataImportProvider : IMetadataImportProvider
+        {
+            public object GetMetadataImport() => throw new NotImplementedException();
+        }
+
+        private class DummySymReaderMetadataProvider : ISymReaderMetadataProvider
+        {
+            public unsafe bool TryGetStandaloneSignature(int standaloneSignatureToken, out byte* signature, out int length)
+                => throw new NotImplementedException();
+
+            public bool TryGetTypeDefinitionInfo(int typeDefinitionToken, out string namespaceName, out string typeName, out TypeAttributes attributes)
+                => throw new NotImplementedException();
+
+            public bool TryGetTypeReferenceInfo(int typeReferenceToken, out string namespaceName, out string typeName)
+                => throw new NotImplementedException();
+        }
+
+        [Theory]
+        [InlineData(DebugInformationFormat.PortablePdb)]
+        [InlineData(DebugInformationFormat.Pdb)]
+        public void DebugInfo(DebugInformationFormat format)
+        {
+            var symBinder = new SymBinder();
+            var metadataImportProvider = new DummyMetadataImportProvider();
+
+            var source = @"
+using System;
+delegate void D();
+class C
+{
+    public static void Main()
+    {
+        int x = 1;
+        D d = () => Console.Write(x);
+        d();
+    }
+}
+";
+            var compilation = CSharpTestBase.CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
+
+            var pdbStream = new MemoryStream();
+            compilation.EmitToArray(new EmitOptions(debugInformationFormat: format), pdbStream: pdbStream);
+            pdbStream.Position = 0;
+
+            var pdbStreamCom = SymUnmanagedStreamFactory.CreateStream(pdbStream);
+
+            ISymUnmanagedReader5 symReader5;
+            if (format == DebugInformationFormat.PortablePdb)
+            {
+                int hr = symBinder.GetReaderFromPdbStream(metadataImportProvider, pdbStreamCom, out var symReader);
+                Assert.Equal(0, hr);
+                symReader5 = (ISymUnmanagedReader5)symReader;
+            }
+            else
+            {
+                symReader5 = SymUnmanagedReaderFactory.CreateReader<ISymUnmanagedReader5>(pdbStream, new DummySymReaderMetadataProvider());
+            }
+
+            var reader = EditAndContinueMethodDebugInfoReader.Create(symReader5, version: 1);
+
+            // Main method
+            var debugInfo = reader.GetDebugInfo(MetadataTokens.MethodDefinitionHandle(5));
+            Assert.Equal(0, debugInfo.GetMethodOrdinal());
+            AssertEx.Equal(new[] { "Offset=0 Ordinal=0 Kind=LambdaDisplayClass", "Offset=33 Ordinal=0 Kind=UserDefined" }, debugInfo.InspectLocalSlots());
+            AssertEx.Equal(new[] { "Offset=43 Id=0#0 Closure=0" }, debugInfo.InspectLambdas());
+            AssertEx.Equal(new[] { "Offset=0 Id=0#0" }, debugInfo.InspectClosures());
+
+            var localSig = reader.GetLocalSignature(MetadataTokens.MethodDefinitionHandle(5));
+            Assert.Equal(MetadataTokens.StandaloneSignatureHandle(1), localSig);
+
+            // method without debug information:
+            debugInfo = reader.GetDebugInfo(MetadataTokens.MethodDefinitionHandle(1));
+            Assert.Equal(-1, debugInfo.GetMethodOrdinal());
+            Assert.Null(debugInfo.InspectLocalSlots());
+            Assert.Null(debugInfo.InspectLambdas());
+            Assert.Null(debugInfo.InspectClosures());
+
+            localSig = reader.GetLocalSignature(MetadataTokens.MethodDefinitionHandle(1));
+            Assert.Equal(default, localSig);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
+++ b/src/EditorFeatures/CSharpTest/Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.Editor.CSharp.UnitTests</RootNamespace>
     <RoslynProjectType>UnitTest</RoslynProjectType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
@@ -51,6 +52,7 @@
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
+    <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
     <PackageReference Include="BasicUndo" Version="$(BasicUndoVersion)" />

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueMethodDebugInfoReader.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueMethodDebugInfoReader.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.Debugging;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.DiaSymReader;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue
+{
+    /// <summary>
+    /// Reader of debug information needed for EnC.
+    /// This object does not own the underlying memory (SymReader/MetadataReader).
+    /// </summary>
+    internal abstract class EditAndContinueMethodDebugInfoReader
+    {
+        public abstract bool IsPortable { get; }
+        public abstract EditAndContinueMethodDebugInformation GetDebugInfo(MethodDefinitionHandle methodHandle);
+        public abstract StandaloneSignatureHandle GetLocalSignature(MethodDefinitionHandle methodHandle);
+
+        private sealed class Native : EditAndContinueMethodDebugInfoReader
+        {
+            private readonly ISymUnmanagedReader5 _symReader;
+            private readonly int _version;
+
+            public Native(ISymUnmanagedReader5 symReader, int version)
+            {
+                Debug.Assert(symReader != null);
+                Debug.Assert(version >= 1);
+
+                _symReader = symReader;
+                _version = version;
+            }
+
+            public override bool IsPortable => false;
+
+            public override StandaloneSignatureHandle GetLocalSignature(MethodDefinitionHandle methodHandle)
+            {
+                var symMethod = (ISymUnmanagedMethod2)_symReader.GetMethodByVersion(MetadataTokens.GetToken(methodHandle), _version);
+
+                // Compiler generated methods (e.g. async kick-off methods) might not have debug information.
+                return symMethod == null ? default : MetadataTokens.StandaloneSignatureHandle(symMethod.GetLocalSignatureToken());
+            }
+
+            public override EditAndContinueMethodDebugInformation GetDebugInfo(MethodDefinitionHandle methodHandle)
+            {
+                int methodToken = MetadataTokens.GetToken(methodHandle);
+
+                byte[] debugInfo;
+                try
+                {
+                    debugInfo = _symReader.GetCustomDebugInfo(methodToken, _version);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // Sometimes the debugger returns the HRESULT for ArgumentOutOfRangeException, rather than E_FAIL,
+                    // for methods without custom debug info (https://github.com/dotnet/roslyn/issues/4138).
+                    debugInfo = null;
+                }
+                catch (Exception e) when (FatalError.ReportWithoutCrash(e)) // likely a bug in the compiler/debugger
+                {
+                    throw new InvalidDataException(e.Message, e);
+                }
+
+                try
+                {
+                    ImmutableArray<byte> localSlots, lambdaMap;
+                    if (debugInfo != null)
+                    {
+                        localSlots = CustomDebugInfoReader.TryGetCustomDebugInfoRecord(debugInfo, CustomDebugInfoKind.EditAndContinueLocalSlotMap);
+                        lambdaMap = CustomDebugInfoReader.TryGetCustomDebugInfoRecord(debugInfo, CustomDebugInfoKind.EditAndContinueLambdaMap);
+                    }
+                    else
+                    {
+                        localSlots = lambdaMap = default;
+                    }
+
+                    return EditAndContinueMethodDebugInformation.Create(localSlots, lambdaMap);
+                }
+                catch (InvalidOperationException e) when (FatalError.ReportWithoutCrash(e)) // likely a bug in the compiler/debugger
+                {
+                    // TODO: CustomDebugInfoReader should throw InvalidDataException
+                    throw new InvalidDataException(e.Message, e);
+                }
+            }
+        }
+
+        private sealed class Portable : EditAndContinueMethodDebugInfoReader
+        {
+            private readonly MetadataReader _pdbReader;
+
+            public Portable(MetadataReader pdbReader)
+            {
+                _pdbReader = pdbReader;
+            }
+
+            public override bool IsPortable => true;
+
+            public override StandaloneSignatureHandle GetLocalSignature(MethodDefinitionHandle methodHandle)
+                => _pdbReader.GetMethodDebugInformation(methodHandle.ToDebugInformationHandle()).LocalSignature;
+
+            public override EditAndContinueMethodDebugInformation GetDebugInfo(MethodDefinitionHandle methodHandle)
+                => EditAndContinueMethodDebugInformation.Create(
+                    compressedSlotMap: GetCdiBytes(methodHandle, PortableCustomDebugInfoKinds.EncLocalSlotMap),
+                    compressedLambdaMap: GetCdiBytes(methodHandle, PortableCustomDebugInfoKinds.EncLambdaAndClosureMap));
+
+            private ImmutableArray<byte> GetCdiBytes(MethodDefinitionHandle methodHandle, Guid kind)
+                => TryGetCustomDebugInformation(_pdbReader, methodHandle, kind, out var cdi) ?
+                    _pdbReader.GetBlobContent(cdi.Value) : default;
+
+            /// <exception cref="BadImageFormatException">Invalid data format.</exception>
+            private static bool TryGetCustomDebugInformation(MetadataReader reader, EntityHandle handle, Guid kind, out CustomDebugInformation customDebugInfo)
+            {
+                bool foundAny = false;
+                customDebugInfo = default;
+                foreach (var infoHandle in reader.GetCustomDebugInformation(handle))
+                {
+                    var info = reader.GetCustomDebugInformation(infoHandle);
+                    var id = reader.GetGuid(info.Kind);
+                    if (id == kind)
+                    {
+                        if (foundAny)
+                        {
+                            throw new BadImageFormatException();
+                        }
+
+                        customDebugInfo = info;
+                        foundAny = true;
+                    }
+                }
+
+                return foundAny;
+            }
+        }
+
+        public unsafe static EditAndContinueMethodDebugInfoReader Create(ISymUnmanagedReader5 symReader, int version)
+        {
+            int hr = symReader.GetPortableDebugMetadataByVersion(version, metadata: out byte* metadata, size: out int size);
+            Marshal.ThrowExceptionForHR(hr);
+
+            if (hr == 0)
+            {
+                return new Portable(new MetadataReader(metadata, size));
+            }
+            else
+            {
+                return new Native(symReader, version);
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -6,7 +6,8 @@
     <RootNamespace>Microsoft.CodeAnalysis</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ApplyPartialNgenOptimization>true</ApplyPartialNgenOptimization>
-
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    
     <!-- NuGet -->
     <IsPackable>true</IsPackable>
     <PackageDescription>
@@ -132,4 +133,5 @@
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
   </ItemGroup>
   <Import Project="..\..\..\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems" Label="Shared" />
+  <Import Project="..\..\..\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems" Label="Shared" />
 </Project>

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -271,6 +271,5 @@
   <ItemGroup>
     <VsdConfigXml Include="ManagedEditAndContinueService.vsdconfigxml" />
   </ItemGroup>
-  <Import Project="..\..\..\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems" Label="Shared" />
   <Import Project="$(RepositoryEngineeringDir)targets\Vsdconfig.targets" />
 </Project>


### PR DESCRIPTION
Encapsulate EnC debug info reading logic in EditAndContinueMethodDebugInfoReader and move it down to Features. Add tests.