### PR TITLE
Remove data flow analysis from convert foreach to for refactoring

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/ConvertForEachToFor/ConvertForEachToForTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertForEachToFor/ConvertForEachToForTests.vb
@@ -395,7 +395,67 @@ Class Test
     End Sub
 End Class
 "
-            Await TestMissingInRegularAndScriptAsync(initial)
+            Dim expected = "
+Class Test
+    Sub Method()
+        Dim {|Rename:array|} = New Integer() {1, 2, 3}
+        For {|Rename:i|} = 0 To array.Length - 1
+            {|Warning:Dim a = array(i)|}
+            a = 1
+        Next
+    End Sub
+End Class
+"
+            Await TestInRegularAndScriptAsync(initial, expected)
+        End Function
+
+        Public Async Function StructPropertyReadFromAndAssignedToLocal() As Task
+            Dim initial = "
+Class Test
+    Sub Method()
+        For Each [||] a In New Integer?() {1, 2, 3}
+            Dim b = a.Value
+        Next
+    End Sub
+End Class
+"
+            Dim expected = "
+Class Test
+    Sub Method()
+        Dim {|Rename:array|} = New Integer?() {1, 2, 3}
+        For {|Rename:i|} = 0 To array.Length - 1
+            Dim a = array(i)
+            Dim b = a.Value
+        Next
+    End Sub
+End Class
+"
+            Await TestInRegularAndScriptAsync(initial, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertForEachToFor)>
+        Public Async Function StructPropertyRead() As Task
+            Dim initial = "
+Class Test
+    Sub Method()
+        For Each [||] a In New Integer?() {1, 2, 3}
+            a.Value
+        Next
+    End Sub
+End Class
+"
+            Dim expected = "
+Class Test
+    Sub Method()
+        Dim {|Rename:array|} = New Integer?() {1, 2, 3}
+        For {|Rename:i|} = 0 To array.Length - 1
+            Dim a = array(i)
+            a.Value
+        Next
+    End Sub
+End Class
+"
+            Await TestInRegularAndScriptAsync(initial, expected)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertForEachToFor)>

--- a/src/Features/CSharp/Portable/ConvertForEachToFor/CSharpConvertForEachToForCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertForEachToFor/CSharpConvertForEachToForCodeRefactoringProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -123,6 +124,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertForEachToFor
                     generator, foreachInfo.ForEachElementType.GenerateTypeSyntax(),
                     foreachStatement.Identifier, foreachInfo.ForEachElementType, collectionVariableName, indexVariable);
 
+                if (IsForEachVariableWrittenInside)
+                {
+                    variableStatement = variableStatement.WithAdditionalAnnotations(CreateWarningAnnotation());
+                }
+
                 bodyBlock = bodyBlock.InsertNodesBefore(
                     bodyBlock.Statements[0], SpecializedCollections.SingletonEnumerable(
                         variableStatement.WithAdditionalAnnotations(Formatter.Annotation)));
@@ -130,5 +136,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertForEachToFor
 
             return bodyBlock;
         }
+
+        protected override bool IsSupported(ILocalSymbol foreachVariable, IForEachLoopOperation forEachOperation, ForEachStatementSyntax foreachStatement)
+            => true;
     }
 }

--- a/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertForEachToFor/AbstractConvertForEachToForCodeRefactoringProvider.cs
@@ -33,12 +33,24 @@ namespace Microsoft.CodeAnalysis.ConvertForEachToFor
         private static readonly ImmutableArray<string> s_KnownInterfaceNames =
             ImmutableArray.Create(typeof(IList<>).FullName, typeof(IReadOnlyList<>).FullName, typeof(IList).FullName);
 
+        protected bool IsForEachVariableWrittenInside { get; private set; }
         protected abstract string Title { get; }
         protected abstract bool ValidLocation(ForEachInfo foreachInfo);
         protected abstract (SyntaxNode start, SyntaxNode end) GetForEachBody(TForEachStatement foreachStatement);
         protected abstract void ConvertToForStatement(
             SemanticModel model, ForEachInfo info, SyntaxEditor editor, CancellationToken cancellationToken);
         protected abstract bool IsValid(TForEachStatement foreachNode);
