### PR TITLE
Track l-value types in conditional operator

### DIFF
--- a/docs/features/nullable-reference-types.md
+++ b/docs/features/nullable-reference-types.md
@@ -93,9 +93,6 @@ Invocation of methods annotated with the following attributes will also affect f
 - `[EnsuresNotNull]` (e.g. `ThrowIfNull`)
 - `[AssertsTrue]` (e.g. `Debug.Assert`) and `[AssertsFalse]`
 
-## Unreachable code
-Expressions that produce an unreachable state produce a not-null r-value and an oblivious l-value.
-
 ## `default`
 If `T` is a reference type, `default(T)` is `T?`.
 ```c#

--- a/docs/features/nullable-reference-types.md
+++ b/docs/features/nullable-reference-types.md
@@ -93,6 +93,9 @@ Invocation of methods annotated with the following attributes will also affect f
 - `[EnsuresNotNull]` (e.g. `ThrowIfNull`)
 - `[AssertsTrue]` (e.g. `Debug.Assert`) and `[AssertsFalse]`
 
+## Unreachable code
+Expressions that produce an unreachable state produce a not-null r-value and an oblivious l-value.
+
 ## `default`
 If `T` is a reference type, `default(T)` is `T?`.
 ```c#

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1367,8 +1367,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)type1 != null);
             Debug.Assert((object)type2 != null);
 
-            // Note, when we are paying attention to nullability, we ignore insignificant differences and oblivious mismatch. 
-            // See TypeCompareKind.UnknownNullableModifierMatchesAny and TypeCompareKind.IgnoreInsignificantNullableModifiersDifference
+            // Note, when we are paying attention to nullability, we ignore oblivious mismatch.
+            // See TypeCompareKind.UnknownNullableModifierMatchesAny
             var compareKind = includeNullability ?
                 TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreNullableModifiersForReferenceTypes :
                 TypeCompareKind.AllIgnoreOptions;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1409,7 +1409,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node.IsSuppressed || node.HasAnyErrors || !IsReachable())
             {
                 resultType = resultType.WithNotNullState();
-                SetResult(resultType, LvalueResultType);
+                SetResult(resultType, TypeWithAnnotations.Create(LvalueResultType.Type));
             }
 
             _callbackOpt?.Invoke(node, resultType.ToTypeWithAnnotations());
@@ -2393,14 +2393,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     refResultType = consequenceRValue.Type.MergeNullability(alternativeRValue.Type, VarianceKind.None);
                 }
 
-                var lValueAnnotation = (consequenceEndReachable, alternativeEndReachable) switch
-                {
-                    (false, false) => NullableAnnotation.Oblivious,
-                    (false, _) => alternativeLValue.NullableAnnotation,
-                    (_, false) => consequenceLValue.NullableAnnotation,
-                    _ => consequenceLValue.NullableAnnotation.EnsureCompatible(alternativeLValue.NullableAnnotation)
-                };
-
+                var lValueAnnotation = consequenceLValue.NullableAnnotation.EnsureCompatible(alternativeLValue.NullableAnnotation);
                 var rValueState = consequenceRValue.State.Join(alternativeRValue.State);
 
                 SetResult(new TypeWithState(refResultType, rValueState), TypeWithAnnotations.Create(refResultType, lValueAnnotation));
@@ -5632,16 +5625,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static bool IsNullabilityMismatch(TypeWithAnnotations type1, TypeWithAnnotations type2)
         {
-            // Note, when we are paying attention to nullability, we ignore insignificant differences and oblivious mismatch.
-            // See TypeCompareKind.UnknownNullableModifierMatchesAny and TypeCompareKind.IgnoreInsignificantNullableModifiersDifference
+            // Note, when we are paying attention to nullability, we ignore oblivious mismatch.
+            // See TypeCompareKind.UnknownNullableModifierMatchesAny
             return type1.Equals(type2, TypeCompareKind.AllIgnoreOptions) &&
                 !type1.Equals(type2, TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreNullableModifiersForReferenceTypes);
         }
 
         private static bool IsNullabilityMismatch(TypeSymbol type1, TypeSymbol type2)
         {
-            // Note, when we are paying attention to nullability, we ignore insignificant differences and oblivious mismatch.
-            // See TypeCompareKind.UnknownNullableModifierMatchesAny and TypeCompareKind.IgnoreInsignificantNullableModifiersDifference
+            // Note, when we are paying attention to nullability, we ignore oblivious mismatch.
+            // See TypeCompareKind.UnknownNullableModifierMatchesAny
             return type1.Equals(type2, TypeCompareKind.AllIgnoreOptions) &&
                 !type1.Equals(type2, TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreNullableModifiersForReferenceTypes);
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2365,8 +2365,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             var consequenceState = this.StateWhenTrue;
             var alternativeState = this.StateWhenFalse;
 
-            bool consequenceEndReachable;
-            bool alternativeEndReachable;
             TypeWithState consequenceRValue;
             TypeWithState alternativeRValue;
 
@@ -2377,9 +2375,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 (consequenceLValue, consequenceRValue) = visitConditionalRefOperand(consequenceState, node.Consequence);
                 consequenceState = this.State;
-                consequenceEndReachable = this.State.Reachable;
                 (alternativeLValue, alternativeRValue) = visitConditionalRefOperand(alternativeState, node.Alternative);
-                alternativeEndReachable = this.State.Reachable;
                 Join(ref this.State, ref consequenceState);
 
                 TypeSymbol refResultType = node.Type.SetUnknownNullabilityForReferenceTypes();
@@ -2404,6 +2400,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression alternative;
             Conversion consequenceConversion;
             Conversion alternativeConversion;
+            bool consequenceEndReachable;
+            bool alternativeEndReachable;
 
             // In cases where one branch is unreachable, we don't need to Unsplit the state
             if (!alternativeState.Reachable)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2393,14 +2393,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     refResultType = consequenceRValue.Type.MergeNullability(alternativeRValue.Type, VarianceKind.None);
                 }
 
-                var lValueAnnotation = (consequenceEndReachable, alternativeEndReachable) switch
-                {
-                    (false, false) => NullableAnnotation.Oblivious,
-                    (false, _) => alternativeLValue.NullableAnnotation,
-                    (_, false) => consequenceLValue.NullableAnnotation,
-                    _ => consequenceLValue.NullableAnnotation.EnsureCompatible(alternativeLValue.NullableAnnotation)
-                };
-
+                var lValueAnnotation = consequenceLValue.NullableAnnotation.EnsureCompatible(alternativeLValue.NullableAnnotation);
                 var rValueState = consequenceRValue.State.Join(alternativeRValue.State);
 
                 SetResult(new TypeWithState(refResultType, rValueState), TypeWithAnnotations.Create(refResultType, lValueAnnotation));

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2432,7 +2432,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         ReportNullabilityMismatchInAssignment(node.Syntax, consequenceLValue, alternativeLValue);
                     }
 
