### PR TITLE
Adjust Find All References and Go To Implementation for Default Interface Methods

### DIFF
--- a/src/EditorFeatures/Core/FindUsages/FindUsagesHelpers.cs
+++ b/src/EditorFeatures/Core/FindUsages/FindUsagesHelpers.cs
@@ -107,6 +107,11 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                     }
                 }
 
+                if (!symbol.IsInterfaceType() && !symbol.IsAbstract)
+                {
+                    return implementationsAndOverrides.Concat(symbol).ToImmutableArray();
+                }
+
                 return implementationsAndOverrides.ToImmutableArray();
             }
             else if ((symbol as INamedTypeSymbol)?.TypeKind == TypeKind.Class)

--- a/src/EditorFeatures/Core/FindUsages/FindUsagesHelpers.cs
+++ b/src/EditorFeatures/Core/FindUsages/FindUsagesHelpers.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
 
                 if (!symbol.IsInterfaceType() && !symbol.IsAbstract)
                 {
-                    return implementationsAndOverrides.Concat(symbol).ToImmutableArray();
+                    implementationsAndOverrides.Add(symbol);
                 }
 
                 return implementationsAndOverrides.ToImmutableArray();

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ExplicitInterfaceMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ExplicitInterfaceMethodSymbols.vb
@@ -50,6 +50,132 @@ class C : I
         End Function
 
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestExplicitMethod3(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface I
+{
+    void {|Definition:G$$oo|}() {}
+}
+ 
+class C : I
+{
+    void I.{|Definition:Goo|}() { }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestExplicitMethod4(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface I
+{
+    void {|Definition:Goo|}() {}
+}
+ 
+class C : I
+{
+    void I.{|Definition:G$$oo|}() { }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestExplicitMethod5(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface I
+{
+    void {|Definition:G$$oo|}();
+}
+ 
+interface C : I
+{
+    void I.{|Definition:Goo|}() { }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestExplicitMethod6(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface I
+{
+    void {|Definition:Goo|}();
+}
+ 
+interface C : I
+{
+    void I.{|Definition:G$$oo|}() { }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestExplicitMethod7(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface I
+{
+    void {|Definition:G$$oo|}() {}
+}
+ 
+interface C : I
+{
+    void I.{|Definition:Goo|}() { }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestExplicitMethod8(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface I
+{
+    void {|Definition:Goo|}() {}
+}
+ 
+interface C : I
+{
+    void I.{|Definition:G$$oo|}() { }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestExplicitMethodAndInheritance(kind As TestKind, host As TestHost) As Task
             Dim input =
 <Workspace>

--- a/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
+++ b/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
@@ -211,13 +211,81 @@ interface $$I { }
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
-        Public Async Function TestWithOneMethodImplementation() As Task
+        Public Async Function TestWithOneMethodImplementation_01() As Task
             Dim workspace =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
         <Document>
 class C : I { public void [|M|]() { } }
 interface I { void $$M(); }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        Public Async Function TestWithOneMethodImplementation_02() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C : I { public void [|M|]() { } }
+interface I { void [|$$M|]() {} }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        Public Async Function TestWithOneMethodImplementation_03() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C : I { void I.[|M|]() { } }
+interface I { void [|$$M|]() {} }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        Public Async Function TestWithOneMethodImplementation_04() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface C : I 
+{
+    void I.[|M|]() { }
+    void M();
+}
+interface I { void $$M(); }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        Public Async Function TestWithOneMethodImplementation_05() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface C : I
+{
+    void I.[|M|]() { }
+    void M();
+}
+interface I { void [|$$M|]() {} }
         </Document>
     </Project>
 </Workspace>

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -50,7 +50,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         private static readonly RelatedTypeCache s_typeToImmediatelyDerivedClassesMap = new RelatedTypeCache();
         private static readonly RelatedTypeCache s_typeToTransitivelyDerivedClassesMap = new RelatedTypeCache();
-        private static readonly RelatedTypeCache s_typeToTransitivelyImplementingTypesMap = new RelatedTypeCache();
+        private static readonly RelatedTypeCache s_typeToTransitivelyImplementingStructuresAndClassesMap = new RelatedTypeCache();
+        private static readonly RelatedTypeCache s_typeToTransitivelyImplementingStructuresClassesAndInterfacesMap = new RelatedTypeCache();
         private static readonly RelatedTypeCache s_typeToImmediatelyDerivedAndImplementingTypesMap = new RelatedTypeCache();
 
         public static async Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindTypesFromCacheOrComputeAsync(
@@ -190,19 +191,19 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// Implementation of <see cref="SymbolFinder.FindImplementationsAsync(SymbolAndProjectId, Solution, IImmutableSet{Project}, CancellationToken)"/> for 
         /// <see cref="INamedTypeSymbol"/>s
         /// </summary>
-        public static Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindTransitivelyImplementingTypesAsync(
+        public static Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindTransitivelyImplementingStructuresAndClassesAsync(
             INamedTypeSymbol type,
             Solution solution,
             IImmutableSet<Project> projects,
             CancellationToken cancellationToken)
         {
             return FindTypesFromCacheOrComputeAsync(
-                type, solution, projects, s_typeToTransitivelyImplementingTypesMap,
-                c => FindTransitivelyImplementingTypesWorkerAsync(type, solution, projects, c),
+                type, solution, projects, s_typeToTransitivelyImplementingStructuresAndClassesMap,
+                c => FindTransitivelyImplementingStructuresAndClassesWorkerAsync(type, solution, projects, c),
                 cancellationToken);
         }
 
-        private static async Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindTransitivelyImplementingTypesWorkerAsync(
+        private static async Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindTransitivelyImplementingStructuresAndClassesWorkerAsync(
             INamedTypeSymbol type,
             Solution solution,
             IImmutableSet<Project> projects,
@@ -215,6 +216,33 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // We only want implementing types here, not derived interfaces.
             return derivedAndImplementingTypes.WhereAsArray(
                 t => t.Symbol.TypeKind == TypeKind.Class || t.Symbol.TypeKind == TypeKind.Struct);
+        }
+
+        /// <summary>
+        /// Implementation of <see cref="SymbolFinder.FindImplementationsAsync(SymbolAndProjectId, Solution, IImmutableSet{Project}, CancellationToken)"/> for 
+        /// <see cref="INamedTypeSymbol"/>s
+        /// </summary>
+        public static Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindTransitivelyImplementingStructuresClassesAndInterfacesAsync(
+            INamedTypeSymbol type,
+            Solution solution,
+            IImmutableSet<Project> projects,
+            CancellationToken cancellationToken)
+        {
+            return FindTypesFromCacheOrComputeAsync(
+                type, solution, projects, s_typeToTransitivelyImplementingStructuresClassesAndInterfacesMap,
+                c => FindTransitivelyImplementingStructuresClassesAndInterfacesWorkerAsync(type, solution, projects, c),
+                cancellationToken);
+        }
+
+        private static async Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindTransitivelyImplementingStructuresClassesAndInterfacesWorkerAsync(
+            INamedTypeSymbol type,
+            Solution solution,
+            IImmutableSet<Project> projects,
+            CancellationToken cancellationToken)
+        {
+            return await FindDerivedAndImplementingTypesAsync(
+                SymbolAndProjectId.Create(type, projectId: null), solution, projects,
+                transitive: true, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var symbol = symbolAndProjectId.Symbol;
             if (symbol is INamedTypeSymbol namedTypeSymbol)
             {
-                var implementingTypes = await DependentTypeFinder.FindTransitivelyImplementingTypesAsync(namedTypeSymbol, solution, projects, cancellationToken).ConfigureAwait(false);
+                var implementingTypes = await DependentTypeFinder.FindTransitivelyImplementingStructuresAndClassesAsync(namedTypeSymbol, solution, projects, cancellationToken).ConfigureAwait(false);
                 return implementingTypes.Select(s => (SymbolAndProjectId)s)
                                         .Where(IsAccessible)
                                         .ToImmutableArray();
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             else if (symbol.IsImplementableMember())
             {
                 var containingType = symbol.ContainingType.OriginalDefinition;
-                var allTypes = await DependentTypeFinder.FindTransitivelyImplementingTypesAsync(containingType, solution, projects, cancellationToken).ConfigureAwait(false);
+                var allTypes = await DependentTypeFinder.FindTransitivelyImplementingStructuresClassesAndInterfacesAsync(containingType, solution, projects, cancellationToken).ConfigureAwait(false);
 
                 ImmutableArray<SymbolAndProjectId>.Builder results = null;
                 foreach (var t in allTypes.Convert<INamedTypeSymbol, ITypeSymbol>())

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.ReplaceTypeParameterBasedOnTypeConstraintVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.ReplaceTypeParameterBasedOnTypeConstraintVisitor.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                             {
                                 var derivedAndImplementedTypes = new List<INamedTypeSymbol>();
                                 var derivedClasses = SymbolFinder.FindDerivedClassesAsync((INamedTypeSymbol)ct, _solution, immutableProjects, _cancellationToken).WaitAndGetResult(_cancellationToken);
-                                var implementedTypes = DependentTypeFinder.FindTransitivelyImplementingTypesAsync((INamedTypeSymbol)ct, _solution, immutableProjects, _cancellationToken).WaitAndGetResult(_cancellationToken);
+                                var implementedTypes = DependentTypeFinder.FindTransitivelyImplementingStructuresAndClassesAsync((INamedTypeSymbol)ct, _solution, immutableProjects, _cancellationToken).WaitAndGetResult(_cancellationToken);
                                 return derivedClasses.Concat(implementedTypes.Select(s => s.Symbol)).ToList();
                             }).ToList();
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -262,8 +262,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             // representing System.Xml.XmlReader will say it implements IDisposable, but
             // the XmlReader.Dispose() method will not be an explicit implementation of
             // IDisposable.Dispose()
-            if (!semanticFacts.SupportsImplicitInterfaceImplementation &&
-                typeSymbol.Locations.Any(location => location.IsInSource))
+            if ((!semanticFacts.SupportsImplicitInterfaceImplementation &&
+                typeSymbol.Locations.Any(location => location.IsInSource)) ||
+                typeSymbol.TypeKind == TypeKind.Interface)
             {
                 return explicitMatches.FirstOrDefault();
             }
@@ -378,12 +379,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             this ITypeSymbol type, ITypeSymbol interfaceType)
         {
             var originalInterfaceType = interfaceType.OriginalDefinition;
-            if (type is INamedTypeSymbol && type.TypeKind == TypeKind.Interface)
-            {
-                // Interfaces don't implement other interfaces. They extend them.
-                return false;
-            }
-
             return type.AllInterfaces.Any(t => SymbolEquivalenceComparer.Instance.Equals(t.OriginalDefinition, originalInterfaceType));
         }
 


### PR DESCRIPTION
- Include non-abstract definition into the implementations result.
- Include implementations from derived interfaces into the result.