### PR TITLE
Readonly members prototype cleanup

### DIFF
--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -61,7 +61,7 @@ This document provides guidance for thinking about language interactions and tes
 - NoPIA
 - Dynamic
 - Ref structs, Readonly structs
-- Readonly members on structs (methods, property accessors, custom event accessors)
+- Readonly members on structs (methods, property/indexer accessors, custom event accessors)
  
 # Code
 - Operators (see Eric's list below)

--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -61,6 +61,7 @@ This document provides guidance for thinking about language interactions and tes
 - NoPIA
 - Dynamic
 - Ref structs, Readonly structs
+- Readonly members on structs (methods, property accessors, custom event accessors)
  
 # Code
 - Operators (see Eric's list below)

--- a/docs/features/readonly-instance-members.md
+++ b/docs/features/readonly-instance-members.md
@@ -176,6 +176,11 @@ The compiler would emit the instance member, as usual, and would additionally em
 
 This would allow the user to safely call said instance method without the compiler needing to make a copy.
 
+Some more "edge" cases that are explicitly permitted:
+
+* Explicit interface implementations are allowed to be `readonly`.
+* Partial methods are allowed to be `readonly`. Both signatures or neither must have the `readonly` keyword.
+
 The restrictions would include:
 
 * The `readonly` modifier cannot be applied to static methods, constructors or destructors.

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1302,7 +1302,6 @@ moreArguments:
             // collect all writeable ref-like arguments, including receiver
             var receiverType = receiverOpt?.Type;
 
-            // PROTOTYPE: does this need to check MethodSymbol.IsEffectivelyReadOnly?
             if (receiverType?.IsRefLikeType == true && receiverType?.IsReadOnly == false)
             {
                 escapeTo = GetValEscape(receiverOpt, scopeOfTheContainingExpression);

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1301,7 +1301,6 @@ moreArguments:
 
             // collect all writeable ref-like arguments, including receiver
             var receiverType = receiverOpt?.Type;
-
             if (receiverType?.IsRefLikeType == true && receiverType?.IsReadOnly == false)
             {
                 escapeTo = GetValEscape(receiverOpt, scopeOfTheContainingExpression);

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1301,6 +1301,8 @@ moreArguments:
 
             // collect all writeable ref-like arguments, including receiver
             var receiverType = receiverOpt?.Type;
+
+            // PROTOTYPE: does this need to check MethodSymbol.IsEffectivelyReadOnly?
             if (receiverType?.IsRefLikeType == true && receiverType?.IsReadOnly == false)
             {
                 escapeTo = GetValEscape(receiverOpt, scopeOfTheContainingExpression);

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8197,6 +8197,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Both partial method declarations must be readonly or neither may be readonly.
+        /// </summary>
+        internal static string ERR_PartialMethodReadOnlyDifference {
+            get {
+                return ResourceManager.GetString("ERR_PartialMethodReadOnlyDifference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Both partial method declarations must be static or neither may be static.
         /// </summary>
         internal static string ERR_PartialMethodStaticDifference {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5448,6 +5448,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_FieldLikeEventCantBeReadOnly" xml:space="preserve">
     <value>Field-like event '{0}' cannot be 'readonly'.</value>
   </data>
+  <data name="ERR_PartialMethodReadOnlyDifference" xml:space="preserve">
+    <value>Both partial method declarations must be readonly or neither may be readonly</value>
+  </data>
   <data name="WRN_NullabilityMismatchInArgument" xml:space="preserve">
     <value>Argument of type '{0}' cannot be used for parameter '{2}' of type '{1}' in '{3}' due to differences in the nullability of reference types.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1689,7 +1689,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AutoPropertyWithSetterCantBeReadOnly = 8658,
         ERR_InvalidPropertyReadOnlyMods = 8659,
         ERR_DuplicatePropertyReadOnlyMods = 8660,
-        ERR_FieldLikeEventCantBeReadOnly = 8661
+        ERR_FieldLikeEventCantBeReadOnly = 8661,
+        ERR_PartialMethodReadOnlyDifference = 8662,
 
         #endregion diagnostics introduced for C# 8.0
 

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -785,7 +785,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = RefKind.None;
             if (!receiver.Type.IsReferenceType && LocalRewriter.CanBePassedByReference(receiver))
             {
-                // PROTOTYPE: does this need to check MethodSymbol.IsEffectivelyReadOnly?
                 result = receiver.Type.IsReadOnly ? RefKind.In : RefKind.Ref;
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -785,6 +785,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = RefKind.None;
             if (!receiver.Type.IsReferenceType && LocalRewriter.CanBePassedByReference(receiver))
             {
+                // PROTOTYPE: does this need to check MethodSymbol.IsEffectivelyReadOnly?
                 result = receiver.Type.IsReadOnly ? RefKind.In : RefKind.Ref;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -1076,6 +1076,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_PartialMethodStaticDifference, implementation.Locations[0]);
             }
 
+            if (definition.IsDeclaredReadOnly != implementation.IsDeclaredReadOnly)
+            {
+                diagnostics.Add(ErrorCode.ERR_PartialMethodReadOnlyDifference, implementation.Locations[0]);
+            }
+
             if (definition.IsExtensionMethod != implementation.IsExtensionMethod)
             {
                 diagnostics.Add(ErrorCode.ERR_PartialMethodExtensionDifference, implementation.Locations[0]);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
@@ -50,9 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return RefKind.Out;
                 }
 
-                // PROTOTYPE: examine remaining locations where TypeSymbol.IsReadOnly is tested on 'this'.
-                // Determine whether it needs to be replaced with e.g. ContainingMethod.IsEffectivelyReadOnly.
-                if (ContainingType.IsReadOnly)
+                if (_containingMethod?.IsEffectivelyReadOnly == true)
                 {
                     return RefKind.In;
                 }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Výstupní proměnná nemůže být deklarovaná jako lokální proměnná podle odkazu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">Porovnávání vzorů není povolené pro typy ukazatelů.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Eine out-Variable kann nicht als lokales ref-Element deklariert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">Der Musterabgleich ist für Zeigertypen unzulässig.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Una variable out no se puede declarar como ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">No se permite la coincidencia de patrones para tipos de puntero.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Impossible de déclarer une variable out en tant que variable locale ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">Les critères spéciaux ne sont pas autorisés pour les types de pointeur.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Non è possibile dichiarare una variabile out come variabile locale ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">I criteri di ricerca non sono consentiti per i tipi di puntatore.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -267,6 +267,11 @@
         <target state="translated">out 変数を ref ローカルと宣言することはできません</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">ポインター型でパターン マッチングを使用することはできません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -267,6 +267,11 @@
         <target state="translated">출력 변수는 참조 로컬로 선언할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">포인터 형식에 대해 패턴 일치가 허용되지 않습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Zmiennej out nie można zadeklarować jako lokalnej zmiennej ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">Dopasowanie wzorca jest niedozwolone dla typów wskaźnika.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Uma variável out não pode ser declarada como uma referência local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">A correspondência de padrões não é permitida para tipos de ponteiro.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Выходная переменная не может быть объявлена как локальная переменная ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">Сопоставление шаблонов запрещено для типов указателей.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -267,6 +267,11 @@
         <target state="translated">Bir out değişkeni ref yerel değeri olarak bildirilemez</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">İşaretçi türleri için desen eşleştirmeye izin verilmez.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -267,6 +267,11 @@
         <target state="translated">out 变量无法声明为 ref 局部变量</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">指针类型不允许进行模式匹配。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -267,6 +267,11 @@
         <target state="translated">out 變數不可宣告為 ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_PartialMethodReadOnlyDifference">
+        <source>Both partial method declarations must be readonly or neither may be readonly</source>
+        <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PointerTypeInPatternMatching">
         <source>Pattern-matching is not permitted for pointer types.</source>
         <target state="translated">指標類型不允許進行模式比對。</target>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -1548,23 +1548,30 @@ public readonly struct S2
                 var s1 = comp.GetMember<NamedTypeSymbol>("S1");
                 Assert.False(s1.GetMethod("M1").IsDeclaredReadOnly);
                 Assert.False(s1.GetMethod("M1").IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.Ref, s1.GetMethod("M1").ThisParameter.RefKind);
 
                 Assert.True(s1.GetMethod("M2").IsDeclaredReadOnly);
                 Assert.True(s1.GetMethod("M2").IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s1.GetMethod("M2").ThisParameter.RefKind);
 
                 Assert.True(s1.GetProperty("P1").GetMethod.IsDeclaredReadOnly);
                 Assert.True(s1.GetProperty("P1").GetMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s1.GetProperty("P1").GetMethod.ThisParameter.RefKind);
                 Assert.False(s1.GetProperty("P1").SetMethod.IsDeclaredReadOnly);
                 Assert.False(s1.GetProperty("P1").SetMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.Ref, s1.GetProperty("P1").SetMethod.ThisParameter.RefKind);
 
                 Assert.True(s1.GetProperty("P2").GetMethod.IsDeclaredReadOnly);
                 Assert.True(s1.GetProperty("P2").GetMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s1.GetProperty("P2").GetMethod.ThisParameter.RefKind);
 
                 Assert.True(s1.GetProperty("P3").GetMethod.IsDeclaredReadOnly);
                 Assert.True(s1.GetProperty("P3").GetMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s1.GetProperty("P3").GetMethod.ThisParameter.RefKind);
 
                 Assert.True(s1.GetProperty("P4").SetMethod.IsDeclaredReadOnly);
                 Assert.True(s1.GetProperty("P4").SetMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s1.GetProperty("P4").SetMethod.ThisParameter.RefKind);
 
                 Assert.False(s1.GetProperty("P5").GetMethod.IsDeclaredReadOnly);
                 Assert.False(s1.GetProperty("P5").GetMethod.IsEffectivelyReadOnly);
@@ -1573,22 +1580,28 @@ public readonly struct S2
 
                 Assert.True(s1.GetEvent("E").AddMethod.IsDeclaredReadOnly);
                 Assert.True(s1.GetEvent("E").AddMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s1.GetEvent("E").AddMethod.ThisParameter.RefKind);
 
                 Assert.True(s1.GetEvent("E").RemoveMethod.IsDeclaredReadOnly);
                 Assert.True(s1.GetEvent("E").RemoveMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s1.GetEvent("E").RemoveMethod.ThisParameter.RefKind);
 
                 var s2 = comp.GetMember<NamedTypeSymbol>("S2");
                 Assert.False(s2.GetMethod("M1").IsDeclaredReadOnly);
                 Assert.True(s2.GetMethod("M1").IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s2.GetMethod("M1").ThisParameter.RefKind);
 
                 Assert.True(s2.GetProperty("P1").GetMethod.IsDeclaredReadOnly);
                 Assert.True(s2.GetProperty("P1").GetMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s2.GetProperty("P1").GetMethod.ThisParameter.RefKind);
 
                 Assert.False(s2.GetProperty("P2").GetMethod.IsDeclaredReadOnly);
                 Assert.True(s2.GetProperty("P2").GetMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s2.GetProperty("P2").GetMethod.ThisParameter.RefKind);
 
                 Assert.False(s2.GetProperty("P3").SetMethod.IsDeclaredReadOnly);
                 Assert.True(s2.GetProperty("P3").SetMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s2.GetProperty("P3").SetMethod.ThisParameter.RefKind);
 
                 Assert.False(s2.GetProperty("P4").GetMethod.IsDeclaredReadOnly);
                 Assert.False(s2.GetProperty("P4").GetMethod.IsEffectivelyReadOnly);
@@ -1597,8 +1610,11 @@ public readonly struct S2
 
                 Assert.False(s2.GetEvent("E").AddMethod.IsDeclaredReadOnly);
                 Assert.True(s2.GetEvent("E").AddMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s2.GetEvent("E").AddMethod.ThisParameter.RefKind);
+
                 Assert.False(s2.GetEvent("E").RemoveMethod.IsDeclaredReadOnly);
                 Assert.True(s2.GetEvent("E").RemoveMethod.IsEffectivelyReadOnly);
+                Assert.Equal(RefKind.RefReadOnly, s2.GetEvent("E").RemoveMethod.ThisParameter.RefKind);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -1546,75 +1546,43 @@ public readonly struct S2
             void verify(CSharpCompilation comp)
             {
                 var s1 = comp.GetMember<NamedTypeSymbol>("S1");
-                Assert.False(s1.GetMethod("M1").IsDeclaredReadOnly);
-                Assert.False(s1.GetMethod("M1").IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.Ref, s1.GetMethod("M1").ThisParameter.RefKind);
 
-                Assert.True(s1.GetMethod("M2").IsDeclaredReadOnly);
-                Assert.True(s1.GetMethod("M2").IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s1.GetMethod("M2").ThisParameter.RefKind);
+                verifyReadOnly(s1.GetMethod("M1"), false, false, RefKind.Ref);
+                verifyReadOnly(s1.GetMethod("M2"), true, true, RefKind.RefReadOnly);
 
-                Assert.True(s1.GetProperty("P1").GetMethod.IsDeclaredReadOnly);
-                Assert.True(s1.GetProperty("P1").GetMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s1.GetProperty("P1").GetMethod.ThisParameter.RefKind);
-                Assert.False(s1.GetProperty("P1").SetMethod.IsDeclaredReadOnly);
-                Assert.False(s1.GetProperty("P1").SetMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.Ref, s1.GetProperty("P1").SetMethod.ThisParameter.RefKind);
+                verifyReadOnly(s1.GetProperty("P1").GetMethod, true, true, RefKind.RefReadOnly);
+                verifyReadOnly(s1.GetProperty("P1").SetMethod, false, false, RefKind.Ref);
 
-                Assert.True(s1.GetProperty("P2").GetMethod.IsDeclaredReadOnly);
-                Assert.True(s1.GetProperty("P2").GetMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s1.GetProperty("P2").GetMethod.ThisParameter.RefKind);
+                verifyReadOnly(s1.GetProperty("P2").GetMethod, true, true, RefKind.RefReadOnly);
+                verifyReadOnly(s1.GetProperty("P3").GetMethod, true, true, RefKind.RefReadOnly);
+                verifyReadOnly(s1.GetProperty("P4").SetMethod, true, true, RefKind.RefReadOnly);
 
-                Assert.True(s1.GetProperty("P3").GetMethod.IsDeclaredReadOnly);
-                Assert.True(s1.GetProperty("P3").GetMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s1.GetProperty("P3").GetMethod.ThisParameter.RefKind);
+                verifyReadOnly(s1.GetProperty("P5").GetMethod, false, false, null);
+                verifyReadOnly(s1.GetProperty("P5").SetMethod, false, false, null);
 
-                Assert.True(s1.GetProperty("P4").SetMethod.IsDeclaredReadOnly);
-                Assert.True(s1.GetProperty("P4").SetMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s1.GetProperty("P4").SetMethod.ThisParameter.RefKind);
-
-                Assert.False(s1.GetProperty("P5").GetMethod.IsDeclaredReadOnly);
-                Assert.False(s1.GetProperty("P5").GetMethod.IsEffectivelyReadOnly);
-                Assert.False(s1.GetProperty("P5").SetMethod.IsDeclaredReadOnly);
-                Assert.False(s1.GetProperty("P5").SetMethod.IsEffectivelyReadOnly);
-
-                Assert.True(s1.GetEvent("E").AddMethod.IsDeclaredReadOnly);
-                Assert.True(s1.GetEvent("E").AddMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s1.GetEvent("E").AddMethod.ThisParameter.RefKind);
-
-                Assert.True(s1.GetEvent("E").RemoveMethod.IsDeclaredReadOnly);
-                Assert.True(s1.GetEvent("E").RemoveMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s1.GetEvent("E").RemoveMethod.ThisParameter.RefKind);
+                verifyReadOnly(s1.GetEvent("E").AddMethod, true, true, RefKind.RefReadOnly);
+                verifyReadOnly(s1.GetEvent("E").RemoveMethod, true, true, RefKind.RefReadOnly);
 
                 var s2 = comp.GetMember<NamedTypeSymbol>("S2");
-                Assert.False(s2.GetMethod("M1").IsDeclaredReadOnly);
-                Assert.True(s2.GetMethod("M1").IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s2.GetMethod("M1").ThisParameter.RefKind);
 
-                Assert.True(s2.GetProperty("P1").GetMethod.IsDeclaredReadOnly);
-                Assert.True(s2.GetProperty("P1").GetMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s2.GetProperty("P1").GetMethod.ThisParameter.RefKind);
+                verifyReadOnly(s2.GetMethod("M1"), false, true, RefKind.RefReadOnly);
 
-                Assert.False(s2.GetProperty("P2").GetMethod.IsDeclaredReadOnly);
-                Assert.True(s2.GetProperty("P2").GetMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s2.GetProperty("P2").GetMethod.ThisParameter.RefKind);
+                verifyReadOnly(s2.GetProperty("P1").GetMethod, true, true, RefKind.RefReadOnly);
+                verifyReadOnly(s2.GetProperty("P2").GetMethod, false, true, RefKind.RefReadOnly);
+                verifyReadOnly(s2.GetProperty("P3").SetMethod, false, true, RefKind.RefReadOnly);
 
-                Assert.False(s2.GetProperty("P3").SetMethod.IsDeclaredReadOnly);
-                Assert.True(s2.GetProperty("P3").SetMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s2.GetProperty("P3").SetMethod.ThisParameter.RefKind);
+                verifyReadOnly(s2.GetProperty("P4").GetMethod, false, false, null);
+                verifyReadOnly(s2.GetProperty("P4").SetMethod, false, false, null);
 
-                Assert.False(s2.GetProperty("P4").GetMethod.IsDeclaredReadOnly);
-                Assert.False(s2.GetProperty("P4").GetMethod.IsEffectivelyReadOnly);
-                Assert.False(s2.GetProperty("P4").SetMethod.IsDeclaredReadOnly);
-                Assert.False(s2.GetProperty("P4").SetMethod.IsEffectivelyReadOnly);
+                verifyReadOnly(s2.GetEvent("E").AddMethod, false, true, RefKind.RefReadOnly);
+                verifyReadOnly(s2.GetEvent("E").RemoveMethod, false, true, RefKind.RefReadOnly);
 
-                Assert.False(s2.GetEvent("E").AddMethod.IsDeclaredReadOnly);
-                Assert.True(s2.GetEvent("E").AddMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s2.GetEvent("E").AddMethod.ThisParameter.RefKind);
-
-                Assert.False(s2.GetEvent("E").RemoveMethod.IsDeclaredReadOnly);
-                Assert.True(s2.GetEvent("E").RemoveMethod.IsEffectivelyReadOnly);
-                Assert.Equal(RefKind.RefReadOnly, s2.GetEvent("E").RemoveMethod.ThisParameter.RefKind);
+                void verifyReadOnly(MethodSymbol method, bool declared, bool effective, RefKind? refKind)
+                {
+                    Assert.Equal(declared, method.IsDeclaredReadOnly);
+                    Assert.Equal(effective, method.IsEffectivelyReadOnly);
+                    Assert.Equal(refKind, method.ThisParameter?.RefKind);
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -2154,10 +2154,56 @@ public struct S2
         }
 
         [Fact]
+        public void ReadOnlyMethod_CallBaseMethod()
+        {
+            var csharp = @"
+public struct S
+{
+    readonly void M()
+    {
+        // no warnings for calls to base members
+        GetType();
+        ToString();
+        GetHashCode();
+        Equals(null);
+    }
+}
+";
+            var comp = CompileAndVerify(csharp);
+            comp.VerifyDiagnostics();
+
+            // ToString/GetHashCode/Equals should pass the address of 'this' (not a temp). GetType should box 'this'.
+            comp.VerifyIL("S.M", @"
+{
+  // Code size       58 (0x3a)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldobj      ""S""
+  IL_0006:  box        ""S""
+  IL_000b:  call       ""System.Type object.GetType()""
+  IL_0010:  pop
+  IL_0011:  ldarg.0
+  IL_0012:  constrained. ""S""
+  IL_0018:  callvirt   ""string object.ToString()""
+  IL_001d:  pop
+  IL_001e:  ldarg.0
+  IL_001f:  constrained. ""S""
+  IL_0025:  callvirt   ""int object.GetHashCode()""
+  IL_002a:  pop
+  IL_002b:  ldarg.0
+  IL_002c:  ldnull
+  IL_002d:  constrained. ""S""
+  IL_0033:  callvirt   ""bool object.Equals(object)""
+  IL_0038:  pop
+  IL_0039:  ret
+}");
+        }
+
+        [Fact]
         public void ReadOnlyMethod_OverrideBaseMethod()
         {
             var csharp = @"
-public struct S1
+public struct S
 {
     // note: GetType can't be overridden
     public override string ToString() => throw null;
@@ -2177,9 +2223,75 @@ public struct S1
         base.Equals(null);
     }
 }
+";
+            var verifier = CompileAndVerify(csharp);
 
-public struct S2
+            verifier.VerifyDiagnostics(
+                // (12,9): warning CS8655: Call to non-readonly member 'ToString' from a 'readonly' member results in an implicit copy of 'this'.
+                //         ToString();
+                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "ToString").WithArguments("ToString", "this").WithLocation(12, 9),
+                // (13,9): warning CS8655: Call to non-readonly member 'GetHashCode' from a 'readonly' member results in an implicit copy of 'this'.
+                //         GetHashCode();
+                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "GetHashCode").WithArguments("GetHashCode", "this").WithLocation(13, 9),
+                // (14,9): warning CS8655: Call to non-readonly member 'Equals' from a 'readonly' member results in an implicit copy of 'this'.
+                //         Equals(null);
+                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "Equals").WithArguments("Equals", "this").WithLocation(14, 9));
+
+            // Verify that calls to non-readonly overrides pass the address of a temp, not the address of 'this'
+            verifier.VerifyIL("S.M", @"
 {
+  // Code size      117 (0x75)
+  .maxstack  2
+  .locals init (S V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldobj      ""S""
+  IL_0006:  stloc.0
+  IL_0007:  ldloca.s   V_0
+  IL_0009:  constrained. ""S""
+  IL_000f:  callvirt   ""string object.ToString()""
+  IL_0014:  pop
+  IL_0015:  ldarg.0
+  IL_0016:  ldobj      ""S""
+  IL_001b:  stloc.0
+  IL_001c:  ldloca.s   V_0
+  IL_001e:  constrained. ""S""
+  IL_0024:  callvirt   ""int object.GetHashCode()""
+  IL_0029:  pop
+  IL_002a:  ldarg.0
+  IL_002b:  ldobj      ""S""
+  IL_0030:  stloc.0
+  IL_0031:  ldloca.s   V_0
+  IL_0033:  ldnull
+  IL_0034:  constrained. ""S""
+  IL_003a:  callvirt   ""bool object.Equals(object)""
+  IL_003f:  pop
+  IL_0040:  ldarg.0
+  IL_0041:  ldobj      ""S""
+  IL_0046:  box        ""S""
+  IL_004b:  call       ""string System.ValueType.ToString()""
+  IL_0050:  pop
+  IL_0051:  ldarg.0
+  IL_0052:  ldobj      ""S""
+  IL_0057:  box        ""S""
+  IL_005c:  call       ""int System.ValueType.GetHashCode()""
+  IL_0061:  pop
+  IL_0062:  ldarg.0
+  IL_0063:  ldobj      ""S""
+  IL_0068:  box        ""S""
+  IL_006d:  ldnull
+  IL_006e:  call       ""bool System.ValueType.Equals(object)""
+  IL_0073:  pop
+  IL_0074:  ret
+}");
+        }
+
+        [Fact]
+        public void ReadOnlyMethod_ReadOnlyOverrideBaseMethod()
+        {
+            var csharp = @"
+public struct S
+{
+    // note: GetType can't be overridden
     public readonly override string ToString() => throw null;
     public readonly override int GetHashCode() => throw null;
     public readonly override bool Equals(object o) => throw null;
@@ -2198,97 +2310,214 @@ public struct S2
 }
 ";
             var verifier = CompileAndVerify(csharp);
-            verifier.VerifyDiagnostics(
-                // (12,9): warning CS8655: Call to non-readonly member 'ToString' from a 'readonly' member results in an implicit copy of 'this'.
-                //         ToString();
-                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "ToString").WithArguments("ToString", "this").WithLocation(12, 9),
-                // (13,9): warning CS8655: Call to non-readonly member 'GetHashCode' from a 'readonly' member results in an implicit copy of 'this'.
-                //         GetHashCode();
-                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "GetHashCode").WithArguments("GetHashCode", "this").WithLocation(13, 9),
-                // (14,9): warning CS8655: Call to non-readonly member 'Equals' from a 'readonly' member results in an implicit copy of 'this'.
-                //         Equals(null);
-                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "Equals").WithArguments("Equals", "this").WithLocation(14, 9));
+            verifier.VerifyDiagnostics();
 
-            verifier.VerifyIL("S1.M", @"
-{
-  // Code size      117 (0x75)
-  .maxstack  2
-  .locals init (S1 V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldobj      ""S1""
-  IL_0006:  stloc.0
-  IL_0007:  ldloca.s   V_0
-  IL_0009:  constrained. ""S1""
-  IL_000f:  callvirt   ""string object.ToString()""
-  IL_0014:  pop
-  IL_0015:  ldarg.0
-  IL_0016:  ldobj      ""S1""
-  IL_001b:  stloc.0
-  IL_001c:  ldloca.s   V_0
-  IL_001e:  constrained. ""S1""
-  IL_0024:  callvirt   ""int object.GetHashCode()""
-  IL_0029:  pop
-  IL_002a:  ldarg.0
-  IL_002b:  ldobj      ""S1""
-  IL_0030:  stloc.0
-  IL_0031:  ldloca.s   V_0
-  IL_0033:  ldnull
-  IL_0034:  constrained. ""S1""
-  IL_003a:  callvirt   ""bool object.Equals(object)""
-  IL_003f:  pop
-  IL_0040:  ldarg.0
-  IL_0041:  ldobj      ""S1""
-  IL_0046:  box        ""S1""
-  IL_004b:  call       ""string System.ValueType.ToString()""
-  IL_0050:  pop
-  IL_0051:  ldarg.0
-  IL_0052:  ldobj      ""S1""
-  IL_0057:  box        ""S1""
-  IL_005c:  call       ""int System.ValueType.GetHashCode()""
-  IL_0061:  pop
-  IL_0062:  ldarg.0
-  IL_0063:  ldobj      ""S1""
-  IL_0068:  box        ""S1""
-  IL_006d:  ldnull
-  IL_006e:  call       ""bool System.ValueType.Equals(object)""
-  IL_0073:  pop
-  IL_0074:  ret
-}");
-
-            verifier.VerifyIL("S2.M", @"
+            // Verify that calls to readonly override members pass the address of 'this' (not a temp)
+            verifier.VerifyIL("S.M", @"
 {
   // Code size       93 (0x5d)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  constrained. ""S2""
+  IL_0001:  constrained. ""S""
   IL_0007:  callvirt   ""string object.ToString()""
   IL_000c:  pop
   IL_000d:  ldarg.0
-  IL_000e:  constrained. ""S2""
+  IL_000e:  constrained. ""S""
   IL_0014:  callvirt   ""int object.GetHashCode()""
   IL_0019:  pop
   IL_001a:  ldarg.0
   IL_001b:  ldnull
-  IL_001c:  constrained. ""S2""
+  IL_001c:  constrained. ""S""
   IL_0022:  callvirt   ""bool object.Equals(object)""
   IL_0027:  pop
   IL_0028:  ldarg.0
-  IL_0029:  ldobj      ""S2""
-  IL_002e:  box        ""S2""
+  IL_0029:  ldobj      ""S""
+  IL_002e:  box        ""S""
   IL_0033:  call       ""string System.ValueType.ToString()""
   IL_0038:  pop
   IL_0039:  ldarg.0
-  IL_003a:  ldobj      ""S2""
-  IL_003f:  box        ""S2""
+  IL_003a:  ldobj      ""S""
+  IL_003f:  box        ""S""
   IL_0044:  call       ""int System.ValueType.GetHashCode()""
   IL_0049:  pop
   IL_004a:  ldarg.0
-  IL_004b:  ldobj      ""S2""
-  IL_0050:  box        ""S2""
+  IL_004b:  ldobj      ""S""
+  IL_0050:  box        ""S""
   IL_0055:  ldnull
   IL_0056:  call       ""bool System.ValueType.Equals(object)""
   IL_005b:  pop
   IL_005c:  ret
+}");
+        }
+
+        [Fact]
+        public void ReadOnlyMethod_NewBaseMethod()
+        {
+            var csharp = @"
+public struct S
+{
+    public new System.Type GetType() => throw null;
+    public new string ToString() => throw null;
+    public new int GetHashCode() => throw null;
+    public new bool Equals(object o) => throw null;
+
+    readonly void M()
+    {
+        // should warn--non-readonly invocation
+        GetType();
+        ToString();
+        GetHashCode();
+        Equals(null);
+
+        // ok
+        base.GetType();
+        base.ToString();
+        base.GetHashCode();
+        base.Equals(null);
+    }
+}
+";
+            var verifier = CompileAndVerify(csharp);
+
+            verifier.VerifyDiagnostics(
+                // (12,9): warning CS8655: Call to non-readonly member 'GetType' from a 'readonly' member results in an implicit copy of 'this'.
+                //         GetType();
+                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "GetType").WithArguments("GetType", "this").WithLocation(12, 9),
+                // (13,9): warning CS8655: Call to non-readonly member 'ToString' from a 'readonly' member results in an implicit copy of 'this'.
+                //         ToString();
+                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "ToString").WithArguments("ToString", "this").WithLocation(13, 9),
+                // (14,9): warning CS8655: Call to non-readonly member 'GetHashCode' from a 'readonly' member results in an implicit copy of 'this'.
+                //         GetHashCode();
+                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "GetHashCode").WithArguments("GetHashCode", "this").WithLocation(14, 9),
+                // (15,9): warning CS8655: Call to non-readonly member 'Equals' from a 'readonly' member results in an implicit copy of 'this'.
+                //         Equals(null);
+                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "Equals").WithArguments("Equals", "this").WithLocation(15, 9));
+
+            // Verify that calls to new non-readonly members pass an address to a temp and that calls to base members use a box.
+            verifier.VerifyIL("S.M", @"
+{
+  // Code size      131 (0x83)
+  .maxstack  2
+  .locals init (S V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldobj      ""S""
+  IL_0006:  stloc.0
+  IL_0007:  ldloca.s   V_0
+  IL_0009:  call       ""System.Type S.GetType()""
+  IL_000e:  pop
+  IL_000f:  ldarg.0
+  IL_0010:  ldobj      ""S""
+  IL_0015:  stloc.0
+  IL_0016:  ldloca.s   V_0
+  IL_0018:  call       ""string S.ToString()""
+  IL_001d:  pop
+  IL_001e:  ldarg.0
+  IL_001f:  ldobj      ""S""
+  IL_0024:  stloc.0
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""int S.GetHashCode()""
+  IL_002c:  pop
+  IL_002d:  ldarg.0
+  IL_002e:  ldobj      ""S""
+  IL_0033:  stloc.0
+  IL_0034:  ldloca.s   V_0
+  IL_0036:  ldnull
+  IL_0037:  call       ""bool S.Equals(object)""
+  IL_003c:  pop
+  IL_003d:  ldarg.0
+  IL_003e:  ldobj      ""S""
+  IL_0043:  box        ""S""
+  IL_0048:  call       ""System.Type object.GetType()""
+  IL_004d:  pop
+  IL_004e:  ldarg.0
+  IL_004f:  ldobj      ""S""
+  IL_0054:  box        ""S""
+  IL_0059:  call       ""string System.ValueType.ToString()""
+  IL_005e:  pop
+  IL_005f:  ldarg.0
+  IL_0060:  ldobj      ""S""
+  IL_0065:  box        ""S""
+  IL_006a:  call       ""int System.ValueType.GetHashCode()""
+  IL_006f:  pop
+  IL_0070:  ldarg.0
+  IL_0071:  ldobj      ""S""
+  IL_0076:  box        ""S""
+  IL_007b:  ldnull
+  IL_007c:  call       ""bool System.ValueType.Equals(object)""
+  IL_0081:  pop
+  IL_0082:  ret
+}");
+        }
+
+        [Fact]
+        public void ReadOnlyMethod_ReadOnlyNewBaseMethod()
+        {
+            var csharp = @"
+public struct S
+{
+    public readonly new System.Type GetType() => throw null;
+    public readonly new string ToString() => throw null;
+    public readonly new int GetHashCode() => throw null;
+    public readonly new bool Equals(object o) => throw null;
+
+    readonly void M()
+    {
+        // no warnings
+        GetType();
+        ToString();
+        GetHashCode();
+        Equals(null);
+
+        base.GetType();
+        base.ToString();
+        base.GetHashCode();
+        base.Equals(null);
+    }
+}
+";
+            var verifier = CompileAndVerify(csharp);
+            verifier.VerifyDiagnostics();
+
+            // Verify that calls to readonly new members pass the address of 'this' (not a temp) and that calls to base members use a box.
+            verifier.VerifyIL("S.M", @"
+{
+  // Code size       99 (0x63)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  call       ""System.Type S.GetType()""
+  IL_0006:  pop
+  IL_0007:  ldarg.0
+  IL_0008:  call       ""string S.ToString()""
+  IL_000d:  pop
+  IL_000e:  ldarg.0
+  IL_000f:  call       ""int S.GetHashCode()""
+  IL_0014:  pop
+  IL_0015:  ldarg.0
+  IL_0016:  ldnull
+  IL_0017:  call       ""bool S.Equals(object)""
+  IL_001c:  pop
+  IL_001d:  ldarg.0
+  IL_001e:  ldobj      ""S""
+  IL_0023:  box        ""S""
+  IL_0028:  call       ""System.Type object.GetType()""
+  IL_002d:  pop
+  IL_002e:  ldarg.0
+  IL_002f:  ldobj      ""S""
+  IL_0034:  box        ""S""
+  IL_0039:  call       ""string System.ValueType.ToString()""
+  IL_003e:  pop
+  IL_003f:  ldarg.0
+  IL_0040:  ldobj      ""S""
+  IL_0045:  box        ""S""
+  IL_004a:  call       ""int System.ValueType.GetHashCode()""
+  IL_004f:  pop
+  IL_0050:  ldarg.0
+  IL_0051:  ldobj      ""S""
+  IL_0056:  box        ""S""
+  IL_005b:  ldnull
+  IL_005c:  call       ""bool System.ValueType.Equals(object)""
+  IL_0061:  pop
+  IL_0062:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -1637,6 +1637,56 @@ public struct S
         }
 
         [Fact]
+        public void ReadOnlyLambda()
+        {
+            var csharp = @"
+public struct S
+{
+    void M1()
+    {
+        M2(readonly () => 42);
+    }
+    void M2(System.Func<int> a)
+    {
+        _ = a();
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (6,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'a' of 'S.M2(Func<int>)'
+                //         M2(readonly () => 42);
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M2").WithArguments("a", "S.M2(System.Func<int>)").WithLocation(6, 9),
+                // (6,12): error CS1026: ) expected
+                //         M2(readonly () => 42);
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "readonly").WithLocation(6, 12),
+                // (6,12): error CS1002: ; expected
+                //         M2(readonly () => 42);
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "readonly").WithLocation(6, 12),
+                // (6,12): error CS0106: The modifier 'readonly' is not valid for this item
+                //         M2(readonly () => 42);
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "readonly").WithArguments("readonly").WithLocation(6, 12),
+                // (6,22): error CS8124: Tuple must contain at least two elements.
+                //         M2(readonly () => 42);
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(6, 22),
+                // (6,24): error CS1001: Identifier expected
+                //         M2(readonly () => 42);
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(6, 24),
+                // (6,24): error CS1003: Syntax error, ',' expected
+                //         M2(readonly () => 42);
+                Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments(",", "=>").WithLocation(6, 24),
+                // (6,27): error CS1002: ; expected
+                //         M2(readonly () => 42);
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "42").WithLocation(6, 27),
+                // (6,29): error CS1002: ; expected
+                //         M2(readonly () => 42);
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(6, 29),
+                // (6,29): error CS1513: } expected
+                //         M2(readonly () => 42);
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(6, 29));
+        }
+
+        [Fact]
         public void ReadOnlyIndexer()
         {
             var csharp = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -351,64 +351,6 @@ public struct S
         }
 
         [Fact]
-        public void ReadOnlyMethod_OverrideBaseMethod()
-        {
-            var csharp = @"
-public struct S1
-{
-    // note: GetType can't be overridden
-    public override string ToString() => throw null;
-    public override int GetHashCode() => throw null;
-    public override bool Equals(object o) => throw null;
-
-    readonly void M()
-    {
-        // should warn--non-readonly invocation
-        ToString();
-        GetHashCode();
-        Equals(null);
-
-        // ok
-        base.ToString();
-        base.GetHashCode();
-        base.Equals(null);
-    }
-}
-
-public struct S2
-{
-    public readonly override string ToString() => throw null;
-    public readonly override int GetHashCode() => throw null;
-    public readonly override bool Equals(object o) => throw null;
-
-    readonly void M()
-    {
-        // no warnings
-        ToString();
-        GetHashCode();
-        Equals(null);
-
-        base.ToString();
-        base.GetHashCode();
-        base.Equals(null);
-    }
-}
-";
-            var comp = CreateCompilation(csharp);
-            comp.VerifyDiagnostics(
-
-                // (12,9): warning CS8655: Call to non-readonly member 'ToString' from a 'readonly' member results in an implicit copy of 'this'.
-                //         ToString();
-                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "ToString").WithArguments("ToString", "this").WithLocation(12, 9),
-                // (13,9): warning CS8655: Call to non-readonly member 'GetHashCode' from a 'readonly' member results in an implicit copy of 'this'.
-                //         GetHashCode();
-                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "GetHashCode").WithArguments("GetHashCode", "this").WithLocation(13, 9),
-                // (14,9): warning CS8655: Call to non-readonly member 'Equals' from a 'readonly' member results in an implicit copy of 'this'.
-                //         Equals(null);
-                Diagnostic(ErrorCode.WRN_ImplicitCopyInReadOnlyMember, "Equals").WithArguments("Equals", "this").WithLocation(14, 9));
-        }
-
-        [Fact]
         public void ReadOnlyMethod_Override_AssignThis()
         {
             var csharp = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -331,26 +331,6 @@ public struct S
         }
 
         [Fact]
-        public void ReadOnlyMethod_CallBaseMethod()
-        {
-            var csharp = @"
-public struct S
-{
-    readonly void M()
-    {
-        // no warnings for calls to base members
-        GetType();
-        ToString();
-        GetHashCode();
-        Equals(null);
-    }
-}
-";
-            var comp = CreateCompilation(csharp);
-            comp.VerifyDiagnostics();
-        }
-
-        [Fact]
         public void ReadOnlyMethod_Override_AssignThis()
         {
             var csharp = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -378,6 +378,84 @@ public struct S
         }
 
         [Fact]
+        public void ReadOnlyMethod_Partial_01()
+        {
+            var csharp = @"
+public partial struct S
+{
+    public int i;
+    readonly partial void M();
+}
+
+public partial struct S
+{
+    readonly partial void M()
+    {
+        i++;
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (12,9): error CS1604: Cannot assign to 'i' because it is read-only
+                //         i++;
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(12, 9));
+        }
+
+        [Fact]
+        public void ReadOnlyMethod_Partial_02()
+        {
+            var csharp = @"
+public partial struct S
+{
+    public int i;
+    partial void M();
+}
+
+public partial struct S
+{
+    readonly partial void M()
+    {
+        i++;
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (10,27): error CS8662: Both partial method declarations must be readonly or neither may be readonly
+                //     readonly partial void M()
+                Diagnostic(ErrorCode.ERR_PartialMethodReadOnlyDifference, "M").WithLocation(10, 27),
+                // (12,9): error CS1604: Cannot assign to 'i' because it is read-only
+                //         i++;
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(12, 9));
+        }
+
+        [Fact]
+        public void ReadOnlyMethod_Partial_03()
+        {
+            var csharp = @"
+public partial struct S
+{
+    public int i;
+    readonly partial void M();
+}
+
+public partial struct S
+{
+    partial void M()
+    {
+        i++;
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics(
+                // (10,18): error CS8662: Both partial method declarations must be readonly or neither may be readonly
+                //     partial void M()
+                Diagnostic(ErrorCode.ERR_PartialMethodReadOnlyDifference, "M").WithLocation(10, 18));
+        }
+
+        [Fact]
         public void ReadOnlyMethod_GetPinnableReference()
         {
             var csharp = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -460,13 +460,18 @@ public interface I
 
 public struct S : I
 {
+    int i;
     readonly void I.M()
     {
+        i = 0;
     }
 }
 ";
             var comp = CreateCompilation(csharp);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (12,9): error CS1604: Cannot assign to 'i' because it is read-only
+                //         i = 0;
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(12, 9));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -456,6 +456,26 @@ public partial struct S
         }
 
         [Fact]
+        public void ReadOnlyMethod_ExplicitInterfaceImplementation()
+        {
+            var csharp = @"
+public interface I
+{
+    void M();
+}
+
+public struct S : I
+{
+    readonly void I.M()
+    {
+    }
+}
+";
+            var comp = CreateCompilation(csharp);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void ReadOnlyMethod_GetPinnableReference()
         {
             var csharp = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -380,6 +380,10 @@ public partial struct S
                 // (12,9): error CS1604: Cannot assign to 'i' because it is read-only
                 //         i++;
                 Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(12, 9));
+
+            var method = comp.GetMember<NamedTypeSymbol>("S").GetMethod("M");
+            Assert.True(method.IsDeclaredReadOnly);
+            Assert.True(method.IsEffectivelyReadOnly);
         }
 
         [Fact]
@@ -408,6 +412,11 @@ public partial struct S
                 // (12,9): error CS1604: Cannot assign to 'i' because it is read-only
                 //         i++;
                 Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "i").WithArguments("i").WithLocation(12, 9));
+
+            var method = comp.GetMember<NamedTypeSymbol>("S").GetMethod("M");
+            // Symbol APIs always return the declaration part of the partial method.
+            Assert.False(method.IsDeclaredReadOnly);
+            Assert.False(method.IsEffectivelyReadOnly);
         }
 
         [Fact]
@@ -433,6 +442,11 @@ public partial struct S
                 // (10,18): error CS8662: Both partial method declarations must be readonly or neither may be readonly
                 //     partial void M()
                 Diagnostic(ErrorCode.ERR_PartialMethodReadOnlyDifference, "M").WithLocation(10, 18));
+
+            var method = comp.GetMember<NamedTypeSymbol>("S").GetMethod("M");
+            // Symbol APIs always return the declaration part of the partial method.
+            Assert.True(method.IsDeclaredReadOnly);
+            Assert.True(method.IsEffectivelyReadOnly);
         }
 
         [Fact]


### PR DESCRIPTION
Related to #32911 

This PR has several minor fixes and adds coverage for some new scenarios.

- Addresses and removes prototype comments (except for the public API ones in #34514)
- Updates `ThisParameterSymbol.RefKind` API to use RefKind.In when containingMethod.IsEffectivelyReadOnly
- Updates compiler test plan to mention readonly members
- Tests codegen of ReadOnlyMethod_OverrideBaseMethod
- Tests `readonly partial` methods: both signatures must contain `readonly`. Is this what we want?
  - Resolution: either both signatures or neither signature must contain 'readonly'.
- Tests readonly explicit interface implementations. These are allowed. Do we want that?
  - Resolution: 'readonly' explicit interface implementations are allowed.

The last few items might need to be hashed out in review and the speclet should probably be updated to be clear about the expected behavior. (done)