-                    lValueResult = TypeWithAnnotations.Create(resultType, consequenceLValue.NullableAnnotation.Join(alternativeLValue.NullableAnnotation));
+                    lValueResult = TypeWithAnnotations.Create(resultType, consequenceLValue.NullableAnnotation.EnsureCompatible(alternativeLValue.NullableAnnotation));
                     rValueResult = new TypeWithState(resultType, consequenceRValue.State.Join(alternativeRValue.State));
                 }
                 else

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -22906,20 +22906,20 @@ class C
     {
         (b ? ref x2 : ref x2)/*T:I<string?>!*/.P.ToString(); // 6
         (b ? ref y2 : ref x2)/*T:I<string!>!*/.P.ToString(); // 7
-        (b ? ref x2 : ref y2)/*T:I<string!>!*/.P.ToString(); // 8
+        (b ? ref x2 : ref y2)/*T:I<string?>!*/.P.ToString(); // 8, 9
         (b ? ref y2 : ref y2)/*T:I<string!>!*/.P.ToString();
     }
     static void F3(bool b, ref IIn<string?> x3, ref IIn<string> y3)
     {
         (b ? ref x3 : ref x3)/*T:IIn<string?>!*/.ToString();
-        (b ? ref y3 : ref x3)/*T:IIn<string!>!*/.ToString(); // 9
-        (b ? ref x3 : ref y3)/*T:IIn<string!>!*/.ToString(); // 10
+        (b ? ref y3 : ref x3)/*T:IIn<string!>!*/.ToString(); // 10
+        (b ? ref x3 : ref y3)/*T:IIn<string?>!*/.ToString(); // 11
         (b ? ref y3 : ref y3)/*T:IIn<string!>!*/.ToString();
     }
     static void F4(bool b, ref IOut<string?> x4, ref IOut<string> y4)
     {
-        (b ? ref x4 : ref x4)/*T:IOut<string?>!*/.P.ToString(); // 11
-        (b ? ref y4 : ref x4)/*T:IOut<string?>!*/.P.ToString(); // 12, 13
+        (b ? ref x4 : ref x4)/*T:IOut<string?>!*/.P.ToString(); // 12
+        (b ? ref y4 : ref x4)/*T:IOut<string!>!*/.P.ToString(); // 13
         (b ? ref x4 : ref y4)/*T:IOut<string?>!*/.P.ToString(); // 14, 15
         (b ? ref y4 : ref y4)/*T:IOut<string!>!*/.P.ToString();
     }
@@ -22948,23 +22948,23 @@ class C
                 // (16,10): warning CS8619: Nullability of reference types in value of type 'I<string>' doesn't match target type 'I<string?>'.
                 //         (b ? ref y2 : ref x2)/*T:I<string!>!*/.P.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref y2 : ref x2").WithArguments("I<string>", "I<string?>").WithLocation(16, 10),
+                // (17,9): warning CS8602: Possible dereference of a null reference.
+                //         (b ? ref x2 : ref y2)/*T:I<string?>!*/.P.ToString(); // 8, 9
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ? ref x2 : ref y2)/*T:I<string?>!*/.P").WithLocation(17, 9),
                 // (17,10): warning CS8619: Nullability of reference types in value of type 'I<string?>' doesn't match target type 'I<string>'.
-                //         (b ? ref x2 : ref y2)/*T:I<string!>!*/.P.ToString(); // 8
+                //         (b ? ref x2 : ref y2)/*T:I<string?>!*/.P.ToString(); // 8, 9
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref x2 : ref y2").WithArguments("I<string?>", "I<string>").WithLocation(17, 10),
                 // (23,10): warning CS8619: Nullability of reference types in value of type 'IIn<string>' doesn't match target type 'IIn<string?>'.
-                //         (b ? ref y3 : ref x3)/*T:IIn<string!>!*/.ToString(); // 9
+                //         (b ? ref y3 : ref x3)/*T:IIn<string!>!*/.ToString(); // 10
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref y3 : ref x3").WithArguments("IIn<string>", "IIn<string?>").WithLocation(23, 10),
                 // (24,10): warning CS8619: Nullability of reference types in value of type 'IIn<string?>' doesn't match target type 'IIn<string>'.
-                //         (b ? ref x3 : ref y3)/*T:IIn<string!>!*/.ToString(); // 10
+                //         (b ? ref x3 : ref y3)/*T:IIn<string?>!*/.ToString(); // 11
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref x3 : ref y3").WithArguments("IIn<string?>", "IIn<string>").WithLocation(24, 10),
                 // (29,9): warning CS8602: Possible dereference of a null reference.
-                //         (b ? ref x4 : ref x4)/*T:IOut<string?>!*/.P.ToString(); // 11
+                //         (b ? ref x4 : ref x4)/*T:IOut<string?>!*/.P.ToString(); // 12
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ? ref x4 : ref x4)/*T:IOut<string?>!*/.P").WithLocation(29, 9),
-                // (30,9): warning CS8602: Possible dereference of a null reference.
-                //         (b ? ref y4 : ref x4)/*T:IOut<string?>!*/.P.ToString(); // 12, 13
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ? ref y4 : ref x4)/*T:IOut<string?>!*/.P").WithLocation(30, 9),
                 // (30,10): warning CS8619: Nullability of reference types in value of type 'IOut<string>' doesn't match target type 'IOut<string?>'.
-                //         (b ? ref y4 : ref x4)/*T:IOut<string?>!*/.P.ToString(); // 12, 13
+                //         (b ? ref y4 : ref x4)/*T:IOut<string!>!*/.P.ToString(); // 13
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref y4 : ref x4").WithArguments("IOut<string>", "IOut<string?>").WithLocation(30, 10),
                 // (31,9): warning CS8602: Possible dereference of a null reference.
                 //         (b ? ref x4 : ref y4)/*T:IOut<string?>!*/.P.ToString(); // 14, 15
