### PR TITLE
Readonly members improved diagnostics

### DIFF
--- a/docs/features/readonly-instance-members.md
+++ b/docs/features/readonly-instance-members.md
@@ -129,7 +129,18 @@ public int Prop
 ```
 
 ### Auto-properties
-Readonly cannot be applied to auto-implemented properties or their accessors. The compiler will treat all auto-implemented getters as readonly.
+Readonly can be applied to auto-implemented properties or `get` accessors. However, the compiler will treat all auto-implemented getters as readonly regardless of whether a `readonly` modifier is present.
+
+```csharp
+// Allowed
+public readonly int Prop1 { get; }
+public int Prop2 { readonly get; }
+public int Prop3 { readonly get; set; }
+
+// Not allowed
+public readonly int Prop4 { get; set; }
+public int Prop5 { get; readonly set; }
+```
 
 ### Events
 Readonly can be applied to manually-implemented events, but not field-like events. Readonly cannot be applied to individual event accessors (add/remove).

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -460,7 +460,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (!isValueType || (RequiresAssignableVariable(valueKind) && (this.ContainingMemberOrLambda as MethodSymbol)?.IsEffectivelyReadOnly == true))
                     {
                         // CONSIDER: the Dev10 name has angle brackets (i.e. "<this>")
-                        Error(diagnostics, GetThisLvalueError(valueKind, isValueType), node, ThisParameterSymbol.SymbolName);
+                        Error(diagnostics, GetThisLvalueError(valueKind, isValueType), node, node);
                         return false;
                     }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -459,7 +459,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var isValueType = ((BoundThisReference)expr).Type.IsValueType;
                     if (!isValueType || (RequiresAssignableVariable(valueKind) && (this.ContainingMemberOrLambda as MethodSymbol)?.IsEffectivelyReadOnly == true))
                     {
-                        // CONSIDER: the Dev10 name has angle brackets (i.e. "<this>")
                         Error(diagnostics, GetThisLvalueError(valueKind, isValueType), node, node);
                         return false;
                     }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -826,15 +826,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Auto-implemented property or accessor &apos;{0}&apos; cannot be marked &apos;readonly&apos;..
-        /// </summary>
-        internal static string ERR_AutoPropertyCantBeReadOnly {
-            get {
-                return ResourceManager.GetString("ERR_AutoPropertyCantBeReadOnly", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Auto-implemented properties inside interfaces cannot have initializers..
         /// </summary>
         internal static string ERR_AutoPropertyInitializerInInterface {
@@ -862,11 +853,29 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Auto-implemented property &apos;{0}&apos; cannot be marked &apos;readonly&apos; because it has a &apos;set&apos; accessor..
+        /// </summary>
+        internal static string ERR_AutoPropertyWithSetterCantBeReadOnly {
+            get {
+                return ResourceManager.GetString("ERR_AutoPropertyWithSetterCantBeReadOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Auto-implemented instance properties in readonly structs must be readonly..
         /// </summary>
         internal static string ERR_AutoPropsInRoStruct {
             get {
                 return ResourceManager.GetString("ERR_AutoPropsInRoStruct", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto-implemented &apos;set&apos; accessor &apos;{0}&apos; cannot be marked &apos;readonly&apos;..
+        /// </summary>
+        internal static string ERR_AutoSetterCantBeReadOnly {
+            get {
+                return ResourceManager.GetString("ERR_AutoSetterCantBeReadOnly", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3931,7 +3931,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot specify &apos;readonly&apos; modifiers on both accessors of property or indexer &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Cannot specify &apos;readonly&apos; modifiers on both accessors of property or indexer &apos;{0}&apos;. Instead, put a &apos;readonly&apos; modifier on the property itself..
         /// </summary>
         internal static string ERR_DuplicatePropertyReadOnlyMods {
             get {
@@ -6271,7 +6271,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot specify &apos;readonly&apos; modifiers on both property or indexer &apos;{0}&apos; and its accessors..
+        ///   Looks up a localized string similar to Cannot specify &apos;readonly&apos; modifiers on both property or indexer &apos;{0}&apos; and its accessor. Remove one of them..
         /// </summary>
         internal static string ERR_InvalidPropertyReadOnlyMods {
             get {
@@ -9655,7 +9655,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Static member &apos;{0}&apos; cannot be &apos;readonly&apos;..
+        ///   Looks up a localized string similar to Static member &apos;{0}&apos; cannot be marked &apos;readonly&apos; because readonly members cannot modify &apos;this&apos; and static members do not have a &apos;this&apos; parameter..
         /// </summary>
         internal static string ERR_StaticMemberCantBeReadOnly {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -835,15 +835,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Auto-implemented property or accessor cannot be marked &apos;readonly&apos;..
-        /// </summary>
-        internal static string ERR_AutoPropertyCantBeReadOnly_Title {
-            get {
-                return ResourceManager.GetString("ERR_AutoPropertyCantBeReadOnly_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Auto-implemented properties inside interfaces cannot have initializers..
         /// </summary>
         internal static string ERR_AutoPropertyInitializerInInterface {
@@ -3940,15 +3931,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot specify &apos;readonly&apos; modifiers on both accessors of property or indexer..
-        /// </summary>
-        internal static string ERR_DuplicatePropertyReadOnlyMods_Title {
-            get {
-                return ResourceManager.GetString("ERR_DuplicatePropertyReadOnlyMods_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; duplicate TypeForwardedToAttribute.
         /// </summary>
         internal static string ERR_DuplicateTypeForwarder {
@@ -4980,15 +4962,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_FieldLikeEventCantBeReadOnly {
             get {
                 return ResourceManager.GetString("ERR_FieldLikeEventCantBeReadOnly", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Field-like event cannot be &apos;readonly&apos;..
-        /// </summary>
-        internal static string ERR_FieldLikeEventCantBeReadOnly_Title {
-            get {
-                return ResourceManager.GetString("ERR_FieldLikeEventCantBeReadOnly_Title", resourceCulture);
             }
         }
         
@@ -6294,15 +6267,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_InvalidPropertyReadOnlyMods {
             get {
                 return ResourceManager.GetString("ERR_InvalidPropertyReadOnlyMods", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot specify &apos;readonly&apos; modifiers on both property or indexer and its accessors..
-        /// </summary>
-        internal static string ERR_InvalidPropertyReadOnlyMods_Title {
-            get {
-                return ResourceManager.GetString("ERR_InvalidPropertyReadOnlyMods_Title", resourceCulture);
             }
         }
         
@@ -9687,15 +9651,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_StaticMemberCantBeReadOnly {
             get {
                 return ResourceManager.GetString("ERR_StaticMemberCantBeReadOnly", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Static member cannot be &apos;readonly&apos;..
-        /// </summary>
-        internal static string ERR_StaticMemberCantBeReadOnly_Title {
-            get {
-                return ResourceManager.GetString("ERR_StaticMemberCantBeReadOnly_Title", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -826,6 +826,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Auto-implemented property or accessor &apos;{0}&apos; cannot be marked &apos;readonly&apos;..
+        /// </summary>
+        internal static string ERR_AutoPropertyCantBeReadOnly {
+            get {
+                return ResourceManager.GetString("ERR_AutoPropertyCantBeReadOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto-implemented property or accessor cannot be marked &apos;readonly&apos;..
+        /// </summary>
+        internal static string ERR_AutoPropertyCantBeReadOnly_Title {
+            get {
+                return ResourceManager.GetString("ERR_AutoPropertyCantBeReadOnly_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Auto-implemented properties inside interfaces cannot have initializers..
         /// </summary>
         internal static string ERR_AutoPropertyInitializerInInterface {
@@ -3913,6 +3931,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot specify &apos;readonly&apos; modifiers on both accessors of property or indexer &apos;{0}&apos;..
+        /// </summary>
+        internal static string ERR_DuplicatePropertyReadOnlyMods {
+            get {
+                return ResourceManager.GetString("ERR_DuplicatePropertyReadOnlyMods", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot specify &apos;readonly&apos; modifiers on both accessors of property or indexer..
+        /// </summary>
+        internal static string ERR_DuplicatePropertyReadOnlyMods_Title {
+            get {
+                return ResourceManager.GetString("ERR_DuplicatePropertyReadOnlyMods_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; duplicate TypeForwardedToAttribute.
         /// </summary>
         internal static string ERR_DuplicateTypeForwarder {
@@ -4935,6 +4971,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_FieldInitRefNonstatic {
             get {
                 return ResourceManager.GetString("ERR_FieldInitRefNonstatic", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field-like event &apos;{0}&apos; cannot be &apos;readonly&apos;..
+        /// </summary>
+        internal static string ERR_FieldLikeEventCantBeReadOnly {
+            get {
+                return ResourceManager.GetString("ERR_FieldLikeEventCantBeReadOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field-like event cannot be &apos;readonly&apos;..
+        /// </summary>
+        internal static string ERR_FieldLikeEventCantBeReadOnly_Title {
+            get {
+                return ResourceManager.GetString("ERR_FieldLikeEventCantBeReadOnly_Title", resourceCulture);
             }
         }
         
@@ -6231,6 +6285,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_InvalidPropertyAccessMod {
             get {
                 return ResourceManager.GetString("ERR_InvalidPropertyAccessMod", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot specify &apos;readonly&apos; modifiers on both property or indexer &apos;{0}&apos; and its accessors..
+        /// </summary>
+        internal static string ERR_InvalidPropertyReadOnlyMods {
+            get {
+                return ResourceManager.GetString("ERR_InvalidPropertyReadOnlyMods", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot specify &apos;readonly&apos; modifiers on both property or indexer and its accessors..
+        /// </summary>
+        internal static string ERR_InvalidPropertyReadOnlyMods_Title {
+            get {
+                return ResourceManager.GetString("ERR_InvalidPropertyReadOnlyMods_Title", resourceCulture);
             }
         }
         
@@ -9606,6 +9678,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_StaticLocalFunctionCannotCaptureVariable {
             get {
                 return ResourceManager.GetString("ERR_StaticLocalFunctionCannotCaptureVariable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Static member &apos;{0}&apos; cannot be &apos;readonly&apos;..
+        /// </summary>
+        internal static string ERR_StaticMemberCantBeReadOnly {
+            get {
+                return ResourceManager.GetString("ERR_StaticMemberCantBeReadOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Static member cannot be &apos;readonly&apos;..
+        /// </summary>
+        internal static string ERR_StaticMemberCantBeReadOnly_Title {
+            get {
+                return ResourceManager.GetString("ERR_StaticMemberCantBeReadOnly_Title", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5430,8 +5430,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_StaticMemberCantBeReadOnly" xml:space="preserve">
     <value>Static member '{0}' cannot be 'readonly'.</value>
   </data>
-  <data name="ERR_AutoPropertyCantBeReadOnly" xml:space="preserve">
-    <value>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</value>
+  <data name="ERR_AutoSetterCantBeReadOnly" xml:space="preserve">
+    <value>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</value>
+  </data>
+  <data name="ERR_AutoPropertyWithSetterCantBeReadOnly" xml:space="preserve">
+    <value>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</value>
   </data>
   <data name="ERR_InvalidPropertyReadOnlyMods" xml:space="preserve">
     <value>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5430,32 +5430,17 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_StaticMemberCantBeReadOnly" xml:space="preserve">
     <value>Static member '{0}' cannot be 'readonly'.</value>
   </data>
-  <data name="ERR_StaticMemberCantBeReadOnly_Title" xml:space="preserve">
-    <value>Static member cannot be 'readonly'.</value>
-  </data>
   <data name="ERR_AutoPropertyCantBeReadOnly" xml:space="preserve">
     <value>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</value>
-  </data>
-  <data name="ERR_AutoPropertyCantBeReadOnly_Title" xml:space="preserve">
-    <value>Auto-implemented property or accessor cannot be marked 'readonly'.</value>
   </data>
   <data name="ERR_InvalidPropertyReadOnlyMods" xml:space="preserve">
     <value>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</value>
   </data>
-  <data name="ERR_InvalidPropertyReadOnlyMods_Title" xml:space="preserve">
-    <value>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</value>
-  </data>
   <data name="ERR_DuplicatePropertyReadOnlyMods" xml:space="preserve">
     <value>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</value>
   </data>
-  <data name="ERR_DuplicatePropertyReadOnlyMods_Title" xml:space="preserve">
-    <value>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</value>
-  </data>
   <data name="ERR_FieldLikeEventCantBeReadOnly" xml:space="preserve">
     <value>Field-like event '{0}' cannot be 'readonly'.</value>
-  </data>
-  <data name="ERR_FieldLikeEventCantBeReadOnly_Title" xml:space="preserve">
-    <value>Field-like event cannot be 'readonly'.</value>
   </data>
   <data name="WRN_NullabilityMismatchInArgument" xml:space="preserve">
     <value>Argument of type '{0}' cannot be used for parameter '{2}' of type '{1}' in '{3}' due to differences in the nullability of reference types.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5427,6 +5427,36 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_ImplicitCopyInReadOnlyMember_Title" xml:space="preserve">
     <value>Call to non-readonly member from a 'readonly' member results in an implicit copy.</value>
   </data>
+  <data name="ERR_StaticMemberCantBeReadOnly" xml:space="preserve">
+    <value>Static member '{0}' cannot be 'readonly'.</value>
+  </data>
+  <data name="ERR_StaticMemberCantBeReadOnly_Title" xml:space="preserve">
+    <value>Static member cannot be 'readonly'.</value>
+  </data>
+  <data name="ERR_AutoPropertyCantBeReadOnly" xml:space="preserve">
+    <value>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</value>
+  </data>
+  <data name="ERR_AutoPropertyCantBeReadOnly_Title" xml:space="preserve">
+    <value>Auto-implemented property or accessor cannot be marked 'readonly'.</value>
+  </data>
+  <data name="ERR_InvalidPropertyReadOnlyMods" xml:space="preserve">
+    <value>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</value>
+  </data>
+  <data name="ERR_InvalidPropertyReadOnlyMods_Title" xml:space="preserve">
+    <value>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</value>
+  </data>
+  <data name="ERR_DuplicatePropertyReadOnlyMods" xml:space="preserve">
+    <value>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</value>
+  </data>
+  <data name="ERR_DuplicatePropertyReadOnlyMods_Title" xml:space="preserve">
+    <value>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</value>
+  </data>
+  <data name="ERR_FieldLikeEventCantBeReadOnly" xml:space="preserve">
+    <value>Field-like event '{0}' cannot be 'readonly'.</value>
+  </data>
+  <data name="ERR_FieldLikeEventCantBeReadOnly_Title" xml:space="preserve">
+    <value>Field-like event cannot be 'readonly'.</value>
+  </data>
   <data name="WRN_NullabilityMismatchInArgument" xml:space="preserve">
     <value>Argument of type '{0}' cannot be used for parameter '{2}' of type '{1}' in '{3}' due to differences in the nullability of reference types.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5428,7 +5428,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Call to non-readonly member from a 'readonly' member results in an implicit copy.</value>
   </data>
   <data name="ERR_StaticMemberCantBeReadOnly" xml:space="preserve">
-    <value>Static member '{0}' cannot be 'readonly'.</value>
+    <value>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</value>
   </data>
   <data name="ERR_AutoSetterCantBeReadOnly" xml:space="preserve">
     <value>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</value>
@@ -5437,10 +5437,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</value>
   </data>
   <data name="ERR_InvalidPropertyReadOnlyMods" xml:space="preserve">
-    <value>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</value>
+    <value>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</value>
   </data>
   <data name="ERR_DuplicatePropertyReadOnlyMods" xml:space="preserve">
-    <value>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</value>
+    <value>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</value>
   </data>
   <data name="ERR_FieldLikeEventCantBeReadOnly" xml:space="preserve">
     <value>Field-like event '{0}' cannot be 'readonly'.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1685,10 +1685,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_NullLiteralMayIntroduceNullT = 8654,
         WRN_ImplicitCopyInReadOnlyMember = 8655,
         ERR_StaticMemberCantBeReadOnly = 8656,
-        ERR_AutoPropertyCantBeReadOnly = 8657,
-        ERR_InvalidPropertyReadOnlyMods = 8658,
-        ERR_DuplicatePropertyReadOnlyMods = 8659,
-        ERR_FieldLikeEventCantBeReadOnly = 8660
+        ERR_AutoSetterCantBeReadOnly = 8657,
+        ERR_AutoPropertyWithSetterCantBeReadOnly = 8658,
+        ERR_InvalidPropertyReadOnlyMods = 8659,
+        ERR_DuplicatePropertyReadOnlyMods = 8660,
+        ERR_FieldLikeEventCantBeReadOnly = 8661
 
         #endregion diagnostics introduced for C# 8.0
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1684,6 +1684,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_DefaultExpressionMayIntroduceNullT = 8653,
         WRN_NullLiteralMayIntroduceNullT = 8654,
         WRN_ImplicitCopyInReadOnlyMember = 8655,
+        ERR_StaticMemberCantBeReadOnly = 8656,
+        ERR_AutoPropertyCantBeReadOnly = 8657,
+        ERR_InvalidPropertyReadOnlyMods = 8658,
+        ERR_DuplicatePropertyReadOnlyMods = 8659,
+        ERR_FieldLikeEventCantBeReadOnly = 8660
 
         #endregion diagnostics introduced for C# 8.0
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -478,10 +478,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // A static member '{0}' cannot be marked as override, virtual, or abstract
                 diagnostics.Add(ErrorCode.ERR_StaticNotVirtual, location, this);
             }
-            else if (IsReadOnly && (IsStatic || HasAssociatedField))
+            else if (IsReadOnly && IsStatic)
             {
-                // The modifier '{0}' is not valid for this item
-                diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.ReadOnlyKeyword));
+                // Static member '{0}' cannot be 'readonly'.
+                diagnostics.Add(ErrorCode.ERR_StaticMemberCantBeReadOnly, location, this);
+            }
+            else if (IsReadOnly && HasAssociatedField)
+            {
+                // Field-like event '{0}' cannot be 'readonly'.
+                diagnostics.Add(ErrorCode.ERR_FieldLikeEventCantBeReadOnly, location, this);
             }
             else if (IsOverride && (IsNew || IsVirtual))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (IsReadOnly && IsStatic)
             {
-                // Static member '{0}' cannot be 'readonly'.
+                // Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.
                 diagnostics.Add(ErrorCode.ERR_StaticMemberCantBeReadOnly, location, this);
             }
             else if (IsReadOnly && HasAssociatedField)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -940,8 +940,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (IsStatic && IsDeclaredReadOnly)
             {
-                // The modifier '{0}' is not valid for this item
-                diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.ReadOnlyKeyword));
+                // Static member '{0}' cannot be 'readonly'.
+                diagnostics.Add(ErrorCode.ERR_StaticMemberCantBeReadOnly, location, this);
             }
             else if (IsAbstract && !ContainingType.IsAbstract && (ContainingType.TypeKind == TypeKind.Class || ContainingType.TypeKind == TypeKind.Submission))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -940,7 +940,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (IsStatic && IsDeclaredReadOnly)
             {
-                // Static member '{0}' cannot be 'readonly'.
+                // Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.
                 diagnostics.Add(ErrorCode.ERR_StaticMemberCantBeReadOnly, location, this);
             }
             else if (IsAbstract && !ContainingType.IsAbstract && (ContainingType.TypeKind == TypeKind.Class || ContainingType.TypeKind == TypeKind.Submission))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -480,10 +480,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // Static member '{0}' cannot be 'readonly'.
                 diagnostics.Add(ErrorCode.ERR_StaticMemberCantBeReadOnly, location, this);
             }
-            else if (LocalDeclaredReadOnly && _isAutoPropertyAccessor)
+            else if (LocalDeclaredReadOnly && _isAutoPropertyAccessor && MethodKind == MethodKind.PropertySet)
             {
-                // Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.
-                diagnostics.Add(ErrorCode.ERR_AutoPropertyCantBeReadOnly, location, this);
+                // Auto-implemented accessor '{0}' cannot be marked 'readonly'.
+                diagnostics.Add(ErrorCode.ERR_AutoSetterCantBeReadOnly, location, this);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -477,7 +477,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (LocalDeclaredReadOnly && IsStatic)
             {
-                // Static member '{0}' cannot be 'readonly'.
+                // Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.
                 diagnostics.Add(ErrorCode.ERR_StaticMemberCantBeReadOnly, location, this);
             }
             else if (LocalDeclaredReadOnly && _isAutoPropertyAccessor && MethodKind == MethodKind.PropertySet)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -910,7 +910,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (IsStatic && HasReadOnlyModifier)
             {
-                // Static member '{0}' cannot be 'readonly'.
+                // Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.
                 diagnostics.Add(ErrorCode.ERR_StaticMemberCantBeReadOnly, location, this);
             }
             else if (IsOverride && (IsNew || IsVirtual))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -179,15 +179,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _isAutoProperty = notRegularProperty && hasGetSyntax;
                 bool isGetterOnly = hasGetSyntax && setSyntax == null;
 
-                if (_isAutoProperty && !IsStatic)
+                if (_isAutoProperty && !IsStatic && !isGetterOnly)
                 {
-                    if (!isGetterOnly && ContainingType.IsReadOnly)
+                    if (ContainingType.IsReadOnly)
                     {
                         diagnostics.Add(ErrorCode.ERR_AutoPropsInRoStruct, location);
                     }
                     else if (HasReadOnlyModifier)
                     {
-                        diagnostics.Add(ErrorCode.ERR_AutoPropertyCantBeReadOnly, location, this);
+                        diagnostics.Add(ErrorCode.ERR_AutoPropertyWithSetterCantBeReadOnly, location, this);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -177,11 +177,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var hasGetSyntax = getSyntax != null;
                 _isAutoProperty = notRegularProperty && hasGetSyntax;
-                bool isReadOnly = hasGetSyntax && setSyntax == null;
+                bool isGetterOnly = hasGetSyntax && setSyntax == null;
 
-                if (_isAutoProperty && !isReadOnly && !IsStatic && ContainingType.IsReadOnly)
+                if (_isAutoProperty && !IsStatic)
                 {
-                    diagnostics.Add(ErrorCode.ERR_AutoPropsInRoStruct, location);
+                    if (!isGetterOnly && ContainingType.IsReadOnly)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_AutoPropsInRoStruct, location);
+                    }
+                    else if (HasReadOnlyModifier)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_AutoPropertyCantBeReadOnly, location, Name);
+                    }
                 }
 
                 if (_isAutoProperty || hasInitializer)
@@ -201,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     string fieldName = GeneratedNames.MakeBackingFieldName(_sourceName);
                     _backingField = new SynthesizedBackingFieldSymbol(this,
                                                                           fieldName,
-                                                                          isReadOnly,
+                                                                          isGetterOnly,
                                                                           this.IsStatic,
                                                                           hasInitializer);
                 }
@@ -210,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     Binder.CheckFeatureAvailability(
                         syntax,
-                        isReadOnly ? MessageID.IDS_FeatureReadonlyAutoImplementedProperties : MessageID.IDS_FeatureAutoImplementedProperties,
+                        isGetterOnly ? MessageID.IDS_FeatureReadonlyAutoImplementedProperties : MessageID.IDS_FeatureAutoImplementedProperties,
                         diagnostics,
                         location);
                 }
@@ -354,6 +361,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         // Check accessibility is set on at most one accessor.
                         diagnostics.Add(ErrorCode.ERR_DuplicatePropertyAccessMods, location, this);
+                    }
+                    else if (_getMethod.LocalDeclaredReadOnly && _setMethod.LocalDeclaredReadOnly)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_DuplicatePropertyReadOnlyMods, location, this);
                     }
                     else if (this.IsAbstract)
                     {
@@ -899,8 +910,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (IsStatic && HasReadOnlyModifier)
             {
-                // The modifier '{0}' is not valid for this item
-                diagnostics.Add(ErrorCode.ERR_BadMemberFlag, location, SyntaxFacts.GetText(SyntaxKind.ReadOnlyKeyword));
+                // Static member '{0}' cannot be 'readonly'.
+                diagnostics.Add(ErrorCode.ERR_StaticMemberCantBeReadOnly, location, this);
             }
             else if (IsOverride && (IsNew || IsVirtual))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     }
                     else if (HasReadOnlyModifier)
                     {
-                        diagnostics.Add(ErrorCode.ERR_AutoPropertyCantBeReadOnly, location, Name);
+                        diagnostics.Add(ErrorCode.ERR_AutoPropertyCantBeReadOnly, location, this);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
@@ -50,6 +50,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return RefKind.Out;
                 }
 
+                // PROTOTYPE: examine remaining locations where TypeSymbol.IsReadOnly is tested on 'this'.
+                // Determine whether it needs to be replaced with e.g. ContainingMethod.IsEffectivelyReadOnly.
                 if (ContainingType.IsReadOnly)
                 {
                     return RefKind.In;

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -32,9 +32,14 @@
         <target state="translated">Ve výrazu as se nepovoluje použití typu odkazu s možnou hodnotou null {0}?; místo toho použijte základní typ {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Ve výrazu as se nepovoluje použití typu odkazu s možnou hodnotou null {0}?; místo toho použijte základní typ {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">Asynchronní příkaz foreach nejde použít pro proměnné typu {0}, protože {0} neobsahuje vhodnou veřejnou definici instance pro {1}.</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">Položka {0} je explicitně implementována více než jednou.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Příkaz foreach nejde použít pro proměnné typu {0}, protože {0} neobsahuje veřejnou definici instance pro {1}. Měli jste v úmyslu await foreach místo foreach?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">Vytvoření neplatného objektu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">Statická lokální funkce nesmí obsahovat odkaz na {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">Asynchronní příkaz foreach nejde použít pro proměnné typu {0}, protože {0} neobsahuje vhodnou veřejnou definici instance pro {1}.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Příkaz foreach nejde použít pro proměnné typu {0}, protože {0} neobsahuje veřejnou definici instance pro {1}. Měli jste v úmyslu await foreach místo foreach?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">Eine asynchrone foreach-Anweisung kann nicht für Variablen vom Typ "{0}" verwendet werden, weil "{0}" keine geeignete öffentliche Instanzdefinition für "{1}" enthält.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Eine foreach-Anweisung kann nicht für Variablen vom Typ "{0}" verwendet werden, weil "{0}" keine öffentliche Instanzendefinition für "{1}" enthält. Meinten Sie "await foreach" statt "foreach"?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -32,9 +32,14 @@
         <target state="translated">Es ist unzulässig, den Nullable-Verweistyp "{0}?" in einem as-Ausdruck zu verwenden. Verwenden Sie stattdessen den zugrunde liegenden Typ "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Es ist unzulässig, den Nullable-Verweistyp "{0}?" in einem as-Ausdruck zu verwenden. Verwenden Sie stattdessen den zugrunde liegenden Typ "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">Eine asynchrone foreach-Anweisung kann nicht für Variablen vom Typ "{0}" verwendet werden, weil "{0}" keine geeignete öffentliche Instanzdefinition für "{1}" enthält.</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">"{0}" ist mehrfach explizit implementiert.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Eine foreach-Anweisung kann nicht für Variablen vom Typ "{0}" verwendet werden, weil "{0}" keine öffentliche Instanzendefinition für "{1}" enthält. Meinten Sie "await foreach" statt "foreach"?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">Ungültige Objekterstellung</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">Eine statische lokale Funktion kann keinen Verweis auf "{0}" enthalten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">Una instrucción foreach asincrónica no puede funcionar en variables de tipo "{0}", porque "{0}" no contiene una definición de instancia pública adecuada para "{1}".</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">La instrucción foreach no puede funcionar en variables de tipo "{0}" porque "{0}" no contiene ninguna definición de instancia pública para "{1}". ¿Quiso decir “await foreach” en lugar de “foreach”?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -32,6 +32,16 @@
         <target state="translated">No se puede usar el tipo "{0}?" que acepta valores NULL en una expresión as; use en su lugar el tipo "{0}" subyacente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">Una instrucción foreach asincrónica no puede funcionar en variables de tipo "{0}", porque "{0}" no contiene una definición de instancia pública adecuada para "{1}".</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">"{0}" está implementado de forma explícita más de una vez.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">La característica "{0}" no está disponible en C# 8.0. Use la versión {1} del lenguaje o una posterior.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">La instrucción foreach no puede funcionar en variables de tipo "{0}" porque "{0}" no contiene ninguna definición de instancia pública para "{1}". ¿Quiso decir “await foreach” en lugar de “foreach”?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">Creación de objeto no válida</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">Una función local estática no puede contener una referencia a "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -32,9 +32,14 @@
         <target state="translated">No se puede usar el tipo "{0}?" que acepta valores NULL en una expresión as; use en su lugar el tipo "{0}" subyacente.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -32,9 +32,14 @@
         <target state="translated">Il n'est pas correct d'utiliser le type de référence Nullable '{0}?' dans une expression as. Utilisez le type sous-jacent '{0}' à la place.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">L'instruction foreach asynchrone ne peut pas fonctionner sur des variables de type '{0}', car '{0}' ne contient aucune définition d'instance publique appropriée pour '{1}'</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">L'instruction foreach ne peut pas fonctionner sur des variables de type '{0}', car '{0}' ne contient pas de définition d'instance publique pour '{1}'. Vouliez-vous dire 'await foreach' plutôt que 'foreach' ?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Il n'est pas correct d'utiliser le type de référence Nullable '{0}?' dans une expression as. Utilisez le type sous-jacent '{0}' à la place.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">L'instruction foreach asynchrone ne peut pas fonctionner sur des variables de type '{0}', car '{0}' ne contient aucune définition d'instance publique appropriée pour '{1}'</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">'{0}' est implémenté explicitement plusieurs fois.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">La fonctionnalité '{0}' n'est pas disponible en C# 8.0. Utilisez la version de langage {1} ou une version ultérieure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">L'instruction foreach ne peut pas fonctionner sur des variables de type '{0}', car '{0}' ne contient pas de définition d'instance publique pour '{1}'. Vouliez-vous dire 'await foreach' plutôt que 'foreach' ?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">Création d'objet non valide</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">Une fonction locale statique ne peut pas contenir de référence à '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Non è consentito usare il tipo riferimento nullable '{0}?' in un'espressione as. Usare il tipo sottostante '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">L'istruzione foreach asincrona non può funzionare con variabili di tipo '{0}' perché '{0}' non contiene una definizione di istanza pubblica idonea per '{1}'</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">'{0}' è implementato più di una volta in modo esplicito.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">La funzionalità '{0}' non è disponibile in C# 8.0. Usare la versione {1} o versioni successive del linguaggio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">L'istruzione foreach non può funzionare con variabili di tipo '{0}' perché '{0}' non contiene una definizione di istanza pubblica per '{1}'. Si intendeva 'await foreach' invece di 'foreach'?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">Creazione oggetto non valida</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">Una funzione locale statica non può contenere un riferimento a '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -32,9 +32,14 @@
         <target state="translated">Non è consentito usare il tipo riferimento nullable '{0}?' in un'espressione as. Usare il tipo sottostante '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">L'istruzione foreach asincrona non può funzionare con variabili di tipo '{0}' perché '{0}' non contiene una definizione di istanza pubblica idonea per '{1}'</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">L'istruzione foreach non può funzionare con variabili di tipo '{0}' perché '{0}' non contiene una definizione di istanza pubblica per '{1}'. Si intendeva 'await foreach' invece di 'foreach'?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">'{0}' は '{1}' の適切なパブリック インスタンス定義を含んでいないため、型 '{0}' の変数に対して非同期 foreach ステートメントを使用することはできません</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">foreach ステートメントは、'{0}' が '{1}' のパブリック インスタンス定義を含んでいないため、型 '{0}' の変数に対して使用できません。'foreach' ではなく 'await foreach' ですか?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -32,6 +32,16 @@
         <target state="translated">as 式で Null 許容参照型 '{0}?' を使用することはできません。代わりに基になる型 '{0}' をご使用ください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">'{0}' は '{1}' の適切なパブリック インスタンス定義を含んでいないため、型 '{0}' の変数に対して非同期 foreach ステートメントを使用することはできません</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">'{0}' が複数回、明示的に実装されています。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">foreach ステートメントは、'{0}' が '{1}' のパブリック インスタンス定義を含んでいないため、型 '{0}' の変数に対して使用できません。'foreach' ではなく 'await foreach' ですか?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">無効なオブジェクト作成</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">静的なローカル関数に '{0}' への参照を含めることはできません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -32,9 +32,14 @@
         <target state="translated">as 式で Null 許容参照型 '{0}?' を使用することはできません。代わりに基になる型 '{0}' をご使用ください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">'{0}' 형식 변수에서 비동기 foreach 문을 수행할 수 없습니다. '{0}'에는 '{1}'의 적합한 공용 인스턴스 정의가 없기 때문입니다.</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">'{0}' 형식 변수에서 foreach 문을 수행할 수 없습니다. '{0}'에는 '{1}'의 공용 인스턴스 정의가 없기 때문입니다. 'foreach' 대신 'await foreach'를 사용하시겠습니까?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -32,6 +32,16 @@
         <target state="translated">식에 nullable 참조 형식 '{0}'을(를) 사용하는 것은 올바르지 않습니다. 대신 기본 형식 '{0}'을(를) 사용하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">'{0}' 형식 변수에서 비동기 foreach 문을 수행할 수 없습니다. '{0}'에는 '{1}'의 적합한 공용 인스턴스 정의가 없기 때문입니다.</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">'{0}'은(는) 두 번 이상 명시적으로 구현됩니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">'{0}' 형식 변수에서 foreach 문을 수행할 수 없습니다. '{0}'에는 '{1}'의 공용 인스턴스 정의가 없기 때문입니다. 'foreach' 대신 'await foreach'를 사용하시겠습니까?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">잘못된 개체 만들기</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">정적 로컬 함수는 '{0}'에 대한 참조를 포함할 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -32,9 +32,14 @@
         <target state="translated">식에 nullable 참조 형식 '{0}'을(를) 사용하는 것은 올바르지 않습니다. 대신 기본 형식 '{0}'을(를) 사용하세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">Asynchroniczna instrukcja foreach nie może operować na zmiennych typu „{0}”, ponieważ typ „{0}” nie zawiera odpowiedniej publicznej definicji wystąpienia elementu „{1}”</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Instrukcja foreach nie może operować na zmiennych typu „{0}”, ponieważ typ „{0}” nie zawiera publicznej definicji wystąpienia elementu „{1}”. Czy planowano użyć instrukcji „await foreach”, a nie „foreach”?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Użycie typu odwołania dopuszczającego wartość null „{0}?” w wyrażeniu „as” jest niedozwolone. Zamiast tego użyj bazowego typu „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">Asynchroniczna instrukcja foreach nie może operować na zmiennych typu „{0}”, ponieważ typ „{0}” nie zawiera odpowiedniej publicznej definicji wystąpienia elementu „{1}”</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">Element „{0}” jest jawnie zaimplementowany więcej niż raz.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">Funkcja „{0}” nie jest dostępna w języku C# 8.0. Użyj języka w wersji {1} lub nowszej.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Instrukcja foreach nie może operować na zmiennych typu „{0}”, ponieważ typ „{0}” nie zawiera publicznej definicji wystąpienia elementu „{1}”. Czy planowano użyć instrukcji „await foreach”, a nie „foreach”?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">Nieprawidłowa operacja tworzenia obiektu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">Statyczna funkcja lokalna nie może zawierać odwołania do elementu „{0}”.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -32,9 +32,14 @@
         <target state="translated">Użycie typu odwołania dopuszczającego wartość null „{0}?” w wyrażeniu „as” jest niedozwolone. Zamiast tego użyj bazowego typu „{0}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -32,9 +32,14 @@
         <target state="translated">É ilegal usar o tipo de referência anulável '{0}?' em uma expressão as; use o tipo subjacente '{0}' em seu lugar.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -32,6 +32,16 @@
         <target state="translated">É ilegal usar o tipo de referência anulável '{0}?' em uma expressão as; use o tipo subjacente '{0}' em seu lugar.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">A instrução foreach assíncrona não pode operar em variáveis do tipo '{0}' porque '{0}' não contém uma definição da instância pública adequada para '{1}'</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">'{0}' é implementado explicitamente mais de uma vez.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">O recurso '{0}' não está disponível em C# 8.0. Use a versão de linguagem {1} ou superior.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">A instrução foreach não pode operar em variáveis do tipo '{0}' porque '{0}' não contém uma definição da instância pública para '{1}'. Você quis dizer 'await foreach' em vez de 'foreach'?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">Criação de objeto inválido</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">Uma função local estática não pode conter uma referência a '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">A instrução foreach assíncrona não pode operar em variáveis do tipo '{0}' porque '{0}' não contém uma definição da instância pública adequada para '{1}'</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">A instrução foreach não pode operar em variáveis do tipo '{0}' porque '{0}' não contém uma definição da instância pública para '{1}'. Você quis dizer 'await foreach' em vez de 'foreach'?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -32,9 +32,14 @@
         <target state="translated">Недопустимо использовать ссылочный тип "{0}", допускающий значения NULL, в выражении "as". Используйте вместо него базовый тип "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Недопустимо использовать ссылочный тип "{0}", допускающий значения NULL, в выражении "as". Используйте вместо него базовый тип "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">Асинхронный оператор foreach не работает с переменными типа "{0}", так как "{0}" не содержит подходящее открытое определение экземпляра для "{1}".</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">"{0}" явно реализуется больше одного раза.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">Функция "{0}" недоступна в C# 8.0. Используйте версию языка {1} или более позднюю.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Оператор foreach не работает с переменными типа "{0}", так как "{0}" не содержит открытое определение экземпляра для "{1}" Возможно, вы имели в виду "await foreach", а не "foreach"?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">Недопустимое создание объекта</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">Статическая локальная функция не может содержать ссылку на "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">Асинхронный оператор foreach не работает с переменными типа "{0}", так как "{0}" не содержит подходящее открытое определение экземпляра для "{1}".</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Оператор foreach не работает с переменными типа "{0}", так как "{0}" не содержит открытое определение экземпляра для "{1}" Возможно, вы имели в виду "await foreach", а не "foreach"?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -32,9 +32,14 @@
         <target state="translated">Boş değer atanabilir '{0}?' başvuru türünün bir as ifadesinde kullanılması yasaktır; bunun yerine temel alınan '{0}' türünü kullanın.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Boş değer atanabilir '{0}?' başvuru türünün bir as ifadesinde kullanılması yasaktır; bunun yerine temel alınan '{0}' türünü kullanın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">'{0}', '{1}' için uygun bir genel örnek tanımı içermediğinden zaman uyumsuz foreach deyimi '{0}' türündeki değişkenlerle çalışmaz</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">'{0}' bir defadan fazla açıkça uygulanmış.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">'{0}' özelliği C# 8.0'da kullanılamaz. Lütfen {1} veya daha yüksek bir dil sürümü kullanın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">'{0}', '{1}' için bir genel örnek tanımı içermediğinden foreach deyimi '{0}' türündeki değişkenlerle çalışamaz. 'foreach' yerine 'await foreach' mi kullanmak istediniz?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">Geçersiz nesne oluşturma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">Statik bir yerel işlev, '{0}' başvurusu içeremez.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">'{0}', '{1}' için uygun bir genel örnek tanımı içermediğinden zaman uyumsuz foreach deyimi '{0}' türündeki değişkenlerle çalışmaz</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">'{0}', '{1}' için bir genel örnek tanımı içermediğinden foreach deyimi '{0}' türündeki değişkenlerle çalışamaz. 'foreach' yerine 'await foreach' mi kullanmak istediniz?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">“{0}”不包含“{1}”的适当公共实例定义，因此异步 foreach 语句不能作用于“{0}”类型的变量</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">“{0}”不包含“{1}”的公共实例定义，因此 foreach 语句不能作用于“{0}”类型的变量。是否希望使用 "await foreach" 而非 "foreach"?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -32,6 +32,16 @@
         <target state="translated">在 as 表达式中使用可以为 null 的引用类型“{0}?”是非法的；请改用基础类型“{0}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">“{0}”不包含“{1}”的适当公共实例定义，因此异步 foreach 语句不能作用于“{0}”类型的变量</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">多次显式实现“{0}”。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">“{0}”不包含“{1}”的公共实例定义，因此 foreach 语句不能作用于“{0}”类型的变量。是否希望使用 "await foreach" 而非 "foreach"?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">对象创建无效</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">静态本地函数不能包含对“{0}”的引用。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -32,9 +32,14 @@
         <target state="translated">在 as 表达式中使用可以为 null 的引用类型“{0}?”是非法的；请改用基础类型“{0}”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -37,11 +37,6 @@
         <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
-        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">因為 '{0}' 不包含適用於 '{1}' 的公用執行個體定義，所以非同步的 foreach 陳述式無法在類型為 '{0}' 的變數上運作</target>
@@ -100,11 +95,6 @@
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -167,11 +157,6 @@
         <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
-        <source>Field-like event cannot be 'readonly'.</source>
-        <target state="new">Field-like event cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">因為 '{0}' 不包含 '{1}' 的公用執行個體定義，所以 foreach 陳述式無法在型別 '{0}' 的變數上作業。您指的是 'await foreach' 而不是 'foreach' 嗎?</target>
@@ -215,11 +200,6 @@
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
         <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
         <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -330,11 +310,6 @@
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
         <source>Static member '{0}' cannot be 'readonly'.</source>
         <target state="new">Static member '{0}' cannot be 'readonly'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
-        <source>Static member cannot be 'readonly'.</source>
-        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -32,9 +32,14 @@
         <target state="translated">在運算式中使用可為 Null 的參考型別 '{0}?' 不合法，請改用基礎類型 '{0}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
-        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
-        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+      <trans-unit id="ERR_AutoPropertyWithSetterCantBeReadOnly">
+        <source>Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</source>
+        <target state="new">Auto-implemented property '{0}' cannot be marked 'readonly' because it has a 'set' accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoSetterCantBeReadOnly">
+        <source>Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented 'set' accessor '{0}' cannot be marked 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -32,6 +32,16 @@
         <target state="translated">在運算式中使用可為 Null 的參考型別 '{0}?' 不合法，請改用基礎類型 '{0}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly">
+        <source>Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor '{0}' cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_AutoPropertyCantBeReadOnly_Title">
+        <source>Auto-implemented property or accessor cannot be marked 'readonly'.</source>
+        <target state="new">Auto-implemented property or accessor cannot be marked 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_AwaitForEachMissingMember">
         <source>Asynchronous foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a suitable public instance definition for '{1}'</source>
         <target state="translated">因為 '{0}' 不包含適用於 '{1}' 的公用執行個體定義，所以非同步的 foreach 陳述式無法在類型為 '{0}' 的變數上運作</target>
@@ -85,6 +95,16 @@
       <trans-unit id="ERR_DuplicateExplicitImpl">
         <source>'{0}' is explicitly implemented more than once.</source>
         <target state="translated">'{0}' 已明確實作多次。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_DuplicatePropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -142,6 +162,16 @@
         <target state="translated">Feature '{0}' is not available in C# 8.0. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly">
+        <source>Field-like event '{0}' cannot be 'readonly'.</source>
+        <target state="new">Field-like event '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FieldLikeEventCantBeReadOnly_Title">
+        <source>Field-like event cannot be 'readonly'.</source>
+        <target state="new">Field-like event cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">因為 '{0}' 不包含 '{1}' 的公用執行個體定義，所以 foreach 陳述式無法在型別 '{0}' 的變數上作業。您指的是 'await foreach' 而不是 'foreach' 嗎?</target>
@@ -180,6 +210,16 @@
       <trans-unit id="ERR_InvalidObjectCreation">
         <source>Invalid object creation</source>
         <target state="translated">無效的物件建立</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_InvalidPropertyReadOnlyMods_Title">
+        <source>Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer and its accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -285,6 +325,16 @@
       <trans-unit id="ERR_StaticLocalFunctionCannotCaptureVariable">
         <source>A static local function cannot contain a reference to '{0}'.</source>
         <target state="translated">靜態區域函式不可包含對 '{0}' 的參考。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly">
+        <source>Static member '{0}' cannot be 'readonly'.</source>
+        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_StaticMemberCantBeReadOnly_Title">
+        <source>Static member cannot be 'readonly'.</source>
+        <target state="new">Static member cannot be 'readonly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicatePropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'.</target>
+        <source>Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both accessors of property or indexer '{0}'. Instead, put a 'readonly' modifier on the property itself.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ElseCannotStartStatement">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidPropertyReadOnlyMods">
-        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</source>
-        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessors.</target>
+        <source>Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</source>
+        <target state="new">Cannot specify 'readonly' modifiers on both property or indexer '{0}' and its accessor. Remove one of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidStackAllocArray">
@@ -313,8 +313,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_StaticMemberCantBeReadOnly">
-        <source>Static member '{0}' cannot be 'readonly'.</source>
-        <target state="new">Static member '{0}' cannot be 'readonly'.</target>
+        <source>Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</source>
+        <target state="new">Static member '{0}' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_SwitchArmSubsumed">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -1086,7 +1086,7 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (5,32): error CS8657: Static member 'S.M()' cannot be 'readonly'.
+                // (5,32): error CS8656: Static member 'S.M()' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.
                 //     public static readonly int M()
                 Diagnostic(ErrorCode.ERR_StaticMemberCantBeReadOnly, "M").WithArguments("S.M()").WithLocation(5, 32));
 
@@ -1133,7 +1133,7 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (7,18): error CS8657: Static member 'S.P.get' cannot be 'readonly'.
+                // (7,18): error CS8656: Static member 'S.P.get' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.
                 //         readonly get
                 Diagnostic(ErrorCode.ERR_StaticMemberCantBeReadOnly, "get").WithArguments("S.P.get").WithLocation(7, 18));
         }
@@ -1150,7 +1150,7 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (5,32): error CS8657: Static member 'S.P' cannot be 'readonly'.
+                // (5,32): error CS8656: Static member 'S.P' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.
                 //     public static readonly int P => i;
                 Diagnostic(ErrorCode.ERR_StaticMemberCantBeReadOnly, "P").WithArguments("S.P").WithLocation(5, 32));
         }
@@ -1201,7 +1201,7 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (7,16): error CS8660: Cannot specify 'readonly' modifiers on both accessors of property or indexer 'S.P4'.
+                // (7,16): error CS8660: Cannot specify 'readonly' modifiers on both accessors of property or indexer 'S.P4'. Instead, put a 'readonly' modifier on the property itself.
                 //     public int P4 { readonly get; readonly set; }
                 Diagnostic(ErrorCode.ERR_DuplicatePropertyReadOnlyMods, "P4").WithArguments("S.P4").WithLocation(7, 16),
                 // (7,44): error CS8657: Auto-implemented 'set' accessor 'S.P4.set' cannot be marked 'readonly'.
@@ -1210,7 +1210,7 @@ public struct S
                 // (8,25): error CS8658: Auto-implemented property 'S.P5' cannot be marked 'readonly' because it has a 'set' accessor.
                 //     public readonly int P5 { get; set; }
                 Diagnostic(ErrorCode.ERR_AutoPropertyWithSetterCantBeReadOnly, "P5").WithArguments("S.P5").WithLocation(8, 25),
-                // (9,39): error CS8659: Cannot specify 'readonly' modifiers on both property or indexer 'S.P6' and its accessors.
+                // (9,39): error CS8659: Cannot specify 'readonly' modifiers on both property or indexer 'S.P6' and its accessor. Remove one of them.
                 //     public readonly int P6 { readonly get; }
                 Diagnostic(ErrorCode.ERR_InvalidPropertyReadOnlyMods, "get").WithArguments("S.P6").WithLocation(9, 39),
                 // (10,35): error CS8657: Auto-implemented 'set' accessor 'S.P7.set' cannot be marked 'readonly'.
@@ -1219,7 +1219,7 @@ public struct S
                 // (11,25): error CS8658: Auto-implemented property 'S.P8' cannot be marked 'readonly' because it has a 'set' accessor.
                 //     public readonly int P8 { get; readonly set; }
                 Diagnostic(ErrorCode.ERR_AutoPropertyWithSetterCantBeReadOnly, "P8").WithArguments("S.P8").WithLocation(11, 25),
-                // (11,44): error CS8659: Cannot specify 'readonly' modifiers on both property or indexer 'S.P8' and its accessors.
+                // (11,44): error CS8659: Cannot specify 'readonly' modifiers on both property or indexer 'S.P8' and its accessor. Remove one of them.
                 //     public readonly int P8 { get; readonly set; }
                 Diagnostic(ErrorCode.ERR_InvalidPropertyReadOnlyMods, "set").WithArguments("S.P8").WithLocation(11, 44));
         }
@@ -1235,7 +1235,7 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (4,38): error CS8659: Cannot specify 'readonly' modifiers on both property or indexer 'S.P' and its accessors.
+                // (4,38): error CS8659: Cannot specify 'readonly' modifiers on both property or indexer 'S.P' and its accessor. Remove one of them.
                 //     public readonly int P { readonly get => 42; }
                 Diagnostic(ErrorCode.ERR_InvalidPropertyReadOnlyMods, "get").WithArguments("S.P").WithLocation(4, 38));
         }
@@ -1252,10 +1252,10 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (4,32): error CS8657: Static member 'S.P1' cannot be 'readonly'.
+                // (4,32): error CS8656: Static member 'S.P1' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.
                 //     public static readonly int P1 { get; set; }
                 Diagnostic(ErrorCode.ERR_StaticMemberCantBeReadOnly, "P1").WithArguments("S.P1").WithLocation(4, 32),
-                // (5,37): error CS8657: Static member 'S.P2.get' cannot be 'readonly'.
+                // (5,37): error CS8656: Static member 'S.P2.get' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.
                 //     public static int P2 { readonly get; }
                 Diagnostic(ErrorCode.ERR_StaticMemberCantBeReadOnly, "get").WithArguments("S.P2.get").WithLocation(5, 37));
         }
@@ -1685,14 +1685,14 @@ public struct S5
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (21,16): error CS8659: Cannot specify 'readonly' modifiers on both accessors of property or indexer 'S3.this[int]'.
+                // (21,16): error CS8660: Cannot specify 'readonly' modifiers on both accessors of property or indexer 'S3.this[int]'. Instead, put a 'readonly' modifier on the property itself.
                 //     public int this[int i]
                 Diagnostic(ErrorCode.ERR_DuplicatePropertyReadOnlyMods, "this").WithArguments("S3.this[int]").WithLocation(21, 16),
-                // (33,18): error CS8658: Cannot specify 'readonly' modifiers on both property or indexer 'S4.this[int]' and its accessors.
-                //         readonly get => 42;
+                // (33,18): error CS8659: Cannot specify 'readonly' modifiers on both property or indexer 'S4.this[int]' and its accessor. Remove one of them.
+                //         readonly get { return i; }
                 Diagnostic(ErrorCode.ERR_InvalidPropertyReadOnlyMods, "get").WithArguments("S4.this[int]").WithLocation(33, 18),
                 // (40,32): error CS0106: The modifier 'static' is not valid for this item
-                //     public static readonly int this[int i]
+                //     public static readonly int this[int i] => i;
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "this").WithArguments("static").WithLocation(40, 32));
         }
 
@@ -1751,7 +1751,7 @@ public struct S1
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (6,52): error CS8657: Static member 'S1.E' cannot be 'readonly'.
+                // (6,52): error CS8656: Static member 'S1.E' cannot be marked 'readonly' because readonly members cannot modify 'this' and static members do not have a 'this' parameter.
                 //     public static readonly event Action<EventArgs> E
                 Diagnostic(ErrorCode.ERR_StaticMemberCantBeReadOnly, "E").WithArguments("S1.E").WithLocation(6, 52));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -1089,6 +1089,10 @@ public struct S
                 // (5,32): error CS8657: Static member 'S.M()' cannot be 'readonly'.
                 //     public static readonly int M()
                 Diagnostic(ErrorCode.ERR_StaticMemberCantBeReadOnly, "M").WithArguments("S.M()").WithLocation(5, 32));
+
+            var method = comp.GetMember<NamedTypeSymbol>("S").GetMethod("M");
+            Assert.True(method.IsDeclaredReadOnly);
+            Assert.False(method.IsEffectivelyReadOnly);
         }
 
         [Fact]
@@ -1191,40 +1195,48 @@ public struct S
     public int P4 { readonly get; readonly set; }
     public readonly int P5 { get; set; }
     public readonly int P6 { readonly get; }
+    public int P7 { get; readonly set; }
+    public readonly int P8 { get; readonly set; }
 }
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (4,30): error CS8658: Auto-implemented property or accessor 'S.P1.get' cannot be marked 'readonly'.
+                // (4,30): error CS8657: Auto-implemented property or accessor 'S.P1.get' cannot be marked 'readonly'.
                 //     public int P1 { readonly get; }
                 Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "get").WithArguments("S.P1.get").WithLocation(4, 30),
-                // (5,25): error CS8658: Auto-implemented property or accessor 'P2' cannot be marked 'readonly'.
+                // (5,25): error CS8657: Auto-implemented property or accessor 'S.P2' cannot be marked 'readonly'.
                 //     public readonly int P2 { get; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "P2").WithArguments("P2").WithLocation(5, 25),
-                // (6,30): error CS8658: Auto-implemented property or accessor 'S.P3.get' cannot be marked 'readonly'.
+                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "P2").WithArguments("S.P2").WithLocation(5, 25),
+                // (6,30): error CS8657: Auto-implemented property or accessor 'S.P3.get' cannot be marked 'readonly'.
                 //     public int P3 { readonly get; set; }
                 Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "get").WithArguments("S.P3.get").WithLocation(6, 30),
-                // (7,16): error CS8660: Cannot specify 'readonly' modifiers on both accessors of property or indexer 'S.P4'.
+                // (7,16): error CS8659: Cannot specify 'readonly' modifiers on both accessors of property or indexer 'S.P4'.
                 //     public int P4 { readonly get; readonly set; }
                 Diagnostic(ErrorCode.ERR_DuplicatePropertyReadOnlyMods, "P4").WithArguments("S.P4").WithLocation(7, 16),
-                // (7,30): error CS8658: Auto-implemented property or accessor 'S.P4.get' cannot be marked 'readonly'.
+                // (7,30): error CS8657: Auto-implemented property or accessor 'S.P4.get' cannot be marked 'readonly'.
                 //     public int P4 { readonly get; readonly set; }
                 Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "get").WithArguments("S.P4.get").WithLocation(7, 30),
-                // (7,44): error CS8658: Auto-implemented property or accessor 'S.P4.set' cannot be marked 'readonly'.
+                // (7,44): error CS8657: Auto-implemented property or accessor 'S.P4.set' cannot be marked 'readonly'.
                 //     public int P4 { readonly get; readonly set; }
                 Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "set").WithArguments("S.P4.set").WithLocation(7, 44),
-                // (8,25): error CS8658: Auto-implemented property or accessor 'P5' cannot be marked 'readonly'.
+                // (8,25): error CS8657: Auto-implemented property or accessor 'S.P5' cannot be marked 'readonly'.
                 //     public readonly int P5 { get; set; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "P5").WithArguments("P5").WithLocation(8, 25),
-                // (9,25): error CS8658: Auto-implemented property or accessor 'P6' cannot be marked 'readonly'.
+                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "P5").WithArguments("S.P5").WithLocation(8, 25),
+                // (9,25): error CS8657: Auto-implemented property or accessor 'S.P6' cannot be marked 'readonly'.
                 //     public readonly int P6 { readonly get; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "P6").WithArguments("P6").WithLocation(9, 25),
-                // (9,39): error CS8659: Cannot specify 'readonly' modifiers on both property or indexer 'S.P6' and its accessors.
+                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "P6").WithArguments("S.P6").WithLocation(9, 25),
+                // (9,39): error CS8658: Cannot specify 'readonly' modifiers on both property or indexer 'S.P6' and its accessors.
                 //     public readonly int P6 { readonly get; }
                 Diagnostic(ErrorCode.ERR_InvalidPropertyReadOnlyMods, "get").WithArguments("S.P6").WithLocation(9, 39),
-                // (9,39): error CS8658: Auto-implemented property or accessor 'S.P6.get' cannot be marked 'readonly'.
-                //     public readonly int P6 { readonly get; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "get").WithArguments("S.P6.get").WithLocation(9, 39));
+                // (10,35): error CS8657: Auto-implemented property or accessor 'S.P7.set' cannot be marked 'readonly'.
+                //     public int P7 { get; readonly set; }
+                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "set").WithArguments("S.P7.set").WithLocation(10, 35),
+                // (11,25): error CS8657: Auto-implemented property or accessor 'S.P8' cannot be marked 'readonly'.
+                //     public readonly int P8 { get; readonly set; }
+                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "P8").WithArguments("S.P8").WithLocation(11, 25),
+                // (11,44): error CS8658: Cannot specify 'readonly' modifiers on both property or indexer 'S.P8' and its accessors.
+                //     public readonly int P8 { get; readonly set; }
+                Diagnostic(ErrorCode.ERR_InvalidPropertyReadOnlyMods, "set").WithArguments("S.P8").WithLocation(11, 44));
         }
 
         [Fact]
@@ -1647,45 +1659,56 @@ public struct S
             var csharp = @"
 public struct S1
 {
-    public readonly int this[int i]
+    // ok
+    public readonly int this[int i] => i;
+}
+
+public struct S2
+{
+    // ok
+    public int this[int i]
     {
-        get => 42;
+        readonly get => i;
         set {}
     }
 }
-";
-            var comp = CreateCompilation(csharp);
-            comp.VerifyDiagnostics();
-        }
 
-        [Fact]
-        public void ReadOnlyExpressionIndexer()
-        {
-            var csharp = @"
-public struct S1
+public struct S3
 {
-    public readonly int this[int i] => 42;
-}
-";
-            var comp = CreateCompilation(csharp);
-            comp.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void ReadOnlyGetExpressionIndexer()
-        {
-            var csharp = @"
-public struct S1
-{
-    public readonly int this[int i]
+    // error
+    public int this[int i]
     {
-        get => 42;
-        set {}
+        readonly get { return i; }
+        readonly set {}
     }
 }
+
+public struct S4
+{
+    // error
+    public readonly int this[int i]
+    {
+        readonly get { return i; }
+    }
+}
+
+public struct S5
+{
+    // error
+    public static readonly int this[int i] => i;
+}
 ";
             var comp = CreateCompilation(csharp);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (21,16): error CS8659: Cannot specify 'readonly' modifiers on both accessors of property or indexer 'S3.this[int]'.
+                //     public int this[int i]
+                Diagnostic(ErrorCode.ERR_DuplicatePropertyReadOnlyMods, "this").WithArguments("S3.this[int]").WithLocation(21, 16),
+                // (33,18): error CS8658: Cannot specify 'readonly' modifiers on both property or indexer 'S4.this[int]' and its accessors.
+                //         readonly get => 42;
+                Diagnostic(ErrorCode.ERR_InvalidPropertyReadOnlyMods, "get").WithArguments("S4.this[int]").WithLocation(33, 18),
+                // (40,32): error CS0106: The modifier 'static' is not valid for this item
+                //     public static readonly int this[int i]
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "this").WithArguments("static").WithLocation(40, 32));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -1201,40 +1201,25 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (4,30): error CS8657: Auto-implemented property or accessor 'S.P1.get' cannot be marked 'readonly'.
-                //     public int P1 { readonly get; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "get").WithArguments("S.P1.get").WithLocation(4, 30),
-                // (5,25): error CS8657: Auto-implemented property or accessor 'S.P2' cannot be marked 'readonly'.
-                //     public readonly int P2 { get; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "P2").WithArguments("S.P2").WithLocation(5, 25),
-                // (6,30): error CS8657: Auto-implemented property or accessor 'S.P3.get' cannot be marked 'readonly'.
-                //     public int P3 { readonly get; set; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "get").WithArguments("S.P3.get").WithLocation(6, 30),
-                // (7,16): error CS8659: Cannot specify 'readonly' modifiers on both accessors of property or indexer 'S.P4'.
+                // (7,16): error CS8660: Cannot specify 'readonly' modifiers on both accessors of property or indexer 'S.P4'.
                 //     public int P4 { readonly get; readonly set; }
                 Diagnostic(ErrorCode.ERR_DuplicatePropertyReadOnlyMods, "P4").WithArguments("S.P4").WithLocation(7, 16),
-                // (7,30): error CS8657: Auto-implemented property or accessor 'S.P4.get' cannot be marked 'readonly'.
+                // (7,44): error CS8657: Auto-implemented 'set' accessor 'S.P4.set' cannot be marked 'readonly'.
                 //     public int P4 { readonly get; readonly set; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "get").WithArguments("S.P4.get").WithLocation(7, 30),
-                // (7,44): error CS8657: Auto-implemented property or accessor 'S.P4.set' cannot be marked 'readonly'.
-                //     public int P4 { readonly get; readonly set; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "set").WithArguments("S.P4.set").WithLocation(7, 44),
-                // (8,25): error CS8657: Auto-implemented property or accessor 'S.P5' cannot be marked 'readonly'.
+                Diagnostic(ErrorCode.ERR_AutoSetterCantBeReadOnly, "set").WithArguments("S.P4.set").WithLocation(7, 44),
+                // (8,25): error CS8658: Auto-implemented property 'S.P5' cannot be marked 'readonly' because it has a 'set' accessor.
                 //     public readonly int P5 { get; set; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "P5").WithArguments("S.P5").WithLocation(8, 25),
-                // (9,25): error CS8657: Auto-implemented property or accessor 'S.P6' cannot be marked 'readonly'.
-                //     public readonly int P6 { readonly get; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "P6").WithArguments("S.P6").WithLocation(9, 25),
-                // (9,39): error CS8658: Cannot specify 'readonly' modifiers on both property or indexer 'S.P6' and its accessors.
+                Diagnostic(ErrorCode.ERR_AutoPropertyWithSetterCantBeReadOnly, "P5").WithArguments("S.P5").WithLocation(8, 25),
+                // (9,39): error CS8659: Cannot specify 'readonly' modifiers on both property or indexer 'S.P6' and its accessors.
                 //     public readonly int P6 { readonly get; }
                 Diagnostic(ErrorCode.ERR_InvalidPropertyReadOnlyMods, "get").WithArguments("S.P6").WithLocation(9, 39),
-                // (10,35): error CS8657: Auto-implemented property or accessor 'S.P7.set' cannot be marked 'readonly'.
+                // (10,35): error CS8657: Auto-implemented 'set' accessor 'S.P7.set' cannot be marked 'readonly'.
                 //     public int P7 { get; readonly set; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "set").WithArguments("S.P7.set").WithLocation(10, 35),
-                // (11,25): error CS8657: Auto-implemented property or accessor 'S.P8' cannot be marked 'readonly'.
+                Diagnostic(ErrorCode.ERR_AutoSetterCantBeReadOnly, "set").WithArguments("S.P7.set").WithLocation(10, 35),
+                // (11,25): error CS8658: Auto-implemented property 'S.P8' cannot be marked 'readonly' because it has a 'set' accessor.
                 //     public readonly int P8 { get; readonly set; }
-                Diagnostic(ErrorCode.ERR_AutoPropertyCantBeReadOnly, "P8").WithArguments("S.P8").WithLocation(11, 25),
-                // (11,44): error CS8658: Cannot specify 'readonly' modifiers on both property or indexer 'S.P8' and its accessors.
+                Diagnostic(ErrorCode.ERR_AutoPropertyWithSetterCantBeReadOnly, "P8").WithArguments("S.P8").WithLocation(11, 25),
+                // (11,44): error CS8659: Cannot specify 'readonly' modifiers on both property or indexer 'S.P8' and its accessors.
                 //     public readonly int P8 { get; readonly set; }
                 Diagnostic(ErrorCode.ERR_InvalidPropertyReadOnlyMods, "set").WithArguments("S.P8").WithLocation(11, 44));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -75,9 +75,9 @@ public readonly struct A
                 // (16,9): error CS1604: Cannot assign to 'this' because it is read-only
                 //         this = default;
                 Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "this").WithArguments("this").WithLocation(16, 9),
-                // (18,9): error CS1604: Cannot assign to 'this' because it is read-only
+                // (18,9): error CS1604: Cannot assign to 'this.x' because it is read-only
                 //         this.x = 1;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "this.x").WithArguments("this").WithLocation(18, 9));
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "this.x").WithArguments("this.x").WithLocation(18, 9));
         }
 
         [Fact()]
@@ -149,12 +149,12 @@ interface I1
                 // (10,25): error CS8342: Field-like events are not allowed in readonly structs.
                 //     public event Action ei1;
                 Diagnostic(ErrorCode.ERR_FieldlikeEventsInRoStruct, "ei1").WithLocation(10, 25),
-                // (43,9): error CS1604: Cannot assign to 'this' because it is read-only
+                // (43,9): error CS1604: Cannot assign to 'e' because it is read-only
                 //         e = () => { };
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "e").WithArguments("this").WithLocation(43, 9),
-                // (46,16): error CS1605: Cannot use 'this' as a ref or out value because it is read-only
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "e").WithArguments("e").WithLocation(43, 9),
+                // (46,16): error CS1605: Cannot use 'e' as a ref or out value because it is read-only
                 //         M1(ref e);
-                Diagnostic(ErrorCode.ERR_RefReadonlyLocal, "e").WithArguments("this").WithLocation(46, 16)
+                Diagnostic(ErrorCode.ERR_RefReadonlyLocal, "e").WithArguments("e").WithLocation(46, 16)
             );
         }
 
@@ -187,10 +187,9 @@ public struct A
                 // (11,9): error CS1604: Cannot assign to 'this' because it is read-only
                 //         this = default;
                 Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "this").WithArguments("this").WithLocation(11, 9),
-                // PROTOTYPE: The error message should state the specific thing being assigned and more specifically why it can't be assigned.
-                // (13,9): error CS1604: Cannot assign to 'this' because it is read-only
+                // (13,9): error CS1604: Cannot assign to 'this.x' because it is read-only
                 //         this.x = 1;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "this.x").WithArguments("this").WithLocation(13, 9));
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "this.x").WithArguments("this.x").WithLocation(13, 9));
         }
 
         [Fact]
@@ -311,9 +310,9 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (21,16): error CS1605: Cannot use 'this' as a ref or out value because it is read-only
+                // (21,16): error CS1605: Cannot use 'f2' as a ref or out value because it is read-only
                 //         M1(ref f2); // error
-                Diagnostic(ErrorCode.ERR_RefReadonlyLocal, "f2").WithArguments("this").WithLocation(21, 16));
+                Diagnostic(ErrorCode.ERR_RefReadonlyLocal, "f2").WithArguments("f2").WithLocation(21, 16));
         }
 
         [Fact]
@@ -425,15 +424,15 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (7,52): error CS1604: Cannot assign to 'this' because it is read-only
+                // (7,52): error CS1604: Cannot assign to 'i' because it is read-only
                 //     public readonly override string ToString() => (i++).ToString();
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(7, 52),
-                // (8,52): error CS1604: Cannot assign to 'this' because it is read-only
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(7, 52),
+                // (8,52): error CS1604: Cannot assign to 'i' because it is read-only
                 //     public readonly override int GetHashCode() => (i++).GetHashCode();
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(8, 52),
-                // (9,56): error CS1604: Cannot assign to 'this' because it is read-only
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(8, 52),
+                // (9,56): error CS1604: Cannot assign to 'i' because it is read-only
                 //     public readonly override bool Equals(object o) => (i++).Equals(o);
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(9, 56));
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(9, 56));
         }
 
         [Fact]
@@ -500,9 +499,9 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (16,9): error CS1604: Cannot assign to 'this' because it is read-only
+                // (16,9): error CS1604: Cannot assign to 'i' because it is read-only
                 //         i++;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(16, 9));
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(16, 9));
         }
 
         [Fact]
@@ -531,9 +530,9 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (16,9): error CS1604: Cannot assign to 'this' because it is read-only
+                // (16,9): error CS1604: Cannot assign to 'i' because it is read-only
                 //         i++;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(16, 9));
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(16, 9));
         }
 
         [Fact]
@@ -660,9 +659,9 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (27,9): error CS1604: Cannot assign to 'this' because it is read-only
+                // (27,9): error CS1604: Cannot assign to 'P2' because it is read-only
                 //         P2 = 2; // error
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "P2").WithArguments("this").WithLocation(27, 9));
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "P2").WithArguments("P2").WithLocation(27, 9));
         }
 
         [Fact]
@@ -683,18 +682,18 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (7,9): error CS1604: Cannot assign to 'this' because it is read-only
+                // (7,9): error CS1604: Cannot assign to 'i' because it is read-only
                 //         i++;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(7, 9),
-                // (8,9): error CS1604: Cannot assign to 'this' because it is read-only
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(7, 9),
+                // (8,9): error CS1604: Cannot assign to 'i' because it is read-only
                 //         i--;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(8, 9),
-                // (9,11): error CS1604: Cannot assign to 'this' because it is read-only
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(8, 9),
+                // (9,11): error CS1604: Cannot assign to 'i' because it is read-only
                 //         ++i;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(9, 11),
-                // (10,11): error CS1604: Cannot assign to 'this' because it is read-only
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(9, 11),
+                // (10,11): error CS1604: Cannot assign to 'i' because it is read-only
                 //         --i;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(10, 11));
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(10, 11));
         }
 
         [Fact]
@@ -713,12 +712,12 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (7,9): error CS1604: Cannot assign to 'this' because it is read-only
+                // (7,9): error CS1604: Cannot assign to 'i' because it is read-only
                 //         i += 1;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(7, 9),
-                // (8,9): error CS1604: Cannot assign to 'this' because it is read-only
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(7, 9),
+                // (8,9): error CS1604: Cannot assign to 'i' because it is read-only
                 //         i -= 1;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(8, 9));
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(8, 9));
         }
 
         [Fact]
@@ -744,9 +743,9 @@ public struct S
             // should warn about E += handler in warning wave (see https://github.com/dotnet/roslyn/issues/33968)
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (11,9): error CS1604: Cannot assign to 'this' because it is read-only
+                // (11,9): error CS1604: Cannot assign to 'E' because it is read-only
                 //         E = handler;
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "E").WithArguments("this").WithLocation(11, 9));
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "E").WithArguments("E").WithLocation(11, 9));
         }
 
         [Fact]
@@ -766,12 +765,12 @@ public struct S
 ";
             var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics(
-                // (8,15): error CS1604: Cannot assign to 'this' because it is read-only
+                // (8,15): error CS1604: Cannot assign to 'i' because it is read-only
                 //         add { i++; }
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(8, 15),
-                // (9,18): error CS1604: Cannot assign to 'this' because it is read-only
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(8, 15),
+                // (9,18): error CS1604: Cannot assign to 'i' because it is read-only
                 //         remove { i--; }
-                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("this").WithLocation(9, 18));
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(9, 18));
         }
 
         [Fact]


### PR DESCRIPTION
- Commit 1 adds the following error codes:
```cs
        ERR_StaticMemberCantBeReadOnly = 8656,
        ERR_AutoPropertyCantBeReadOnly = 8657,
        ERR_InvalidPropertyReadOnlyMods = 8658,
        ERR_DuplicatePropertyReadOnlyMods = 8659,
        ERR_FieldLikeEventCantBeReadOnly = 8660
```
- Commit 2 updates the symbol classes to use these error codes
- Commit 3 improves errors for writable usage of readonly instance variables

cc @jcouv @agocke @333fred who have had questions or suggestions about what the language should do in some of these cases.