### PR TITLE
Do not return null task In RemoveHostClientExtensions

### DIFF
--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public static Task<RemoteHostClient> TryGetRemoteHostClientAsync(
             this Workspace workspace, CancellationToken cancellationToken)
-            => workspace.Services.GetService<IRemoteHostClientService>()?.TryGetRemoteHostClientAsync(cancellationToken) ?? Task.FromResult<RemoteHostClient>(null);
+            => workspace.Services.GetService<IRemoteHostClientService>()?.TryGetRemoteHostClientAsync(cancellationToken) ?? SpecializedTasks.Default<RemoteHostClient>();
 
         public static Task<bool> TryRunRemoteAsync(
             this RemoteHostClient client, string serviceName, Solution solution, string targetName, object argument, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public static Task<RemoteHostClient> TryGetRemoteHostClientAsync(
             this Workspace workspace, CancellationToken cancellationToken)
-            => workspace.Services.GetService<IRemoteHostClientService>()?.TryGetRemoteHostClientAsync(cancellationToken);
+            => workspace.Services.GetService<IRemoteHostClientService>()?.TryGetRemoteHostClientAsync(cancellationToken) ?? Task.FromResult<RemoteHostClient>(null);
 
         public static Task<bool> TryRunRemoteAsync(
             this RemoteHostClient client, string serviceName, Solution solution, string targetName, object argument, CancellationToken cancellationToken)


### PR DESCRIPTION
If `IRemoveHostClientService` does not exist, this extension can return a null task. Instead it should return a task with a null result.