@@ -23084,6 +23084,62 @@ class C
                 // (15,30): error CS0103: The name 'error' does not exist in the current context
                 //         (b ? ref error : ref error)/*T:!*/.ToString();
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(15, 30)
+                );
+        }
+
+        [Fact]
+        [WorkItem(33664, "https://github.com/dotnet/roslyn/issues/33664")]
+        public void ConditionalOperator_WithError_Nested()
+        {
+            var source = @"
+class C<T>
+{
+    static void F1(bool b, ref C<string?> x1, ref C<string> y1)
+    {
+        (b ? ref x1 : ref error)/*T:!*/.ToString();
+        (b ? ref x1 : ref error)/*T:!*/.ToString();
+        (b ? ref error : ref x1)/*T:!*/.ToString();
+        (b ? ref error : ref error)/*T:!*/.ToString();
+
+        (b ? ref y1 : ref error)/*T:!*/.ToString();
+        (b ? ref y1 : ref error)/*T:!*/.ToString();
+        (b ? ref error : ref y1)/*T:!*/.ToString();
+        (b ? ref error : ref error)/*T:!*/.ToString();
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyTypes();
+            comp.VerifyDiagnostics(
+                // (6,27): error CS0103: The name 'error' does not exist in the current context
+                //         (b ? ref x1 : ref error)/*T:!*/.ToString();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(6, 27),
+                // (7,27): error CS0103: The name 'error' does not exist in the current context
+                //         (b ? ref x1 : ref error)/*T:!*/.ToString();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(7, 27),
+                // (8,18): error CS0103: The name 'error' does not exist in the current context
+                //         (b ? ref error : ref x1)/*T:!*/.ToString();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(8, 18),
+                // (9,18): error CS0103: The name 'error' does not exist in the current context
+                //         (b ? ref error : ref error)/*T:!*/.ToString();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(9, 18),
+                // (9,30): error CS0103: The name 'error' does not exist in the current context
+                //         (b ? ref error : ref error)/*T:!*/.ToString();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(9, 30),
+                // (11,27): error CS0103: The name 'error' does not exist in the current context
+                //         (b ? ref y1 : ref error)/*T:!*/.ToString();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(11, 27),
+                // (12,27): error CS0103: The name 'error' does not exist in the current context
+                //         (b ? ref y1 : ref error)/*T:!*/.ToString();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(12, 27),
+                // (13,18): error CS0103: The name 'error' does not exist in the current context
+                //         (b ? ref error : ref y1)/*T:!*/.ToString();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(13, 18),
+                // (14,18): error CS0103: The name 'error' does not exist in the current context
+                //         (b ? ref error : ref error)/*T:!*/.ToString();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(14, 18),
+                // (14,30): error CS0103: The name 'error' does not exist in the current context
+                //         (b ? ref error : ref error)/*T:!*/.ToString();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(14, 30)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -22905,22 +22905,22 @@ class C
     static void F2(bool b, ref I<string?> x2, ref I<string> y2)
     {
         (b ? ref x2 : ref x2)/*T:I<string?>!*/.P.ToString(); // 6
-        (b ? ref y2 : ref x2)/*T:I<string!>!*/.P.ToString(); // 7
-        (b ? ref x2 : ref y2)/*T:I<string?>!*/.P.ToString(); // 8, 9
+        (b ? ref y2 : ref x2)/*T:I<string>!*/.P.ToString(); // 7
+        (b ? ref x2 : ref y2)/*T:I<string>!*/.P.ToString(); // 8, 9
         (b ? ref y2 : ref y2)/*T:I<string!>!*/.P.ToString();
     }
     static void F3(bool b, ref IIn<string?> x3, ref IIn<string> y3)
     {
         (b ? ref x3 : ref x3)/*T:IIn<string?>!*/.ToString();
-        (b ? ref y3 : ref x3)/*T:IIn<string!>!*/.ToString(); // 10
-        (b ? ref x3 : ref y3)/*T:IIn<string?>!*/.ToString(); // 11
+        (b ? ref y3 : ref x3)/*T:IIn<string>!*/.ToString(); // 10
+        (b ? ref x3 : ref y3)/*T:IIn<string>!*/.ToString(); // 11
         (b ? ref y3 : ref y3)/*T:IIn<string!>!*/.ToString();
     }
     static void F4(bool b, ref IOut<string?> x4, ref IOut<string> y4)
     {
         (b ? ref x4 : ref x4)/*T:IOut<string?>!*/.P.ToString(); // 12
-        (b ? ref y4 : ref x4)/*T:IOut<string!>!*/.P.ToString(); // 13
-        (b ? ref x4 : ref y4)/*T:IOut<string?>!*/.P.ToString(); // 14, 15
+        (b ? ref y4 : ref x4)/*T:IOut<string>!*/.P.ToString(); // 13
+        (b ? ref x4 : ref y4)/*T:IOut<string>!*/.P.ToString(); // 14
         (b ? ref y4 : ref y4)/*T:IOut<string!>!*/.P.ToString();
     }
 }";
@@ -22946,37 +22946,31 @@ class C
                 //         (b ? ref x2 : ref x2)/*T:I<string?>!*/.P.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ? ref x2 : ref x2)/*T:I<string?>!*/.P").WithLocation(15, 9),
                 // (16,10): warning CS8619: Nullability of reference types in value of type 'I<string>' doesn't match target type 'I<string?>'.
-                //         (b ? ref y2 : ref x2)/*T:I<string!>!*/.P.ToString(); // 7
+                //         (b ? ref y2 : ref x2)/*T:I<string>!*/.P.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref y2 : ref x2").WithArguments("I<string>", "I<string?>").WithLocation(16, 10),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
-                //         (b ? ref x2 : ref y2)/*T:I<string?>!*/.P.ToString(); // 8, 9
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ? ref x2 : ref y2)/*T:I<string?>!*/.P").WithLocation(17, 9),
                 // (17,10): warning CS8619: Nullability of reference types in value of type 'I<string?>' doesn't match target type 'I<string>'.
-                //         (b ? ref x2 : ref y2)/*T:I<string?>!*/.P.ToString(); // 8, 9
+                //         (b ? ref x2 : ref y2)/*T:I<string>!*/.P.ToString(); // 8, 9
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref x2 : ref y2").WithArguments("I<string?>", "I<string>").WithLocation(17, 10),
                 // (23,10): warning CS8619: Nullability of reference types in value of type 'IIn<string>' doesn't match target type 'IIn<string?>'.
-                //         (b ? ref y3 : ref x3)/*T:IIn<string!>!*/.ToString(); // 10
+                //         (b ? ref y3 : ref x3)/*T:IIn<string>!*/.ToString(); // 10
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref y3 : ref x3").WithArguments("IIn<string>", "IIn<string?>").WithLocation(23, 10),
                 // (24,10): warning CS8619: Nullability of reference types in value of type 'IIn<string?>' doesn't match target type 'IIn<string>'.
-                //         (b ? ref x3 : ref y3)/*T:IIn<string?>!*/.ToString(); // 11
+                //         (b ? ref x3 : ref y3)/*T:IIn<string>!*/.ToString(); // 11
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref x3 : ref y3").WithArguments("IIn<string?>", "IIn<string>").WithLocation(24, 10),
                 // (29,9): warning CS8602: Possible dereference of a null reference.
                 //         (b ? ref x4 : ref x4)/*T:IOut<string?>!*/.P.ToString(); // 12
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ? ref x4 : ref x4)/*T:IOut<string?>!*/.P").WithLocation(29, 9),
                 // (30,10): warning CS8619: Nullability of reference types in value of type 'IOut<string>' doesn't match target type 'IOut<string?>'.
-                //         (b ? ref y4 : ref x4)/*T:IOut<string!>!*/.P.ToString(); // 13
+                //         (b ? ref y4 : ref x4)/*T:IOut<string>!*/.P.ToString(); // 13
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref y4 : ref x4").WithArguments("IOut<string>", "IOut<string?>").WithLocation(30, 10),
-                // (31,9): warning CS8602: Possible dereference of a null reference.
-                //         (b ? ref x4 : ref y4)/*T:IOut<string?>!*/.P.ToString(); // 14, 15
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ? ref x4 : ref y4)/*T:IOut<string?>!*/.P").WithLocation(31, 9),
                 // (31,10): warning CS8619: Nullability of reference types in value of type 'IOut<string?>' doesn't match target type 'IOut<string>'.
