### PR TITLE
Export additional code styles in .editorconfig generation

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Input;
 using System.Windows.Navigation;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -53,7 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         internal static IEnumerable<(string feature, ImmutableArray<IOption> options)> GetLanguageAgnosticEditorConfigOptions()
         {
             yield return (WorkspacesResources.Core_EditorConfig_Options, FormattingOptions.AllOptions);
-            yield return (WorkspacesResources.dot_NET_Coding_Conventions, CodeStyleOptions.AllOptions);
+            yield return (WorkspacesResources.dot_NET_Coding_Conventions, GenerationOptions.AllOptions.Concat(CodeStyleOptions.AllOptions));
         }
 
         private void LearnMoreHyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)

--- a/src/VisualStudio/Core/Test/Options/BasicEditorConfigGeneratorTests.vb
+++ b/src/VisualStudio/Core/Test/Options/BasicEditorConfigGeneratorTests.vb
@@ -90,10 +90,51 @@ visual_basic_preferred_modifier_order = partial,default,private,protected,public
 visual_basic_style_unused_value_assignment_preference = unused_local_variable:suggestion
 visual_basic_style_unused_value_expression_statement_preference = unused_local_variable:silent
 
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, friend, private, protected, protected_friend
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, friend, private, protected, protected_friend
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, friend, private, protected, protected_friend
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
 "
                 Dim editorConfigOptions = VisualBasic.Options.Formatting.CodeStylePage.TestAccessor.GetEditorConfigOptions()
                 Dim actualText = EditorConfigFileGenerator.Generate(editorConfigOptions, workspace.Options, LanguageNames.VisualBasic)
-                Assert.Equal(expectedText, actualText)
+                AssertEx.EqualOrDiff(expectedText, actualText)
             End Using
         End Sub
 
@@ -176,10 +217,51 @@ visual_basic_preferred_modifier_order = partial,default,private,protected,public
 visual_basic_style_unused_value_assignment_preference = unused_local_variable:suggestion
 visual_basic_style_unused_value_expression_statement_preference = unused_local_variable:silent
 
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, friend, private, protected, protected_friend
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, friend, private, protected, protected_friend
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, friend, private, protected, protected_friend
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
 "
                 Dim editorConfigOptions = VisualBasic.Options.Formatting.CodeStylePage.TestAccessor.GetEditorConfigOptions()
                 Dim actualText = EditorConfigFileGenerator.Generate(editorConfigOptions, changedOptions, LanguageNames.VisualBasic)
-                Assert.Equal(expectedText, actualText)
+                AssertEx.EqualOrDiff(expectedText, actualText)
             End Using
         End Sub
     End Class

--- a/src/VisualStudio/Core/Test/Options/BasicEditorConfigGeneratorTests.vb
+++ b/src/VisualStudio/Core/Test/Options/BasicEditorConfigGeneratorTests.vb
@@ -35,6 +35,10 @@ insert_final_newline = false
 
 #### .NET Coding Conventions ####
 
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:silent
 dotnet_style_qualification_for_field = false:silent
@@ -116,6 +120,10 @@ end_of_line = crlf
 insert_final_newline = false
 
 #### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
 
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:silent

--- a/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
+++ b/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
@@ -167,10 +167,51 @@ csharp_space_between_square_brackets = false
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
 
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
 "
                 Dim editorConfigOptions = CSharp.Options.Formatting.CodeStylePage.TestAccessor.GetEditorConfigOptions()
                 Dim actualText = EditorConfigFileGenerator.Generate(editorConfigOptions, workspace.Options, LanguageNames.CSharp)
-                Assert.Equal(expectedText, actualText)
+                AssertEx.EqualOrDiff(expectedText, actualText)
             End Using
         End Sub
 
@@ -331,10 +372,51 @@ csharp_space_between_square_brackets = false
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
 
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
 "
                 Dim editorConfigOptions = CSharp.Options.Formatting.CodeStylePage.TestAccessor.GetEditorConfigOptions()
                 Dim actualText = EditorConfigFileGenerator.Generate(editorConfigOptions, changedOptions, LanguageNames.CSharp)
-                Assert.Equal(expectedText, actualText)
+                AssertEx.EqualOrDiff(expectedText, actualText)
             End Using
         End Sub
     End Class

--- a/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
+++ b/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
@@ -34,6 +34,10 @@ insert_final_newline = false
 
 #### .NET Coding Conventions ####
 
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:silent
 dotnet_style_qualification_for_field = false:silent
@@ -193,6 +197,10 @@ end_of_line = crlf
 insert_final_newline = false
 
 #### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
 
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:silent

