### PR TITLE
Move checks in build.ps1 into try/catch block

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -62,16 +62,6 @@ param (
 
     [parameter(ValueFromRemainingArguments=$true)][string[]]$properties)
 
-if ($PSVersionTable.PSVersion.Major -lt "5") {
-    Write-Host "PowerShell version must be 5 or greater (version $($PSVersionTable.PSVersion) detected)"
-    exit 1
-}
-
-$regKeyProperty = Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem -Name "LongPathsEnabled" -ErrorAction Ignore
-if (($null -eq $regKeyProperty) -or ($regKeyProperty.LongPathsEnabled -ne 1)) {
-    Write-Warning "LongPath is not enabled, you may experience build errors. You can avoid these by enabling LongPath with ``reg ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1``"
-}
-
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
@@ -530,6 +520,16 @@ function List-Processes() {
 }
 
 try {
+    if ($PSVersionTable.PSVersion.Major -lt "5") {
+        Write-Host "PowerShell version must be 5 or greater (version $($PSVersionTable.PSVersion) detected)"
+        exit 1
+    }
+
+    $regKeyProperty = Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem -Name "LongPathsEnabled" -ErrorAction Ignore
+    if (($null -eq $regKeyProperty) -or ($regKeyProperty.LongPathsEnabled -ne 1)) {
+        Write-Host "LongPath is not enabled, you may experience build errors. You can avoid these by enabling LongPath with ``reg ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1``"
+    }
+
     Process-Arguments
 
     . (Join-Path $PSScriptRoot "build-utils.ps1")


### PR DESCRIPTION
Moves the powershell version and longpath checks into the try/catch block. 

Also changes the `Write-Warning` to `Write-Host` to better fit the rest of the output in the script