-                //         (b ? ref x4 : ref y4)/*T:IOut<string?>!*/.P.ToString(); // 14, 15
+                //         (b ? ref x4 : ref y4)/*T:IOut<string>!*/.P.ToString(); // 14, 15
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref x4 : ref y4").WithArguments("IOut<string?>", "IOut<string>").WithLocation(31, 10));
         }
 
         [Fact]
         [WorkItem(33664, "https://github.com/dotnet/roslyn/issues/33664")]
-        public void ConditionalOperator_WithAlteredStates()
+        public void ConditionalOperator_Ref_WithAlteredStates()
         {
             var source = @"
 class C
@@ -23032,7 +23026,95 @@ class C
 
         [Fact]
         [WorkItem(33664, "https://github.com/dotnet/roslyn/issues/33664")]
-        public void ConditionalOperator_WithError()
+        public void ConditionalOperator_WithUnreachable()
+        {
+            var source = @"
+class C
+{
+    static void F1(bool b, string? x1, string y1)
+    {
+        ((b && false) ? x1 : x1)/*T:string?*/.ToString(); // 1
+        ((b && false) ? x1 : y1)/*T:string!*/.ToString();
+        ((b && false) ? y1 : x1)/*T:string?*/.ToString(); // 2
+        ((b && false) ? y1 : y1)/*T:string!*/.ToString();
+
+        ((b || true) ? x1 : x1)/*T:string?*/.ToString(); // 3
+        ((b || true) ? x1 : y1)/*T:string?*/.ToString(); // 4
+        ((b || true) ? y1 : x1)/*T:string!*/.ToString();
+        ((b || true) ? y1 : y1)/*T:string!*/.ToString();
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyTypes();
+            comp.VerifyDiagnostics(
+                // (6,10): warning CS8602: Possible dereference of a null reference.
+                //         ((b && false) ? x1 : x1)/*T:string?*/.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b && false) ? x1 : x1").WithLocation(6, 10),
+                // (8,10): warning CS8602: Possible dereference of a null reference.
+                //         ((b && false) ? y1 : x1)/*T:string?*/.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b && false) ? y1 : x1").WithLocation(8, 10),
+                // (11,10): warning CS8602: Possible dereference of a null reference.
+                //         ((b || true) ? x1 : x1)/*T:string?*/.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b || true) ? x1 : x1").WithLocation(11, 10),
+                // (12,10): warning CS8602: Possible dereference of a null reference.
+                //         ((b || true) ? x1 : y1)/*T:string?*/.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b || true) ? x1 : y1").WithLocation(12, 10)
+                );
+        }
+
+        [Fact]
+        [WorkItem(33664, "https://github.com/dotnet/roslyn/issues/33664")]
+        public void ConditionalOperator_Ref_WithUnreachable()
+        {
+            var source = @"
+class C
+{
+    static void F1(bool b, ref string? x1, ref string y1)
+    {
+        ((b && false) ? ref x1 : ref x1)/*T:string?*/ = null;
+        ((b && false) ? ref x1 : ref y1)/*T:string!*/ = null; // 1, 2
+        ((b && false) ? ref y1 : ref x1)/*T:string?*/ = null; // 3
+        ((b && false) ? ref y1 : ref y1)/*T:string!*/ = null; // 4
+
+        ((b || true) ? ref x1 : ref x1)/*T:string?*/ = null;
+        ((b || true) ? ref x1 : ref y1)/*T:string?*/ = null; // 5
+        ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 6, 7
+        ((b || true) ? ref y1 : ref y1)/*T:string!*/ = null; // 8
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyTypes();
+            comp.VerifyDiagnostics(
+                // (7,10): warning CS8619: Nullability of reference types in value of type 'string?' doesn't match target type 'string'.
+                //         ((b && false) ? ref x1 : ref y1)/*T:string!*/ = null; // 1, 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(b && false) ? ref x1 : ref y1").WithArguments("string?", "string").WithLocation(7, 10),
+                // (7,57): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         ((b && false) ? ref x1 : ref y1)/*T:string!*/ = null; // 1, 2
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 57),
+                // (8,10): warning CS8619: Nullability of reference types in value of type 'string' doesn't match target type 'string?'.
+                //         ((b && false) ? ref y1 : ref x1)/*T:string?*/ = null; // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(b && false) ? ref y1 : ref x1").WithArguments("string", "string?").WithLocation(8, 10),
+                // (9,57): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         ((b && false) ? ref y1 : ref y1)/*T:string!*/ = null; // 4
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(9, 57),
+                // (12,10): warning CS8619: Nullability of reference types in value of type 'string?' doesn't match target type 'string'.
+                //         ((b || true) ? ref x1 : ref y1)/*T:string?*/ = null; // 5
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(b || true) ? ref x1 : ref y1").WithArguments("string?", "string").WithLocation(12, 10),
+                // (13,10): warning CS8619: Nullability of reference types in value of type 'string' doesn't match target type 'string?'.
+                //         ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 6, 7
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(b || true) ? ref y1 : ref x1").WithArguments("string", "string?").WithLocation(13, 10),
+                // (13,56): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 6, 7
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 56),
+                // (14,56): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         ((b || true) ? ref y1 : ref y1)/*T:string!*/ = null; // 8
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(14, 56)
+                );
+        }
+
+        [Fact]
+        [WorkItem(33664, "https://github.com/dotnet/roslyn/issues/33664")]
+        public void ConditionalOperator_Ref_WithError()
         {
             var source = @"
 class C
@@ -23089,7 +23171,7 @@ class C
 
         [Fact]
         [WorkItem(33664, "https://github.com/dotnet/roslyn/issues/33664")]
-        public void ConditionalOperator_WithError_Nested()
+        public void ConditionalOperator_Ref_WithError_Nested()
         {
             var source = @"
 class C<T>
@@ -23152,7 +23234,7 @@ class C<T>
     static void F(bool b)
     {
         var x = b ? new[] { x } : default;
-        x[0].ToString(); // 1
+        x[0].ToString();
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
@@ -23162,10 +23244,7 @@ class C<T>
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x").WithArguments("x").WithLocation(5, 29),
                 // (5,29): error CS0165: Use of unassigned local variable 'x'
                 //         var x = b ? new[] { x } : default;
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(5, 29),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
-                //         x[0].ToString(); // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 9));
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(5, 29));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -23584,65 +23584,6 @@ class C
                 );
         }
 
-        [Fact, WorkItem(33982, "https://github.com/dotnet/roslyn/issues/33982")]
-        public void ConditionalOperator_AssignToRef()
-        {
-            var comp = CreateCompilation(@"
-interface I< T> { }
-interface IIn<in T> { }
-interface IOut<out T> { }
-class C
-{
-    static void F1(bool b, object? x, object y)
-    {
-        ref var xy = ref b ? ref x : ref y; // 1
-        ref var yx = ref b ? ref y : ref x; // 2
-    }
-    static void F2(bool b, I<object> x, I<object?> y)
-    {
-        ref var xy = ref b ? ref x : ref y; // 3
-        ref var yx = ref b ? ref y : ref x; // 4
-    }
-    static void F2(bool b, IOut<object> x, IOut<object?> y)
-    {
-        ref var xy = ref b ? ref x : ref y; // 5
-        ref var yx = ref b ? ref y : ref x; // 6
-    }
-    static void F2(bool b, IIn<object> x, IIn<object?> y)
-    {
-        ref var xy = ref b ? ref x : ref y; // 7
-        ref var yx = ref b ? ref y : ref x; // 8
-    }
-}", options: WithNonNullTypesTrue());
-
-            comp.VerifyDiagnostics(
-                // (9,26): warning CS8619: Nullability of reference types in value of type 'object?' doesn't match target type 'object'.
-                //         ref var xy = ref b ? ref x : ref y; // 1
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref x : ref y").WithArguments("object?", "object").WithLocation(9, 26),
-                // (10,26): warning CS8619: Nullability of reference types in value of type 'object' doesn't match target type 'object?'.
-                //         ref var yx = ref b ? ref y : ref x; // 2
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref y : ref x").WithArguments("object", "object?").WithLocation(10, 26),
-                // (14,26): warning CS8619: Nullability of reference types in value of type 'I<object>' doesn't match target type 'I<object?>'.
-                //         ref var xy = ref b ? ref x : ref y; // 3
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref x : ref y").WithArguments("I<object>", "I<object?>").WithLocation(14, 26),
-                // (15,26): warning CS8619: Nullability of reference types in value of type 'I<object?>' doesn't match target type 'I<object>'.
-                //         ref var yx = ref b ? ref y : ref x; // 4
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref y : ref x").WithArguments("I<object?>", "I<object>").WithLocation(15, 26),
-                // (19,26): warning CS8619: Nullability of reference types in value of type 'IOut<object>' doesn't match target type 'IOut<object?>'.
-                //         ref var xy = ref b ? ref x : ref y; // 5
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref x : ref y").WithArguments("IOut<object>", "IOut<object?>").WithLocation(19, 26),
-                // (20,26): warning CS8619: Nullability of reference types in value of type 'IOut<object?>' doesn't match target type 'IOut<object>'.
-                //         ref var yx = ref b ? ref y : ref x; // 6
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref y : ref x").WithArguments("IOut<object?>", "IOut<object>").WithLocation(20, 26),
-                // (24,26): warning CS8619: Nullability of reference types in value of type 'IIn<object>' doesn't match target type 'IIn<object?>'.
-                //         ref var xy = ref b ? ref x : ref y; // 7
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref x : ref y").WithArguments("IIn<object>", "IIn<object?>").WithLocation(24, 26),
-                // (25,26): warning CS8619: Nullability of reference types in value of type 'IIn<object?>' doesn't match target type 'IIn<object>'.
-                //         ref var yx = ref b ? ref y : ref x; // 8
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref y : ref x").WithArguments("IIn<object?>", "IIn<object>").WithLocation(25, 26)
-                );
-        }
-
         [Fact]
         public void IdentityConversion_ConditionalOperator()
         {
@@ -72349,7 +72290,6 @@ class Outer
     ref S M1<S>(S x) => throw null!;
 }
 ";
-            // Unexpected diagnostics due to https://github.com/dotnet/roslyn/issues/33924
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (10,9): warning CS8602: Possible dereference of a null reference.
                 //         M1(z0).ToString();
@@ -72380,7 +72320,6 @@ class Outer<T>
     T M2() => throw null!;
 }
 ";
-            // Unexpected diagnostics due to https://github.com/dotnet/roslyn/issues/33924
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (10,9): warning CS8602: Possible dereference of a null reference.
                 //         z0.ToString();
@@ -72409,7 +72348,6 @@ class Outer<T>
     T M2() => throw null!;
 }
 ";
-            // Unexpected diagnostics due to https://github.com/dotnet/roslyn/issues/33924
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (9,9): warning CS8602: Possible dereference of a null reference.
                 //         M1(z0).ToString();
@@ -72439,7 +72377,6 @@ class Outer<T>
     T M2() => throw null!;
 }
 ";
-            // Unexpected diagnostics due to https://github.com/dotnet/roslyn/issues/33924
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (9,9): warning CS8602: Possible dereference of a null reference.
                 //         z0.ToString();
@@ -72466,7 +72403,6 @@ class Outer<T>
     T M2() => throw null!;
 }
 ";
