### PR TITLE
Change preview warnings from a background to a border marker

### DIFF
--- a/src/EditorFeatures/Core.Wpf/PreviewWarningTagDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/PreviewWarningTagDefinition.cs
@@ -16,8 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging.Tags
     {
         public PreviewWarningTagDefinition()
         {
-            // this.Border = new Pen(Brushes.Yellow, thickness: 1.5);
-            this.BackgroundColor = Colors.Yellow;
+            this.Border = new Pen(Brushes.Chocolate, thickness: 1.5);
             this.DisplayName = EditorFeaturesResources.Preview_Warning;
             this.ZOrder = 10;
         }

--- a/src/EditorFeatures/Core.Wpf/PreviewWarningTagDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/PreviewWarningTagDefinition.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging.Tags
     {
         public PreviewWarningTagDefinition()
         {
-            this.Border = new Pen(Brushes.Chocolate, thickness: 1.5);
+            this.Border = new Pen(new SolidColorBrush(Color.FromRgb(230, 117, 64)), thickness: 1.5);
             this.DisplayName = EditorFeaturesResources.Preview_Warning;
             this.ZOrder = 10;
         }


### PR DESCRIPTION
- Changes PreviewWarning marker from being a solid background to just being a border marker.

Before:
![image](https://user-images.githubusercontent.com/1408396/55010885-0b5e9900-4fb3-11e9-80dd-acf87edf1556.png)

After:
![image](https://user-images.githubusercontent.com/611219/55095708-d9fad180-5075-11e9-8816-a74d333bbf8e.png)

Fixes https://github.com/dotnet/roslyn/issues/34445