--- a/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
@@ -210,6 +211,31 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             return builder.ToImmutable();
+        }
+
+        public static NotificationOption ToNotificationOption(this ReportDiagnostic reportDiagnostic, DiagnosticSeverity defaultSeverity)
+        {
+            switch (reportDiagnostic.WithDefaultSeverity(defaultSeverity))
+            {
+                case ReportDiagnostic.Error:
+                    return NotificationOption.Error;
+
+                case ReportDiagnostic.Warn:
+                    return NotificationOption.Warning;
+
+                case ReportDiagnostic.Info:
+                    return NotificationOption.Suggestion;
+
+                case ReportDiagnostic.Hidden:
+                    return NotificationOption.Silent;
+
+                case ReportDiagnostic.Suppress:
+                    return NotificationOption.None;
+
+                case ReportDiagnostic.Default:
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(reportDiagnostic);
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Editing/GenerationOptions.cs
+++ b/src/Workspaces/Core/Portable/Editing/GenerationOptions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Editing
@@ -7,15 +9,20 @@ namespace Microsoft.CodeAnalysis.Editing
     internal class GenerationOptions
     {
         public static readonly PerLanguageOption<bool> PlaceSystemNamespaceFirst = new PerLanguageOption<bool>(nameof(GenerationOptions),
+            CodeStyleOptionGroups.Usings,
             nameof(PlaceSystemNamespaceFirst), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
                 EditorConfigStorageLocation.ForBoolOption("dotnet_sort_system_directives_first"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PlaceSystemNamespaceFirst")});
 
         public static readonly PerLanguageOption<bool> SeparateImportDirectiveGroups = new PerLanguageOption<bool>(
-            nameof(GenerationOptions), nameof(SeparateImportDirectiveGroups), defaultValue: false,
+            nameof(GenerationOptions), CodeStyleOptionGroups.Usings, nameof(SeparateImportDirectiveGroups), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
                 EditorConfigStorageLocation.ForBoolOption("dotnet_separate_import_directive_groups"),
                 new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(SeparateImportDirectiveGroups)}")});
+
+        public static readonly ImmutableArray<IOption> AllOptions = ImmutableArray.Create<IOption>(
+            PlaceSystemNamespaceFirst,
+            SeparateImportDirectiveGroups);
     }
 }

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_NamingStyle.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_NamingStyle.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.NamingStyles;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 {
@@ -100,6 +101,30 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                 default:
                     capitalization = default;
                     return false;
+            }
+        }
+
+        public static string ToEditorConfigString(this Capitalization capitalization)
+        {
+            switch (capitalization)
+            {
+                case Capitalization.PascalCase:
+                    return "pascal_case";
+
+                case Capitalization.CamelCase:
+                    return "camel_case";
+
+                case Capitalization.FirstUpper:
+                    return "first_word_upper";
+
+                case Capitalization.AllUpper:
+                    return "all_upper";
+
+                case Capitalization.AllLower:
+                    return "all_lower";
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(capitalization);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_SymbolSpec.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_SymbolSpec.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles.SymbolSpecification;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
@@ -280,6 +281,207 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             }
 
             return builder.ToImmutableAndFree();
+        }
+
+        public static string ToEditorConfigString(this ImmutableArray<SymbolKindOrTypeKind> symbols)
+        {
+            if (symbols.IsDefaultOrEmpty)
+            {
+                return "";
+            }
+
+            if (_all.All(symbols.Contains) && symbols.All(_all.Contains))
+            {
+                return "*";
+            }
+
+            return string.Join(", ", symbols.Select(symbol => symbol.ToEditorConfigString()));
+        }
+
+        private static string ToEditorConfigString(this SymbolKindOrTypeKind symbol)
+        {
+            switch (symbol.MethodKind)
+            {
+                case MethodKind.Ordinary:
+                    return "method";
+
+                case MethodKind.LocalFunction:
+                    return "local_function";
+
+                case null:
+                    break;
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(symbol);
+            }
+
+            switch (symbol.TypeKind)
+            {
+                case TypeKind.Class:
+                    return "class";
+
+                case TypeKind.Struct:
+                    return "struct";
+
+                case TypeKind.Interface:
+                    return "interface";
+
+                case TypeKind.Enum:
+                    return "enum";
+
+                case TypeKind.Delegate:
+                    return "delegate";
+
+                case null:
+                    break;
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(symbol);
+            }
+
+            switch (symbol.SymbolKind)
+            {
+                case SymbolKind.Namespace:
+                    return "namespace";
+
+                case SymbolKind.Property:
+                    return "property";
+
+                case SymbolKind.Field:
+                    return "field";
+
+                case SymbolKind.Event:
+                    return "event";
+
+                case SymbolKind.Parameter:
+                    return "parameter";
+
+                case SymbolKind.TypeParameter:
+                    return "type_parameter";
+
+                case SymbolKind.Local:
+                    return "local";
+
+                case null:
+                    break;
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(symbol);
+            }
+
+            throw ExceptionUtilities.UnexpectedValue(symbol);
+        }
+
+        public static string ToEditorConfigString(this ImmutableArray<Accessibility> accessibilities, string languageName)
+        {
+            if (accessibilities.IsDefaultOrEmpty)
+            {
+                return "";
+            }
+
+            if (_allAccessibility.All(accessibilities.Contains) && accessibilities.All(_allAccessibility.Contains))
+            {
+                return "*";
+            }
+
+            return string.Join(", ", accessibilities.Select(accessibility => accessibility.ToEditorConfigString(languageName)));
+        }
+
+        private static string ToEditorConfigString(this Accessibility accessibility, string languageName)
+        {
+            switch (accessibility)
+            {
+                case Accessibility.NotApplicable:
+                    return "local";
+
+                case Accessibility.Private:
+                    return "private";
+
+                case Accessibility.ProtectedAndInternal:
+                    return "private_protected";
+
+                case Accessibility.Protected:
+                    return "protected";
+
+                case Accessibility.Internal:
+                    if (languageName == LanguageNames.VisualBasic)
+                    {
+                        return "friend";
+                    }
+                    else
+                    {
+                        return "internal";
+                    }
+
+                case Accessibility.ProtectedOrInternal:
+                    if (languageName == LanguageNames.VisualBasic)
+                    {
+                        return "protected_friend";
+                    }
+                    else
+                    {
+                        return "protected_internal";
+                    }
+
+                case Accessibility.Public:
+                    return "public";
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(accessibility);
+            }
+        }
+
+        public static string ToEditorConfigString(this ImmutableArray<ModifierKind> modifiers, string languageName)
+        {
+            if (modifiers.IsDefaultOrEmpty)
+            {
+                return "";
+            }
+
+            if (_allModifierKind.All(modifiers.Contains) && modifiers.All(_allModifierKind.Contains))
+            {
+                return "*";
+            }
+
+            return string.Join(", ", modifiers.Select(modifier => modifier.ToEditorConfigString(languageName)));
+        }
+
+        private static string ToEditorConfigString(this ModifierKind modifier, string languageName)
+        {
+            switch (modifier.ModifierKindWrapper)
+            {
+                case ModifierKindEnum.IsAbstract:
+                    if (languageName == LanguageNames.VisualBasic)
+                    {
+                        return "must_inherit";
+                    }
+                    else
+                    {
+                        return "abstract";
+                    }
+
+                case ModifierKindEnum.IsStatic:
+                    if (languageName == LanguageNames.VisualBasic)
+                    {
+                        return "shared";
+                    }
+                    else
+                    {
+                        return "static";
+                    }
+
+                case ModifierKindEnum.IsAsync:
+                    return "async";
+
+                case ModifierKindEnum.IsReadOnly:
+                    return "readonly";
+
+                case ModifierKindEnum.IsConst:
+                    return "const";
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(modifier);
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigFileGenerator.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigFileGenerator.cs
@@ -1,10 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Simplification;
 
 namespace Microsoft.CodeAnalysis.Options
 {
@@ -37,6 +42,8 @@ namespace Microsoft.CodeAnalysis.Options
             {
                 AppendOptionsToEditorConfig(optionSet, feature, options, language, editorconfig);
             }
+
+            AppendNamingStylePreferencesToEditorConfig(optionSet, language, editorconfig);
 
             return editorconfig.ToString();
         }
@@ -77,6 +84,121 @@ namespace Microsoft.CodeAnalysis.Options
                 Debug.Assert(!string.IsNullOrEmpty(editorConfigString));
                 return editorConfigString;
             }
+        }
+
+        private static void AppendNamingStylePreferencesToEditorConfig(OptionSet optionSet, string language, StringBuilder editorconfig)
+        {
+            editorconfig.AppendLine($"#### {WorkspacesResources.Naming_styles} ####");
+
+            var namingStylePreferences = optionSet.GetOption(SimplificationOptions.NamingPreferences, language);
+            var serializedNameMap = AssignNamesToNamingStyleElements(namingStylePreferences);
+            var ruleNameMap = AssignNamesToNamingStyleRules(namingStylePreferences, serializedNameMap);
+            var referencedElements = new HashSet<Guid>();
+
+            editorconfig.AppendLine();
+            editorconfig.AppendLine($"# {WorkspacesResources.Naming_rules}");
+
+            foreach (var namingRule in namingStylePreferences.NamingRules)
+            {
+                referencedElements.Add(namingRule.SymbolSpecificationID);
+                referencedElements.Add(namingRule.NamingStyleID);
+
+                editorconfig.AppendLine();
+                editorconfig.AppendLine($"dotnet_naming_rule.{ruleNameMap[namingRule]}.severity = {namingRule.EnforcementLevel.ToNotificationOption(defaultSeverity: DiagnosticSeverity.Hidden).ToEditorConfigString()}");
+                editorconfig.AppendLine($"dotnet_naming_rule.{ruleNameMap[namingRule]}.symbols = {serializedNameMap[namingRule.SymbolSpecificationID]}");
+                editorconfig.AppendLine($"dotnet_naming_rule.{ruleNameMap[namingRule]}.style = {serializedNameMap[namingRule.NamingStyleID]}");
+            }
+
+            editorconfig.AppendLine();
+            editorconfig.AppendLine($"# {WorkspacesResources.Symbol_specifications}");
+
+            foreach (var symbolSpecification in namingStylePreferences.SymbolSpecifications)
+            {
+                if (!referencedElements.Contains(symbolSpecification.ID))
+                {
+                    continue;
+                }
+
+                editorconfig.AppendLine();
+                editorconfig.AppendLine($"dotnet_naming_symbols.{serializedNameMap[symbolSpecification.ID]}.applicable_kinds = {symbolSpecification.ApplicableSymbolKindList.ToEditorConfigString()}");
+                editorconfig.AppendLine($"dotnet_naming_symbols.{serializedNameMap[symbolSpecification.ID]}.applicable_accessibilities = {symbolSpecification.ApplicableAccessibilityList.ToEditorConfigString(language)}");
+                editorconfig.AppendLine($"dotnet_naming_symbols.{serializedNameMap[symbolSpecification.ID]}.required_modifiers = {symbolSpecification.RequiredModifierList.ToEditorConfigString(language)}");
+            }
+
+            editorconfig.AppendLine();
+            editorconfig.AppendLine($"# {WorkspacesResources.Naming_styles}");
+
+            foreach (var namingStyle in namingStylePreferences.NamingStyles)
+            {
+                if (!referencedElements.Contains(namingStyle.ID))
+                {
+                    continue;
+                }
+
+                editorconfig.AppendLine();
+                editorconfig.AppendLine($"dotnet_naming_style.{serializedNameMap[namingStyle.ID]}.required_prefix = {namingStyle.Prefix}");
+                editorconfig.AppendLine($"dotnet_naming_style.{serializedNameMap[namingStyle.ID]}.required_suffix = {namingStyle.Suffix}");
+                editorconfig.AppendLine($"dotnet_naming_style.{serializedNameMap[namingStyle.ID]}.word_separator = {namingStyle.WordSeparator}");
+                editorconfig.AppendLine($"dotnet_naming_style.{serializedNameMap[namingStyle.ID]}.capitalization = {namingStyle.CapitalizationScheme.ToEditorConfigString()}");
+            }
+        }
+
+        private static ImmutableDictionary<Guid, string> AssignNamesToNamingStyleElements(NamingStylePreferences namingStylePreferences)
+        {
+            var symbolSpecificationNames = new HashSet<string>();
+            var builder = ImmutableDictionary.CreateBuilder<Guid, string>();
+            foreach (var symbolSpecification in namingStylePreferences.SymbolSpecifications)
+            {
+                var name = ToSnakeCaseName(symbolSpecification.Name);
+                if (!symbolSpecificationNames.Add(name))
+                {
+                    name = symbolSpecification.ID.ToString("n");
+                }
+
+                builder.Add(symbolSpecification.ID, name);
+            }
+
+            var namingStyleNames = new HashSet<string>();
+            foreach (var namingStyle in namingStylePreferences.NamingStyles)
+            {
+                var name = ToSnakeCaseName(namingStyle.Name);
+                if (!namingStyleNames.Add(name))
+                {
+                    name = namingStyle.ID.ToString("n");
+                }
+
+                builder.Add(namingStyle.ID, name);
+            }
+
+            return builder.ToImmutable();
+
+            static string ToSnakeCaseName(string name)
+            {
+                return new string(name
+                    .Select(ch =>
+                    {
+                        if (char.IsLetterOrDigit(ch))
+                        {
+                            return char.ToLowerInvariant(ch);
+                        }
+                        else
+                        {
+                            return '_';
+                        }
+                    })
+                    .ToArray());
+            }
+        }
+
+        private static ImmutableDictionary<SerializableNamingRule, string> AssignNamesToNamingStyleRules(NamingStylePreferences namingStylePreferences, ImmutableDictionary<Guid, string> serializedNameMap)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<SerializableNamingRule, string>();
+            foreach (var rule in namingStylePreferences.NamingRules)
+            {
+                builder.Add(rule, $"{serializedNameMap[rule.SymbolSpecificationID]}_should_be_{serializedNameMap[rule.NamingStyleID]}");
+            }
+
+            return builder.ToImmutable();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
@@ -1142,6 +1142,24 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Naming rules.
+        /// </summary>
+        internal static string Naming_rules {
+            get {
+                return ResourceManager.GetString("Naming_rules", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Naming styles.
+        /// </summary>
+        internal static string Naming_styles {
+            get {
+                return ResourceManager.GetString("Naming_styles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Nested quantifier {0}.
         /// </summary>
         internal static string Nested_quantifier_0 {
@@ -3309,6 +3327,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Symbol_0_is_not_from_source {
             get {
                 return ResourceManager.GetString("Symbol_0_is_not_from_source", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Symbol specifications.
+        /// </summary>
+        internal static string Symbol_specifications {
+            get {
+                return ResourceManager.GetString("Symbol_specifications", resourceCulture);
             }
         }
         

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -1499,4 +1499,13 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="DateTimeKind_must_be_Utc" xml:space="preserve">
     <value>DateTimeKind must be Utc</value>
   </data>
+  <data name="Naming_styles" xml:space="preserve">
+    <value>Naming styles</value>
+  </data>
+  <data name="Naming_rules" xml:space="preserve">
+    <value>Naming rules</value>
+  </data>
+  <data name="Symbol_specifications" xml:space="preserve">
+    <value>Symbol specifications</value>
+  </data>
 </root>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Předvolby modifikátorů</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">Předvolby nových řádků</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">Přidávání projektů se nepodporuje.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Einstellungen für Modifizierer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">Einstellungen für neue Zeilen</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">Das Hinzufügen von Projekten wird nicht unterstützt.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Preferencias de modificador</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">Nuevas preferencias de línea</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">No se admite la adición de proyectos.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Préférences de modificateur</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">Préférences de nouvelle ligne</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">L'ajout de projets n'est pas pris en charge.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Preferenze per modificatore</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">Preferenze per nuova riga</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">L'aggiunta di progetti non è supportata.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
@@ -52,6 +52,16 @@
         <target state="translated">修飾子設定</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">改行設定</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">プロジェクトの追加はサポートされていません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
@@ -52,6 +52,16 @@
         <target state="translated">한정자 기본 설정</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">새 줄 기본 설정</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">프로젝트 추가가 지원되지 않습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Preferencje modyfikatora</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">Preferencje nowego wiersza</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">Dodawanie projektów nie jest obsługiwane.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Preferências de modificador</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">Preferências de nova linha</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">Não há suporte para adicionar projetos.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Предпочтения модификатора</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">Предпочтения для новых строк</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">Добавление проектов не поддерживается.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Değiştirici tercihleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">Yeni satır tercihleri</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">Projelerin eklenmesi desteklenmiyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
@@ -52,6 +52,16 @@
         <target state="translated">修饰符首选项</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">新行首选项</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">不支持添加项目。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
@@ -52,6 +52,16 @@
         <target state="translated">修飾詞喜好設定</target>
         <note />
       </trans-unit>
+      <trans-unit id="Naming_rules">
+        <source>Naming rules</source>
+        <target state="new">Naming rules</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Naming_styles">
+        <source>Naming styles</source>
+        <target state="new">Naming styles</target>
+        <note />
+      </trans-unit>
       <trans-unit id="New_line_preferences">
         <source>New line preferences</source>
         <target state="translated">新行喜好設定</target>
@@ -1275,6 +1285,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Adding_projects_is_not_supported">
         <source>Adding projects is not supported.</source>
         <target state="translated">不支援新增專案。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Symbol_specifications">
+        <source>Symbol specifications</source>
+        <target state="new">Symbol specifications</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeOrNamespaceUsageInfo_BaseType">


### PR DESCRIPTION
~~Builds on #33946~~
Possibly supersedes #34122 

* Export using directives styles when generating .editorconfig (Fixes #33766)
* Export naming styles when generating .editorconfig (Fixes #30086)