-            // Unexpected diagnostics due to https://github.com/dotnet/roslyn/issues/33924
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (9,9): warning CS8602: Possible dereference of a null reference.
                 //         z0.ToString();
@@ -72578,7 +72514,6 @@ class Outer
     ref S M1<S>(S x) => throw null!;
 }
 ";
-            // Unexpected diagnostics due to https://github.com/dotnet/roslyn/issues/33924
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (10,9): warning CS8602: Possible dereference of a null reference.
                 //         M1(z0).ToString();
@@ -72610,7 +72545,6 @@ class Outer<T>
     T M2() => throw null!;
 }
 ";
-            // Unexpected diagnostics due to https://github.com/dotnet/roslyn/issues/33924
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (9,9): warning CS8602: Possible dereference of a null reference.
                 //         M1(z0).ToString();
@@ -72641,7 +72575,6 @@ class Outer<T>
     T M2() => throw null!;
 }
 ";
-            // Unexpected diagnostics due to https://github.com/dotnet/roslyn/issues/33924
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (10,9): warning CS8602: Possible dereference of a null reference.
                 //         z0.ToString();
@@ -72668,7 +72601,6 @@ class Outer<T>
     T M2() => throw null!;
 }
 ";
-            // Unexpected diagnostics due to https://github.com/dotnet/roslyn/issues/33924
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (9,9): warning CS8602: Possible dereference of a null reference.
                 //         z0.ToString();
