### PR TITLE
Merge in 3.0 SDK switchover

### DIFF
--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -18,7 +18,8 @@ The minimal required version of .NET Framework is 4.7.2.
 1. [Visual Studio 2019 RC](https://visualstudio.microsoft.com/downloads/#2019rc)
     - Ensure C#, VB, MSBuild, .NET Core and Visual Studio Extensibility are included in the selected work loads
     - Ensure Visual Studio is on Version "RC1" or greater
-1. [.NET Core SDK 2.1.401](https://www.microsoft.com/net/download/core) (the installers are: [Windows x64 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.401/dotnet-sdk-2.1.401-win-x64.exe), [Windows x86 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.401/dotnet-sdk-2.1.401-win-x86.exe))
+    - Ensure "Use Previews" is checked in Tools -> Options -> Projects and Solutions -> .NET Core
+1. [.NET Core SDK 3.0 Preview 3](https://dotnet.microsoft.com/download/dotnet-core/3.0) [Windows x64 installer](https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-3.0.100-preview3-windows-x64-installer)
 1. [PowerShell 5.0 or newer](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell). If you are on Windows 10, you are fine; you'll only need to upgrade if you're on Windows 7. The download link is under the "upgrading existing Windows PowerShell" heading.
 1. Run Restore.cmd
 1. Open Roslyn.sln

--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -19,7 +19,7 @@ The minimal required version of .NET Framework is 4.7.2.
     - Ensure C#, VB, MSBuild, .NET Core and Visual Studio Extensibility are included in the selected work loads
     - Ensure Visual Studio is on Version "RC1" or greater
     - Ensure "Use Previews" is checked in Tools -> Options -> Projects and Solutions -> .NET Core
-1. [.NET Core SDK 3.0 Preview 3](https://dotnet.microsoft.com/download/dotnet-core/3.0) [Windows x64 installer](https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-3.0.100-preview3-windows-x64-installer)
+1. [.NET Core SDK 3.0 Preview 4](https://dotnet.microsoft.com/download/dotnet-core/3.0) [Windows x64 installer](https://dotnetcli.azureedge.net/dotnet/Sdk/3.0.100-preview4-010391/dotnet-sdk-3.0.100-preview4-010391-win-x64.exe )
 1. [PowerShell 5.0 or newer](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell). If you are on Windows 10, you are fine; you'll only need to upgrade if you're on Windows 7. The download link is under the "upgrading existing Windows PowerShell" heading.
 1. Run Restore.cmd
 1. Open Roslyn.sln

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -72,8 +72,6 @@
     <!-- PROTOTYPE(DefaultInterfaceImplementation): The MicrosoftNetCoreILAsmVersion was 2.0.0 -->
     <MicrosoftNetCoreILAsmVersion>3.0.0-preview4-27420-71</MicrosoftNetCoreILAsmVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.2</MicrosoftNETCorePlatformsVersion>
-    <!-- PROTOTYPE(DefaultInterfaceImplementation): The MicrosoftNETCoreRuntimeCoreCLRVersion was 2.0.0 -->
-    <MicrosoftNETCoreRuntimeCoreCLRVersion>3.0.0-preview4-27420-5</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <!-- Using a private build of Microsoft.Net.Test.SDK to work around issue https://github.com/Microsoft/vstest/issues/1764 -->
     <MicrosoftNETTestSdkVersion>15.9.0-dev2</MicrosoftNETTestSdkVersion>
     <MicrosoftNETCoreTestHostVersion>1.1.0</MicrosoftNETCoreTestHostVersion>
@@ -319,12 +317,6 @@
       https://vside.myget.org/F/vs-impl/api/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnet.myget.org/F/system-commandline/api/v3/index.json;
-      
-      <!--
-      PROTOTYPE(DefaultInterfaceImplementation): added the https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json (Microsoft.NETCore.App) and 
-                                                 https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json (Microsoft.NETCore.ILAsm) sources below
-      -->
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json;
     </RestoreSources>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,7 +67,7 @@
     <MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>14.3.25407-alpha</MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta1-63011-01</MicrosoftMetadataVisualizerVersion>
     <MicrosoftMSXMLVersion>8.0.0.0-alpha</MicrosoftMSXMLVersion>
-    <MicrosoftNetCompilersToolsetVersion>3.1.0-beta1-19127-06</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>3.1.0-beta1-19164-01</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNetCoreAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftNetCoreAnalyzersVersion>
     <!-- PROTOTYPE(DefaultInterfaceImplementation): The MicrosoftNetCoreILAsmVersion was 2.0.0 -->
     <MicrosoftNetCoreILAsmVersion>3.0.0-preview4-27420-71</MicrosoftNetCoreILAsmVersion>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -223,8 +223,6 @@ function BuildSolution() {
     # an arcade bug
     # https://github.com/dotnet/arcade/issues/2220
     $quietRestore = !($ci -or ($bootstrapDir -ne ""))
-
-    # PROTOTYPE(DefaultInterfaceImplementation): Added "netcoreapp3.0%3B", original value was "netcoreapp2.1"
     $testTargetFrameworks = if ($testCoreClr) { "netcoreapp3.0%3Bnetcoreapp2.1" } else { "" }
     
     $ibcSourceBranchName = GetIbcSourceBranchName

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -34,6 +34,7 @@ param (
     [switch]$bootstrap,
     [string]$bootstrapConfiguration = "Release",
     [switch][Alias('bl')]$binaryLog,
+    [switch]$buildServerLog,
     [switch]$ci,
     [switch]$procdump,
     [switch]$skipAnalyzers,
@@ -75,6 +76,7 @@ function Print-Usage() {
     Write-Host "  -verbosity <value>        Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
     Write-Host "  -deployExtensions         Deploy built vsixes (short: -d)"
     Write-Host "  -binaryLog                Create MSBuild binary log (short: -bl)"
+    Write-Host "  -buildServerLog           Create Roslyn build server log"
     Write-Host ""
     Write-Host "Actions:"
     Write-Host "  -restore                  Restore packages (short: -r)"
@@ -163,6 +165,9 @@ function Process-Arguments() {
 
     if ($ci) {
         $script:binaryLog = $true
+        if ($bootstrap) {
+            $script:buildServerLog = $true
+        }
     }
 
     if ($test32 -and $test64) {
@@ -205,6 +210,11 @@ function BuildSolution() {
     Write-Host "$($solution):"
 
     $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "Build.binlog") } else { "" }
+
+    if ($buildServerLog) {
+        ${env:ROSLYNCOMMANDLINELOGFILE} = Join-Path $LogDir "Build.Server.log"
+    }
+
     $projects = Join-Path $RepoRoot $solution
     $enableAnalyzers = !$skipAnalyzers
     $toolsetBuildProj = InitializeToolset
@@ -226,36 +236,41 @@ function BuildSolution() {
     # Workaround for some machines in the AzDO pool not allowing long paths (%5c is msbuild escaped backslash)
     $ibcDir = Join-Path $RepoRoot ".o%5c"
 
-    # Setting /p:TreatWarningsAsErrors=true is a workaround for https://github.com/Microsoft/msbuild/issues/3062.
-    # We don't pass /warnaserror to msbuild ($warnAsError is set to $false by default above), but set 
-    # /p:TreatWarningsAsErrors=true so that compiler reported warnings, other than IDE0055 are treated as errors. 
-    # Warnings reported from other msbuild tasks are not treated as errors for now.
-    MSBuild $toolsetBuildProj `
-        $bl `
-        /p:Configuration=$configuration `
-        /p:Projects=$projects `
-        /p:RepoRoot=$RepoRoot `
-        /p:Restore=$restore `
-        /p:Build=$build `
-        /p:Test=$testCoreClr `
-        /p:Rebuild=$rebuild `
-        /p:Pack=$pack `
-        /p:Sign=$sign `
-        /p:Publish=$publish `
-        /p:ContinuousIntegrationBuild=$ci `
-        /p:OfficialBuildId=$officialBuildId `
-        /p:UseRoslynAnalyzers=$enableAnalyzers `
-        /p:BootstrapBuildPath=$bootstrapDir `
-        /p:QuietRestore=$quietRestore `
-        /p:QuietRestoreBinaryLog=$binaryLog `
-        /p:TestTargetFrameworks=$testTargetFrameworks `
-        /p:TreatWarningsAsErrors=true `
-        /p:VisualStudioIbcSourceBranchName=$ibcSourceBranchName `
-        /p:VisualStudioIbcDropId=$ibcDropId `
-        /p:EnablePartialNgenOptimization=$applyOptimizationData `
-        /p:IbcOptimizationDataDir=$ibcDir `
-        $suppressExtensionDeployment `
-        @properties
+    try {
+        # Setting /p:TreatWarningsAsErrors=true is a workaround for https://github.com/Microsoft/msbuild/issues/3062.
+        # We don't pass /warnaserror to msbuild ($warnAsError is set to $false by default above), but set 
+        # /p:TreatWarningsAsErrors=true so that compiler reported warnings, other than IDE0055 are treated as errors. 
+        # Warnings reported from other msbuild tasks are not treated as errors for now.
+        MSBuild $toolsetBuildProj `
+            $bl `
+            /p:Configuration=$configuration `
+            /p:Projects=$projects `
+            /p:RepoRoot=$RepoRoot `
+            /p:Restore=$restore `
+            /p:Build=$build `
+            /p:Test=$testCoreClr `
+            /p:Rebuild=$rebuild `
+            /p:Pack=$pack `
+            /p:Sign=$sign `
+            /p:Publish=$publish `
+            /p:ContinuousIntegrationBuild=$ci `
+            /p:OfficialBuildId=$officialBuildId `
+            /p:UseRoslynAnalyzers=$enableAnalyzers `
+            /p:BootstrapBuildPath=$bootstrapDir `
+            /p:QuietRestore=$quietRestore `
+            /p:QuietRestoreBinaryLog=$binaryLog `
+            /p:TestTargetFrameworks=$testTargetFrameworks `
+            /p:TreatWarningsAsErrors=true `
+            /p:VisualStudioIbcSourceBranchName=$ibcSourceBranchName `
+            /p:VisualStudioIbcDropId=$ibcDropId `
+            /p:EnablePartialNgenOptimization=$applyOptimizationData `
+            /p:IbcOptimizationDataDir=$ibcDir `
+            $suppressExtensionDeployment `
+            @properties
+    }
+    finally {
+        ${env:ROSLYNCOMMANDLINELOGFILE} = $null
+    }
 }
 
 
@@ -567,6 +582,15 @@ try {
                 Capture-Screenshot $screenshotPath
             }
         }
+    }
+
+    if ($ci) {
+        $global:_DotNetInstallDir = Join-Path $RepoRoot ".dotnet"
+        InstallDotNetSdk $global:_DotNetInstallDir $GlobalJson.tools.dotnet
+
+        # Make sure a 2.1 runtime is installed so we can run our tests. Most of them still 
+        # target netcoreapp2.1.
+        InstallDotNetSdk $global:_DotNetInstallDir "2.1.503"
     }
 
     if ($bootstrap) {

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -283,6 +283,9 @@ function BuildSolution {
 
 InitializeDotNetCli $restore
 
+# Make sure we have a 2.1 runtime available for running our tests
+InstallDotNetSdk $_InitializeDotNetCli 2.1.503
+
 bootstrap_dir=""
 if [[ "$bootstrap" == true ]]; then
   MakeBootstrapBuild

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -249,7 +249,6 @@ function BuildSolution {
     mono_tool="/p:MonoTool=\"$mono_path\""
   elif [[ "$test_core_clr" == true ]]; then
     test=true
-    # PROTOTYPE(DefaultInterfaceImplementation): Added /p:TestTargetFrameworks=netcoreapp3.0%3Bnetcoreapp2.1
     test_runtime="/p:TestRuntime=Core /p:TestTargetFrameworks=netcoreapp3.0%3Bnetcoreapp2.1"
     mono_tool=""
   fi

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -94,9 +94,6 @@ function InitializeDotNetCli([bool]$install) {
   # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
   $env:DOTNET_MULTILEVEL_LOOKUP=0
 
-  # PROTOTYPE(DefaultInterfaceImplementation): Set this to be able to run apps targeting netcoreapp2.1 against netcoreapp3.0
-  $env:DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
-
   # Disable first run since we do not need all ASP.NET packages restored.
   $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -83,9 +83,6 @@ function InitializeDotNetCli {
   # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
   export DOTNET_MULTILEVEL_LOOKUP=0
 
-  # PROTOTYPE(DefaultInterfaceImplementation): Set this to be able to run apps targeting netcoreapp2.1 against netcoreapp3.0
-  export DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
-
   # Disable first run since we want to control all package sources
   export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <Reference Include="System.Configuration" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
+    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -103,10 +103,13 @@ namespace BuildBoss
                         string.Empty,
                         assetRelativeNames);
 
+            // Temporarily inserting Microsoft.DiaSymReader.Native.arm.dll while SDK team tracks down why 
+            // it's being inserted into destkop builds.
+            // https://github.com/dotnet/cli/issues/10979
             allGood &= VerifyVsix(
                         textWriter,
                         FindVsix("Roslyn.Compilers.Extension"),
-                        assetRelativeNames.Concat(new[] { "Roslyn.Compilers.Extension.dll" }));
+                        assetRelativeNames.Concat(new[] { "Roslyn.Compilers.Extension.dll", "Microsoft.DiaSymReader.Native.arm.dll" }));
             return allGood;
         }
 
@@ -172,6 +175,7 @@ namespace BuildBoss
             // root as well. That copy is unnecessary.
             coreClrAssets.RemoveAll(asset =>
                 PathComparer.Equals("Microsoft.DiaSymReader.Native.amd64.dll", asset.FileRelativeName) ||
+                PathComparer.Equals("Microsoft.DiaSymReader.Native.arm.dll", asset.FileRelativeName) ||
                 PathComparer.Equals("Microsoft.DiaSymReader.Native.x86.dll", asset.FileRelativeName));
 
             // Move all of the assets into bincore as that is where the non-MSBuild task assets will go

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListNetCore.cs
@@ -30,7 +30,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             base.ErrorLevelWarning();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorList)]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/34211"), Trait(Traits.Feature, Traits.Features.ErrorList)]
         [Trait(Traits.Feature, Traits.Features.NetCore)]
         public override void ErrorsDuringMethodBodyEditing()
         {

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
@@ -26,7 +26,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             base.OpenCSharpThenVBSolution();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        [WpfFact(Skip = "https://github.com/dotnet/cli/issues/10989"), Trait(Traits.Feature, Traits.Features.Workspace)]
         [Trait(Traits.Feature, Traits.Features.NetCore)]
         public override void MetadataReference()
         {


### PR DESCRIPTION
The last commit removes all of the PROTOTYPE comments around the 3.0 SDK usage. 