### PR TITLE
Wait for fully loaded workspace before allowing code cleanup.

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
@@ -27,6 +27,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities;
+using Roslyn.Utilities;
 using __VSHPROPID8 = Microsoft.VisualStudio.Shell.Interop.__VSHPROPID8;
 using IVsHierarchyItemManager = Microsoft.VisualStudio.Shell.IVsHierarchyItemManager;
 
@@ -377,7 +378,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             var document = buffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
             {
-                return Task.FromResult(false);
+                return SpecializedTasks.False;
             }
 
             return FixAsync(buffer.GetWorkspace(), ApplyFixAsync, context, document.Name, cancellationToken);


### PR DESCRIPTION
Redo of #34175 with the new master changes.

Wait until solution is fully loaded when the user hits the code broom.
![code_broom_wait](https://user-images.githubusercontent.com/5749229/54462191-18b29280-472c-11e9-97e8-d366640cc1d3.gif)