@@ -72723,7 +72655,6 @@ class Outer<T>
     T M2() => throw null!;
 }
 ";
-            // Unexpected diagnostics due to https://github.com/dotnet/roslyn/issues/33924
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
                 // (9,9): warning CS8602: Possible dereference of a null reference.
                 //         z0.ToString();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -921,10 +921,7 @@ public class C
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y2").WithArguments("y2").WithLocation(7, 16),
                 // (8,9): error CS8598: The suppression operator is not allowed in this context
                 //         y2! = null;
-                Diagnostic(ErrorCode.ERR_IllegalSuppression, "y2").WithLocation(8, 9),
-                // (8,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         y2! = null;
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(8, 15)
+                Diagnostic(ErrorCode.ERR_IllegalSuppression, "y2").WithLocation(8, 9)
                 );
         }
 
@@ -1832,10 +1829,7 @@ public class C
                 Diagnostic(ErrorCode.ERR_InvalidInitializerElementInitializer, "P! = null").WithLocation(7, 23),
                 // (7,23): error CS8598: The suppression operator is not allowed in this context
                 //         _ = new C() { P! = null };
-                Diagnostic(ErrorCode.ERR_IllegalSuppression, "P").WithLocation(7, 23),
-                // (7,28): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
-                //         _ = new C() { P! = null };
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 28)
+                Diagnostic(ErrorCode.ERR_IllegalSuppression, "P").WithLocation(7, 23)
                 );
         }
 
@@ -4055,10 +4049,7 @@ class C
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(6, 16),
                 // (7,9): error CS8598: The suppression operator is not allowed in this context
                 //         x! = null;
-                Diagnostic(ErrorCode.ERR_IllegalSuppression, "x").WithLocation(7, 9),
-                // (7,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         x! = null;
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(7, 14)
+                Diagnostic(ErrorCode.ERR_IllegalSuppression, "x").WithLocation(7, 9)
                 );
         }
 
@@ -6721,13 +6712,7 @@ class C
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("string?", "string").WithLocation(7, 29),
                 // (8,10): error CS8598: The suppression operator is not allowed in this context
                 //         (y2! = ref y) = ref y;
-                Diagnostic(ErrorCode.ERR_IllegalSuppression, "y2").WithLocation(8, 10),
-                // (8,20): warning CS8601: Possible null reference assignment.
-                //         (y2! = ref y) = ref y;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y").WithLocation(8, 20),
-                // (8,29): warning CS8601: Possible null reference assignment.
-                //         (y2! = ref y) = ref y;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y").WithLocation(8, 29)
+                Diagnostic(ErrorCode.ERR_IllegalSuppression, "y2").WithLocation(8, 10)
                 );
         }
 
@@ -23007,16 +22992,16 @@ class C
 
     void M(bool b, string? s)
     {
-        _ = (b ? ref D2(s) : ref D2(s!)) /*T:C.MyDelegate<string>!*/; // 9, unexpected type
-        _ = (b ? ref D2(s!) : ref D2(s)) /*T:C.MyDelegate<string>!*/; // 10, unexpected type
-        _ = (true ? ref D2(s) : ref D2(s!)) /*T:C.MyDelegate<string>!*/; // 11, unexpected type
+        _ = (b ? ref D2(s) : ref D2(s!)) /*T:C.MyDelegate<string>!*/; // 9
+        _ = (b ? ref D2(s!) : ref D2(s)) /*T:C.MyDelegate<string>!*/; // 10
+        _ = (true ? ref D2(s) : ref D2(s!)) /*T:C.MyDelegate<string>!*/; // 11
         _ = (true ? ref D2(s!) : ref D2(s)) /*T:C.MyDelegate<string!>!*/;
         _ = (false ? ref D2(s) : ref D2(s!)) /*T:C.MyDelegate<string!>!*/;
-        _ = (false ? ref D2(s!) : ref D2(s)) /*T:C.MyDelegate<string>!*/; // unexpected type
+        _ = (false ? ref D2(s!) : ref D2(s)) /*T:C.MyDelegate<string>!*/; // 12
     }
 }";
 
-            // See TODO2
+            // See https://github.com/dotnet/roslyn/issues/34392
             // Best type inference involving lambda conversion should agree with method type inference
             // Missing diagnostics
 
@@ -23024,13 +23009,13 @@ class C
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
                 // (36,14): warning CS8619: Nullability of reference types in value of type 'C.MyDelegate<string?>' doesn't match target type 'C.MyDelegate<string>'.
-                //         _ = (b ? ref D2(s) : ref D2(s!)) /*T:C.MyDelegate<string>!*/; // 9, unexpected type
+                //         _ = (b ? ref D2(s) : ref D2(s!)) /*T:C.MyDelegate<string>!*/; // 9
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref D2(s) : ref D2(s!)").WithArguments("C.MyDelegate<string?>", "C.MyDelegate<string>").WithLocation(36, 14),
                 // (37,14): warning CS8619: Nullability of reference types in value of type 'C.MyDelegate<string>' doesn't match target type 'C.MyDelegate<string?>'.
-                //         _ = (b ? ref D2(s!) : ref D2(s)) /*T:C.MyDelegate<string>!*/; // 10, unexpected type
+                //         _ = (b ? ref D2(s!) : ref D2(s)) /*T:C.MyDelegate<string>!*/; // 10
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref D2(s!) : ref D2(s)").WithArguments("C.MyDelegate<string>", "C.MyDelegate<string?>").WithLocation(37, 14),
                 // (38,14): warning CS8619: Nullability of reference types in value of type 'C.MyDelegate<string?>' doesn't match target type 'C.MyDelegate<string>'.