+
+        /// <summary>
+        /// Perform language specific checks if the conversion is supported.
+        /// C#: Currently nothing blocking a conversion
+        /// VB: Nested foreach loops sharing a single Next statement, Next statements with multiple variables and next statements
+        /// not using the loop variable are not supported.
+        /// </summary>
+        protected abstract bool IsSupported(ILocalSymbol foreachVariable, IForEachLoopOperation forEachOperation, TForEachStatement foreachStatement);
+
+        protected SyntaxAnnotation CreateWarningAnnotation()
+            => WarningAnnotation.Create(FeaturesResources.Warning_colon_semantics_may_change_when_converting_statement);
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
@@ -139,29 +151,14 @@ namespace Microsoft.CodeAnalysis.ConvertForEachToFor
                 return null;
             }
 
-            // VB can have Next variable. but we only support
-            // simple 1 variable case.
-            if (operation.NextVariables.Length > 1)
+            // Perform language specific checks if the foreachStatement
+            // is using unsupported features
+            if (!IsSupported(foreachVariable, operation, foreachStatement))
             {
                 return null;
             }
 
-            // it is okay to omit variable in Next, but if it presents, it must be same as one in the loop
-            if (!operation.NextVariables.IsEmpty)
-            {
-                var nextVariable = operation.NextVariables[0] as ILocalReferenceOperation;
-                if (nextVariable == null || nextVariable.Local?.Equals(foreachVariable) == false)
-                {
-                    // we do not support anything else than local reference for next variable
-                    // operation
-                    return null;
-                }
-            }
-
-            if (CheckIfForEachVariableIsWrittenInside(model, foreachVariable, foreachStatement))
-            {
-                return null;
-            }
+            IsForEachVariableWrittenInside = CheckIfForEachVariableIsWrittenInside(model, foreachVariable, foreachStatement);
 
             var foreachCollection = RemoveImplicitConversion(operation.Collection);
             if (foreachCollection == null)

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -4643,6 +4643,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Warning: Semantics may change when converting statement..
+        /// </summary>
+        internal static string Warning_colon_semantics_may_change_when_converting_statement {
+            get {
+                return ResourceManager.GetString("Warning_colon_semantics_may_change_when_converting_statement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Warning: Method overrides symbol from metadata.
         /// </summary>
         internal static string Warning_Method_overrides_symbol_from_metadata {

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1681,4 +1681,7 @@ This version used in: {2}</value>
   <data name="Wrap_and_align_long_call_chain" xml:space="preserve">
     <value>Wrap and align long call chain</value>
   </data>
+  <data name="Warning_colon_semantics_may_change_when_converting_statement" xml:space="preserve">
+    <value>Warning: Semantics may change when converting statement.</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -547,6 +547,11 @@
         <target state="translated">Warnung: Durch die Änderung des Namespaces kann der Code ungültig werden oder seine Bedeutung verändern.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_call_chain">
         <source>Wrap and align call chain</source>
         <target state="new">Wrap and align call chain</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -552,6 +552,11 @@
         <target state="new">Wrap and align call chain</target>
         <note />
       </trans-unit>
+      <trans-unit id="Warning_colon_semantics_may_change_when_converting_statement">
+        <source>Warning: Semantics may change when converting statement.</source>
+        <target state="new">Warning: Semantics may change when converting statement.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_and_align_expression">
         <source>Wrap and align expression</source>
         <target state="new">Wrap and align expression</target>


### PR DESCRIPTION
Allow refactoring foreach loops to for loops even when the loop variable is written to. If dataflow analysis shows that it's written to a warning annotation is added to the refactoring to give the user a hint that semantics may change.

Adds two more tests to cover regressions in the scenario reported in #32739 