-                //         _ = (true ? ref D2(s) : ref D2(s!)) /*T:C.MyDelegate<string>!*/; // 11, unexpected type
+                //         _ = (true ? ref D2(s) : ref D2(s!)) /*T:C.MyDelegate<string>!*/; // 11
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "true ? ref D2(s) : ref D2(s!)").WithArguments("C.MyDelegate<string?>", "C.MyDelegate<string>").WithLocation(38, 14),
                 // (41,14): warning CS8619: Nullability of reference types in value of type 'C.MyDelegate<string>' doesn't match target type 'C.MyDelegate<string?>'.
                 //         _ = (false ? ref D2(s!) : ref D2(s)) /*T:C.MyDelegate<string>!*/; // unexpected type
@@ -23279,8 +23264,8 @@ class C
 {
     static void F1(bool b)
     {
-        (b ? ref M1(false ? 1 : throw new System.Exception()) : ref M2(2)) /*T:string!*/ = null; // 1, 2
-        (b ? ref M1(1) : ref M2(false ? 2 : throw new System.Exception())) /*T:string?*/ = null; // 3
+        (b ? ref M1(false ? 1 : throw new System.Exception()) : ref M2(2)) /*T:string!*/ = null; // 1
+        (b ? ref M1(1) : ref M2(false ? 2 : throw new System.Exception())) /*T:string?*/ = null;
     }
     static ref string? M1(int i) => throw null!;
     static ref string M2(int i) => throw null!;
@@ -23288,15 +23273,9 @@ class C
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
-                // (6,10): warning CS8619: Nullability of reference types in value of type 'string?' doesn't match target type 'string'.
-                //         (b ? ref M1(false ? 1 : throw new System.Exception()) : ref M2(2)) /*T:string!*/ = null; // 1, 2
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref M1(false ? 1 : throw new System.Exception()) : ref M2(2)").WithArguments("string?", "string").WithLocation(6, 10),
                 // (6,92): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         (b ? ref M1(false ? 1 : throw new System.Exception()) : ref M2(2)) /*T:string!*/ = null; // 1, 2
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 92),
-                // (7,10): warning CS8619: Nullability of reference types in value of type 'string?' doesn't match target type 'string'.
-                //         (b ? ref M1(1) : ref M2(false ? 2 : throw new System.Exception())) /*T:string?*/ = null; // 3
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref M1(1) : ref M2(false ? 2 : throw new System.Exception())").WithArguments("string?", "string").WithLocation(7, 10)
+                //         (b ? ref M1(false ? 1 : throw new System.Exception()) : ref M2(2)) /*T:string!*/ = null; // 1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 92)
                 );
         }
 
@@ -23330,42 +23309,30 @@ class C
     static void F1(bool b, ref string? x1, ref string y1)
     {
         ((b && false) ? ref x1 : ref x1)/*T:string?*/ = null;
-        ((b && false) ? ref x1 : ref y1)/*T:string!*/ = null; // 1, 2
-        ((b && false) ? ref y1 : ref x1)/*T:string?*/ = null; // 3
-        ((b && false) ? ref y1 : ref y1)/*T:string!*/ = null; // 4
+        ((b && false) ? ref x1 : ref y1)/*T:string!*/ = null; // 1
+        ((b && false) ? ref y1 : ref x1)/*T:string?*/ = null;
+        ((b && false) ? ref y1 : ref y1)/*T:string!*/ = null; // 2
 
         ((b || true) ? ref x1 : ref x1)/*T:string?*/ = null;
-        ((b || true) ? ref x1 : ref y1)/*T:string?*/ = null; // 5
-        ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 6, 7
-        ((b || true) ? ref y1 : ref y1)/*T:string!*/ = null; // 8
+        ((b || true) ? ref x1 : ref y1)/*T:string?*/ = null;
+        ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 3
+        ((b || true) ? ref y1 : ref y1)/*T:string!*/ = null; // 4
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
-                // (7,10): warning CS8619: Nullability of reference types in value of type 'string?' doesn't match target type 'string'.
-                //         ((b && false) ? ref x1 : ref y1)/*T:string!*/ = null; // 1, 2
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(b && false) ? ref x1 : ref y1").WithArguments("string?", "string").WithLocation(7, 10),
                 // (7,57): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         ((b && false) ? ref x1 : ref y1)/*T:string!*/ = null; // 1, 2
+                //         ((b && false) ? ref x1 : ref y1)/*T:string!*/ = null; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 57),
-                // (8,10): warning CS8619: Nullability of reference types in value of type 'string' doesn't match target type 'string?'.
-                //         ((b && false) ? ref y1 : ref x1)/*T:string?*/ = null; // 3
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(b && false) ? ref y1 : ref x1").WithArguments("string", "string?").WithLocation(8, 10),
                 // (9,57): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         ((b && false) ? ref y1 : ref y1)/*T:string!*/ = null; // 4
+                //         ((b && false) ? ref y1 : ref y1)/*T:string!*/ = null; // 2
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(9, 57),
-                // (12,10): warning CS8619: Nullability of reference types in value of type 'string?' doesn't match target type 'string'.
-                //         ((b || true) ? ref x1 : ref y1)/*T:string?*/ = null; // 5
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(b || true) ? ref x1 : ref y1").WithArguments("string?", "string").WithLocation(12, 10),
-                // (13,10): warning CS8619: Nullability of reference types in value of type 'string' doesn't match target type 'string?'.
-                //         ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 6, 7
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(b || true) ? ref y1 : ref x1").WithArguments("string", "string?").WithLocation(13, 10),
                 // (13,56): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 6, 7
+                //         ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 56),
                 // (14,56): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         ((b || true) ? ref y1 : ref y1)/*T:string!*/ = null; // 8
+                //         ((b || true) ? ref y1 : ref y1)/*T:string!*/ = null; // 4
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(14, 56)
                 );
         }
@@ -30820,7 +30787,7 @@ class C
     }
     T M2<T>(T x, T y) => throw null!;
 }";
-            // See TODO2
+            // See https://github.com/dotnet/roslyn/issues/34392
             // Best type inference involving lambda conversion should agree with method type inference
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyTypes();
@@ -41814,18 +41781,12 @@ class C
                 // (7,9): error CS8598: The suppression operator is not allowed in this context
                 //         t! = s;
                 Diagnostic(ErrorCode.ERR_IllegalSuppression, "t").WithLocation(7, 9),
-                // (7,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         t! = s;
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "s").WithLocation(7, 14),
                 // (8,9): error CS8598: The suppression operator is not allowed in this context
                 //         t! += s;
                 Diagnostic(ErrorCode.ERR_IllegalSuppression, "t").WithLocation(8, 9),
                 // (9,10): error CS8598: The suppression operator is not allowed in this context
                 //         (t!) = s;
-                Diagnostic(ErrorCode.ERR_IllegalSuppression, "t").WithLocation(9, 10),
-                // (9,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         (t!) = s;
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "s").WithLocation(9, 16)
+                Diagnostic(ErrorCode.ERR_IllegalSuppression, "t").WithLocation(9, 10)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -23280,7 +23280,7 @@ class C
     static void F1(bool b)
     {
         (b ? ref M1(false ? 1 : throw new System.Exception()) : ref M2(2)) /*T:string!*/ = null; // 1, 2
-        (b ? ref M1(1) : ref M2(false ? 2 : throw new System.Exception())) /*T:string?*/ = null; // 3
+        (b ? ref M1(1) : ref M2(false ? 2 : throw new System.Exception())) /*T:string?*/ = null; // 3, 4
     }
     static ref string? M1(int i) => throw null!;
     static ref string M2(int i) => throw null!;
@@ -23295,8 +23295,11 @@ class C
                 //         (b ? ref M1(false ? 1 : throw new System.Exception()) : ref M2(2)) /*T:string!*/ = null; // 1, 2
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 92),
                 // (7,10): warning CS8619: Nullability of reference types in value of type 'string?' doesn't match target type 'string'.
-                //         (b ? ref M1(1) : ref M2(false ? 2 : throw new System.Exception())) /*T:string?*/ = null; // 3
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref M1(1) : ref M2(false ? 2 : throw new System.Exception())").WithArguments("string?", "string").WithLocation(7, 10)
+                //         (b ? ref M1(1) : ref M2(false ? 2 : throw new System.Exception())) /*T:string?*/ = null; // 3, 4
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b ? ref M1(1) : ref M2(false ? 2 : throw new System.Exception())").WithArguments("string?", "string").WithLocation(7, 10),
+                // (7,92): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         (b ? ref M1(1) : ref M2(false ? 2 : throw new System.Exception())) /*T:string?*/ = null; // 3, 4
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 92)
                 );
         }
 
@@ -23331,13 +23334,13 @@ class C
     {
         ((b && false) ? ref x1 : ref x1)/*T:string?*/ = null;
         ((b && false) ? ref x1 : ref y1)/*T:string!*/ = null; // 1, 2
-        ((b && false) ? ref y1 : ref x1)/*T:string?*/ = null; // 3
-        ((b && false) ? ref y1 : ref y1)/*T:string!*/ = null; // 4
+        ((b && false) ? ref y1 : ref x1)/*T:string?*/ = null; // 3, 4
+        ((b && false) ? ref y1 : ref y1)/*T:string!*/ = null; // 5
 
         ((b || true) ? ref x1 : ref x1)/*T:string?*/ = null;
-        ((b || true) ? ref x1 : ref y1)/*T:string?*/ = null; // 5
-        ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 6, 7
-        ((b || true) ? ref y1 : ref y1)/*T:string!*/ = null; // 8
+        ((b || true) ? ref x1 : ref y1)/*T:string?*/ = null; // 6, 7
+        ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 8, 9
+        ((b || true) ? ref y1 : ref y1)/*T:string!*/ = null; // 10
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
@@ -23350,22 +23353,28 @@ class C
                 //         ((b && false) ? ref x1 : ref y1)/*T:string!*/ = null; // 1, 2
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 57),
                 // (8,10): warning CS8619: Nullability of reference types in value of type 'string' doesn't match target type 'string?'.
-                //         ((b && false) ? ref y1 : ref x1)/*T:string?*/ = null; // 3
+                //         ((b && false) ? ref y1 : ref x1)/*T:string?*/ = null; // 3, 4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(b && false) ? ref y1 : ref x1").WithArguments("string", "string?").WithLocation(8, 10),
+                // (8,57): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         ((b && false) ? ref y1 : ref x1)/*T:string?*/ = null; // 3, 4
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 57),
                 // (9,57): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         ((b && false) ? ref y1 : ref y1)/*T:string!*/ = null; // 4
+                //         ((b && false) ? ref y1 : ref y1)/*T:string!*/ = null; // 5
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(9, 57),
                 // (12,10): warning CS8619: Nullability of reference types in value of type 'string?' doesn't match target type 'string'.
-                //         ((b || true) ? ref x1 : ref y1)/*T:string?*/ = null; // 5
+                //         ((b || true) ? ref x1 : ref y1)/*T:string?*/ = null; // 6, 7
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(b || true) ? ref x1 : ref y1").WithArguments("string?", "string").WithLocation(12, 10),
+                // (12,56): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         ((b || true) ? ref x1 : ref y1)/*T:string?*/ = null; // 6, 7
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 56),
                 // (13,10): warning CS8619: Nullability of reference types in value of type 'string' doesn't match target type 'string?'.
-                //         ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 6, 7
+                //         ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 8, 9
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(b || true) ? ref y1 : ref x1").WithArguments("string", "string?").WithLocation(13, 10),
                 // (13,56): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 6, 7
+                //         ((b || true) ? ref y1 : ref x1)/*T:string!*/ = null; // 8, 9
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 56),
                 // (14,56): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         ((b || true) ? ref y1 : ref y1)/*T:string!*/ = null; // 8
+                //         ((b || true) ? ref y1 : ref y1)/*T:string!*/ = null; // 10
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(14, 56)
                 );
         }


### PR DESCRIPTION
This PR also makes assignments to ref variable produce safety warnings


- Fixes https://github.com/dotnet/roslyn/issues/33982 (Mismatched null assignment through a ref variable should be a safety warning)
- Fixes https://github.com/dotnet/roslyn/issues/30432 (Report nullability warning for best common type mismatch with `ref`)
- Fixes https://github.com/dotnet/roslyn/issues/33664 (Conditional ref operator should require same nullability)
- Fixes https://github.com/dotnet/roslyn/issues/33924 (Conditional expression should compute nullable result state from result state of operands)
- Closes https://github.com/dotnet/roslyn/issues/29869 (Confirm ``` /*T:...*/``` expectations in ConditionalOperator_14 unit-test)
- Closes https://github.com/dotnet/roslyn/issues/32701 (Missing warning for assigning an annotated possible null value to an unconstrained generic)
- Relates to https://github.com/dotnet/roslyn/issues/33025 (Track null state through ref assignments to ref ternaries)