### PR TITLE
Message tweak: Dereference of a possibly null reference

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CSharpResources {
@@ -15467,7 +15467,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Possible dereference of a null reference..
+        ///   Looks up a localized string similar to Dereference of a possibly null reference..
         /// </summary>
         internal static string WRN_NullReferenceReceiver {
             get {
@@ -15476,7 +15476,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Possible dereference of a null reference..
+        ///   Looks up a localized string similar to Dereference of a possibly null reference..
         /// </summary>
         internal static string WRN_NullReferenceReceiver_Title {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5302,10 +5302,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Possible null reference assignment.</value>
   </data>
   <data name="WRN_NullReferenceReceiver" xml:space="preserve">
-    <value>Possible dereference of a null reference.</value>
+    <value>Dereference of a possibly null reference.</value>
   </data>
   <data name="WRN_NullReferenceReceiver_Title" xml:space="preserve">
-    <value>Possible dereference of a null reference.</value>
+    <value>Dereference of a possibly null reference.</value>
   </data>
   <data name="WRN_NullReferenceReturn" xml:space="preserve">
     <value>Possible null reference return.</value>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1323,13 +1323,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Může jít o vyhodnocení odkazu null.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Může jít o vyhodnocení odkazu null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Může jít o vyhodnocení odkazu null.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Může jít o vyhodnocení odkazu null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1323,13 +1323,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Mögliche Dereferenzierung eines Nullverweises.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Mögliche Dereferenzierung eines Nullverweises.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Mögliche Dereferenzierung eines Nullverweises.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Mögliche Dereferenzierung eines Nullverweises.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1325,13 +1325,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Posible desreferencia de una referencia nula.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Posible desreferencia de una referencia nula.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Posible desreferencia de una referencia nula</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Posible desreferencia de una referencia nula</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1324,13 +1324,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Déréférencement possible d'une référence null.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Déréférencement possible d'une référence null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Déréférencement possible d'une référence null.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Déréférencement possible d'une référence null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1323,13 +1323,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Possibile dereferenziamento di un riferimento Null.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Possibile dereferenziamento di un riferimento Null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Possibile dereferenziamento di un riferimento Null.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Possibile dereferenziamento di un riferimento Null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1323,13 +1323,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Null 参照の逆参照である可能性があります。</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Null 参照の逆参照である可能性があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Null 参照の逆参照である可能性があります。</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Null 参照の逆参照である可能性があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1323,13 +1323,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">가능한 null 참조의 역참조입니다.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">가능한 null 참조의 역참조입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">가능한 null 참조의 역참조입니다.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">가능한 null 참조의 역참조입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1323,13 +1323,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Możliwe wyłuskanie odwołania o wartości null.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Możliwe wyłuskanie odwołania o wartości null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Możliwe wyłuskanie odwołania o wartości null.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Możliwe wyłuskanie odwołania o wartości null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1323,13 +1323,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Possível desreferência de uma referência nula.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Possível desreferência de uma referência nula.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Possível desreferência de uma referência nula.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Possível desreferência de uma referência nula.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1323,13 +1323,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Возможно, разыменование ссылки, допускающей значение NULL.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Возможно, разыменование ссылки, допускающей значение NULL.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Возможно, разыменование ссылки, допускающей значение NULL.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Возможно, разыменование ссылки, допускающей значение NULL.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1324,13 +1324,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Null başvuruya yönelik olası başvuru.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Null başvuruya yönelik olası başvuru.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">Null başvuruya yönelik olası başvuru.</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">Null başvuruya yönelik olası başvuru.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1324,13 +1324,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">null 引用可能的取消引用。</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">null 引用可能的取消引用。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">null 引用可能的取消引用。</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">null 引用可能的取消引用。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1323,13 +1323,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">可能有 Null 參考的取值 (Dereference)。</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">可能有 Null 參考的取值 (Dereference)。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReceiver_Title">
-        <source>Possible dereference of a null reference.</source>
-        <target state="translated">可能有 Null 參考的取值 (Dereference)。</target>
+        <source>Dereference of a possibly null reference.</source>
+        <target state="needs-review-translation">可能有 Null 參考的取值 (Dereference)。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_NullReferenceReturn">

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -1524,31 +1524,31 @@ class C
 }";
             var comp2 = CreateCompilation(new[] { source2 }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyDiagnostics(
-                // (5,9): warning CS8602: Possible dereference of a null reference.
+                // (5,9): warning CS8602: Dereference of a possibly null reference.
                 //         A.Nested._1.Item1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "A.Nested._1.Item1").WithLocation(5, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         A.Nested._2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "A.Nested._2").WithLocation(7, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         A.Nested._4.Item1.Item1[0].ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "A.Nested._4.Item1.Item1[0]").WithLocation(10, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         A.Nested._4.Item2.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "A.Nested._4.Item2").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         A.Long._1.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "A.Long._1").WithLocation(13, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         A.Long._3.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "A.Long._3").WithLocation(15, 9),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         A.Long._5.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "A.Long._5").WithLocation(17, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         A.Long._7.ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "A.Long._7").WithLocation(19, 9),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         A.Long._9.ToString(); // 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "A.Long._9").WithLocation(21, 9));
 
@@ -1653,13 +1653,13 @@ public class B<T> :
 }";
             var comp2 = CreateCompilation(new[] { source2 }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8, references: new[] { comp.EmitToImageReference() });
             comp2.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.Field._9.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.Field._9").WithLocation(6, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.Method(default)._9.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.Method(default)._9").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.Property._9.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.Property._9").WithLocation(10, 9));
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -284,7 +284,7 @@ public class C
 }", options: WithNonNullTypesTrue());
 
             comp.VerifyDiagnostics(
-                // (12,23): warning CS8602: Possible dereference of a null reference.
+                // (12,23): warning CS8602: Dereference of a possibly null reference.
                 //         new C() { f = { f2 = null, f3 = null }};
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "{ f2 = null, f3 = null }").WithLocation(12, 23)
                 );
@@ -354,7 +354,7 @@ public class C
 }", options: WithNonNullTypesTrue());
 
             comp.VerifyDiagnostics(
-                // (10,25): warning CS8602: Possible dereference of a null reference.
+                // (10,25): warning CS8602: Dereference of a possibly null reference.
                 //         new C() { [0] = { f2 = null }};
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "{ f2 = null }").WithLocation(10, 25)
                 );
@@ -379,10 +379,10 @@ public class C
 }", options: WithNonNullTypesTrue());
 
             comp.VerifyDiagnostics(
-                // (12,24): warning CS8602: Possible dereference of a null reference.
+                // (12,24): warning CS8602: Dereference of a possibly null reference.
                 //         new C() { fc = { fb = { f2 = null} }};
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "{ fb = { f2 = null} }").WithLocation(12, 24),
-                // (12,31): warning CS8602: Possible dereference of a null reference.
+                // (12,31): warning CS8602: Dereference of a possibly null reference.
                 //         new C() { fc = { fb = { f2 = null} }};
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "{ f2 = null}").WithLocation(12, 31)
                 );
@@ -406,7 +406,7 @@ public class C
 }", options: WithNonNullTypesTrue());
 
             comp.VerifyDiagnostics(
-                // (11,23): warning CS8602: Possible dereference of a null reference.
+                // (11,23): warning CS8602: Dereference of a possibly null reference.
                 //         new C() { f = { [0] = null }};
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "{ [0] = null }").WithLocation(11, 23)
                 );
@@ -432,7 +432,7 @@ public class C
 }", options: WithNonNullTypesTrue());
 
             comp.VerifyDiagnostics(
-                // (13,23): warning CS8602: Possible dereference of a null reference.
+                // (13,23): warning CS8602: Dereference of a possibly null reference.
                 //         new C() { f = { 1 }};
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "{ 1 }").WithLocation(13, 23)
                 );
@@ -463,7 +463,7 @@ class C
             // https://github.com/dotnet/roslyn/issues/33257
 
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         L(o)[0].ToString(); // Should get a warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "L(o)[0]").WithLocation(7, 9)
                 );
@@ -496,7 +496,7 @@ public class Main
                 // (14,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o2 = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(14, 14),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         L(o2)[0].Field.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "L(o2)[0].Field").WithLocation(15, 9)
                 );
@@ -526,7 +526,7 @@ public class Program
 ", options: WithNonNullTypesTrue());
 
             comp.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         y[0][0].ToString(); // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y[0][0]").WithLocation(11, 9)
                 );
@@ -679,7 +679,7 @@ class C
 }", options: WithNonNullTypesTrue());
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
-                // (13,11): warning CS8602: Possible dereference of a null reference.
+                // (13,11): warning CS8602: Dereference of a possibly null reference.
                 //         x?.Field.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".Field").WithLocation(13, 11)
                 );
@@ -712,7 +712,7 @@ class C
 }", options: WithNonNullTypesTrue());
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
-                // (14,11): warning CS8602: Possible dereference of a null reference.
+                // (14,11): warning CS8602: Dereference of a possibly null reference.
                 //         x?.Field.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".Field").WithLocation(14, 11)
                 );
@@ -743,7 +743,7 @@ class C
 }", options: WithNonNullTypesTrue());
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Field?.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(16, 9)
                 );
@@ -806,7 +806,7 @@ class C
                 // (8,29): error CS0246: The type or namespace name 'Missing' could not be found (are you missing a using directive or an assembly reference?)
                 //     static void M<T>(int i, Missing m, string s, T t)
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Missing").WithArguments("Missing").WithLocation(8, 29),
-                // (13,19): warning CS8602: Possible dereference of a null reference.
+                // (13,19): warning CS8602: Dereference of a possibly null reference.
                 //         Create(t)?.M().ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".M()").WithLocation(13, 19)
                 );
@@ -840,7 +840,7 @@ class C
                 // (4,74): error CS0246: The type or namespace name 'Missing' could not be found (are you missing a using directive or an assembly reference?)
                 //     void F(object? maybeNull, object nonNull, Missing? annotatedMissing, Missing unannotatedMissing)
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Missing").WithArguments("Missing").WithLocation(4, 74),
-                // (6,15): warning CS8602: Possible dereference of a null reference.
+                // (6,15): warning CS8602: Dereference of a possibly null reference.
                 //         lock (maybeNull) { }
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "maybeNull").WithLocation(6, 15),
                 // (8,15): error CS0185: 'Missing?' is not a reference type as required by the lock statement
@@ -1914,13 +1914,13 @@ public class C
                 // (7,9): error CS8598: The suppression operator is not allowed in this context
                 //         d.M!(); // 1
                 Diagnostic(ErrorCode.ERR_IllegalSuppression, "d.M").WithLocation(7, 9),
-                // (14,17): warning CS8602: Possible dereference of a null reference.
+                // (14,17): warning CS8602: Dereference of a possibly null reference.
                 //         int y = d.y; // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "d").WithLocation(14, 17),
                 // (17,9): error CS8598: The suppression operator is not allowed in this context
                 //         d.M!(); // 3
                 Diagnostic(ErrorCode.ERR_IllegalSuppression, "d.M").WithLocation(17, 9),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         d.M!(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "d").WithLocation(17, 9)
                 );
@@ -2160,10 +2160,10 @@ class Test
             // Tracked by https://github.com/dotnet/roslyn/issues/32697
 
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         s /*T:string?*/ .ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2 /*T:string?*/ .ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(9, 9)
                 );
@@ -2744,7 +2744,7 @@ class C
                 // (6,23): warning CS8619: Nullability of reference types in value of type 'C?' doesn't match target type 'C'.
                 //         ref C y = ref x; // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("C?", "C").WithLocation(6, 23),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(7, 9),
                 // (11,24): warning CS8619: Nullability of reference types in value of type 'C' doesn't match target type 'C?'.
@@ -2762,7 +2762,7 @@ class C
                 // (24,24): warning CS8619: Nullability of reference types in value of type 'C' doesn't match target type 'C?'.
                 //         ref C? y = ref x; // 7
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("C", "C?").WithLocation(24, 24),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(25, 9)
                 );
@@ -2844,13 +2844,13 @@ struct S<T>
                 // (6,18): warning CS8619: Nullability of reference types in value of type 'string?' doesn't match target type 'string'.
                 //         foreach (ref string item in collection)
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "ref string").WithArguments("string?", "string").WithLocation(6, 18),
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             item.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "item").WithLocation(8, 13));
 
             verify("string", "string");
             verify("string?", "string?",
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             item.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "item").WithLocation(8, 13));
 
@@ -2868,7 +2868,7 @@ struct S<T>
                 // (6,18): warning CS8619: Nullability of reference types in value of type 'C<dynamic>?' doesn't match target type 'C<object?>'.
                 //         foreach (ref C<object?> item in collection)
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "ref C<object?>").WithArguments("C<dynamic>?", "C<object?>").WithLocation(6, 18),
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             item.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "item").WithLocation(8, 13));
 
@@ -2876,12 +2876,12 @@ struct S<T>
             verify("var", "string");
 
             verify("var", "string?",
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             item.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "item").WithLocation(8, 13));
 
             verify("T", "T",
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             item.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "item").WithLocation(8, 13));
 
@@ -2918,7 +2918,7 @@ class C<T>
         public void RefAssignment_Foreach_Nested()
         {
             verify(fieldType: "string?",
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             item.Field.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "item.Field").WithLocation(9, 13));
 
@@ -3591,16 +3591,16 @@ class C
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (18,57): warning CS8602: Possible dereference of a null reference.
+                // (18,57): warning CS8602: Dereference of a possibly null reference.
                 //         _ = c ?? throw new System.ArgumentNullException(c.ToString()); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(18, 57),
-                // (22,18): warning CS8602: Possible dereference of a null reference.
+                // (22,18): warning CS8602: Dereference of a possibly null reference.
                 //         _ = s ?? s.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(22, 18),
-                // (27,18): warning CS8602: Possible dereference of a null reference.
+                // (27,18): warning CS8602: Dereference of a possibly null reference.
                 //         _ = s ?? s.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(27, 18),
-                // (33,18): warning CS8602: Possible dereference of a null reference.
+                // (33,18): warning CS8602: Dereference of a possibly null reference.
                 //         _ = s ?? s.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(33, 18));
         }
@@ -3830,7 +3830,7 @@ class C
 }";
             var comp = CreateCompilationWithIndexAndRange(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t2.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2").WithLocation(8, 9)
                 );
@@ -3861,16 +3861,16 @@ class C
 }";
             var comp = CreateCompilationWithIndexAndRange(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         tuple2.Item1.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "tuple2.Item1").WithLocation(11, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         tuple2.Item2.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "tuple2.Item2").WithLocation(12, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         tuple3.Item1.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "tuple3.Item1").WithLocation(15, 9),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         tuple3.Item2.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "tuple3.Item2").WithLocation(16, 9)
                 );
@@ -3922,7 +3922,7 @@ class C
                 // (5,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         t = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(5, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         t2 /*T:T?*/ .ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2").WithLocation(7, 9)
                 );
@@ -3977,7 +3977,7 @@ class C
 }";
             var comp = CreateCompilationWithIndexAndRange(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t2[0].ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2[0]").WithLocation(8, 9)
                 );
@@ -4003,16 +4003,16 @@ class C
 }";
             var comp = CreateCompilationWithIndexAndRange(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         a[0].Item1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a[0].Item1").WithLocation(7, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         a[0].Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a[0].Item2").WithLocation(8, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         b[0].Item1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0].Item1").WithLocation(11, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         b[0].Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0].Item2").WithLocation(12, 9)
                 );
@@ -4037,7 +4037,7 @@ class C
                 // (7,29): warning CS8654: A null literal introduces a null value when 'T' is a non-nullable reference type.
                 //         var t2 = new[] { t, null }; // 1
                 Diagnostic(ErrorCode.WRN_NullLiteralMayIntroduceNullT, "null").WithArguments("T").WithLocation(7, 29),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t2[0].ToString(); // warn   // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2[0]").WithLocation(8, 9)
                 );
@@ -4289,7 +4289,7 @@ class Program
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (6,16): warning CS8602: Possible dereference of a null reference.
+                // (6,16): warning CS8602: Dereference of a possibly null reference.
                 //         return x[          // warning: possibly null
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 16)
                 );
@@ -4403,13 +4403,13 @@ class C<T>
                 // (12,25): warning CS8619: Nullability of reference types in value of type 'C<string>' doesn't match target type 'C<string?>'.
                 //         var a = new[] { x, y };
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("C<string>", "C<string?>").WithLocation(12, 25),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         a[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a[0]").WithLocation(13, 9),
                 // (15,28): warning CS8619: Nullability of reference types in value of type 'C<string>' doesn't match target type 'C<string?>'.
                 //         var b = new[] { y, x };
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("C<string>", "C<string?>").WithLocation(15, 28),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         b[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(16, 9)
                 );
@@ -4445,10 +4445,10 @@ class C<T>
 }";
             var comp = CreateCompilationWithIndexAndRange(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(12, 9),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(21, 9)
                 );
@@ -4484,10 +4484,10 @@ class C<T>
 }";
             var comp = CreateCompilationWithIndexAndRange(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(12, 9),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(21, 9)
                 );
@@ -4514,7 +4514,7 @@ class C<T>
 }";
             var comp = CreateCompilationWithIndexAndRange(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(12, 9)
                 );
@@ -4542,10 +4542,10 @@ class C<T>
 }";
             var comp = CreateCompilationWithIndexAndRange(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.Item1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1.Item1").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1.Item2").WithLocation(13, 9)
                 );
@@ -4586,10 +4586,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(18, 9),
-                // (26,9): warning CS8602: Possible dereference of a null reference.
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(26, 9)
                 );
@@ -4630,10 +4630,10 @@ class C<T>
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(18, 9),
-                // (26,9): warning CS8602: Possible dereference of a null reference.
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(26, 9)
                 );
@@ -4678,13 +4678,13 @@ class C<T>
                 // (15,27): warning CS8619: Nullability of reference types in value of type 'C<string>' doesn't match target type 'C<string?>'.
                 //             if (b) return x;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("C<string>", "C<string?>").WithLocation(15, 27),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(18, 9),
                 // (24,20): warning CS8619: Nullability of reference types in value of type 'C<string>' doesn't match target type 'C<string?>'.
                 //             return x;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("C<string>", "C<string?>").WithLocation(24, 20),
-                // (26,9): warning CS8602: Possible dereference of a null reference.
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(26, 9)
                 );
@@ -4765,13 +4765,13 @@ class C<T>
                 // (10,20): warning CS8619: Nullability of reference types in value of type 'C<object?>' doesn't match target type 'C<object>'.
                 //             return y;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("C<object?>", "C<object>").WithLocation(10, 20),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(13, 9),
                 // (18,27): warning CS8619: Nullability of reference types in value of type 'C<object?>' doesn't match target type 'C<object>'.
                 //             if (b) return y;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("C<object?>", "C<object>").WithLocation(18, 27),
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(22, 9)
                 );
@@ -4802,7 +4802,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.Item1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1.Item1").WithLocation(13, 9)
                 );
@@ -6502,7 +6502,7 @@ class C
 
             var c = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8);
             c.VerifyDiagnostics(
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             o.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(12, 13)
                 );
@@ -6530,7 +6530,7 @@ class C
 
             var c = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8);
             c.VerifyDiagnostics(
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(12, 13)
                 );
@@ -6560,7 +6560,7 @@ class C
 
             var c = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             c.VerifyDiagnostics(
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //             c.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(14, 13)
                 );
@@ -6707,7 +6707,7 @@ class C2
                 // (15,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         z = null; // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(15, 13),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(16, 9)
             };
@@ -6871,7 +6871,7 @@ public class C
 ";
             var c = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             c.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.field!.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(7, 9)
                 );
@@ -6913,7 +6913,7 @@ class C
 ";
             var c = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             c.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -7242,7 +7242,7 @@ class C<T> where T : class
                 // (35,35): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C<T>'. Nullability of type argument 'string?' doesn't match 'class' constraint.
                 //     delegate string? MyDelegate(C<string?> x); // warn 18 and 19
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "string?").WithArguments("C<T>", "T", "string?").WithLocation(35, 35),
-                // (37,17): warning CS8602: Possible dereference of a null reference.
+                // (37,17): warning CS8602: Dereference of a possibly null reference.
                 //     void M4() { Event(new C<string?>()); } // warn 21
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Event").WithLocation(37, 17),
                 // (37,29): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C<T>'. Nullability of type argument 'string?' doesn't match 'class' constraint.
@@ -7323,7 +7323,7 @@ class Client
 ";
             var comp2 = CreateCompilation(new[] { client }, options: WithNonNullTypesTrue(), references: new[] { c.ToMetadataReference() });
             comp2.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.M("").ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, @"c.M("""")").WithLocation(6, 9)
                 );
@@ -7333,14 +7333,14 @@ class Client
 
             comp2 = CreateCompilation(new[] { client }, options: WithNonNullTypesTrue(), references: new[] { c.EmitToImageReference() });
             comp2.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.M("").ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, @"c.M("""")").WithLocation(6, 9)
                 );
 
             comp2 = CreateCompilation(new[] { client }, options: WithNonNullTypesTrue(), references: new[] { c.ToMetadataReference() });
             comp2.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.M("").ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, @"c.M("""")").WithLocation(6, 9)
                 );
@@ -8155,19 +8155,19 @@ public class D : C
 
             var comp2C = CreateCompilation(new[] { source2 }, options: WithNonNullTypesTrue(), references: new[] { ref0, ref1 });
             comp2C.VerifyDiagnostics(
-                // (5,9): warning CS8602: Possible dereference of a null reference.
+                // (5,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((I)a).F(o).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((I)a).F(o)").WithLocation(5, 9),
                 // (6,18): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         ((I)a).G(null).ToString();
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 18),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((I)b).F(o).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((I)b).F(o)").WithLocation(12, 9),
                 // (13,18): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         ((I)b).G(null).ToString();
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 18),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((I)d).F(o).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((I)d).F(o)").WithLocation(19, 9),
                 // (20,18): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -8284,19 +8284,19 @@ class P
                 // (19,18): warning CS8604: Possible null reference argument for parameter 'x' in 'object? A.F(object x, object? y)'.
                 //         ((A)c).F(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("x", "object? A.F(object x, object? y)").WithLocation(19, 18),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((A)c).F(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A)c).F(x, y)").WithLocation(19, 9),
-                // (23,9): warning CS8602: Possible dereference of a null reference.
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.F(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F(x, y)").WithLocation(23, 9),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.G(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.G(x, y)").WithLocation(24, 9),
                 // (27,18): warning CS8604: Possible null reference argument for parameter 'x' in 'object? A.F(object x, object? y)'.
                 //         ((A)c).F(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("x", "object? A.F(object x, object? y)").WithLocation(27, 18),
-                // (27,9): warning CS8602: Possible dereference of a null reference.
+                // (27,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((A)c).F(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A)c).F(x, y)").WithLocation(27, 9));
         }
@@ -9372,16 +9372,16 @@ class C
                 // (60,11): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
                 //     string?[] FalseNCollection() => throw null!; // 5
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(60, 11),
-                // (16,13): warning CS8602: Possible dereference of a null reference.
+                // (16,13): warning CS8602: Dereference of a possibly null reference.
                 //             ns /*T:string?*/ .ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns").WithLocation(16, 13),
-                // (26,13): warning CS8602: Possible dereference of a null reference.
+                // (26,13): warning CS8602: Dereference of a possibly null reference.
                 //             ns1 /*T:string?*/ .ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns1").WithLocation(26, 13),
-                // (36,13): warning CS8602: Possible dereference of a null reference.
+                // (36,13): warning CS8602: Dereference of a possibly null reference.
                 //             ns /*T:string?*/ .ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns").WithLocation(36, 13),
-                // (46,13): warning CS8602: Possible dereference of a null reference.
+                // (46,13): warning CS8602: Dereference of a possibly null reference.
                 //             ns1 /*T:string?*/ .ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns1").WithLocation(46, 13)
                 );
@@ -9536,22 +9536,22 @@ class C
                 // (11,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         s2 = null; // warn 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(11, 14),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         ns2 /*T:string?*/ .ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns2").WithLocation(14, 9),
                 // (19,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         s3 = null; // warn 3
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(19, 14),
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         ns3 /*T:string?*/ .ToString(); // warn 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns3").WithLocation(22, 9),
                 // (27,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         s4 = null; // warn 5
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(27, 14),
-                // (30,9): warning CS8602: Possible dereference of a null reference.
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
                 //         ns4 /*T:string?*/ .ToString(); // warn 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns4").WithLocation(30, 9),
-                // (38,9): warning CS8602: Possible dereference of a null reference.
+                // (38,9): warning CS8602: Dereference of a possibly null reference.
                 //         ns5 /*T:string?*/ .ToString(); // warn 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns5").WithLocation(38, 9)
                 );
@@ -9700,25 +9700,25 @@ public class Base
                 // (11,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         s2 = null; // warn 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(11, 14),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         ns2 /*T:string?*/ .ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns2").WithLocation(14, 9),
                 // (19,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         s3 = null; // warn 3
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(19, 14),
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         ns3 /*T:string?*/ .ToString(); // warn 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns3").WithLocation(22, 9),
                 // (27,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         s4 = null; // warn 5
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(27, 14),
-                // (30,9): warning CS8602: Possible dereference of a null reference.
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
                 //         ns4 /*T:string?*/ .ToString(); // warn 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns4").WithLocation(30, 9),
                 // (35,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         s5 = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(35, 14),
-                // (38,9): warning CS8602: Possible dereference of a null reference.
+                // (38,9): warning CS8602: Dereference of a possibly null reference.
                 //         ns5 /*T:string?*/ .ToString(); // warn 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ns5").WithLocation(38, 9)
                 );
@@ -9986,7 +9986,7 @@ public struct D<T, NT>
                 // (14,18): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         t.Item = null; // warn 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(14, 18),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         nt.Item /*T:S?*/ .ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "nt.Item").WithLocation(15, 9),
                 // (23,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
@@ -14567,13 +14567,13 @@ struct S2
                 // (40,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         z5 = x5;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x5").WithLocation(40, 14),
-                // (53,18): warning CS8602: Possible dereference of a null reference.
+                // (53,18): warning CS8602: Dereference of a possibly null reference.
                 //         CL1 y7 = x7.P1;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x7").WithLocation(53, 18),
                 // (54,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z7 = x7?.P1;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x7?.P1").WithLocation(54, 18),
-                // (64,18): warning CS8602: Possible dereference of a null reference.
+                // (64,18): warning CS8602: Dereference of a possibly null reference.
                 //         CL1 u8 = x8.M1();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x8").WithLocation(64, 18),
                 // (65,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -14594,7 +14594,7 @@ struct S2
                 // (95,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         u11 = x11.F2;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x11.F2").WithLocation(95, 15),
-                // (101,15): warning CS8602: Possible dereference of a null reference.
+                // (101,15): warning CS8602: Dereference of a possibly null reference.
                 //         v11 = y11.F1;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y11").WithLocation(101, 15),
                 // (108,15): error CS0170: Use of possibly unassigned field 'F3'
@@ -14684,7 +14684,7 @@ struct S2
                 // (286,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         z29 = x29[1];
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x29[1]").WithLocation(286, 15),
-                // (291,15): warning CS8602: Possible dereference of a null reference.
+                // (291,15): warning CS8602: Dereference of a possibly null reference.
                 //         z30 = x30[y30];
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x30").WithLocation(291, 15),
                 // (296,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -15065,7 +15065,7 @@ class C
                 // (7,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         Missing(F(x = null)); // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(7, 23),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 9),
                 // (10,9): error CS0103: The name 'Missing' does not exist in the current context
@@ -15113,7 +15113,7 @@ class C
                 // (7,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         bad.Missing(F(x = null)); // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(7, 27),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 9),
                 // (10,9): error CS0103: The name 'bad' does not exist in the current context
@@ -15154,7 +15154,7 @@ class C
                 // (7,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             F(x = null) /*warn*/,
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(7, 19),
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString() /*warn*/,
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13)
                 );
@@ -15192,10 +15192,10 @@ class C
                 // (6,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         if (G(F(x = null)))
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(6, 21),
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13),
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(12, 13)
                 );
@@ -15232,10 +15232,10 @@ class C
                 // (6,39): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         if (Missing(x) && Missing(x = null))
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(6, 39),
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13),
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(12, 13)
                 );
@@ -15684,7 +15684,7 @@ class CL0<T>
                 // (5,28): warning CS8604: Possible null reference argument for parameter 'z' in 'void C.G(out object x, ref object y, in object z)'.
                 //         G(out x, ref y, in z);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "z").WithArguments("z", "void C.G(out object x, ref object y, in object z)").WithLocation(5, 28),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(8, 9)
                 );
@@ -15716,10 +15716,10 @@ class CL0<T>
                 // (5,22): warning CS8620: Argument of type 'object' cannot be used for parameter 'y' of type 'object?' in 'void C.G(out object? x, ref object? y, in object? z)' due to differences in the nullability of reference types.
                 //         G(out x, ref y, in z);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("object", "object?", "y", "void C.G(out object? x, ref object? y, in object? z)").WithLocation(5, 22),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(7, 9));
         }
@@ -16581,10 +16581,10 @@ public class C
 
             // https://github.com/dotnet/roslyn/issues/29855: there should only be one diagnostic
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // ok
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 13)
                 );
@@ -16613,7 +16613,7 @@ public class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13)
                 );
@@ -16640,7 +16640,7 @@ class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             c1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1").WithLocation(8, 13)
                 );
@@ -16675,10 +16675,10 @@ public class C
                 // (7,13): error CS0103: The name 'Missing' does not exist in the current context
                 //         if (Missing(MyIsNullOrEmpty(s)))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(7, 13),
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 13)
                 );
@@ -16711,10 +16711,10 @@ public class C
 
             // https://github.com/dotnet/roslyn/issues/29855: there should only be one diagnostic
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // ok
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 13)
                 );
@@ -16747,10 +16747,10 @@ public class C
 
             // https://github.com/dotnet/roslyn/issues/29855: there should only be one diagnostic
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // ok
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 13)
                 );
@@ -16795,7 +16795,7 @@ public class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13)
                 );
@@ -16829,13 +16829,13 @@ public class C
 ", NotNullWhenTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //             s2.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(10, 13),
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(14, 13),
-                // (15,13): warning CS8602: Possible dereference of a null reference.
+                // (15,13): warning CS8602: Dereference of a possibly null reference.
                 //             s2.ToString(); // warn 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(15, 13)
                 );
@@ -16869,10 +16869,10 @@ public class C
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //             s2.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(10, 13),
-                // (15,13): warning CS8602: Possible dereference of a null reference.
+                // (15,13): warning CS8602: Dereference of a possibly null reference.
                 //             s2.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(15, 13)
                 );
@@ -16909,10 +16909,10 @@ public class C
                 // (7,13): error CS0103: The name 'Missing' does not exist in the current context
                 //         if (Missing(M(s, out string? s2)))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(7, 13),
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //             s2.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(10, 13),
-                // (15,13): warning CS8602: Possible dereference of a null reference.
+                // (15,13): warning CS8602: Dereference of a possibly null reference.
                 //             s2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(15, 13)
                 );
@@ -17037,7 +17037,7 @@ public class C
                 // (6,15): warning CS8620: Argument of type 'string' cannot be used as an input of type 'string?' for parameter 'value' in 'void C.M(ref string? value)' due to differences in the nullability of reference types.
                 //         M(ref s); // warn 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "s").WithArguments("string", "string?", "value", "void C.M(ref string? value)").WithLocation(6, 15),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -17063,7 +17063,7 @@ public class C
                 // (7,15): warning CS8620: Argument of type 'string' cannot be used as an input of type 'string?' for parameter 'value' in 'void C.M(ref string? value)' due to differences in the nullability of reference types.
                 //         M(ref s); // warn 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "s").WithArguments("string", "string?", "value", "void C.M(ref string? value)").WithLocation(7, 15),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9)
                 );
@@ -17095,10 +17095,10 @@ public class C
             VerifyOutVar(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 13),
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(12, 13)
                 );
@@ -17167,7 +17167,7 @@ public class C
             VerifyOutVar(c, "string!"); // https://github.com/dotnet/roslyn/issues/29856: expecting string?
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?*/.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -17234,7 +17234,7 @@ public class C
             VerifyVarLocal(c, "string!"); // https://github.com/dotnet/roslyn/issues/29856: expecting string?
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?*/.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -17279,7 +17279,7 @@ public class C
             VerifyOutVar(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:*/.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -17306,7 +17306,7 @@ public class C
                 // (6,9): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.CopyOrDefault<T>(T, out T?)'. Nullability of type argument 'string?' doesn't match 'class' constraint.
                 //         CopyOrDefault(key, out var s);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "CopyOrDefault").WithArguments("C.CopyOrDefault<T>(T, out T?)", "T", "string?").WithLocation(6, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?*/.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -17331,7 +17331,7 @@ public class C
             VerifyOutVar(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?*/.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9)
                 );
@@ -17355,7 +17355,7 @@ public class C
             VerifyOutVar(c, "string?[]!");
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?[]!*/[0].ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s/*T:string?[]!*/[0]").WithLocation(7, 9)
                 );
@@ -17382,7 +17382,7 @@ public class C
                 // (6,9): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.CopyOrDefault<T>(T, out T?[])'. Nullability of type argument 'string?' doesn't match 'class' constraint.
                 //         CopyOrDefault(key, out var s);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "CopyOrDefault").WithArguments("C.CopyOrDefault<T>(T, out T?[])", "T", "string?").WithLocation(6, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?[]!*/[0].ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s/*T:string?[]!*/[0]").WithLocation(7, 9)
                 );
@@ -17511,7 +17511,7 @@ class C
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             e2.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "e2").WithLocation(12, 13));
         }
@@ -17543,13 +17543,13 @@ class C
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9),
                 // (11,15): warning CS8620: Argument of type 'string' cannot be used for parameter 's' of type 'string?' in 'void C.M(ref string? s)' due to differences in the nullability of reference types.
                 //         M(ref s2); // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "s2").WithArguments("string", "string?", "s", "void C.M(ref string? s)").WithLocation(11, 15),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(12, 9),
                 // (14,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -17643,7 +17643,7 @@ class C
                 // (11,15): warning CS8620: Argument of type 'string' cannot be used as an input of type 'string?' for parameter 's' in 'void C.M(ref string? s)' due to differences in the nullability of reference types.
                 //         M(ref field); // 3
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "field").WithArguments("string", "string?", "s", "void C.M(ref string? s)").WithLocation(11, 15),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         field.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "field").WithLocation(12, 9),
                 // (14,15): error CS0206: A property or indexer may not be passed as an out or ref parameter
@@ -17680,13 +17680,13 @@ public static class Extension
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9),
                 // (11,20): warning CS8620: Argument of type 'string' cannot be used as an input of type 'string?' for parameter 's' in 'void Extension.M(C c, ref string? s)' due to differences in the nullability of reference types.
                 //         this.M(ref s2); // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "s2").WithArguments("string", "string?", "s", "void Extension.M(C c, ref string? s)").WithLocation(11, 20),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(12, 9)
                 );
@@ -17710,7 +17710,7 @@ class C
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(8, 9)
                 );
@@ -17791,19 +17791,19 @@ class C<T>
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 9),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         v2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v2").WithLocation(14, 9),
                 // (17,25): warning CS8620: Argument of type 'string?' cannot be used as an input of type 'string' for parameter 's' in 'string? C<T>.M2<string?>(ref string s, string? u)' due to differences in the nullability of reference types.
                 //         var v3 = M2(ref s, s); // 4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "s").WithArguments("string?", "string", "s", "string? C<T>.M2<string?>(ref string s, string? u)").WithLocation(17, 25),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         v3.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v3").WithLocation(19, 9)
                 );
@@ -17883,13 +17883,13 @@ class C
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9),
                 // (11,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         M(out s2); // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "s2").WithLocation(11, 15),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(12, 9)
                 );
@@ -17915,13 +17915,13 @@ class C
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9),
                 // (9,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         M(out string s2); // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "string s2").WithLocation(9, 15),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(10, 9)
                 );
@@ -17969,7 +17969,7 @@ class C
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(8, 9)
                 );
@@ -18051,16 +18051,16 @@ class C<T>
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 9),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         v2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v2").WithLocation(14, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         v3.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v3").WithLocation(19, 9)
                 );
@@ -18199,7 +18199,7 @@ public class C
                 // (6,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         Copy(key, out string s);
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "string s").WithLocation(6, 23),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?*/.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -18223,7 +18223,7 @@ public class C
             VerifyOutVar(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?*/.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -18247,7 +18247,7 @@ public class C
             VerifyOutVar(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?*/.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -18291,7 +18291,7 @@ public class C
             VerifyVarLocal(c, "string!"); // https://github.com/dotnet/roslyn/issues/29856: expecting string?
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?*/.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -18339,7 +18339,7 @@ public class C
                 // (6,17): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.Copy<T>(T)'. Nullability of type argument 'string?' doesn't match 'class' constraint.
                 //         var s = Copy(key);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "Copy").WithArguments("C.Copy<T>(T)", "T", "string?").WithLocation(6, 17),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?*/.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -18364,7 +18364,7 @@ public class C
             VerifyVarLocal(c, "string?");
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s/*T:string?*/.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9)
                 );
@@ -18577,7 +18577,7 @@ public class C
                 // (6,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         s = null; // warn
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -18601,7 +18601,7 @@ public class C
                 // (6,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         s = default; // warn
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 9)
                 );
@@ -18632,7 +18632,7 @@ public class C
 ", NotNullWhenTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 13)
                 );
@@ -18664,7 +18664,7 @@ public class C
 ", NotNullWhenTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 13)
                 );
@@ -18798,7 +18798,7 @@ class C
 ", AssertsTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9)
                 );
@@ -18826,7 +18826,7 @@ class C
                 // (7,9): error CS0103: The name 'Missing' does not exist in the current context
                 //         Missing(MyAssert(c == null));
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "Missing").WithArguments("Missing").WithLocation(7, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9)
                 );
@@ -18947,7 +18947,7 @@ class C
 ", AssertsTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9)
                 );
@@ -19021,7 +19021,7 @@ class C
 ", AssertsTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9)
                 );
@@ -19048,7 +19048,7 @@ class C
                 // (7,23): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         Assert(Method(null), "hello");
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 23),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9)
                 );
@@ -19076,7 +19076,7 @@ class C
 ", AssertsTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(13, 9)
                 );
@@ -19102,7 +19102,7 @@ class C
 ", AssertsTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(11, 9)
                 );
@@ -19146,7 +19146,7 @@ class C
 ", AssertsFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9)
                 );
@@ -19177,7 +19177,7 @@ public class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13)
                 );
@@ -19230,10 +19230,10 @@ public class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //             s2.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(10, 13)
                 );
@@ -19269,10 +19269,10 @@ public class C
 ", NotNullWhenFalseAttributeDefinition, NotNullWhenTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
-                // (15,13): warning CS8602: Possible dereference of a null reference.
+                // (15,13): warning CS8602: Dereference of a possibly null reference.
                 //             s2.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(15, 13)
                 );
@@ -19305,7 +19305,7 @@ class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13)
                 );
@@ -19334,7 +19334,7 @@ class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (7,23): warning CS8602: Possible dereference of a null reference.
+                // (7,23): warning CS8602: Dereference of a possibly null reference.
                 //         if (Method(s, s.ToString())) // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 23)
                 );
@@ -19363,10 +19363,10 @@ class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 13)
                 );
@@ -19402,10 +19402,10 @@ class C
                 // (17,34): error CS0246: The type or namespace name 'NotNullWhenFalse' could not be found (are you missing a using directive or an assembly reference?)
                 //     static bool MyIsNullOrEmpty([NotNullWhenFalse] string? s) => throw null!;
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "NotNullWhenFalse").WithArguments("NotNullWhenFalse").WithLocation(17, 34),
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 13),
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(12, 13)
                 );
@@ -19462,10 +19462,10 @@ namespace System.Runtime.CompilerServices
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 13)
                 );
@@ -19496,7 +19496,7 @@ public class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 13)
                 );
@@ -19545,7 +19545,7 @@ public class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13)
                 );
@@ -19579,7 +19579,7 @@ public static class Extension
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13)
                 );
@@ -19608,7 +19608,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 13)
                 );
@@ -19667,7 +19667,7 @@ namespace System
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 13)
                 );
@@ -19727,7 +19727,7 @@ namespace System
 ", NotNullWhenTrueAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13)
                 );
@@ -19840,7 +19840,7 @@ namespace System
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 13)
                 );
@@ -19869,7 +19869,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(12, 13)
                 );
@@ -19947,7 +19947,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 13)
                 );
@@ -20007,10 +20007,10 @@ public class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 13)
                 );
@@ -20091,10 +20091,10 @@ public class D
 ";
             var compilation = CreateCompilationWithIL(new[] { source }, il, options: WithNonNullTypesTrue());
             compilation.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 13),
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(12, 13)
                 );
@@ -20119,7 +20119,7 @@ class C
 ", NotNullWhenFalseAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9)
                 );
@@ -20262,7 +20262,7 @@ public class C
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9)
                 );
@@ -20286,7 +20286,7 @@ public class C
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9)
                 );
@@ -20419,7 +20419,7 @@ public interface Interface
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9)
                 );
@@ -20451,7 +20451,7 @@ public interface Interface
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9)
                 );
@@ -20503,13 +20503,13 @@ public class C
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(9, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // warn 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(13, 9)
                 );
@@ -20610,10 +20610,10 @@ public class D
 ", options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b").WithLocation(8, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(9, 9)
                 );
@@ -20640,7 +20640,7 @@ public class C
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(11, 9)
                 );
@@ -20682,7 +20682,7 @@ public class C
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(7, 9)
                 );
@@ -20709,10 +20709,10 @@ public class C
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,32): warning CS8602: Possible dereference of a null reference.
+                // (8,32): warning CS8602: Dereference of a possibly null reference.
                 //         if (s != string.Empty) s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 32),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(10, 9)
                 );
@@ -20736,7 +20736,7 @@ public class C
 
             // https://github.com/dotnet/roslyn/issues/29865: Should we be able to trace that s2 was assigned a non-null value?
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(8, 9)
                 );
@@ -20802,7 +20802,7 @@ public class C
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s1.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s1").WithLocation(8, 9)
                 );
@@ -20825,7 +20825,7 @@ public class C
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(8, 9)
                 );
@@ -20851,7 +20851,7 @@ public class C
 
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2/*T:string?*/.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(8, 9)
                 );
@@ -20894,7 +20894,7 @@ public class C
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (7,24): warning CS8602: Possible dereference of a null reference.
+                // (7,24): warning CS8602: Dereference of a possibly null reference.
                 //         ThrowIfNull(s, s.ToString()); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 24)
                 );
@@ -20919,7 +20919,7 @@ class C
 ", EnsuresNotNullAttributeDefinition }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9)
                 );
@@ -21235,10 +21235,10 @@ class CL1
                  // (28,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //             z2 = y2;
                  Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2").WithLocation(28, 18),
-                 // (34,16): warning CS8602: Possible dereference of a null reference.
+                 // (34,16): warning CS8602: Dereference of a possibly null reference.
                  //         return x3.M1();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(34, 16),
-                 // (44,30): warning CS8602: Possible dereference of a null reference.
+                 // (44,30): warning CS8602: Dereference of a possibly null reference.
                  //         return x5 == null && x5.M1();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x5").WithLocation(44, 30)
                 );
@@ -21302,7 +21302,7 @@ class CL1
                 // (20,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z3 = x3 ?? y3;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3 ?? y3").WithLocation(20, 18),
-                // (26,24): warning CS8602: Possible dereference of a null reference.
+                // (26,24): warning CS8602: Dereference of a possibly null reference.
                 //         CL1 z4 = x4 ?? x4.M1();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x4").WithLocation(26, 24));
         }
@@ -21425,7 +21425,7 @@ class CL1
                 // (20,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z3 = x3 != null ? x3 : y3;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3 != null ? x3 : y3").WithLocation(20, 18),
-                // (26,36): warning CS8602: Possible dereference of a null reference.
+                // (26,36): warning CS8602: Dereference of a possibly null reference.
                 //         CL1 z4 = x4 != null ? x4 : x4.M1();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x4").WithLocation(26, 36),
                 // (44,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -21498,7 +21498,7 @@ class CL1
                 // (20,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         CL1 z3 = x3 == null ? y3 : x3;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3 == null ? y3 : x3").WithLocation(20, 18),
-                // (26,31): warning CS8602: Possible dereference of a null reference.
+                // (26,31): warning CS8602: Dereference of a possibly null reference.
                 //         CL1 z4 = x4 == null ? x4.M1() : x4;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x4").WithLocation(26, 31),
                 // (44,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -21532,7 +21532,7 @@ class CL1
 }
 ", options: WithNonNullTypesTrue());
             c.VerifyDiagnostics(
-                // (11,16): warning CS8602: Possible dereference of a null reference.
+                // (11,16): warning CS8602: Dereference of a possibly null reference.
                 //         return x1.P2; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(11, 16)
                 );
@@ -21559,7 +21559,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(13, 9));
         }
@@ -21585,7 +21585,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(13, 9)
                 );
@@ -21608,7 +21608,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(9, 9)
                 );
@@ -21644,7 +21644,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         y1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(22, 9)
                 );
@@ -21680,7 +21680,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         y1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(22, 9)
                 );
@@ -21782,46 +21782,46 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                // (17,13): warning CS8602: Possible dereference of a null reference.
+                // (17,13): warning CS8602: Dereference of a possibly null reference.
                 //             c1._cField.ToString(); // warn 1 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1").WithLocation(17, 13),
-                // (17,13): warning CS8602: Possible dereference of a null reference.
+                // (17,13): warning CS8602: Dereference of a possibly null reference.
                 //             c1._cField.ToString(); // warn 1 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1._cField").WithLocation(17, 13),
 
-                // (30,13): warning CS8602: Possible dereference of a null reference.
+                // (30,13): warning CS8602: Dereference of a possibly null reference.
                 //             c2._cField.ToString(); // warn 3 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(30, 13),
-                // (30,13): warning CS8602: Possible dereference of a null reference.
+                // (30,13): warning CS8602: Dereference of a possibly null reference.
                 //             c2._cField.ToString(); // warn 3 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2._cField").WithLocation(30, 13),
 
-                // (43,13): warning CS8602: Possible dereference of a null reference.
+                // (43,13): warning CS8602: Dereference of a possibly null reference.
                 //             c3._cField._cField.ToString(); // warn 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c3._cField._cField").WithLocation(43, 13),
 
-                // (47,13): warning CS8602: Possible dereference of a null reference.
+                // (47,13): warning CS8602: Dereference of a possibly null reference.
                 //             c3.ToString(); // warn 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c3").WithLocation(47, 13),
 
-                // (59,13): warning CS8602: Possible dereference of a null reference.
+                // (59,13): warning CS8602: Dereference of a possibly null reference.
                 //             c4._nonNullCField._cField._nonNullCField._cField.ToString(); // warn 7 8 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c4").WithLocation(59, 13),
-                // (59,13): warning CS8602: Possible dereference of a null reference.
+                // (59,13): warning CS8602: Dereference of a possibly null reference.
                 //             c4._nonNullCField._cField._nonNullCField._cField.ToString(); // warn 7 8 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c4._nonNullCField._cField").WithLocation(59, 13),
-                // (59,13): warning CS8602: Possible dereference of a null reference.
+                // (59,13): warning CS8602: Dereference of a possibly null reference.
                 //             c4._nonNullCField._cField._nonNullCField._cField.ToString(); // warn 7 8 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c4._nonNullCField._cField._nonNullCField._cField").WithLocation(59, 13),
 
-                // (67,13): warning CS8602: Possible dereference of a null reference.
+                // (67,13): warning CS8602: Dereference of a possibly null reference.
                 //             c5._cField.ToString(); // warn 10 11
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c5").WithLocation(67, 13),
-                // (67,13): warning CS8602: Possible dereference of a null reference.
+                // (67,13): warning CS8602: Dereference of a possibly null reference.
                 //             c5._cField.ToString(); // warn 10 11
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c5._cField").WithLocation(67, 13),
 
-                // (79,13): warning CS8602: Possible dereference of a null reference.
+                // (79,13): warning CS8602: Dereference of a possibly null reference.
                 //             c6._cField.GetC().ToString(); // warn 12
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c6._cField.GetC()").WithLocation(79, 13)
             );
@@ -21851,10 +21851,10 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             c1[0].ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1[0]").WithLocation(9, 13),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             c1.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1").WithLocation(13, 13)
             );
@@ -21880,7 +21880,7 @@ class C
 }" }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(12, 13)
                 );
@@ -21904,10 +21904,10 @@ class C
 }" }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //             c2.Prop.ToString(); // warn 1 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(10, 13),
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //             c2.Prop.ToString(); // warn 1 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2.Prop").WithLocation(10, 13)
                 );
@@ -21930,7 +21930,7 @@ class C
 }" }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             y.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 13)
                 );
@@ -21957,7 +21957,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(12, 13)
                 );
@@ -21985,7 +21985,7 @@ class C : Base
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(13, 13)
                 );
@@ -22012,7 +22012,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             o.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(12, 13)
                 );
@@ -22039,7 +22039,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             o.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(12, 13)
                 );
@@ -22066,7 +22066,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             o.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(12, 13)
                 );
@@ -22131,7 +22131,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13)
                 );
@@ -22158,7 +22158,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(12, 13)
                 );
@@ -22186,7 +22186,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(13, 13)
                 );
@@ -22214,7 +22214,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(9, 13)
                 );
@@ -22241,7 +22241,7 @@ class C
                 // (7,18): error CS0150: A constant value is expected
                 //         if (x is nonConstant)
                 Diagnostic(ErrorCode.ERR_ConstantExpected, "nonConstant").WithLocation(7, 18),
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(9, 13)
                 );
@@ -22273,7 +22273,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (10,17): warning CS8602: Possible dereference of a null reference.
+                // (10,17): warning CS8602: Dereference of a possibly null reference.
                 //                 x.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(10, 17)
                 );
@@ -22303,7 +22303,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (10,17): warning CS8602: Possible dereference of a null reference.
+                // (10,17): warning CS8602: Dereference of a possibly null reference.
                 //                 x.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(10, 17)
                 );
@@ -22331,7 +22331,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(13, 13)
                 );
@@ -22360,10 +22360,10 @@ class C
 
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13),
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             c /*T:object?*/ .ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(9, 13)
                 );
@@ -22391,10 +22391,10 @@ class C
 
             c.VerifyTypes();
             c.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13),
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(12, 13)
                 );
@@ -22446,13 +22446,13 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(6, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         w.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         v.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v").WithLocation(10, 9));
         }
@@ -22473,10 +22473,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,10): warning CS8602: Possible dereference of a null reference.
+                // (5,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? x : y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x : y").WithLocation(5, 10),
-                // (6,10): warning CS8602: Possible dereference of a null reference.
+                // (6,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? y : x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y : x").WithLocation(6, 10));
         }
@@ -22497,10 +22497,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,10): warning CS8602: Possible dereference of a null reference.
+                // (5,10): warning CS8602: Dereference of a possibly null reference.
                 //         (false ? x : y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "false ? x : y").WithLocation(5, 10),
-                // (8,10): warning CS8602: Possible dereference of a null reference.
+                // (8,10): warning CS8602: Dereference of a possibly null reference.
                 //         (true ? y : x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "true ? y : x").WithLocation(8, 10));
         }
@@ -22524,16 +22524,16 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,10): warning CS8602: Possible dereference of a null reference.
+                // (5,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? x : y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x : y").WithLocation(5, 10),
-                // (6,10): warning CS8602: Possible dereference of a null reference.
+                // (6,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? y : x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y : x").WithLocation(6, 10),
-                // (10,10): warning CS8602: Possible dereference of a null reference.
+                // (10,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? x : y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x : y").WithLocation(10, 10),
-                // (11,10): warning CS8602: Possible dereference of a null reference.
+                // (11,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? y : x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y : x").WithLocation(11, 10));
         }
@@ -22606,28 +22606,28 @@ class C
                 // (14,10): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'default' and 'default'
                 //         (b ? default: default).ToString();
                 Diagnostic(ErrorCode.ERR_InvalidQM, "b ? default: default").WithArguments("default", "default").WithLocation(14, 10),
-                // (5,10): warning CS8602: Possible dereference of a null reference.
+                // (5,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? null : x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? null : x").WithLocation(5, 10),
-                // (6,10): warning CS8602: Possible dereference of a null reference.
+                // (6,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? null : y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? null : y").WithLocation(6, 10),
-                // (7,10): warning CS8602: Possible dereference of a null reference.
+                // (7,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? x: null).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x: null").WithLocation(7, 10),
-                // (8,10): warning CS8602: Possible dereference of a null reference.
+                // (8,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? y: null).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y: null").WithLocation(8, 10),
-                // (10,10): warning CS8602: Possible dereference of a null reference.
+                // (10,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? default : x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? default : x").WithLocation(10, 10),
-                // (11,10): warning CS8602: Possible dereference of a null reference.
+                // (11,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? default : y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? default : y").WithLocation(11, 10),
-                // (12,10): warning CS8602: Possible dereference of a null reference.
+                // (12,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? x: default).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x: default").WithLocation(12, 10),
-                // (13,10): warning CS8602: Possible dereference of a null reference.
+                // (13,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? y: default).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y: default").WithLocation(13, 10)
                 );
@@ -22773,10 +22773,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,10): warning CS8602: Possible dereference of a null reference.
+                // (6,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? x : throw new Exception()).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x : throw new Exception()").WithLocation(6, 10),
-                // (8,10): warning CS8602: Possible dereference of a null reference.
+                // (8,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? throw new Exception() : x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? throw new Exception() : x").WithLocation(8, 10));
         }
@@ -22898,16 +22898,16 @@ class C
                 // (16,13): error CS0165: Use of unassigned local variable 'y1'
                 //             y1.ToString(); // unassigned (if)
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y1").WithArguments("y1").WithLocation(16, 13),
-                // (17,13): warning CS8602: Possible dereference of a null reference.
+                // (17,13): warning CS8602: Dereference of a possibly null reference.
                 //             z1.ToString(); // may be null (if)
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z1").WithLocation(17, 13),
-                // (18,13): warning CS8602: Possible dereference of a null reference.
+                // (18,13): warning CS8602: Dereference of a possibly null reference.
                 //             w1.ToString(); // may be null (if)
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w1").WithLocation(18, 13),
-                // (24,13): warning CS8602: Possible dereference of a null reference.
+                // (24,13): warning CS8602: Dereference of a possibly null reference.
                 //             z1.ToString(); // may be null (else)
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z1").WithLocation(24, 13),
-                // (25,13): warning CS8602: Possible dereference of a null reference.
+                // (25,13): warning CS8602: Dereference of a possibly null reference.
                 //             w1.ToString(); // may be null (else)
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w1").WithLocation(25, 13),
                 // (37,13): error CS0165: Use of unassigned local variable 'y2'
@@ -22916,13 +22916,13 @@ class C
                 // (43,13): error CS0165: Use of unassigned local variable 'x2'
                 //             x2.ToString(); // unassigned (else)
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x2").WithArguments("x2").WithLocation(43, 13),
-                // (39,13): warning CS8602: Possible dereference of a null reference.
+                // (39,13): warning CS8602: Dereference of a possibly null reference.
                 //             w2.ToString(); // may be null (if)
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w2").WithLocation(39, 13),
-                // (45,13): warning CS8602: Possible dereference of a null reference.
+                // (45,13): warning CS8602: Dereference of a possibly null reference.
                 //             z2.ToString(); // may be null (else)
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z2").WithLocation(45, 13),
-                // (46,13): warning CS8602: Possible dereference of a null reference.
+                // (46,13): warning CS8602: Dereference of a possibly null reference.
                 //             w2.ToString(); // may be null (else)
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w2").WithLocation(46, 13),
                 // (57,13): error CS0165: Use of unassigned local variable 'x3'
@@ -22931,13 +22931,13 @@ class C
                 // (65,13): error CS0165: Use of unassigned local variable 'y3'
                 //             y3.ToString(); // unassigned (else)
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y3").WithArguments("y3").WithLocation(65, 13),
-                // (59,13): warning CS8602: Possible dereference of a null reference.
+                // (59,13): warning CS8602: Dereference of a possibly null reference.
                 //             z3.ToString(); // may be null (if)
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z3").WithLocation(59, 13),
-                // (66,13): warning CS8602: Possible dereference of a null reference.
+                // (66,13): warning CS8602: Dereference of a possibly null reference.
                 //             z3.ToString(); // may be null (else)
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z3").WithLocation(66, 13),
-                // (67,13): warning CS8602: Possible dereference of a null reference.
+                // (67,13): warning CS8602: Dereference of a possibly null reference.
                 //             w3.ToString(); // may be null (else)
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w3").WithLocation(67, 13));
         }
@@ -23601,13 +23601,13 @@ class C<T>
                 // (9,29): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         if (b ? c && F(x1 = y1) : true) // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y1").WithLocation(9, 29),
-                // (11,13): warning CS8602: Possible dereference of a null reference.
+                // (11,13): warning CS8602: Dereference of a possibly null reference.
                 //             x1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(11, 13),
                 // (16,36): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         if (b ? true : c && F(x2 = y2)) // 3
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y2").WithLocation(16, 36),
-                // (18,13): warning CS8602: Possible dereference of a null reference.
+                // (18,13): warning CS8602: Dereference of a possibly null reference.
                 //             x2.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(18, 13));
         }
@@ -24179,10 +24179,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(6, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         v.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v").WithLocation(11, 9));
         }
@@ -24211,10 +24211,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,18): warning CS8602: Possible dereference of a null reference.
+                // (8,18): warning CS8602: Dereference of a possibly null reference.
                 //                 (x ?? y).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x ?? y").WithLocation(8, 18),
-                // (14,33): warning CS8602: Possible dereference of a null reference.
+                // (14,33): warning CS8602: Dereference of a possibly null reference.
                 //                 if (y != null) (y ?? x).ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y ?? x").WithLocation(14, 33)
 );
@@ -24238,7 +24238,7 @@ class C
                 // (5,10): error CS0019: Operator '??' cannot be applied to operands of type '<null>' and '<null>'
                 //         (null ?? null).ToString();
                 Diagnostic(ErrorCode.ERR_BadBinaryOps, "null ?? null").WithArguments("??", "<null>", "<null>").WithLocation(5, 10),
-                // (7,10): warning CS8602: Possible dereference of a null reference.
+                // (7,10): warning CS8602: Dereference of a possibly null reference.
                 //         (null ?? y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "null ?? y").WithLocation(7, 10));
         }
@@ -24448,13 +24448,13 @@ public class NotNull
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             (a ?? c)[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(a ?? c)[0]").WithLocation(8, 13),
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             (b ?? c)[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ?? c)[0]").WithLocation(9, 13),
-                // (15,13): warning CS8602: Possible dereference of a null reference.
+                // (15,13): warning CS8602: Dereference of a possibly null reference.
                 //             (b ?? c)[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ?? c)[0]").WithLocation(15, 13));
         }
@@ -24632,10 +24632,10 @@ class C
                 // (23,14): warning CS8620: Nullability of reference types in argument of type 'IIn<object>' doesn't match target type 'IIn<object?>' for parameter 'x' in 'void C.FIn(IIn<object?>? x)'.
                 //         FIn((y1 ?? x1)/*T:IIn<object!>?*/);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y1 ?? x1").WithArguments("IIn<object>", "IIn<object?>", "x", "void C.FIn(IIn<object?>? x)").WithLocation(23, 14),
-                // (27,9): warning CS8602: Possible dereference of a null reference.
+                // (27,9): warning CS8602: Dereference of a possibly null reference.
                 //         FOut((x2 ?? y2)/*T:IOut<object?>?*/).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "FOut((x2 ?? y2)/*T:IOut<object?>?*/)").WithLocation(27, 9),
-                // (28,9): warning CS8602: Possible dereference of a null reference.
+                // (28,9): warning CS8602: Dereference of a possibly null reference.
                 //         FOut((y2 ?? x2)/*T:IOut<object?>?*/).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "FOut((y2 ?? x2)/*T:IOut<object?>?*/)").WithLocation(28, 9),
                 // (34,14): warning CS8620: Nullability of reference types in argument of type 'IIn<object>' doesn't match target type 'IIn<object?>' for parameter 'x' in 'void C.FIn(IIn<object?>? x)'.
@@ -24647,13 +24647,13 @@ class C
                 // (37,14): warning CS8620: Nullability of reference types in argument of type 'IIn<object>' doesn't match target type 'IIn<object?>' for parameter 'x' in 'void C.FIn(IIn<object?>? x)'.
                 //         FIn((FIn(x3) ?? FIn(y3))/*T:IIn<object!>?*/); // D
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "FIn(x3) ?? FIn(y3)").WithArguments("IIn<object>", "IIn<object?>", "x", "void C.FIn(IIn<object?>? x)").WithLocation(37, 14),
-                // (41,9): warning CS8602: Possible dereference of a null reference.
+                // (41,9): warning CS8602: Dereference of a possibly null reference.
                 //         FOut((FOut(x4) ?? FOut(y4))/*T:IOut<object?>?*/).ToString(); // A
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "FOut((FOut(x4) ?? FOut(y4))/*T:IOut<object?>?*/)").WithLocation(41, 9),
-                // (43,9): warning CS8602: Possible dereference of a null reference.
+                // (43,9): warning CS8602: Dereference of a possibly null reference.
                 //         FOut((FOut(x4) ?? FOut(y4))/*T:IOut<object?>?*/).ToString(); // B
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "FOut((FOut(x4) ?? FOut(y4))/*T:IOut<object?>?*/)").WithLocation(43, 9),
-                // (44,9): warning CS8602: Possible dereference of a null reference.
+                // (44,9): warning CS8602: Dereference of a possibly null reference.
                 //         FOut((FOut(y4) ?? FOut(x4))/*T:IOut<object?>?*/).ToString(); // C
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "FOut((FOut(y4) ?? FOut(x4))/*T:IOut<object?>?*/)").WithLocation(44, 9));
         }
@@ -24675,10 +24675,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,9): warning CS8602: Possible dereference of a null reference.
+                // (5,9): warning CS8602: Dereference of a possibly null reference.
                 //         (x ?? y).Item1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(x ?? y).Item1").WithLocation(5, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         (x ?? y).Item1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(x ?? y).Item1").WithLocation(9, 9));
         }
@@ -24731,7 +24731,7 @@ class C
                 // (14,10): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'B<object?>'.
                 //         (x1 ?? y1)/*T:B<object?>*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x1").WithArguments("A<object>", "B<object?>").WithLocation(14, 10),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         (x1 ?? y1)/*T:B<object?>*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(x1 ?? y1)/*T:B<object?>*/.F").WithLocation(14, 9),
                 // (18,10): warning CS8619: Nullability of reference types in value of type 'A<object?>' doesn't match target type 'B<object>'.
@@ -24740,7 +24740,7 @@ class C
                 // (22,16): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'B<object?>'.
                 //         (y3 ?? x3)/*T:B<object?>*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x3").WithArguments("B<object>", "B<object?>").WithLocation(22, 16),
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         (y3 ?? x3)/*T:B<object?>*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(y3 ?? x3)/*T:B<object?>*/.F").WithLocation(22, 9),
                 // (26,16): warning CS8619: Nullability of reference types in value of type 'B<object?>' doesn't match target type 'B<object>'.
@@ -24752,7 +24752,7 @@ class C
                 // (30,10): warning CS8629: Nullable value type may be null.
                 //         (x5 ?? y5)/*T:B<object?>?*/.Value.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "x5 ?? y5").WithLocation(30, 10),
-                // (30,9): warning CS8602: Possible dereference of a null reference.
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
                 //         (x5 ?? y5)/*T:B<object?>?*/.Value.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(x5 ?? y5)/*T:B<object?>?*/.Value.F").WithLocation(30, 9),
                 // (31,16): warning CS8619: Nullability of reference types in value of type 'B<object>?' doesn't match target type 'B<object?>?'.
@@ -24761,7 +24761,7 @@ class C
                 // (31,10): warning CS8629: Nullable value type may be null.
                 //         (y5 ?? x5)/*T:B<object?>?*/.Value.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "y5 ?? x5").WithLocation(31, 10),
-                // (31,9): warning CS8602: Possible dereference of a null reference.
+                // (31,9): warning CS8602: Dereference of a possibly null reference.
                 //         (y5 ?? x5)/*T:B<object?>?*/.Value.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(y5 ?? x5)/*T:B<object?>?*/.Value.F").WithLocation(31, 9),
                 // (35,10): warning CS8619: Nullability of reference types in value of type 'A<object?>' doesn't match target type 'B<object>?'.
@@ -24831,7 +24831,7 @@ class C
                 // (14,10): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'B<object?>'.
                 //         (x1 ?? y1)/*T:B<object?>!*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x1").WithArguments("A<object>", "B<object?>").WithLocation(14, 10),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         (x1 ?? y1)/*T:B<object?>!*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(x1 ?? y1)/*T:B<object?>!*/.F").WithLocation(14, 9),
                 // (18,10): warning CS8619: Nullability of reference types in value of type 'A<object?>' doesn't match target type 'B<object>'.
@@ -24840,7 +24840,7 @@ class C
                 // (22,16): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'B<object?>'.
                 //         (y3 ?? x3)/*T:B<object?>!*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x3").WithArguments("B<object>", "B<object?>").WithLocation(22, 16),
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         (y3 ?? x3)/*T:B<object?>!*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(y3 ?? x3)/*T:B<object?>!*/.F").WithLocation(22, 9),
                 // (26,16): warning CS8619: Nullability of reference types in value of type 'B<object?>' doesn't match target type 'B<object>'.
@@ -24849,31 +24849,31 @@ class C
                 // (30,10): warning CS8619: Nullability of reference types in value of type 'A<object>' doesn't match target type 'B<object?>'.
                 //         (x5 ?? y5)/*T:B<object?>?*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x5").WithArguments("A<object>", "B<object?>").WithLocation(30, 10),
-                // (30,10): warning CS8602: Possible dereference of a null reference.
+                // (30,10): warning CS8602: Dereference of a possibly null reference.
                 //         (x5 ?? y5)/*T:B<object?>?*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x5 ?? y5").WithLocation(30, 10),
-                // (30,9): warning CS8602: Possible dereference of a null reference.
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
                 //         (x5 ?? y5)/*T:B<object?>?*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(x5 ?? y5)/*T:B<object?>?*/.F").WithLocation(30, 9),
                 // (31,16): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'B<object?>'.
                 //         (y5 ?? x5)/*T:B<object?>?*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x5").WithArguments("B<object>", "B<object?>").WithLocation(31, 16),
-                // (31,10): warning CS8602: Possible dereference of a null reference.
+                // (31,10): warning CS8602: Dereference of a possibly null reference.
                 //         (y5 ?? x5)/*T:B<object?>?*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y5 ?? x5").WithLocation(31, 10),
-                // (31,9): warning CS8602: Possible dereference of a null reference.
+                // (31,9): warning CS8602: Dereference of a possibly null reference.
                 //         (y5 ?? x5)/*T:B<object?>?*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(y5 ?? x5)/*T:B<object?>?*/.F").WithLocation(31, 9),
                 // (35,10): warning CS8619: Nullability of reference types in value of type 'A<object?>' doesn't match target type 'B<object>'.
                 //         (x6 ?? y6)/*T:B<object!>?*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x6").WithArguments("A<object?>", "B<object>").WithLocation(35, 10),
-                // (35,10): warning CS8602: Possible dereference of a null reference.
+                // (35,10): warning CS8602: Dereference of a possibly null reference.
                 //         (x6 ?? y6)/*T:B<object!>?*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x6 ?? y6").WithLocation(35, 10),
                 // (36,16): warning CS8619: Nullability of reference types in value of type 'B<object?>' doesn't match target type 'B<object>'.
                 //         (y6 ?? x6)/*T:B<object!>?*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x6").WithArguments("B<object?>", "B<object>").WithLocation(36, 16),
-                // (36,10): warning CS8602: Possible dereference of a null reference.
+                // (36,10): warning CS8602: Dereference of a possibly null reference.
                 //         (y6 ?? x6)/*T:B<object!>?*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y6 ?? x6").WithLocation(36, 10));
         }
@@ -24896,16 +24896,16 @@ class C
 }";
             var comp = CreateCompilationWithMscorlib40AndSystemCore(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,10): warning CS8602: Possible dereference of a null reference.
+                // (5,10): warning CS8602: Dereference of a possibly null reference.
                 //         (x ?? y).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x ?? y").WithLocation(5, 10),
-                // (7,10): warning CS8602: Possible dereference of a null reference.
+                // (7,10): warning CS8602: Dereference of a possibly null reference.
                 //         (y ?? x).ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y ?? x").WithLocation(7, 10),
-                // (9,10): warning CS8602: Possible dereference of a null reference.
+                // (9,10): warning CS8602: Dereference of a possibly null reference.
                 //         (z ?? x).ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z ?? x").WithLocation(9, 10),
-                // (10,10): warning CS8602: Possible dereference of a null reference.
+                // (10,10): warning CS8602: Dereference of a possibly null reference.
                 //         (z ?? y).ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z ?? y").WithLocation(10, 10));
         }
@@ -25017,22 +25017,22 @@ public class NotNull
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), references: new[] { ref0, ref1 });
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
-                // (14,14): warning CS8602: Possible dereference of a null reference.
+                // (14,14): warning CS8602: Dereference of a possibly null reference.
                 //             (x2.Object ?? y2.String)/*T:object?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2.Object ?? y2.String").WithLocation(14, 14),
-                // (24,14): warning CS8602: Possible dereference of a null reference.
+                // (24,14): warning CS8602: Dereference of a possibly null reference.
                 //             (y3.String ?? x3.Object)/*T:object?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y3.String ?? x3.Object").WithLocation(24, 14),
-                // (30,14): warning CS8602: Possible dereference of a null reference.
+                // (30,14): warning CS8602: Dereference of a possibly null reference.
                 //             (x4.Object ?? y4.String)/*T:object?*/.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x4.Object ?? y4.String").WithLocation(30, 14),
-                // (32,14): warning CS8602: Possible dereference of a null reference.
+                // (32,14): warning CS8602: Dereference of a possibly null reference.
                 //             (y4.String ?? x4.Object)/*T:object?*/.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y4.String ?? x4.Object").WithLocation(32, 14),
-                // (56,14): warning CS8602: Possible dereference of a null reference.
+                // (56,14): warning CS8602: Dereference of a possibly null reference.
                 //             (y7.String ?? x7.Object)/*T:object?*/.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y7.String ?? x7.Object").WithLocation(56, 14),
-                // (62,14): warning CS8602: Possible dereference of a null reference.
+                // (62,14): warning CS8602: Dereference of a possibly null reference.
                 //             (x8.Object ?? y8.String)/*T:object?*/.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x8.Object ?? y8.String").WithLocation(62, 14));
         }
@@ -25071,25 +25071,25 @@ class C
                 // (12,10): warning CS8619: Nullability of reference types in value of type 'B<object?>' doesn't match target type 'A<object>'.
                 //         (y ?? x).F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("B<object?>", "A<object>").WithLocation(12, 10),
-                // (12,10): warning CS8602: Possible dereference of a null reference.
+                // (12,10): warning CS8602: Dereference of a possibly null reference.
                 //         (y ?? x).F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y ?? x").WithLocation(12, 10),
                 // (16,15): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'A<object?>'.
                 //         (z ?? w).F.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "w").WithArguments("B<object>", "A<object?>").WithLocation(16, 15),
-                // (16,10): warning CS8602: Possible dereference of a null reference.
+                // (16,10): warning CS8602: Dereference of a possibly null reference.
                 //         (z ?? w).F.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z ?? w").WithLocation(16, 10),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         (z ?? w).F.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(z ?? w).F").WithLocation(16, 9),
                 // (17,10): warning CS8619: Nullability of reference types in value of type 'B<object>' doesn't match target type 'A<object?>'.
                 //         (w ?? z).F.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "w").WithArguments("B<object>", "A<object?>").WithLocation(17, 10),
-                // (17,10): warning CS8602: Possible dereference of a null reference.
+                // (17,10): warning CS8602: Dereference of a possibly null reference.
                 //         (w ?? z).F.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w ?? z").WithLocation(17, 10),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         (w ?? z).F.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(w ?? z).F").WithLocation(17, 9));
         }
@@ -25127,13 +25127,13 @@ class C
                 // (10,14): warning CS8619: Nullability of reference types in value of type 'IIn<object>' doesn't match target type 'IIn<string?>'.
                 //             (x ?? y)/*T:IIn<string?>!*/.F(string.Empty, null); // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("IIn<object>", "IIn<string?>").WithLocation(10, 14),
-                // (12,14): warning CS8602: Possible dereference of a null reference.
+                // (12,14): warning CS8602: Dereference of a possibly null reference.
                 //             (y ?? x)/*T:IIn<string?>?*/.F(string.Empty, null); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y ?? x").WithLocation(12, 14),
                 // (12,19): warning CS8619: Nullability of reference types in value of type 'IIn<object>' doesn't match target type 'IIn<string?>'.
                 //             (y ?? x)/*T:IIn<string?>?*/.F(string.Empty, null); // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "x").WithArguments("IIn<object>", "IIn<string?>").WithLocation(12, 19),
-                // (18,14): warning CS8602: Possible dereference of a null reference.
+                // (18,14): warning CS8602: Dereference of a possibly null reference.
                 //             (z ?? w)/*T:IIn<string!>?*/.F(string.Empty, null); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z ?? w").WithLocation(18, 14),
                 // (18,57): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
@@ -25180,16 +25180,16 @@ class C
                 // (12,14): warning CS8619: Nullability of reference types in value of type 'IOut<string?>' doesn't match target type 'IOut<object>'.
                 //             (y ?? x)/*T:IOut<object!>?*/.P.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("IOut<string?>", "IOut<object>").WithLocation(12, 14),
-                // (12,14): warning CS8602: Possible dereference of a null reference.
+                // (12,14): warning CS8602: Dereference of a possibly null reference.
                 //             (y ?? x)/*T:IOut<object!>?*/.P.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y ?? x").WithLocation(12, 14),
-                // (18,13): warning CS8602: Possible dereference of a null reference.
+                // (18,13): warning CS8602: Dereference of a possibly null reference.
                 //             (z ?? w)/*T:IOut<object?>?*/.P.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(z ?? w)/*T:IOut<object?>?*/.P").WithLocation(18, 13),
-                // (18,14): warning CS8602: Possible dereference of a null reference.
+                // (18,14): warning CS8602: Dereference of a possibly null reference.
                 //             (z ?? w)/*T:IOut<object?>?*/.P.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z ?? w").WithLocation(18, 14),
-                // (20,13): warning CS8602: Possible dereference of a null reference.
+                // (20,13): warning CS8602: Dereference of a possibly null reference.
                 //             (w ?? z)/*T:IOut<object?>!*/.P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(w ?? z)/*T:IOut<object?>!*/.P").WithLocation(20, 13));
         }
@@ -25246,16 +25246,16 @@ class CL1
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (15,13): warning CS8602: Possible dereference of a null reference.
+                // (15,13): warning CS8602: Dereference of a possibly null reference.
                 //             x1.M1(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(15, 13),
-                // (28,13): warning CS8602: Possible dereference of a null reference.
+                // (28,13): warning CS8602: Dereference of a possibly null reference.
                 //             x2.M1(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(28, 13),
                 // (29,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             y2 = z2;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "z2").WithLocation(29, 18),
-                // (30,13): warning CS8602: Possible dereference of a null reference.
+                // (30,13): warning CS8602: Dereference of a possibly null reference.
                 //             y2.M2(y2);
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(30, 13));
         }
@@ -25475,7 +25475,7 @@ class CL1
                 // (7,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         s = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(7, 13),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 9));
 
@@ -25532,7 +25532,7 @@ class CL1
 
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(6, 9));
 
@@ -25564,7 +25564,7 @@ class CL1
                 // (5,9): error CS0841: Cannot use local variable 't' before it is declared
                 //         t = null;
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "t").WithArguments("t").WithLocation(5, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(7, 9));
 
@@ -25632,7 +25632,7 @@ class CL1
 
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(9, 13));
 
@@ -25664,7 +25664,7 @@ class CL1
 
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(8, 13));
 
@@ -25698,7 +25698,7 @@ class CL1
 
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(9, 13));
 
@@ -25733,7 +25733,7 @@ class CL1
 
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(9, 13));
 
@@ -25870,7 +25870,7 @@ class CL1
                 // (9,28): error CS0037: Cannot convert null to 'int' because it is a non-nullable value type
                 //         var u = new[] { 1, null };
                 Diagnostic(ErrorCode.ERR_ValueCantBeNull, "null").WithArguments("int").WithLocation(9, 28),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t[0]").WithLocation(8, 9));
         }
@@ -25894,7 +25894,7 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         b[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(9, 9));
         }
@@ -26057,7 +26057,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (12,18): warning CS8602: Possible dereference of a null reference.
+                // (12,18): warning CS8602: Dereference of a possibly null reference.
                 //         var z1 = u1[0];
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u1").WithLocation(12, 18)
                 );
@@ -26189,7 +26189,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (18,18): warning CS8602: Possible dereference of a null reference.
+                // (18,18): warning CS8602: Dereference of a possibly null reference.
                 //         var z2 = u2.Length;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u2").WithLocation(18, 18)
                 );
@@ -26333,7 +26333,7 @@ class C
                 // (33,16): warning CS8603: Possible null reference return.
                 //         return u5;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "u5").WithLocation(33, 16),
-                // (39,9): warning CS8602: Possible dereference of a null reference.
+                // (39,9): warning CS8602: Dereference of a possibly null reference.
                 //         u6[0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6").WithLocation(39, 9),
                 // (39,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -26345,7 +26345,7 @@ class C
                 // (46,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object [][,] u7 = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(46, 27),
-                // (47,9): warning CS8602: Possible dereference of a null reference.
+                // (47,9): warning CS8602: Dereference of a possibly null reference.
                 //         u7[0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u7").WithLocation(47, 9),
                 // (47,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -26357,31 +26357,31 @@ class C
                 // (53,28): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object []?[,] u8 = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(53, 28),
-                // (54,9): warning CS8602: Possible dereference of a null reference.
+                // (54,9): warning CS8602: Dereference of a possibly null reference.
                 //         u8[0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u8").WithLocation(54, 9),
-                // (55,9): warning CS8602: Possible dereference of a null reference.
+                // (55,9): warning CS8602: Dereference of a possibly null reference.
                 //         u8[0,0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u8[0,0]").WithLocation(55, 9),
-                // (56,9): warning CS8602: Possible dereference of a null reference.
+                // (56,9): warning CS8602: Dereference of a possibly null reference.
                 //         u8[0,0][0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u8[0,0]").WithLocation(56, 9),
                 // (56,22): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         u8[0,0][0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(56, 22),
-                // (57,9): warning CS8602: Possible dereference of a null reference.
+                // (57,9): warning CS8602: Dereference of a possibly null reference.
                 //         u8[0,0][0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u8[0,0]").WithLocation(57, 9),
-                // (63,9): warning CS8602: Possible dereference of a null reference.
+                // (63,9): warning CS8602: Dereference of a possibly null reference.
                 //         u9[0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9").WithLocation(63, 9),
-                // (64,9): warning CS8602: Possible dereference of a null reference.
+                // (64,9): warning CS8602: Dereference of a possibly null reference.
                 //         u9[0,0][0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0,0]").WithLocation(64, 9),
                 // (64,22): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         u9[0,0][0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(64, 22),
-                // (65,9): warning CS8602: Possible dereference of a null reference.
+                // (65,9): warning CS8602: Dereference of a possibly null reference.
                 //         u9[0,0][0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0,0]").WithLocation(65, 9)
                 );
@@ -26444,13 +26444,13 @@ class C
                 // (16,53): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //                                     new object[,] {{null}}};
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(16, 53),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         u6[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(18, 9),
                 // (18,22): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         u6[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(18, 22),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         u6[0][0,0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u6[0]").WithLocation(19, 9),
                 // (24,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -26480,13 +26480,13 @@ class C
                 // (42,54): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //                                      new object[,] {{null}}};
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(42, 54),
-                // (44,9): warning CS8602: Possible dereference of a null reference.
+                // (44,9): warning CS8602: Dereference of a possibly null reference.
                 //         u9[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(44, 9),
                 // (44,22): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         u9[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(44, 22),
-                // (45,9): warning CS8602: Possible dereference of a null reference.
+                // (45,9): warning CS8602: Dereference of a possibly null reference.
                 //         u9[0][0,0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u9[0]").WithLocation(45, 9)
                 );
@@ -26599,10 +26599,10 @@ class CL0<T>
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         b[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(10, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         c[0][0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c[0][0]").WithLocation(13, 9));
         }
@@ -26634,16 +26634,16 @@ class CL0<T>
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         b[0].ToString();      // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(8, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         c[0][0].ToString();   // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c[0][0]").WithLocation(13, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         d[0][0].ToString();   // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "d[0][0]").WithLocation(15, 9),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         e[0][0].ToString();   // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "e[0][0]").WithLocation(17, 9)
                 );
@@ -26676,13 +26676,13 @@ class CL0<T>
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,13): warning CS8602: Possible dereference of a null reference.
+                // (11,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = c[0].Length;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c[0]").WithLocation(11, 13),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = d[0].Length;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "d[0]").WithLocation(13, 13),
-                // (15,13): warning CS8602: Possible dereference of a null reference.
+                // (15,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = e[0].Length;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "e[0]").WithLocation(15, 13));
         }
@@ -26701,7 +26701,7 @@ class CL0<T>
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { y, x })[1].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { y, x })[1]").WithLocation(6, 9));
         }
@@ -26746,10 +26746,10 @@ class CL0<T>
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             a[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a[0]").WithLocation(9, 13),
-                // (11,13): warning CS8602: Possible dereference of a null reference.
+                // (11,13): warning CS8602: Dereference of a possibly null reference.
                 //             b[0][0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0][0]").WithLocation(11, 13));
         }
@@ -26781,25 +26781,25 @@ class CL0<T>
                 // (5,39): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         var a = new[] { new object(), (string)null };
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string)null").WithLocation(5, 39),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         a[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a[0]").WithLocation(6, 9),
                 // (7,25): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         var b = new[] { (object)null, s };
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(object)null").WithLocation(7, 25),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         b[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(8, 9),
                 // (9,28): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         var c = new[] { s, (object)null };
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(object)null").WithLocation(9, 28),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         c[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c[0]").WithLocation(10, 9),
                 // (11,25): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         var d = new[] { (string)null, new object() };
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string)null").WithLocation(11, 25),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         d[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "d[0]").WithLocation(12, 9));
         }
@@ -26886,13 +26886,13 @@ class C
                 // (8,32): warning CS8619: Nullability of reference types in value of type 'C<object?>' doesn't match target type 'C<object>'.
                 //             var c = new[] { a, b };
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b").WithArguments("C<object?>", "C<object>").WithLocation(8, 32),
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             c[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c[0]").WithLocation(9, 13),
                 // (10,29): warning CS8619: Nullability of reference types in value of type 'C<object?>' doesn't match target type 'C<object>'.
                 //             var d = new[] { b, a };
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b").WithArguments("C<object?>", "C<object>").WithLocation(10, 29),
-                // (11,13): warning CS8602: Possible dereference of a null reference.
+                // (11,13): warning CS8602: Dereference of a possibly null reference.
                 //             d[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "d[0]").WithLocation(11, 13),
                 // (15,32): warning CS8619: Nullability of reference types in value of type 'C<object?>' doesn't match target type 'C<object>'.
@@ -27428,7 +27428,7 @@ public interface I<T> { }
                 // (5,35): warning CS8601: Possible null reference assignment.
                 //         var a = new object[] { x, y };
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y").WithLocation(5, 35),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         b[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(8, 9));
         }
@@ -27475,58 +27475,58 @@ class C
                 // (8,21): warning CS8619: Nullability of reference types in value of type 'I<object?>' doesn't match target type 'I<object>'.
                 //         (new[] { x, y })[0].ToString(); // A1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("I<object?>", "I<object>").WithLocation(8, 21),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x, z })[0].ToString(); // A2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x, z })[0]").WithLocation(9, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x, w })[0].ToString(); // A3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x, w })[0]").WithLocation(10, 9),
                 // (10,21): warning CS8619: Nullability of reference types in value of type 'I<object?>' doesn't match target type 'I<object>'.
                 //         (new[] { x, w })[0].ToString(); // A3
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "w").WithArguments("I<object?>", "I<object>").WithLocation(10, 21),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { y, z })[0].ToString(); // A4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { y, z })[0]").WithLocation(11, 9),
                 // (11,18): warning CS8619: Nullability of reference types in value of type 'I<object?>' doesn't match target type 'I<object>'.
                 //         (new[] { y, z })[0].ToString(); // A4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "y").WithArguments("I<object?>", "I<object>").WithLocation(11, 18),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { y, w })[0].ToString(); // A5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { y, w })[0]").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { w, z })[0].ToString(); // A6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { w, z })[0]").WithLocation(13, 9),
                 // (13,18): warning CS8619: Nullability of reference types in value of type 'I<object?>' doesn't match target type 'I<object>'.
                 //         (new[] { w, z })[0].ToString(); // A6
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "w").WithArguments("I<object?>", "I<object>").WithLocation(13, 18),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x, z })[0].ToString(); // B2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x, z })[0]").WithLocation(18, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x, w })[0].ToString(); // B3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x, w })[0]").WithLocation(19, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { y, z })[0].ToString(); // B4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { y, z })[0]").WithLocation(20, 9),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { y, w })[0].ToString(); // B5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { y, w })[0]").WithLocation(21, 9),
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { w, z })[0].ToString(); // B6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { w, z })[0]").WithLocation(22, 9),
-                // (27,9): warning CS8602: Possible dereference of a null reference.
+                // (27,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x, z })[0].ToString(); // C2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x, z })[0]").WithLocation(27, 9),
-                // (28,9): warning CS8602: Possible dereference of a null reference.
+                // (28,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x, w })[0].ToString(); // C3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x, w })[0]").WithLocation(28, 9),
-                // (29,9): warning CS8602: Possible dereference of a null reference.
+                // (29,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { y, z })[0].ToString(); // C4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { y, z })[0]").WithLocation(29, 9),
-                // (30,9): warning CS8602: Possible dereference of a null reference.
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { y, w })[0].ToString(); // C5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { y, w })[0]").WithLocation(30, 9),
-                // (31,9): warning CS8602: Possible dereference of a null reference.
+                // (31,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { w, z })[0].ToString(); // C6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { w, z })[0]").WithLocation(31, 9)
                 );
@@ -27581,37 +27581,37 @@ public class B : A<object>
             comp.VerifyTypes();
             // https://github.com/dotnet/roslyn/issues/30376: `!` should suppress conversion warnings.
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x, x! })[0].ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x, x! })[0]").WithLocation(6, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x!, x })[0].ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x!, x })[0]").WithLocation(7, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x, y })[0].ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x, y })[0]").WithLocation(11, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x, y! })[0].ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x, y! })[0]").WithLocation(12, 9),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { z, z! })[0].F.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { z, z! })[0].F").WithLocation(18, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { z!, z })[0].F.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { z!, z })[0].F").WithLocation(19, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { z!, z! })[0].F.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { z!, z! })[0].F").WithLocation(20, 9),
-                // (23,9): warning CS8602: Possible dereference of a null reference.
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { z, w })[0].F.ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { z, w })[0].F").WithLocation(23, 9),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { z, w! })[0].F.ToString(); // 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { z, w! })[0].F").WithLocation(24, 9),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { z!, w })[0].F.ToString(); // 10
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { z!, w })[0].F").WithLocation(25, 9),
-                // (26,9): warning CS8602: Possible dereference of a null reference.
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { z!, w! })[0].F.ToString(); // 11
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { z!, w! })[0].F").WithLocation(26, 9));
         }
@@ -27755,10 +27755,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x, y })[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x, y })[0]").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { y, x })[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { y, x })[0]").WithLocation(13, 9));
         }
@@ -27784,10 +27784,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { x, y })[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { x, y })[0]").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new[] { y, x })[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { y, x })[0]").WithLocation(13, 9));
         }
@@ -28717,16 +28717,16 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         new { x, y }.y.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "new { x, y }.y").WithLocation(6, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         new { y, x }.y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "new { y, x }.y").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         new { x = x, y = y }.y.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "new { x = x, y = y }.y").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         new { x = y, y = x }.x.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "new { x = y, y = x }.x").WithLocation(11, 9));
         }
@@ -28786,13 +28786,13 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.y/*T:T?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.y").WithLocation(7, 9),
                 // (8,13): warning CS8619: Nullability of reference types in value of type '<anonymous type: T x, T y>' doesn't match target type '<anonymous type: T x, T y>'.
                 //         a = new { x = y, y = x }; // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new { x = y, y = x }").WithArguments("<anonymous type: T x, T y>", "<anonymous type: T x, T y>").WithLocation(8, 13),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.x/*T:T?*/.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.x").WithLocation(9, 9));
             comp.VerifyTypes();
@@ -28856,13 +28856,13 @@ class C
                 // (5,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T x = null; // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(5, 15),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.x/*T:T?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.x").WithLocation(8, 9),
                 // (12,13): warning CS8619: Nullability of reference types in value of type '<anonymous type: T x, T y>' doesn't match target type '<anonymous type: T x, T y>'.
                 //         a = new { x, y }; // 3
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new { x, y }").WithArguments("<anonymous type: T x, T y>", "<anonymous type: T x, T y>").WithLocation(12, 13),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.y/*T:T?*/.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.y").WithLocation(14, 9));
             comp.VerifyTypes();
@@ -28922,7 +28922,7 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         a2.t.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a2.t").WithLocation(12, 9));
         }
@@ -28949,7 +28949,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         a2.t.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a2.t").WithLocation(13, 9));
         }
@@ -28993,7 +28993,7 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,9): warning CS8602: Possible dereference of a null reference.
+                // (5,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new { P = o }).P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new { P = o }).P").WithLocation(5, 9));
         }
@@ -29014,7 +29014,7 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,9): warning CS8602: Possible dereference of a null reference.
+                // (5,9): warning CS8602: Dereference of a possibly null reference.
                 //         (new { P = new[] { o }}).P[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new { P = new[] { o }}).P[0]").WithLocation(5, 9));
         }
@@ -30145,7 +30145,7 @@ class C
                 // (7,18): warning CS8622: Nullability of reference types in type of parameter 's2' of 'lambda expression' doesn't match the target delegate 'D<string>'.
                 //         var d2 = (D<string>)((string? s2) => { s2.ToString(); return s2; });
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate, "(D<string>)((string? s2) => { s2.ToString(); return s2; })").WithArguments("s2", "lambda expression", "D<string>").WithLocation(7, 18),
-                // (7,48): warning CS8602: Possible dereference of a null reference.
+                // (7,48): warning CS8602: Dereference of a possibly null reference.
                 //         var d2 = (D<string>)((string? s2) => { s2.ToString(); return s2; });
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(7, 48),
                 // (10,21): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'D<T>'. Nullability of type argument 'string?' doesn't match 'class' constraint.
@@ -30154,7 +30154,7 @@ class C
                 // (10,53): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         var d3 = (D<string?>)((string s1) => { s1 = null; return s1; }!);
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(10, 53),
-                // (11,48): warning CS8602: Possible dereference of a null reference.
+                // (11,48): warning CS8602: Dereference of a possibly null reference.
                 //         var d4 = (D<string>)((string? s2) => { s2.ToString(); return s2; }!);
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(11, 48)
                 );
@@ -30213,7 +30213,7 @@ class C
                 // (16,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object z2 = x2; // warning
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2").WithLocation(16, 21),
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         z2.ToString(); // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z2").WithLocation(22, 9));
         }
@@ -30300,10 +30300,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(() => { if (b) return x; return y; }).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => { if (b) return x; return y; })").WithLocation(10, 9),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(() => { if (b) return x; return y; }).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => { if (b) return x; return y; })").WithLocation(14, 9));
         }
@@ -30329,10 +30329,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(() => o).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => o)").WithLocation(10, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(() => { return o; }).ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => { return o; })").WithLocation(12, 9));
         }
@@ -30396,7 +30396,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(y => F(z => z, y), x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y => F(z => z, y), x)").WithLocation(10, 9));
         }
@@ -30714,10 +30714,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,31): warning CS8602: Possible dereference of a null reference.
+                // (9,31): warning CS8602: Dereference of a possibly null reference.
                 //         F(x, y => F(y, z => { y.ToString(); z.ToString(); }));
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 31),
-                // (9,45): warning CS8602: Possible dereference of a null reference.
+                // (9,45): warning CS8602: Dereference of a possibly null reference.
                 //         F(x, y => F(y, z => { y.ToString(); z.ToString(); }));
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(9, 45));
         }
@@ -30835,7 +30835,7 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(() => y).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => y)").WithLocation(10, 9));
         }
@@ -30891,10 +30891,10 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(() => { if (x.Length > 0) return x; return null; }).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => { if (x.Length > 0) return x; return null; })").WithLocation(9, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(() => { if (x.Length == 0) return null; return x; }).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => { if (x.Length == 0) return null; return x; })").WithLocation(10, 9));
         }
@@ -30957,10 +30957,10 @@ static class E
                 // (5,13): error CS0815: Cannot assign lambda expression to an implicitly-typed variable
                 //         var z = y => y ?? x.ToString();
                 Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, "z = y => y ?? x.ToString()").WithArguments("lambda expression").WithLocation(5, 13),
-                // (5,27): warning CS8602: Possible dereference of a null reference.
+                // (5,27): warning CS8602: Dereference of a possibly null reference.
                 //         var z = y => y ?? x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(5, 27),
-                // (6,53): warning CS8602: Possible dereference of a null reference.
+                // (6,53): warning CS8602: Dereference of a possibly null reference.
                 //         System.Func<object?, object> z2 = y => y ?? x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 53),
                 // (7,48): warning CS8603: Possible null reference return.
@@ -31026,16 +31026,16 @@ static class E
                 // (15,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object z2 = x2; // warning
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2").WithLocation(15, 21),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         z2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z2").WithLocation(17, 9),
                 // (28,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             z3 = x3;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x3").WithLocation(28, 18),
-                // (36,9): warning CS8602: Possible dereference of a null reference.
+                // (36,9): warning CS8602: Dereference of a possibly null reference.
                 //         f().ToString(); // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "f()").WithLocation(36, 9),
-                // (37,25): warning CS8602: Possible dereference of a null reference.
+                // (37,25): warning CS8602: Dereference of a possibly null reference.
                 //         if (x4 != null) f().ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "f()").WithLocation(37, 25));
         }
@@ -31090,13 +31090,13 @@ class C
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/29892: Should report warnings for `y3.ToString()`.
             comp.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             x1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(8, 13),
-                // (16,13): warning CS8602: Possible dereference of a null reference.
+                // (16,13): warning CS8602: Dereference of a possibly null reference.
                 //             x2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(16, 13),
-                // (36,13): warning CS8602: Possible dereference of a null reference.
+                // (36,13): warning CS8602: Dereference of a possibly null reference.
                 //             x4.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x4").WithLocation(36, 13));
         }
@@ -31297,19 +31297,19 @@ class Program
                 // (10,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         T x = new T() { F = 1, P = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 36),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.P.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.P").WithLocation(12, 9),
                 // (13,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         C y = new T() { F = 2, P = null }; // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 36),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.P.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.P").WithLocation(15, 9),
                 // (16,39): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         C z = (C)new T() { F = 3, P = null }; // 5
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(16, 39),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.P.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z.P").WithLocation(18, 9));
         }
@@ -31344,19 +31344,19 @@ class Program
                 // (10,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         T x = new T() { P = 1, Q = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 36),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Q.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Q").WithLocation(12, 9),
                 // (13,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         I y = new T() { P = 2, Q = null }; // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 36),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Q.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Q").WithLocation(15, 9),
                 // (16,39): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         I z = (I)new T() { P = 3, Q = null }; // 5
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(16, 39),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.Q.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z.Q").WithLocation(18, 9));
         }
@@ -31391,19 +31391,19 @@ class Program
                 // (10,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         T x = new T() { P = 1, Q = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 36),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Q.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Q").WithLocation(12, 9),
                 // (13,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         I y = new T() { P = 2, Q = null }; // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 36),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Q.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Q").WithLocation(15, 9),
                 // (16,39): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         I z = (I)new T() { P = 3, Q = null }; // 5
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(16, 39),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.Q.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z.Q").WithLocation(18, 9));
         }
@@ -31438,19 +31438,19 @@ class Program
                 // (10,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         T x = new T() { P = 1, Q = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 36),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Q.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Q").WithLocation(12, 9),
                 // (13,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         I y = new T() { P = 2, Q = null }; // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 36),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Q.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Q").WithLocation(15, 9),
                 // (16,39): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         I z = (I)new T() { P = 3, Q = null }; // 5
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(16, 39),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.Q.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z.Q").WithLocation(18, 9));
         }
@@ -31924,10 +31924,10 @@ class CL0
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                 // (9,14): warning CS8602: Possible dereference of a null reference.
+                 // (9,14): warning CS8602: Dereference of a possibly null reference.
                  //         x1 = x1[(dynamic)0];
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(9, 14),
-                 // (14,14): warning CS8602: Possible dereference of a null reference.
+                 // (14,14): warning CS8602: Dereference of a possibly null reference.
                  //         x2 = x2[0];
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(14, 14)
                 );
@@ -32258,10 +32258,10 @@ class CL0
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                 // (9,14): warning CS8602: Possible dereference of a null reference.
+                 // (9,14): warning CS8602: Dereference of a possibly null reference.
                  //         x1 = x1.M1((dynamic)0);
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(9, 14),
-                 // (14,14): warning CS8602: Possible dereference of a null reference.
+                 // (14,14): warning CS8602: Dereference of a possibly null reference.
                  //         x2 = x2.M1(0);
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(14, 14)
                 );
@@ -32294,7 +32294,7 @@ class C
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                 // (19,22): warning CS8602: Possible dereference of a null reference.
+                 // (19,22): warning CS8602: Dereference of a possibly null reference.
                  //         dynamic y3 = x3.M1;
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(19, 22)
                 );
@@ -32850,7 +32850,7 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9));
 
@@ -32883,7 +32883,7 @@ class C
 
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9)
                 );
@@ -32922,7 +32922,7 @@ class C
                 // (5,17): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         var s = default(T);
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default(T)").WithArguments("T").WithLocation(5, 17),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9),
                 // (7,17): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
@@ -32931,7 +32931,7 @@ class C
                 // (7,25): error CS8627: A nullable type parameter must be known to be a value type or non-nullable reference type. Consider adding a 'class', 'struct', or type constraint.
                 //         var t = default(T?);
                 Diagnostic(ErrorCode.ERR_NullableUnconstrainedTypeParameter, "T?").WithLocation(7, 25),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(8, 9)
                 );
@@ -32967,10 +32967,10 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(8, 9));
 
@@ -33008,7 +33008,7 @@ class C
                 // (5,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         string s = default;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(5, 20),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9));
 
@@ -33042,7 +33042,7 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9)
                 );
@@ -33079,7 +33079,7 @@ class C
                 // (5,15): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         T s = default;
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(5, 15),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9)
                 );
@@ -33114,10 +33114,10 @@ class C
                 // (5,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T s = default;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(5, 15),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(8, 9));
 
@@ -33160,10 +33160,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(9, 9),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(18, 9));
         }
@@ -33222,7 +33222,7 @@ class C<T>
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 9));
         }
@@ -33246,7 +33246,7 @@ class C<T>
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9));
         }
@@ -33274,7 +33274,7 @@ class C<T>
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(11, 9),
                 // (14,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -33333,7 +33333,7 @@ class C
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/33011: Deconstruction should infer `string?` for `var y`.
             comp.VerifyDiagnostics();
-            //// (11,13): warning CS8602: Possible dereference of a null reference.
+            //// (11,13): warning CS8602: Dereference of a possibly null reference.
             ////             y.ToString();
             //Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(11, 13));
         }
@@ -33354,7 +33354,7 @@ class C
             // https://github.com/dotnet/roslyn/issues/33011: Should report WRN_NullReferenceReceiver.
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics();
-            //// (7,9): warning CS8602: Possible dereference of a null reference.
+            //// (7,9): warning CS8602: Dereference of a possibly null reference.
             ////         ((x, _) = t).Item2.ToString();
             //Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((x, _) = t).Item2").WithLocation(7, 9));
         }
@@ -34153,7 +34153,7 @@ class CL0
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                 // (10,28): warning CS8602: Possible dereference of a null reference.
+                 // (10,28): warning CS8602: Dereference of a possibly null reference.
                  //         System.Action u1 = x1.M1;
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(10, 28)
                 );
@@ -35239,16 +35239,16 @@ class B
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         F1(x, x!).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1(x, x!)").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         F1(x!, x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1(x!, x)").WithLocation(13, 9),
-                // (23,9): warning CS8602: Possible dereference of a null reference.
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
                 //         F2(z, z!).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2(z, z!)").WithLocation(23, 9),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         F2(z!, z).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2(z!, z)").WithLocation(24, 9));
         }
@@ -36298,7 +36298,7 @@ class Test
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         E1();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "E1").WithLocation(12, 9),
                 // (20,12): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -36433,13 +36433,13 @@ class CL0
                  // (10,28): error CS0029: Cannot implicitly convert type 'void' to 'System.Action'
                  //         System.Action v1 = x1.E1 += y1;
                  Diagnostic(ErrorCode.ERR_NoImplicitConv, "x1.E1 += y1").WithArguments("void", "System.Action").WithLocation(10, 28),
-                 // (10,28): warning CS8602: Possible dereference of a null reference.
+                 // (10,28): warning CS8602: Dereference of a possibly null reference.
                  //         System.Action v1 = x1.E1 += y1;
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(10, 28),
                  // (15,28): error CS0029: Cannot implicitly convert type 'void' to 'System.Action'
                  //         System.Action v2 = x2.E1 -= y2;
                  Diagnostic(ErrorCode.ERR_NoImplicitConv, "x2.E1 -= y2").WithArguments("void", "System.Action").WithLocation(15, 28),
-                 // (15,28): warning CS8602: Possible dereference of a null reference.
+                 // (15,28): warning CS8602: Dereference of a possibly null reference.
                  //         System.Action v2 = x2.E1 -= y2;
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(15, 28)
                 );
@@ -36465,7 +36465,7 @@ class Test
 " }, options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                 // (12,28): warning CS8602: Possible dereference of a null reference.
+                 // (12,28): warning CS8602: Dereference of a possibly null reference.
                  //         System.Action v1 = x1.E1;
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(12, 28)
                 );
@@ -37091,7 +37091,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,15): warning CS8602: Possible dereference of a null reference.
+                // (7,15): warning CS8602: Dereference of a possibly null reference.
                 //         await x; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 15));
         }
@@ -37111,7 +37111,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9)
                 );
@@ -37131,7 +37131,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,15): warning CS8602: Possible dereference of a null reference.
+                // (6,15): warning CS8602: Dereference of a possibly null reference.
                 //         await Async();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Async()").WithLocation(6, 15)
                 );
@@ -37156,7 +37156,7 @@ public static class Extensions
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,15): warning CS8602: Possible dereference of a null reference.
+                // (6,15): warning CS8602: Dereference of a possibly null reference.
                 //         await Async();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Async()").WithLocation(6, 15)
                 );
@@ -37176,7 +37176,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,15): warning CS8602: Possible dereference of a null reference.
+                // (6,15): warning CS8602: Dereference of a possibly null reference.
                 //         await task; // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "task").WithLocation(6, 15)
                 );
@@ -37197,7 +37197,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,15): warning CS8602: Possible dereference of a null reference.
+                // (7,15): warning CS8602: Dereference of a possibly null reference.
                 //         await c?.M(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c?.M()").WithLocation(7, 15)
                 );
@@ -37218,7 +37218,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,14): warning CS8602: Possible dereference of a null reference.
+                // (7,14): warning CS8602: Dereference of a possibly null reference.
                 //         _ = (c?.field)[0]; // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c?.field").WithLocation(7, 14)
                 );
@@ -37240,7 +37240,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,14): warning CS8602: Possible dereference of a null reference.
+                // (8,14): warning CS8602: Dereference of a possibly null reference.
                 //         _ = (c?.field).M(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c?.field").WithLocation(8, 14)
                 );
@@ -37262,7 +37262,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,14): warning CS8602: Possible dereference of a null reference.
+                // (8,14): warning CS8602: Dereference of a possibly null reference.
                 //         _ = (c?.field)[0]; // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c?.field").WithLocation(8, 14)
                 );
@@ -37284,7 +37284,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,14): warning CS8602: Possible dereference of a null reference.
+                // (8,14): warning CS8602: Dereference of a possibly null reference.
                 //         _ = (c?.field).field; // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c?.field").WithLocation(8, 14)
                 );
@@ -37316,10 +37316,10 @@ class C
 }";
             var comp = CreateCompilation(source.Replace("OPERATOR", op), options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13),
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //             s2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(14, 13)
                 );
@@ -37389,10 +37389,10 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8602: Possible dereference of a null reference.
+                // (7,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 13),
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             s2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(12, 13)
                 );
@@ -37414,7 +37414,7 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 13)
                 );
@@ -39638,7 +39638,7 @@ class CL1<T>
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                // (39,9): warning CS8602: Possible dereference of a null reference.
+                // (39,9): warning CS8602: Dereference of a possibly null reference.
                 //         M3().P1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M3().P1").WithLocation(39, 9),
                 // (50,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -39826,7 +39826,7 @@ class CL0<T>
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                 // (8,9): warning CS8602: Possible dereference of a null reference.
+                 // (8,9): warning CS8602: Dereference of a possibly null reference.
                  //         CL0<string?>.M1().ToString();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "CL0<string?>.M1()").WithLocation(8, 9)
                 );
@@ -39889,7 +39889,7 @@ class CL1<T>
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                 // (30,9): warning CS8602: Possible dereference of a null reference.
+                 // (30,9): warning CS8602: Dereference of a possibly null reference.
                  //         M3.P1.ToString();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M3.P1").WithLocation(30, 9),
                  // (38,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -39926,7 +39926,7 @@ class CL0<T>
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                 // (8,9): warning CS8602: Possible dereference of a null reference.
+                 // (8,9): warning CS8602: Dereference of a possibly null reference.
                  //         CL0<string?>.M1.ToString();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "CL0<string?>.M1").WithLocation(8, 9)
                 );
@@ -39998,7 +39998,7 @@ class CL1<T>
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                // (30,9): warning CS8602: Possible dereference of a null reference.
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
                 //         M3.P1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M3.P1").WithLocation(30, 9),
                 // (38,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -40035,7 +40035,7 @@ class CL0<T>
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                 // (8,9): warning CS8602: Possible dereference of a null reference.
+                 // (8,9): warning CS8602: Dereference of a possibly null reference.
                  //         CL0<string?>.M1.ToString();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "CL0<string?>.M1").WithLocation(8, 9)
                 );
@@ -40101,7 +40101,7 @@ class C
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                 // (29,9): warning CS8602: Possible dereference of a null reference.
+                 // (29,9): warning CS8602: Dereference of a possibly null reference.
                  //         M3().ToString();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M3()").WithLocation(29, 9)
                 );
@@ -40196,13 +40196,13 @@ class CL1<T>
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                 // (35,18): warning CS8602: Possible dereference of a null reference.
+                 // (35,18): warning CS8602: Dereference of a possibly null reference.
                  //         M3(b3 => b3.P1.ToString());
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b3.P1").WithLocation(35, 18),
                  // (44,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                  //         M4(a4 => {a4.P1 = null;});
                  Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(44, 27),
-                 // (64,25): warning CS8602: Possible dereference of a null reference.
+                 // (64,25): warning CS8602: Dereference of a possibly null reference.
                  //         D3 v31 = b31 => b31.P1.ToString();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b31.P1").WithLocation(64, 25),
                  // (70,35): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -40284,16 +40284,16 @@ delegate void CL2<T>(T? x) where T : class;
                                                                 options: TestOptions.ReleaseDll);
 
             c.VerifyDiagnostics(
-                 // (10,18): warning CS8602: Possible dereference of a null reference.
+                 // (10,18): warning CS8602: Dereference of a possibly null reference.
                  //         M1(a1 => a1.ToString());
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a1").WithLocation(10, 18),
-                 // (16,33): warning CS8602: Possible dereference of a null reference.
+                 // (16,33): warning CS8602: Dereference of a possibly null reference.
                  //         CL0<string?> u2 = a2 => a2.ToString();
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a2").WithLocation(16, 33),
-                 // (42,18): warning CS8602: Possible dereference of a null reference.
+                 // (42,18): warning CS8602: Dereference of a possibly null reference.
                  //         M4(a5 => a5.ToString());
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a5").WithLocation(42, 18),
-                 // (51,18): warning CS8602: Possible dereference of a null reference.
+                 // (51,18): warning CS8602: Dereference of a possibly null reference.
                  //         M5(a6 => a6.ToString());
                  Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a6").WithLocation(51, 18)
                 );
@@ -40568,28 +40568,28 @@ class CL0<T>
                                                                 options: WithNonNullTypesTrue());
 
             c.VerifyDiagnostics(
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(x2)[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(x2)[0]").WithLocation(15, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(x3).P1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(x3).P1").WithLocation(20, 9),
                 // (25,9): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.M1<T>(T?)'. Nullability of type argument 'string?' doesn't match 'class' constraint.
                 //         M1<string?>(x11).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "M1<string?>").WithArguments("C.M1<T>(T?)", "T", "string?").WithLocation(25, 9),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1<string?>(x11).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1<string?>(x11)").WithLocation(25, 9),
-                // (30,9): warning CS8602: Possible dereference of a null reference.
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1<string?[]>(x12)[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1<string?[]>(x12)[0]").WithLocation(30, 9),
                 // (35,9): warning CS8634: The type 'CL0<string?>?' cannot be used as type parameter 'T' in the generic type or method 'C.M1<T>(T?)'. Nullability of type argument 'CL0<string?>?' doesn't match 'class' constraint.
                 //         M1<CL0<string?>?>(x13).P1.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "M1<CL0<string?>?>").WithArguments("C.M1<T>(T?)", "T", "CL0<string?>?").WithLocation(35, 9),
-                // (35,9): warning CS8602: Possible dereference of a null reference.
+                // (35,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1<CL0<string?>?>(x13).P1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1<CL0<string?>?>(x13)").WithLocation(35, 9),
-                // (35,9): warning CS8602: Possible dereference of a null reference.
+                // (35,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1<CL0<string?>?>(x13).P1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1<CL0<string?>?>(x13).P1").WithLocation(35, 9),
                 // (41,14): warning CS8618: Non-nullable property 'P1' is uninitialized.
@@ -40797,7 +40797,7 @@ static class Extensions
                 // (17,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
                 //         ((p != null) ? p.MiddleName : null).F();
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("s", "void Extensions.F(string s)").WithLocation(17, 10),
-                // (18,10): warning CS8602: Possible dereference of a null reference.
+                // (18,10): warning CS8602: Dereference of a possibly null reference.
                 //         (p.MiddleName ?? null).F();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "p").WithLocation(18, 10),
                 // (18,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
@@ -40867,7 +40867,7 @@ class Program
                 // (19,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
                 //         G((p != null) ? p.MiddleName : null);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("name", "void Program.G(string name)").WithLocation(19, 11),
-                // (20,11): warning CS8602: Possible dereference of a null reference.
+                // (20,11): warning CS8602: Dereference of a possibly null reference.
                 //         G(p.MiddleName ?? null);
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "p").WithLocation(20, 11),
                 // (20,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
@@ -41824,10 +41824,10 @@ class C
 }";
             var comp = CreateCompilation(src, options: WithNonNullTypesTrue(TestOptions.DebugDll));
             comp.VerifyDiagnostics(
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         s3.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s3").WithLocation(21, 9),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         s4.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s4").WithLocation(25, 9));
         }
@@ -42097,7 +42097,7 @@ class C2
                 // (9,44): warning CS8619: Nullability of reference types in value of type '(string?, (C<string>, string))' doesn't match target type '(string, (C<string>, string))'.
                 //         (string, (C<string>, string)) t1 = (null, (c, null));
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(null, (c, null))").WithArguments("(string?, (C<string>, string))", "(string, (C<string>, string))").WithLocation(9, 44),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         t1.Item1.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1.Item1").WithLocation(10, 9),
 
@@ -42105,7 +42105,7 @@ class C2
                 // (14,51): warning CS8619: Nullability of reference types in value of type '(C<string?> c, string?)' doesn't match target type '(C<string>, string)'.
                 //         (string, (C<string>, string)) t2 = (null, (c, null))!;
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(c, null)").WithArguments("(C<string?> c, string?)", "(C<string>, string)").WithLocation(14, 51),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         t2.Item1.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2.Item1").WithLocation(15, 9),
 
@@ -42113,12 +42113,12 @@ class C2
                 // (19,44): warning CS8619: Nullability of reference types in value of type '(string?, (C<string>, string))' doesn't match target type '(string, (C<string>, string))'.
                 //         (string, (C<string>, string)) t3 = (null, (c, null)!);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(null, (c, null)!)").WithArguments("(string?, (C<string>, string))", "(string, (C<string>, string))").WithLocation(19, 44),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         t3.Item1.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t3.Item1").WithLocation(20, 9),
 
                 // line 4
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         t4.Item1.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t4.Item1").WithLocation(25, 9),
 
@@ -42131,7 +42131,7 @@ class C2
                 // (44,51): warning CS8619: Nullability of reference types in value of type '(C<string?> c, string?)' doesn't match target type '(C<string>, string)'.
                 //         (string, (C<string>, string)) t8 = (null, (c, null))!; // warn
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(c, null)").WithArguments("(C<string?> c, string?)", "(C<string>, string)").WithLocation(44, 51),
-                // (45,9): warning CS8602: Possible dereference of a null reference.
+                // (45,9): warning CS8602: Dereference of a possibly null reference.
                 //         t8.Item1.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t8.Item1").WithLocation(45, 9));
 
@@ -42342,16 +42342,16 @@ class C
                 // (5,9): warning CS8653: A default expression introduces a null value when 'T1' is a non-nullable reference type.
                 //         default(T1).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default(T1)").WithArguments("T1").WithLocation(5, 9),
-                // (5,9): warning CS8602: Possible dereference of a null reference.
+                // (5,9): warning CS8602: Dereference of a possibly null reference.
                 //         default(T1).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "default(T1)").WithLocation(5, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         t1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1").WithLocation(7, 9),
                 // (12,9): warning CS1720: Expression will always cause a System.NullReferenceException because the default value of 'T2' is null
                 //         default(T2).ToString(); // 3
                 Diagnostic(ErrorCode.WRN_DotOnDefault, "default(T2).ToString").WithArguments("T2").WithLocation(12, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         default(T2).ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "default(T2)").WithLocation(12, 9),
                 // (13,9): warning CS1720: Expression will always cause a System.NullReferenceException because the default value of 'T2' is null
@@ -42644,7 +42644,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         i.F();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "i").WithLocation(15, 9));
         }
@@ -42760,7 +42760,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,13): warning CS8602: Possible dereference of a null reference.
+                // (11,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(11, 13)
                 );
@@ -42847,7 +42847,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8602: Possible dereference of a null reference.
+                // (7,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 13)
                 );
@@ -42873,7 +42873,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8602: Possible dereference of a null reference.
+                // (7,13): warning CS8602: Dereference of a possibly null reference.
                 //             s.ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(7, 13)
                 );
@@ -42965,13 +42965,13 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(19, 9),
                 // (23,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x3 = null; // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(23, 14),
-                // (29,9): warning CS8602: Possible dereference of a null reference.
+                // (29,9): warning CS8602: Dereference of a possibly null reference.
                 //         x3.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(29, 9));
             comp.VerifyTypes();
@@ -43032,13 +43032,13 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (23,9): warning CS8602: Possible dereference of a null reference.
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
                 //         t2.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2").WithLocation(23, 9),
                 // (29,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         t3 = null; // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(29, 14),
-                // (35,9): warning CS8602: Possible dereference of a null reference.
+                // (35,9): warning CS8602: Dereference of a possibly null reference.
                 //         t3.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t3").WithLocation(35, 9));
         }
@@ -43071,7 +43071,7 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         t1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1").WithLocation(10, 9));
         }
@@ -43108,10 +43108,10 @@ class C
             // https://github.com/dotnet/roslyn/issues/30952: `is` declaration does not set not nullable for declared local.
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(12, 9),
-                // (23,9): warning CS8602: Possible dereference of a null reference.
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(23, 9));
         }
@@ -43209,7 +43209,7 @@ class C
                 // (11,13): error CS0165: Use of unassigned local variable 'y1'
                 //             y1.ToString(); // 1
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y1").WithArguments("y1").WithLocation(11, 13),
-                // (21,13): warning CS8602: Possible dereference of a null reference.
+                // (21,13): warning CS8602: Dereference of a possibly null reference.
                 //             x2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(21, 13),
                 // (22,13): error CS0165: Use of unassigned local variable 'y2'
@@ -43218,7 +43218,7 @@ class C
                 // (27,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x3 = null; // 4
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(27, 14),
-                // (33,13): warning CS8602: Possible dereference of a null reference.
+                // (33,13): warning CS8602: Dereference of a possibly null reference.
                 //             x3.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(33, 13),
                 // (34,13): error CS0165: Use of unassigned local variable 'y3'
@@ -43267,7 +43267,7 @@ class C
                 // (7,9): error CS0165: Use of unassigned local variable 'y1'
                 //         y1.ToString(); // 1
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y1").WithArguments("y1").WithLocation(7, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(12, 9),
                 // (13,9): error CS0165: Use of unassigned local variable 'y2'
@@ -43276,7 +43276,7 @@ class C
                 // (17,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x3 = null; // 4
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(17, 14),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         x3.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(19, 9),
                 // (20,9): error CS0165: Use of unassigned local variable 'y3'
@@ -44212,7 +44212,7 @@ class A : System.Attribute
                 // (5,9): error CS0269: Use of unassigned out parameter 'c'
                 //         c.ToString(); // 1
                 Diagnostic(ErrorCode.ERR_UseDefViolationOut, "c").WithArguments("c").WithLocation(5, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(7, 9));
         }
@@ -44242,7 +44242,7 @@ class A : System.Attribute
                 // (7,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object o = c.F;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.F").WithLocation(7, 20),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F").WithLocation(8, 9));
         }
@@ -44272,7 +44272,7 @@ class A : System.Attribute
                 // (7,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object o = s.F;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "s.F").WithLocation(7, 20),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.F").WithLocation(8, 9)
                 );
@@ -44304,7 +44304,7 @@ struct S
                 // (7,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         c = s.F;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "s.F").WithLocation(7, 13),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.F").WithLocation(8, 9),
                 // (13,17): warning CS0649: Field 'S.F' is never assigned to, and will always have its default value null
@@ -44380,7 +44380,7 @@ struct S
                 // (7,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         c = s.P;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "s.P").WithLocation(7, 13),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.P").WithLocation(8, 9));
         }
@@ -44403,7 +44403,7 @@ struct S
                 // (6,13): warning CS8601: Possible null reference assignment.
                 //         o = P;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "P").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "P").WithLocation(7, 9));
         }
@@ -44426,7 +44426,7 @@ struct S
                 // (6,13): warning CS8601: Possible null reference assignment.
                 //         o = P;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "P").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "P").WithLocation(7, 9));
         }
@@ -44449,7 +44449,7 @@ struct S
                 // (6,13): warning CS8601: Possible null reference assignment.
                 //         o = P;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "P").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "P").WithLocation(7, 9));
         }
@@ -44478,7 +44478,7 @@ struct S
                 // (6,13): warning CS8601: Possible null reference assignment.
                 //         o = P;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "P").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "P").WithLocation(7, 9)
                 );
@@ -44588,7 +44588,7 @@ namespace System
 }";
             var comp = CreateEmptyCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (16,22): warning CS8602: Possible dereference of a null reference.
+                // (16,22): warning CS8602: Dereference of a possibly null reference.
                 //             _value = _f.GetHashCode();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "_f").WithLocation(16, 22)
                 );
@@ -44828,7 +44828,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (17,11): warning CS8602: Possible dereference of a null reference.
+                // (17,11): warning CS8602: Dereference of a possibly null reference.
                 //         w?.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".F").WithLocation(17, 11));
         }
@@ -45177,13 +45177,13 @@ class C
                 // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         var b1 = (B)s;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(B)s").WithLocation(16, 18),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         b1.F();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b1").WithLocation(17, 9),
                 // (18,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         B b2 = (B)s;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(B)s").WithLocation(18, 16),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         b2.F();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b2").WithLocation(19, 9),
                 // (20,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -45192,7 +45192,7 @@ class C
                 // (20,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         A a = (B)s;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(B)s").WithLocation(20, 15),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.F();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(21, 9));
         }
@@ -46056,13 +46056,13 @@ static class E
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         F((x, y)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((x, y)).Item2").WithLocation(7, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         F((y, x)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, x)).Item2").WithLocation(8, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         F((y, y)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, y)).Item2").WithLocation(9, 9));
         }
@@ -46087,13 +46087,13 @@ static class E
                 // (8,9): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.F<T>((T, T?))'. Nullability of type argument 'string?' doesn't match 'class' constraint.
                 //         F((y, x)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F").WithArguments("C.F<T>((T, T?))", "T", "string?").WithLocation(8, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         F((y, x)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, x)).Item2").WithLocation(8, 9),
                 // (9,9): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.F<T>((T, T?))'. Nullability of type argument 'string?' doesn't match 'class' constraint.
                 //         F((y, y)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F").WithArguments("C.F<T>((T, T?))", "T", "string?").WithLocation(9, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         F((y, y)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, y)).Item2").WithLocation(9, 9));
         }
@@ -46118,13 +46118,13 @@ static class E
                 // (8,9): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.F<T>((T, T?))'. Nullability of type argument 'string?' doesn't match 'class' constraint.
                 //         F(z).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F").WithArguments("C.F<T>((T, T?))", "T", "string?").WithLocation(8, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(z).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(z)").WithLocation(8, 9),
                 // (9,9): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.F<T>((T, T?))'. Nullability of type argument 'string?' doesn't match 'class' constraint.
                 //         F(w).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F").WithArguments("C.F<T>((T, T?))", "T", "string?").WithLocation(9, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(w).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(w)").WithLocation(9, 9));
         }
@@ -46278,7 +46278,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item1.Item1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1.Item1").WithLocation(8, 13));
         }
@@ -46307,13 +46307,13 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             t._7.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t._7").WithLocation(8, 13),
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             t._8.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t._8").WithLocation(9, 13),
-                // (11,13): warning CS8602: Possible dereference of a null reference.
+                // (11,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item2").WithLocation(11, 13));
         }
@@ -46345,16 +46345,16 @@ class C
                 // (6,33): warning CS8619: Nullability of reference types in value of type '(object? a, string)' doesn't match target type '(object, string? b)'.
                 //         (object, string? b) u = t; // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "t").WithArguments("(object? a, string)", "(object, string? b)").WithLocation(6, 33),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1").WithLocation(9, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item1.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1").WithLocation(11, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item2.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item2").WithLocation(12, 9));
             comp.VerifyTypes();
@@ -46386,16 +46386,16 @@ class C
                 // (5,46): warning CS8619: Nullability of reference types in value of type '(object?, object? x, object y)' doesn't match target type '(object x, object? y, object? z)'.
                 //         (object x, object? y, object? z) t = (null, x, y)/*T:(object?, object? x, object! y)*/; // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(null, x, y)").WithArguments("(object?, object? x, object y)", "(object x, object? y, object? z)").WithLocation(5, 46),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.x.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.x").WithLocation(7, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.y.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.y").WithLocation(8, 9),
                 // (11,34): warning CS8619: Nullability of reference types in value of type '(object x, object?)' doesn't match target type '(object x, object y)'.
                 //         (object x, object y) u = (x, default)/*T:(object! x, object?)*/; // 4
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(x, default)").WithArguments("(object x, object?)", "(object x, object y)").WithLocation(11, 34),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.y.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.y").WithLocation(14, 9));
             comp.VerifyTypes();
@@ -46437,13 +46437,13 @@ class Program
                 // (12,22): warning CS8619: Nullability of reference types in value of type '(A?, A)' doesn't match target type '(A, A?)'.
                 //         (A, A?) t1 = (null, new A() { F = 1 }); // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(null, new A() { F = 1 })").WithArguments("(A?, A)", "(A, A?)").WithLocation(12, 22),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         u1.x.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u1.x").WithLocation(14, 9),
                 // (20,22): warning CS8619: Nullability of reference types in value of type '(A?, A)' doesn't match target type '(A, A?)'.
                 //         (A, A?) t2 = (null, new B() { F = 2 }); // 3
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(null, new B() { F = 2 })").WithArguments("(A?, A)", "(A, A?)").WithLocation(20, 22),
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         u2.x.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u2.x").WithLocation(22, 9));
             comp.VerifyTypes();
@@ -46474,16 +46474,16 @@ class Program
                 // (6,31): warning CS8619: Nullability of reference types in value of type '(object?, string)' doesn't match target type '(object, string?)'.
                 //         (object, string?) u = t; // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "t").WithArguments("(object?, string)", "(object, string?)").WithLocation(6, 31),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1").WithLocation(7, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2").WithLocation(8, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item1.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1").WithLocation(9, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item2.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item2").WithLocation(10, 9));
             comp.VerifyTypes();
@@ -46514,10 +46514,10 @@ class Program
                 // (6,35): warning CS8619: Nullability of reference types in value of type '(object?, string)' doesn't match target type '(object a, string? b)'.
                 //         (object a, string? b) u = t; // 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "t").WithArguments("(object?, string)", "(object a, string? b)").WithLocation(6, 35),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item2.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item2").WithLocation(10, 9));
             comp.VerifyTypes();
@@ -46551,13 +46551,13 @@ class Program
                 // (5,52): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (object, string) t = ((object, string))(x, y)/*T:(object! x, string? y)*/; // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y").WithLocation(5, 52),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2").WithLocation(9, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item2").WithLocation(11, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         v.Item2.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v.Item2").WithLocation(13, 9));
             comp.VerifyTypes();
@@ -46591,16 +46591,16 @@ class Program
             // https://github.com/dotnet/roslyn/issues/31395: Nullability of class fields
             // are not inherited on assignment (see t.Item2.F and u.Item2.F).
             comp.VerifyDiagnostics(
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item1.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1.F").WithLocation(14, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2.F").WithLocation(15, 9),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item1.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1.F").WithLocation(16, 9),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item2.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item2.F").WithLocation(17, 9));
             comp.VerifyTypes();
@@ -46644,25 +46644,25 @@ class Program
                 // (6,13): warning CS8619: Nullability of reference types in value of type '(object, object, object, object?, object?, (object? y, object x), object, object, object?, object?)' doesn't match target type '(object?, object, object?, object, object?, (object, object?), object, object, object?, object)'.
                 //             (x, x, x, y, y, (y, x), x, x, y, y)/*T:(object!, object!, object!, object?, object?, (object? y, object! x), object!, object!, object?, object?)*/; // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(x, x, x, y, y, (y, x), x, x, y, y)").WithArguments("(object, object, object, object?, object?, (object? y, object x), object, object, object?, object?)", "(object?, object, object?, object, object?, (object, object?), object, object, object?, object)").WithLocation(6, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item4.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item4").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item5.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item5").WithLocation(11, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item6.Item1.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item6.Item1").WithLocation(12, 9),
-                // (18,13): warning CS8602: Possible dereference of a null reference.
+                // (18,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item9.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item9").WithLocation(18, 13),
-                // (19,13): warning CS8602: Possible dereference of a null reference.
+                // (19,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item10.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item10").WithLocation(19, 13),
-                // (24,13): warning CS8602: Possible dereference of a null reference.
+                // (24,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item2.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item2").WithLocation(24, 13),
-                // (25,13): warning CS8602: Possible dereference of a null reference.
+                // (25,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item3.ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item3").WithLocation(25, 13));
             comp.VerifyTypes();
@@ -46706,28 +46706,28 @@ class Program
                 // (6,13): warning CS8619: Nullability of reference types in value of type '(object, object, object, object?, object?, (object, object?), object, object, object?, object?)' doesn't match target type '(object?, object, object?, object, object?, (object, object?), object, object, object?, object)'.
                 //             (x, x, x, default, default, default, x, x, default, default)/*T:(object!, object!, object!, object?, object?, (object!, object?), object!, object!, object?, object?)*/; // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(x, x, x, default, default, default, x, x, default, default)").WithArguments("(object, object, object, object?, object?, (object, object?), object, object, object?, object?)", "(object?, object, object?, object, object?, (object, object?), object, object, object?, object)").WithLocation(6, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item4.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item4").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item5.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item5").WithLocation(11, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item6.Item1.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item6.Item1").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item6.Item2.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item6.Item2").WithLocation(13, 9),
-                // (18,13): warning CS8602: Possible dereference of a null reference.
+                // (18,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item9.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item9").WithLocation(18, 13),
-                // (19,13): warning CS8602: Possible dereference of a null reference.
+                // (19,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item10.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item10").WithLocation(19, 13),
-                // (24,13): warning CS8602: Possible dereference of a null reference.
+                // (24,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item2.ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item2").WithLocation(24, 13),
-                // (25,13): warning CS8602: Possible dereference of a null reference.
+                // (25,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item3.ToString(); // 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item3").WithLocation(25, 13));
             comp.VerifyTypes();
@@ -46756,7 +46756,7 @@ class Program
                 // (6,31): warning CS8619: Nullability of reference types in value of type '(object?, string)' doesn't match target type '(object, string?)'.
                 //         (object, string?) t = new ValueTuple<object?, string>(null, "") { Item1 = x }; // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, @"new ValueTuple<object?, string>(null, """") { Item1 = x }").WithArguments("(object?, string)", "(object, string?)").WithLocation(6, 31),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1").WithLocation(10, 9));
             comp.VerifyTypes();
@@ -46814,25 +46814,25 @@ class Program
                 // (14,59): warning CS8604: Possible null reference argument for parameter 'item3' in '(object, object?, object).(object item1, object? item2, object item3)'.
                 //             new ValueTuple<object, object?, object>(x, y, y))/*T:(object?, object!, object?, object!, object?, (object!, object?), object!, object!, object?, object!)*/; // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y").WithArguments("item3", "(object, object?, object).(object item1, object? item2, object item3)").WithLocation(14, 59),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item4.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item4").WithLocation(18, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item5.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item5").WithLocation(19, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item6.Item1.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item6.Item1").WithLocation(20, 9),
-                // (26,13): warning CS8602: Possible dereference of a null reference.
+                // (26,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item9.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item9").WithLocation(26, 13),
-                // (27,13): warning CS8602: Possible dereference of a null reference.
+                // (27,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item10.ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item10").WithLocation(27, 13),
-                // (32,13): warning CS8602: Possible dereference of a null reference.
+                // (32,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item2.ToString(); // 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item2").WithLocation(32, 13),
-                // (33,13): warning CS8602: Possible dereference of a null reference.
+                // (33,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item3.ToString(); // 10
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item3").WithLocation(33, 13));
             comp.VerifyTypes();
@@ -46884,34 +46884,34 @@ class Program
                 // (10,13): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //             default, // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(10, 13),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item4.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item4").WithLocation(18, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item5.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item5").WithLocation(19, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item6.Item1.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item6.Item1").WithLocation(20, 9),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item6.Item2.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item6.Item2").WithLocation(21, 9),
-                // (25,13): warning CS8602: Possible dereference of a null reference.
+                // (25,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item8.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item8").WithLocation(25, 13),
-                // (26,13): warning CS8602: Possible dereference of a null reference.
+                // (26,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item9.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item9").WithLocation(26, 13),
-                // (27,13): warning CS8602: Possible dereference of a null reference.
+                // (27,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item10.ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item10").WithLocation(27, 13),
-                // (31,13): warning CS8602: Possible dereference of a null reference.
+                // (31,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item1.ToString(); // 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item1").WithLocation(31, 13),
-                // (32,13): warning CS8602: Possible dereference of a null reference.
+                // (32,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item2.ToString(); // 10
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item2").WithLocation(32, 13),
-                // (33,13): warning CS8602: Possible dereference of a null reference.
+                // (33,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item3.ToString(); // 11
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item3").WithLocation(33, 13));
             comp.VerifyTypes();
@@ -46969,25 +46969,25 @@ class Program
                 // (14,13): warning CS8620: Nullability of reference types in argument of type '(object x, object?, object?)' doesn't match target type '(object, object?, object)' for parameter 'rest' in '(object?, object, object?, object, object?, (object, object?), object, object, object?, object).(object? item1, object item2, object? item3, object item4, object? item5, (object, object?) item6, object item7, (object, object?, object) rest)'.
                 //             (x, y, y))/*T:(object?, object!, object?, object!, object?, (object!, object?), object!, object!, object?, object!)*/; // 3
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(x, y, y)").WithArguments("(object x, object?, object?)", "(object, object?, object)", "rest", "(object?, object, object?, object, object?, (object, object?), object, object, object?, object).(object? item1, object item2, object? item3, object item4, object? item5, (object, object?) item6, object item7, (object, object?, object) rest)").WithLocation(14, 13),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item4.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item4").WithLocation(18, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item5.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item5").WithLocation(19, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item6.Item1.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item6.Item1").WithLocation(20, 9),
-                // (26,13): warning CS8602: Possible dereference of a null reference.
+                // (26,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item9.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item9").WithLocation(26, 13),
-                // (27,13): warning CS8602: Possible dereference of a null reference.
+                // (27,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item10.ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item10").WithLocation(27, 13),
-                // (32,13): warning CS8602: Possible dereference of a null reference.
+                // (32,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item2.ToString(); // 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item2").WithLocation(32, 13),
-                // (33,13): warning CS8602: Possible dereference of a null reference.
+                // (33,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item3.ToString(); // 10
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item3").WithLocation(33, 13));
             comp.VerifyTypes();
@@ -47039,34 +47039,34 @@ class Program
                 // (10,13): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //             default, // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(10, 13),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item4.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item4").WithLocation(18, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item5.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item5").WithLocation(19, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item6.Item1.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item6.Item1").WithLocation(20, 9),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item6.Item2.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item6.Item2").WithLocation(21, 9),
-                // (25,13): warning CS8602: Possible dereference of a null reference.
+                // (25,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item8.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item8").WithLocation(25, 13),
-                // (26,13): warning CS8602: Possible dereference of a null reference.
+                // (26,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item9.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item9").WithLocation(26, 13),
-                // (27,13): warning CS8602: Possible dereference of a null reference.
+                // (27,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Item10.ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item10").WithLocation(27, 13),
-                // (31,13): warning CS8602: Possible dereference of a null reference.
+                // (31,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item1.ToString(); // 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item1").WithLocation(31, 13),
-                // (32,13): warning CS8602: Possible dereference of a null reference.
+                // (32,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item2.ToString(); // 10
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item2").WithLocation(32, 13),
-                // (33,13): warning CS8602: Possible dereference of a null reference.
+                // (33,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.Rest.Item3.ToString(); // 11
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item3").WithLocation(33, 13));
             comp.VerifyTypes();
@@ -47098,10 +47098,10 @@ class Program
                 // (7,21): error CS1729: '(object?, string)' does not contain a constructor that takes 3 arguments
                 //         var u = new ValueTuple<object?, string>(null, null, 3);
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount, "ValueTuple<object?, string>").WithArguments("(object?, string)", "3").WithLocation(7, 21),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1").WithLocation(10, 9));
             comp.VerifyTypes();
@@ -47137,10 +47137,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (16,17): warning CS8602: Possible dereference of a null reference.
+                // (16,17): warning CS8602: Dereference of a possibly null reference.
                 //                 u.y.ToString()) : // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.y").WithLocation(16, 17),
-                // (20,17): warning CS8602: Possible dereference of a null reference.
+                // (20,17): warning CS8602: Dereference of a possibly null reference.
                 //                 v.x.ToString(), // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v.x").WithLocation(20, 17));
             comp.VerifyTypes();
@@ -47171,16 +47171,16 @@ class Program
                 // (6,15): warning CS8619: Nullability of reference types in value of type '(object? x, (string z, object? w) y)' doesn't match target type '(object x, (string? z, object w) y)'.
                 //         c.F = t; // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "t").WithArguments("(object? x, (string z, object? w) y)", "(object x, (string? z, object w) y)").WithLocation(6, 15),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.F.x.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F.x").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.F.y.w.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F.y.w").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item1.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1").WithLocation(11, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item2.Item2.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item2.Item2").WithLocation(13, 9));
             comp.VerifyTypes();
@@ -47208,10 +47208,10 @@ class Program
                 // (5,32): warning CS8619: Nullability of reference types in value of type '(object?, object s)' doesn't match target type '(object, object?)?'.
                 //         (object, object?)? t = (null, s); // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(null, s)").WithArguments("(object?, object s)", "(object, object?)?").WithLocation(5, 32),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Value.Item1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Value.Item1").WithLocation(7, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1").WithLocation(9, 9));
         }
@@ -47234,7 +47234,7 @@ class Program
                 // (5,31): error CS0165: Use of unassigned local variable 't'
                 //         (string, string?) t = t;
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "t").WithArguments("t").WithLocation(5, 31),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2").WithLocation(7, 9));
         }
@@ -47290,7 +47290,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(12, 9));
         }
@@ -47318,7 +47318,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(11, 9));
         }
@@ -47344,7 +47344,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Item1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Item1").WithLocation(7, 9));
         }
@@ -47367,7 +47367,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Item1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Item1").WithLocation(6, 9));
         }
@@ -47401,10 +47401,10 @@ class Program
             // https://github.com/dotnet/roslyn/issues/31395: Nullability of class members should be copied on assignment.
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.G.ToString(); // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.G").WithLocation(16, 9),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(17, 9)
                 );
@@ -47436,10 +47436,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.G.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.G").WithLocation(15, 9),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.G.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.G").WithLocation(17, 9)
                 );
@@ -47472,10 +47472,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Value.G.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Value.G").WithLocation(16, 9),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Value.G.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Value.G").WithLocation(18, 9)
                 );
@@ -47499,7 +47499,7 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             o.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(9, 13)
                 );
@@ -47525,7 +47525,7 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,13): warning CS8602: Possible dereference of a null reference.
+                // (11,13): warning CS8602: Dereference of a possibly null reference.
                 //             t.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(11, 13)
                 );
@@ -47550,7 +47550,7 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             c.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(9, 13)
                 );
@@ -47578,7 +47578,7 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         o.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(15, 9)
                 );
@@ -47600,10 +47600,10 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,18): warning CS8602: Possible dereference of a null reference.
+                // (6,18): warning CS8602: Dereference of a possibly null reference.
                 //         _ = s ?? s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 18),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(9, 9)
                 );
@@ -47622,7 +47622,7 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,15): warning CS8602: Possible dereference of a null reference.
+                // (6,15): warning CS8602: Dereference of a possibly null reference.
                 //         s ??= s.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(6, 15)
                 );
@@ -47655,10 +47655,10 @@ class C
             // so affects both branches
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8602: Possible dereference of a null reference.
+                // (7,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 13),
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //             y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(14, 13)
                 );
@@ -47681,10 +47681,10 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(10, 9)
                 );
@@ -47711,10 +47711,10 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8602: Possible dereference of a null reference.
+                // (7,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 13),
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //             y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(14, 13)
                 );
@@ -47736,7 +47736,7 @@ class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8602: Possible dereference of a null reference.
+                // (7,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 13)
                 );
@@ -47799,10 +47799,10 @@ class Program
                 // (10,37): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         S? x = new S() { F = 1, G = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 37),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Value.G.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Value.G").WithLocation(13, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Value.G.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Value.G").WithLocation(15, 9));
         }
@@ -47934,13 +47934,13 @@ class Program
                 // (15,17): error CS0029: Cannot implicitly convert type 'A' to 'B?'
                 //         B? b1 = a1; // 1
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "a1").WithArguments("A", "B?").WithLocation(15, 17),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         b1.Value.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b1.Value.F").WithLocation(17, 9),
                 // (22,17): error CS0029: Cannot implicitly convert type 'A?' to 'B?'
                 //         B? b2 = a2; // 3
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "a2").WithArguments("A?", "B?").WithLocation(22, 17),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         b2.Value.F.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b2.Value.F").WithLocation(24, 9),
                 // (28,17): error CS0029: Cannot implicitly convert type 'A?' to 'B?'
@@ -47949,7 +47949,7 @@ class Program
                 // (29,13): warning CS8629: Nullable value type may be null.
                 //         _ = b3.Value; // 6
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "b3").WithLocation(29, 13),
-                // (30,9): warning CS8602: Possible dereference of a null reference.
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
                 //         b3.Value.F.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b3.Value.F").WithLocation(30, 9)
                 );
@@ -47980,7 +47980,7 @@ class Program
                 // (10,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         S x = new S() { F = 1, G = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 36),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Value.G.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Value.G").WithLocation(13, 9));
         }
@@ -48010,7 +48010,7 @@ class Program
                 // (10,37): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         S? x = new S() { F = 1, G = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 37),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.G.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.G").WithLocation(13, 9));
         }
@@ -48129,15 +48129,16 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item1.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1.F").WithLocation(14, 9),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.x.Value.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.x.Value.F").WithLocation(16, 9),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         v.Item1.Value.F.ToString(); // 3
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v.Item1.Value.F").WithLocation(18, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v.Item1.Value.F").WithLocation(18, 9)
+                );
         }
 
         [Fact]
@@ -48165,10 +48166,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item1.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1.F").WithLocation(13, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Value.a.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Value.a.F").WithLocation(15, 9));
         }
@@ -48192,10 +48193,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.b.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.b").WithLocation(10, 9));
         }
@@ -48219,10 +48220,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.b.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.b").WithLocation(10, 9));
         }
@@ -48249,10 +48250,10 @@ class Program
                 // (7,38): warning CS8619: Nullability of reference types in value of type '(object? x, object y, object? z)' doesn't match target type '(object, object, object)'.
                 //         (object, object, object) t = (x, y, z); // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(x, y, z)").WithArguments("(object? x, object y, object? z)", "(object, object, object)").WithLocation(7, 38),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item3.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item3").WithLocation(10, 9));
         }
@@ -48280,10 +48281,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         default(S<T>).F/*T:T*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "default(S<T>).F").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         default(S<U>).F/*T:U?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "default(S<U>).F").WithLocation(13, 9),
                 // (14,13): warning CS8629: Nullable value type may be null.
@@ -48316,10 +48317,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         new S<T>().F/*T:T*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "new S<T>().F").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         new S<U>().F/*T:U?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "new S<U>().F").WithLocation(13, 9),
                 // (14,13): warning CS8629: Nullable value type may be null.
@@ -48351,10 +48352,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F/*T:object?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.F").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F/*T:object?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(13, 9));
             comp.VerifyTypes();
@@ -48412,10 +48413,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F/*T:object?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.F").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F/*T:object?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(13, 9));
             comp.VerifyTypes();
@@ -48478,10 +48479,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.G/*T:string?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.G").WithLocation(13, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F/*T:object?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(15, 9),
                 // (17,47): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -48490,10 +48491,10 @@ class Program
                 // (17,60): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         var z = new S<object, string>() { F = default, G = default }; // 3, 4
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(17, 60),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.F/*T:object?*/.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z.F").WithLocation(18, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.G/*T:string?*/.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z.G").WithLocation(19, 9));
             comp.VerifyTypes();
@@ -48527,7 +48528,7 @@ class Program
                 // (5,14): error CS0568: Structs cannot contain explicit parameterless constructors
                 //     internal S() { F = default!; }
                 Diagnostic(ErrorCode.ERR_StructsCantContainDefaultConstructor, "S").WithLocation(5, 14),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F/*T:object?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.F").WithLocation(13, 9));
             comp.VerifyTypes();
@@ -48585,16 +48586,16 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.F/*T:T1*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1.F").WithLocation(11, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         y1.F/*T:T1*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1.F").WithLocation(12, 9),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.F/*T:T2?*/.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2.F").WithLocation(17, 9),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         y2.F/*T:T2?*/.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2.F").WithLocation(18, 9),
                 // (23,13): warning CS8629: Nullable value type may be null.
@@ -48635,7 +48636,7 @@ class Program
                 // (9,67): error CS1736: Default parameter value for 'z' must be a compile-time constant
                 //     static void F<T>(S<T> x = new S<T>(), S<T> y = null, S<T> z = new S<T>(default)) where T : class
                 Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "new S<T>(default)").WithArguments("z").WithLocation(9, 67),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F/*T:T?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.F").WithLocation(11, 9));
             comp.VerifyTypes();
@@ -48664,7 +48665,7 @@ class Program
                 // (8,42): error CS1525: Invalid expression term ','
                 //     static void F<T>(S<T> x = /*missing*/, S<T> y = default) where T : class
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, ",").WithArguments(",").WithLocation(8, 42),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F/*T:T?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(11, 9));
             comp.VerifyTypes();
@@ -48743,16 +48744,16 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         s1.S1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s1.S1").WithLocation(22, 9),
-                // (23,9): warning CS8602: Possible dereference of a null reference.
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
                 //         s1.T.T1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s1.T.T1").WithLocation(23, 9),
-                // (29,9): warning CS8602: Possible dereference of a null reference.
+                // (29,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2.S1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2.S1").WithLocation(29, 9),
-                // (30,9): warning CS8602: Possible dereference of a null reference.
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
                 //         s2.T.T1.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2.T.T1").WithLocation(30, 9));
         }
@@ -48820,10 +48821,10 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F/*T:object?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.F").WithLocation(17, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F/*T:object?*/.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(19, 9));
             comp.VerifyTypes();
@@ -48871,7 +48872,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,9): warning CS8602: Possible dereference of a null reference.
+                // (5,9): warning CS8602: Dereference of a possibly null reference.
                 //         default((object?, string))/*T:(object?, string!)*/.Item2.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "default((object?, string))/*T:(object?, string!)*/.Item2").WithLocation(5, 9),
                 // (6,13): warning CS8629: Nullable value type may be null.
@@ -48897,7 +48898,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         new ValueTuple<object?, string>()/*T:(object?, string!)*/.Item2.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "new ValueTuple<object?, string>()/*T:(object?, string!)*/.Item2").WithLocation(6, 9),
                 // (7,13): warning CS8629: Nullable value type may be null.
@@ -48926,16 +48927,16 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item1/*T:object?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1").WithLocation(7, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.Item2/*T:string?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2.Item2").WithLocation(8, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item1/*T:object?*/.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1").WithLocation(9, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item2.Item2/*T:string?*/.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item2.Item2").WithLocation(10, 9));
             comp.VerifyTypes();
@@ -48987,16 +48988,16 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item1/*T:object?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1").WithLocation(8, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.Item2/*T:string?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2.Item2").WithLocation(9, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item1/*T:object?*/.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item2.Item2/*T:string?*/.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item2.Item2").WithLocation(11, 9));
             comp.VerifyTypes();
@@ -49075,19 +49076,19 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.x/*T:T*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.x").WithLocation(8, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.y/*T:U?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.y").WithLocation(9, 9),
                 // (10,13): warning CS8629: Nullable value type may be null.
                 //         _ = t.z/*T:V?*/.Value; // 3
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "t.z").WithLocation(10, 13),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.x/*T:T*/.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.x").WithLocation(11, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.y/*T:U?*/.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.y").WithLocation(12, 9),
                 // (13,13): warning CS8629: Nullable value type may be null.
@@ -49130,22 +49131,22 @@ class Program
                 // (6,24): error CS1736: Default parameter value for 'z' must be a compile-time constant
                 //         (T, U, V?) z = (default(T), new U(), new V()))
                 Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "(default(T), new U(), new V())").WithArguments("z").WithLocation(6, 24),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Item1/*T:T*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Item1").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Item2/*T:U?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Item2").WithLocation(11, 9),
                 // (12,13): warning CS8629: Nullable value type may be null.
                 //         _ = x.Item3/*T:V?*/.Value; // 3
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "x.Item3").WithLocation(12, 13),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Item1/*T:T*/.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Item1").WithLocation(13, 9),
                 // (15,13): warning CS8629: Nullable value type may be null.
                 //         _ = y.Item3/*T:V?*/.Value; // 5
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "y.Item3").WithLocation(15, 13),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.Item1/*T:T*/.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z.Item1").WithLocation(16, 9),
                 // (18,13): warning CS8629: Nullable value type may be null.
@@ -49306,7 +49307,7 @@ class C
                 // (32,11): error CS0070: The event '(object, object).E2' can only appear on the left hand side of += or -= (except when used from within the type '(object, object)')
                 //         z.E2?.Invoke().ToString();
                 Diagnostic(ErrorCode.ERR_BadEventUsage, "E2").WithArguments("(object, object).E2", "(object, object)").WithLocation(32, 11),
-                // (26,9): warning CS8602: Possible dereference of a null reference.
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.P1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.P1").WithLocation(26, 9),
                 // (17,31): warning CS0414: The field 'ValueTuple<T1, T2>.E2' is assigned but its value is never used
@@ -49359,10 +49360,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), targetFramework: TargetFramework.Mscorlib46);
             comp.VerifyDiagnostics(
-                // (29,9): warning CS8602: Possible dereference of a null reference.
+                // (29,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F.ToString();        // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(29, 9),
-                // (30,9): warning CS8602: Possible dereference of a null reference.
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Item2.ToString();    // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Item2").WithLocation(30, 9));
         }
@@ -49430,10 +49431,10 @@ class C
 
             var comp2 = CreateEmptyCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp2.VerifyDiagnostics(
-                // (44,9): warning CS8602: Possible dereference of a null reference.
+                // (44,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(44, 9),
-                // (45,9): warning CS8602: Possible dereference of a null reference.
+                // (45,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.P").WithLocation(45, 9));
         }
@@ -49680,10 +49681,10 @@ class P
                 // (9,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y = x;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x").WithLocation(9, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(11, 9),
                 // (12,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -49725,10 +49726,10 @@ class C
                 // (11,15): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         c.P = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 15),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.F.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.P.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.P").WithLocation(13, 9));
         }
@@ -49766,13 +49767,13 @@ class Program
                 // (11,36): warning CS8601: Possible null reference assignment.
                 //         c1 = new C<object>() { F = c1.F }; // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c1.F").WithLocation(11, 36),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         c1.F.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1.F").WithLocation(12, 9),
                 // (17,31): warning CS8653: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         c2 = new C<T>() { F = default }; // 4
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(17, 31),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         c2.F.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2.F").WithLocation(19, 9));
         }
@@ -49810,10 +49811,10 @@ class Program
 }";
             var comp1 = CreateCompilation(new[] { source1 }, options: WithNonNullTypesTrue(), references: new[] { comp0.EmitToImageReference() });
             comp1.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F").WithLocation(9, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.P.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.P").WithLocation(10, 9));
         }
@@ -49991,34 +49992,34 @@ class C
                 // (12,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         ((A<string>)null).F.ToString();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(A<string>)null").WithLocation(12, 10),
-                // (12,10): warning CS8602: Possible dereference of a null reference.
+                // (12,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string>)null).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string>)null").WithLocation(12, 10),
-                // (13,10): warning CS8602: Possible dereference of a null reference.
+                // (13,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string>?)null).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string>?)null").WithLocation(13, 10),
                 // (14,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         ((A<string?>)default).F.ToString();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(A<string?>)default").WithLocation(14, 10),
-                // (14,10): warning CS8602: Possible dereference of a null reference.
+                // (14,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string?>)default).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string?>)default").WithLocation(14, 10),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string?>)default).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A<string?>)default).F").WithLocation(14, 9),
-                // (15,10): warning CS8602: Possible dereference of a null reference.
+                // (15,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string?>?)default).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string?>?)default").WithLocation(15, 10),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string?>?)default).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A<string?>?)default).F").WithLocation(15, 9),
                 // (19,10): warning CS8619: Nullability of reference types in value of type 'A<string>' doesn't match target type 'B2'.
                 //         ((B2?)x1).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(B2?)x1").WithArguments("A<string>", "B2").WithLocation(19, 10),
-                // (19,10): warning CS8602: Possible dereference of a null reference.
+                // (19,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((B2?)x1).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(B2?)x1").WithLocation(19, 10),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((B2?)x1).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((B2?)x1).F").WithLocation(19, 9),
                 // (20,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -50027,19 +50028,19 @@ class C
                 // (20,10): warning CS8619: Nullability of reference types in value of type 'A<string>' doesn't match target type 'B2'.
                 //         ((B2)y1).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(B2)y1").WithArguments("A<string>", "B2").WithLocation(20, 10),
-                // (20,10): warning CS8602: Possible dereference of a null reference.
+                // (20,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((B2)y1).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(B2)y1").WithLocation(20, 10),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((B2)y1).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((B2)y1).F").WithLocation(20, 9),
                 // (24,10): warning CS8619: Nullability of reference types in value of type 'B1' doesn't match target type 'A<string?>'.
                 //         ((A<string?>?)x2).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(A<string?>?)x2").WithArguments("B1", "A<string?>").WithLocation(24, 10),
-                // (24,10): warning CS8602: Possible dereference of a null reference.
+                // (24,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string?>?)x2).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string?>?)x2").WithLocation(24, 10),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string?>?)x2).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A<string?>?)x2).F").WithLocation(24, 9),
                 // (25,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -50048,31 +50049,31 @@ class C
                 // (25,10): warning CS8619: Nullability of reference types in value of type 'B1' doesn't match target type 'A<string?>'.
                 //         ((A<string?>)y2).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(A<string?>)y2").WithArguments("B1", "A<string?>").WithLocation(25, 10),
-                // (25,10): warning CS8602: Possible dereference of a null reference.
+                // (25,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string?>)y2).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string?>)y2").WithLocation(25, 10),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string?>)y2).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((A<string?>)y2).F").WithLocation(25, 9),
-                // (29,10): warning CS8602: Possible dereference of a null reference.
+                // (29,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((B2?)x3).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(B2?)x3").WithLocation(29, 10),
-                // (29,9): warning CS8602: Possible dereference of a null reference.
+                // (29,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((B2?)x3).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((B2?)x3).F").WithLocation(29, 9),
                 // (30,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         ((B2)y3).F.ToString();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(B2)y3").WithLocation(30, 10),
-                // (30,10): warning CS8602: Possible dereference of a null reference.
+                // (30,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((B2)y3).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(B2)y3").WithLocation(30, 10),
-                // (30,9): warning CS8602: Possible dereference of a null reference.
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((B2)y3).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((B2)y3).F").WithLocation(30, 9),
                 // (34,10): warning CS8619: Nullability of reference types in value of type 'B2' doesn't match target type 'A<string>'.
                 //         ((A<string>?)x4).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(A<string>?)x4").WithArguments("B2", "A<string>").WithLocation(34, 10),
-                // (34,10): warning CS8602: Possible dereference of a null reference.
+                // (34,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string>?)x4).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string>?)x4").WithLocation(34, 10),
                 // (35,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -50081,7 +50082,7 @@ class C
                 // (35,10): warning CS8619: Nullability of reference types in value of type 'B2' doesn't match target type 'A<string>'.
                 //         ((A<string>)y4).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(A<string>)y4").WithArguments("B2", "A<string>").WithLocation(35, 10),
-                // (35,10): warning CS8602: Possible dereference of a null reference.
+                // (35,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((A<string>)y4).F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(A<string>)y4").WithLocation(35, 10)
                 );
@@ -50538,16 +50539,16 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (15,13): warning CS8602: Possible dereference of a null reference.
+                // (15,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(15, 13),
                 // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (object y in e)
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "object").WithLocation(16, 18),
-                // (17,13): warning CS8602: Possible dereference of a null reference.
+                // (17,13): warning CS8602: Dereference of a possibly null reference.
                 //             y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(17, 13),
-                // (19,13): warning CS8602: Possible dereference of a null reference.
+                // (19,13): warning CS8602: Dereference of a possibly null reference.
                 //             z.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(19, 13));
         }
@@ -50619,22 +50620,22 @@ class C
 }";
             var comp = CreateEmptyCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (50,13): warning CS8602: Possible dereference of a null reference.
+                // (50,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(50, 13),
                 // (51,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (object y in e)
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "object").WithLocation(51, 18),
-                // (52,13): warning CS8602: Possible dereference of a null reference.
+                // (52,13): warning CS8602: Dereference of a possibly null reference.
                 //             y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(52, 13),
-                // (57,13): warning CS8602: Possible dereference of a null reference.
+                // (57,13): warning CS8602: Dereference of a possibly null reference.
                 //             z.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(57, 13),
                 // (58,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (object w in e)
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "object").WithLocation(58, 18),
-                // (59,13): warning CS8602: Possible dereference of a null reference.
+                // (59,13): warning CS8602: Dereference of a possibly null reference.
                 //             w.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w").WithLocation(59, 13));
         }
@@ -50660,10 +50661,10 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13),
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //             y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(10, 13));
         }
@@ -50716,22 +50717,22 @@ class P
                 // (10,28): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'C<T>'. Nullability of type argument 'T?' doesn't match 'class' constraint.
                 //     static void F<T>(C<T?> c) where T : class
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "c").WithArguments("C<T>", "T", "T?").WithLocation(10, 28),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(13, 13),
-                // (15,13): warning CS8602: Possible dereference of a null reference.
+                // (15,13): warning CS8602: Dereference of a possibly null reference.
                 //             y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(15, 13),
                 // (16,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (T z in c)
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "T").WithLocation(16, 18),
-                // (17,13): warning CS8602: Possible dereference of a null reference.
+                // (17,13): warning CS8602: Dereference of a possibly null reference.
                 //             z.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(17, 13),
                 // (18,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (object w in c)
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "object").WithLocation(18, 18),
-                // (19,13): warning CS8602: Possible dereference of a null reference.
+                // (19,13): warning CS8602: Dereference of a possibly null reference.
                 //             w.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w").WithLocation(19, 13));
         }
@@ -50779,7 +50780,7 @@ class P
                 // (25,34): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'S<T>'. Nullability of type argument 'T?' doesn't match 'class' constraint.
                 //         foreach (var x2 in new S<T?>())
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "T?").WithArguments("S<T>", "T", "T?").WithLocation(25, 34),
-                // (26,13): warning CS8602: Possible dereference of a null reference.
+                // (26,13): warning CS8602: Dereference of a possibly null reference.
                 //             x2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(26, 13),
                 // (27,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -50788,19 +50789,19 @@ class P
                 // (27,32): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'S<T>'. Nullability of type argument 'T?' doesn't match 'class' constraint.
                 //         foreach (T y2 in new S<T?>())
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "T?").WithArguments("S<T>", "T", "T?").WithLocation(27, 32),
-                // (28,13): warning CS8602: Possible dereference of a null reference.
+                // (28,13): warning CS8602: Dereference of a possibly null reference.
                 //             y2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(28, 13),
                 // (29,33): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'S<T>'. Nullability of type argument 'T?' doesn't match 'class' constraint.
                 //         foreach (T? z2 in new S<T?>())
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "T?").WithArguments("S<T>", "T", "T?").WithLocation(29, 33),
-                // (30,13): warning CS8602: Possible dereference of a null reference.
+                // (30,13): warning CS8602: Dereference of a possibly null reference.
                 //             z2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z2").WithLocation(30, 13),
                 // (31,38): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'S<T>'. Nullability of type argument 'T?' doesn't match 'class' constraint.
                 //         foreach (object? w2 in new S<T?>())
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "T?").WithArguments("S<T>", "T", "T?").WithLocation(31, 38),
-                // (32,13): warning CS8602: Possible dereference of a null reference.
+                // (32,13): warning CS8602: Dereference of a possibly null reference.
                 //             w2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w2").WithLocation(32, 13));
         }
@@ -50839,10 +50840,10 @@ static class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //             a1.P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a1.P").WithLocation(10, 13),
-                // (24,13): warning CS8602: Possible dereference of a null reference.
+                // (24,13): warning CS8602: Dereference of a possibly null reference.
                 //             a3.P.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a3.P").WithLocation(24, 13));
         }
@@ -50871,25 +50872,25 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //             a1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a1").WithLocation(8, 13),
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //             a2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a2").WithLocation(10, 13),
                 // (11,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (A a3 in c)
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "A").WithLocation(11, 18),
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             a3.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a3").WithLocation(12, 13),
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //             b1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b1").WithLocation(14, 13),
                 // (15,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (B b2 in c)
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "B").WithLocation(15, 18),
-                // (16,13): warning CS8602: Possible dereference of a null reference.
+                // (16,13): warning CS8602: Dereference of a possibly null reference.
                 //             b2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b2").WithLocation(16, 13));
         }
@@ -50924,10 +50925,10 @@ class C
             // for `A<object> a3 in c` and `B b1 in c`.
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //             a1.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a1.F").WithLocation(13, 13),
-                // (15,13): warning CS8602: Possible dereference of a null reference.
+                // (15,13): warning CS8602: Dereference of a possibly null reference.
                 //             a2.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a2.F").WithLocation(15, 13));
         }
@@ -50965,10 +50966,10 @@ class C
                 // (15,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (B y in e)
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "B").WithLocation(15, 18),
-                // (16,13): warning CS8602: Possible dereference of a null reference.
+                // (16,13): warning CS8602: Dereference of a possibly null reference.
                 //             y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(16, 13),
-                // (19,13): warning CS8602: Possible dereference of a null reference.
+                // (19,13): warning CS8602: Dereference of a possibly null reference.
                 //             z.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(19, 13)
                 );
@@ -51007,16 +51008,16 @@ class C
                 // (13,27): error CS0186: Use of null is not valid in this context
                 //         foreach (var z in default(IEnumerable)) // 3
                 Diagnostic(ErrorCode.ERR_NullNotValid, "default(IEnumerable)").WithLocation(13, 27),
-                // (7,27): warning CS8602: Possible dereference of a null reference.
+                // (7,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var x in (IEnumerable?)null) // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable?)null").WithLocation(7, 27),
                 // (10,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (var y in (IEnumerable<object>)default) // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(IEnumerable<object>)default").WithLocation(10, 27),
-                // (10,27): warning CS8602: Possible dereference of a null reference.
+                // (10,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var y in (IEnumerable<object>)default) // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable<object>)default").WithLocation(10, 27),
-                // (13,27): warning CS8602: Possible dereference of a null reference.
+                // (13,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var z in default(IEnumerable)) // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "default(IEnumerable)").WithLocation(13, 27));
         }
@@ -51067,19 +51068,19 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,27): warning CS8602: Possible dereference of a null reference.
+                // (7,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var x in c1) // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1").WithLocation(7, 27),
                 // (16,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (var y in (IEnumerable)c1) // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(IEnumerable)c1").WithLocation(16, 27),
-                // (16,27): warning CS8602: Possible dereference of a null reference.
+                // (16,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var y in (IEnumerable)c1) // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable)c1").WithLocation(16, 27),
-                // (29,27): warning CS8602: Possible dereference of a null reference.
+                // (29,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var x in c2) // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(29, 27),
-                // (35,27): warning CS8602: Possible dereference of a null reference.
+                // (35,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var y in (IEnumerable?)c2) // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable?)c2").WithLocation(35, 27));
         }
@@ -51126,25 +51127,25 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,27): warning CS8602: Possible dereference of a null reference.
+                // (7,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var x in t1) // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1").WithLocation(7, 27),
-                // (13,27): warning CS8602: Possible dereference of a null reference.
+                // (13,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var y in (IEnumerable<object>?)t1) // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable<object>?)t1").WithLocation(13, 27),
                 // (19,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (var z in (IEnumerable<object>)t1) // 3
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(IEnumerable<object>)t1").WithLocation(19, 27),
-                // (19,27): warning CS8602: Possible dereference of a null reference.
+                // (19,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var z in (IEnumerable<object>)t1) // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable<object>)t1").WithLocation(19, 27),
-                // (25,27): warning CS8602: Possible dereference of a null reference.
+                // (25,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var w in (IEnumerable?)t2) // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable?)t2").WithLocation(25, 27),
                 // (31,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (var v in (IEnumerable)t2) // 5
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(IEnumerable)t2").WithLocation(31, 27),
-                // (31,27): warning CS8602: Possible dereference of a null reference.
+                // (31,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var v in (IEnumerable)t2) // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable)t2").WithLocation(31, 27));
         }
@@ -51194,25 +51195,25 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,27): warning CS8602: Possible dereference of a null reference.
+                // (7,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var x in t1) // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1").WithLocation(7, 27),
-                // (16,27): warning CS8602: Possible dereference of a null reference.
+                // (16,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var w in (IEnumerable?)t1) // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable?)t1").WithLocation(16, 27),
                 // (22,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (var v in (IEnumerable)t1) // 3
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(IEnumerable)t1").WithLocation(22, 27),
-                // (22,27): warning CS8602: Possible dereference of a null reference.
+                // (22,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var v in (IEnumerable)t1) // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable)t1").WithLocation(22, 27),
-                // (28,27): warning CS8602: Possible dereference of a null reference.
+                // (28,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var y in (IEnumerable<object>?)t2) // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable<object>?)t2").WithLocation(28, 27),
                 // (34,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         foreach (var z in (IEnumerable<object>)t2) // 5
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(IEnumerable<object>)t2").WithLocation(34, 27),
-                // (34,27): warning CS8602: Possible dereference of a null reference.
+                // (34,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var z in (IEnumerable<object>)t2) // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable<object>)t2").WithLocation(34, 27)
                 );
@@ -51249,7 +51250,7 @@ class C
             // https://github.com/dotnet/roslyn/issues/29972: Should report WRN_NullReferenceReceiver using Enumerable.GetEnumerator.
 
             comp.VerifyDiagnostics(
-                // (13,27): warning CS8602: Possible dereference of a null reference.
+                // (13,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var y in (IEnumerable?)e) // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable?)e").WithLocation(13, 27)
                 );
@@ -51316,7 +51317,7 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y)").WithLocation(11, 9));
         }
@@ -51357,7 +51358,7 @@ class C
                 // (10,12): warning CS8620: Nullability of reference types in argument of type 'I<string>' doesn't match target type 'I<string?>' for parameter 't' in 'string C.F1<string>(I<string?> t)'.
                 //         F1(x1).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x1").WithArguments("I<string>", "I<string?>", "t", "string C.F1<string>(I<string?> t)").WithLocation(10, 12),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         F1(y1).ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1(y1)").WithLocation(11, 9),
                 // (19,12): warning CS8620: Nullability of reference types in argument of type 'I<string>' doesn't match target type 'I<string?>' for parameter 't' in 'string C.F2<string>(I<string?> t)'.
@@ -52037,13 +52038,13 @@ class Program
                 // (6,9): warning CS8634: The type 'C?' cannot be used as type parameter 'T' in the generic type or method 'C.F<T>(T, T?)'. Nullability of type argument 'C?' doesn't match 'class' constraint.
                 //         F(x, x).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F").WithArguments("C.F<T>(T, T?)", "T", "C?").WithLocation(6, 9),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(x, x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, x)").WithLocation(6, 9),
                 // (7,9): warning CS8634: The type 'C?' cannot be used as type parameter 'T' in the generic type or method 'C.F<T>(T, T?)'. Nullability of type argument 'C?' doesn't match 'class' constraint.
                 //         F(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F").WithArguments("C.F<T>(T, T?)", "T", "C?").WithLocation(7, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, y)").WithLocation(7, 9));
         }
@@ -52067,10 +52068,10 @@ class Program
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(x, x).ToString(); // warning: may be null
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, x)").WithLocation(6, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(x, y).ToString(); // warning may be null
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, y)").WithLocation(7, 9),
                 // (8,9): warning CS8631: The type 'C?' cannot be used as type parameter 'U' in the generic type or method 'C.F<T, U>(T, U)'. Nullability of type argument 'C?' doesn't match constraint type 'C'.
@@ -52575,19 +52576,19 @@ class C
                 // (14,11): warning CS8620: Nullability of reference types in argument of type 'I<string?>' doesn't match target type 'I<string>' for parameter 'x' in 'string C.F<string>(I<string> x, I<string> y)'.
                 //         F(y1, x1)/*T:string!*/.ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y1").WithArguments("I<string?>", "I<string>", "x", "string C.F<string>(I<string> x, I<string> y)").WithLocation(14, 11),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(y1, y1)/*T:string?*/.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y1, y1)").WithLocation(15, 9),
-                // (26,9): warning CS8602: Possible dereference of a null reference.
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(y2, y2)/*T:string?*/.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y2, y2)").WithLocation(26, 9),
-                // (35,9): warning CS8602: Possible dereference of a null reference.
+                // (35,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(x3, y3)/*T:string?*/.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x3, y3)").WithLocation(35, 9),
-                // (36,9): warning CS8602: Possible dereference of a null reference.
+                // (36,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(y3, x3)/*T:string?*/.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y3, x3)").WithLocation(36, 9),
-                // (37,9): warning CS8602: Possible dereference of a null reference.
+                // (37,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(y3, y3)/*T:string?*/.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y3, y3)").WithLocation(37, 9));
         }
@@ -52660,13 +52661,13 @@ class C
                 // (36,9): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.F<T>(IOut<T>, IOut<T?>)'. Nullability of type argument 'string?' doesn't match 'class' constraint.
                 //         F(y3, x3).ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F").WithArguments("C.F<T>(IOut<T>, IOut<T?>)", "T", "string?").WithLocation(36, 9),
-                // (36,9): warning CS8602: Possible dereference of a null reference.
+                // (36,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(y3, x3).ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y3, x3)").WithLocation(36, 9),
                 // (37,9): warning CS8634: The type 'string?' cannot be used as type parameter 'T' in the generic type or method 'C.F<T>(IOut<T>, IOut<T?>)'. Nullability of type argument 'string?' doesn't match 'class' constraint.
                 //         F(y3, y3).ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F").WithArguments("C.F<T>(IOut<T>, IOut<T?>)", "T", "string?").WithLocation(37, 9),
-                // (37,9): warning CS8602: Possible dereference of a null reference.
+                // (37,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(y3, y3).ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y3, y3)").WithLocation(37, 9));
         }
@@ -52745,13 +52746,13 @@ public class NotNull
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), references: new[] { ref0, ref1 });
             comp.VerifyTypes();
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(x2.A1, y2.A2)/*T:A<object?>!*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x2.A1, y2.A2)/*T:A<object?>!*/.F").WithLocation(10, 9),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(x3.A2, y3.A1)/*T:A<object?>!*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x3.A2, y3.A1)/*T:A<object?>!*/.F").WithLocation(14, 9),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(x4.A2, y4.A2)/*T:A<object?>!*/.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x4.A2, y4.A2)/*T:A<object?>!*/.F").WithLocation(18, 9),
                 // (30,11): warning CS8620: Nullability of reference types in argument of type 'A<object?>' doesn't match target type 'A<object>' for parameter 'x' in 'A<object> C.F<A<object>>(A<object> x, A<object> y)'.
@@ -52824,7 +52825,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(y: y, x: x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y: y, x: x)").WithLocation(10, 9));
         }
@@ -52850,7 +52851,7 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y)").WithLocation(11, 9));
         }
@@ -52874,7 +52875,7 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(F2()).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(F2())").WithLocation(9, 9));
         }
@@ -52898,7 +52899,7 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(Q).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(Q)").WithLocation(9, 9));
         }
@@ -52922,7 +52923,7 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(F2).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(F2)").WithLocation(9, 9));
         }
@@ -52969,10 +52970,10 @@ class C
                 // (9,9): error CS0411: The type arguments for method 'C.F<T>(T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         F(default).ToString();
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "F").WithArguments("C.F<T>(T)").WithLocation(9, 9),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(default(object)).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(default(object))").WithLocation(6, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(default(string)).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(default(string))").WithLocation(8, 9));
         }
@@ -52993,7 +52994,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(t).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(t).Item2").WithLocation(8, 9));
         }
@@ -53021,16 +53022,16 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(t).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(t).Item2").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(t).y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(t).y").WithLocation(10, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(u).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(u).Item2").WithLocation(13, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(u).b.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(u).b").WithLocation(15, 9));
         }
@@ -53051,7 +53052,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.y").WithLocation(8, 9));
         }
@@ -53144,13 +53145,13 @@ class C
                 new[] { source }, options: WithNonNullTypesTrue(),
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (9,17): warning CS8602: Possible dereference of a null reference.
+                // (9,17): warning CS8602: Dereference of a possibly null reference.
                 //                 F(x ?? x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x ?? x)").WithLocation(9, 17),
-                // (12,17): warning CS8602: Possible dereference of a null reference.
+                // (12,17): warning CS8602: Dereference of a possibly null reference.
                 //                 F(x ?? y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x ?? y)").WithLocation(12, 17),
-                // (18,17): warning CS8602: Possible dereference of a null reference.
+                // (18,17): warning CS8602: Dereference of a possibly null reference.
                 //                 F(y ?? y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y ?? y)").WithLocation(18, 17));
         }
@@ -53211,10 +53212,10 @@ class C<T>
                 // (4,24): warning CS8653: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //     internal T field = default;
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(4, 24),
-                // (8,16): warning CS8602: Possible dereference of a null reference.
+                // (8,16): warning CS8602: Dereference of a possibly null reference.
                 //         if (c) a.field.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.field").WithLocation(8, 16),
-                // (11,16): warning CS8602: Possible dereference of a null reference.
+                // (11,16): warning CS8602: Dereference of a possibly null reference.
                 //         if (c) b.field.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.field").WithLocation(11, 16));
         }
@@ -53339,7 +53340,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F").WithLocation(9, 9));
         }
@@ -53390,22 +53391,22 @@ class Program
                 // (26,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.A; // 3
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.A").WithLocation(26, 13),
-                // (28,13): warning CS8602: Possible dereference of a null reference.
+                // (28,13): warning CS8602: Dereference of a possibly null reference.
                 //         o = c.B.A; // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.B").WithLocation(28, 13),
                 // (28,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.A; // 4
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.A").WithLocation(28, 13),
-                // (30,13): warning CS8602: Possible dereference of a null reference.
+                // (30,13): warning CS8602: Dereference of a possibly null reference.
                 //         o = c.B.A; // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.B").WithLocation(30, 13),
                 // (30,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.A; // 5
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.A").WithLocation(30, 13),
-                // (32,13): warning CS8602: Possible dereference of a null reference.
+                // (32,13): warning CS8602: Dereference of a possibly null reference.
                 //         o = c.B.A; // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(32, 13),
-                // (32,13): warning CS8602: Possible dereference of a null reference.
+                // (32,13): warning CS8602: Dereference of a possibly null reference.
                 //         o = c.B.A; // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.B").WithLocation(32, 13),
                 // (32,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -53454,7 +53455,7 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (17,13): warning CS8602: Possible dereference of a null reference.
+                // (17,13): warning CS8602: Dereference of a possibly null reference.
                 //         o = c.A.A; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.A").WithLocation(17, 13),
                 // (17,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -53475,7 +53476,7 @@ class Program
                 // (30,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.F; // 4
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.F").WithLocation(30, 13),
-                // (32,13): warning CS8602: Possible dereference of a null reference.
+                // (32,13): warning CS8602: Dereference of a possibly null reference.
                 //         o = c.A.A; // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.A").WithLocation(32, 13),
                 // (32,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -53527,7 +53528,7 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (17,13): warning CS8602: Possible dereference of a null reference.
+                // (17,13): warning CS8602: Dereference of a possibly null reference.
                 //         o = c.A.A; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.A").WithLocation(17, 13),
                 // (17,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -53548,7 +53549,7 @@ class Program
                 // (30,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         o = c.B.P; // 4
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "c.B.P").WithLocation(30, 13),
-                // (32,13): warning CS8602: Possible dereference of a null reference.
+                // (32,13): warning CS8602: Dereference of a possibly null reference.
                 //         o = c.A.A; // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.A").WithLocation(32, 13),
                 // (32,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -53812,16 +53813,16 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.G.F2.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.G.F2").WithLocation(19, 9),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.G.F1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.G.F1").WithLocation(21, 9),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.G.F1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.G.F1").WithLocation(24, 9),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.G.F2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.G.F2").WithLocation(25, 9));
         }
@@ -53859,16 +53860,16 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.G.F2.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.G.F2").WithLocation(19, 9),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.G.F1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.G.F1").WithLocation(21, 9),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.G.F1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.G.F1").WithLocation(24, 9),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.G.F2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.G.F2").WithLocation(25, 9));
         }
@@ -53906,16 +53907,16 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.Q.P2.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.Q.P2").WithLocation(19, 9),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.Q.P1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.Q.P1").WithLocation(21, 9),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.Q.P1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.Q.P1").WithLocation(24, 9),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.Q.P2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.Q.P2").WithLocation(25, 9));
         }
@@ -53939,7 +53940,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.E.Invoke(); // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.E").WithLocation(9, 9));
         }
@@ -53976,10 +53977,10 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.F").WithLocation(18, 9),
-                // (23,9): warning CS8602: Possible dereference of a null reference.
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.F").WithLocation(23, 9));
         }
@@ -54020,19 +54021,19 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.F").WithLocation(17, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.F").WithLocation(20, 9),
-                // (23,9): warning CS8602: Possible dereference of a null reference.
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.F.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.F").WithLocation(23, 9),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.F.F.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.F.F").WithLocation(24, 9),
-                // (27,9): warning CS8602: Possible dereference of a null reference.
+                // (27,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.F.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.F").WithLocation(27, 9));
         }
@@ -54066,7 +54067,7 @@ class Program
                 // (15,36): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         a = new B() { FA = 2, FB = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(15, 36),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((B)a).FB.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((B)a).FB").WithLocation(17, 9));
         }
@@ -54099,7 +54100,7 @@ class Program
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/31395: Nullability of class members should be copied on assignment.
             comp.VerifyDiagnostics(
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.FA.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.FA").WithLocation(15, 9),
                 // (16,28): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -54135,7 +54136,7 @@ class Program
                 // (14,16): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         b.PB = null; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(14, 16),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((IB)(object)b).PB.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((IB)(object)b).PB").WithLocation(16, 9));
         }
@@ -54176,10 +54177,10 @@ class Program
                 // (16,13): error CS0266: Cannot implicitly convert type 'object' to 'IB'. An explicit conversion exists (are you missing a cast?)
                 //         b = o; // 2
                 Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "o").WithArguments("object", "IB").WithLocation(16, 13),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.PA.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.PA").WithLocation(17, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((IB)o).PA.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((IB)o).PA").WithLocation(20, 9));
         }
@@ -54367,7 +54368,7 @@ class Program
                 // (10,37): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         T? t = new T() { P = 4, Q = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 37),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Value.Q.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Value.Q").WithLocation(12, 9));
         }
@@ -54399,13 +54400,13 @@ class Program
                 // (10,55): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (C, C)? t = (new C() { F = 1 }, new C() { G = null }); // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 55),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         (((C, C))t).Item2.G.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(((C, C))t).Item2.G").WithLocation(12, 9),
                 // (13,55): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (C, C)? u = (new C() { F = 2 }, new C() { G = null }); // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 55),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((C)u.Value.Item2).G.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((C)u.Value.Item2).G").WithLocation(15, 9));
         }
@@ -54437,13 +54438,13 @@ class Program
                 // (10,55): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (S, S)? t = (new S() { F = 1 }, new S() { G = null }); // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 55),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         (((S, S))t).Item2.G.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(((S, S))t).Item2.G").WithLocation(12, 9),
                 // (13,55): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (S, S)? u = (new S() { F = 2 }, new S() { G = null }); // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 55),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((S)u.Value.Item2).G.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((S)u.Value.Item2).G").WithLocation(15, 9));
         }
@@ -54476,7 +54477,7 @@ class Program
                 // (13,61): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (B, object) t = (new B() { FA = 1 }, new B() { FB = null }); // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 61),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((B)t.Item2).FB.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((B)t.Item2).FB").WithLocation(16, 9));
         }
@@ -54508,7 +54509,7 @@ class Program
                 // (13,61): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (B, object) t = (new B() { FA = 1 }, new B() { FB = null }); // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 61),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         (((B, B))t).Item2.FB.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(((B, B))t).Item2.FB").WithLocation(15, 9));
         }
@@ -54553,19 +54554,19 @@ class Program
                 // (13,38): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         B b = new B() { FA = 1, FB = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 38),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.Item1.FA.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2.Item1.FA").WithLocation(17, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.Item1.FA.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2.Item1.FA").WithLocation(20, 9),
                 // (22,13): error CS0266: Cannot implicitly convert type '(B, (A, A))' to '(A, (B, B))'. An explicit conversion exists (are you missing a cast?)
                 //         u = t; // 4
                 Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "t").WithArguments("(B, (A, A))", "(A, (B, B))").WithLocation(22, 13),
-                // (23,9): warning CS8602: Possible dereference of a null reference.
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item1.FA.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1.FA").WithLocation(23, 9),
-                // (26,9): warning CS8602: Possible dereference of a null reference.
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.Item1.FA.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.Item1.FA").WithLocation(26, 9));
         }
@@ -54593,7 +54594,7 @@ class Program
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/34086: Track state across Nullable<T> conversions with nested conversions.
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         (((C, object))t).Item1.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(((C, object))t).Item1.F").WithLocation(10, 9));
         }
@@ -54627,7 +54628,7 @@ class Program
                 // (10,61): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (S?, object?) t = (new S() { F = 1 }, new S() { G = null }); // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 61),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         (((S, S))t).Item1.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(((S, S))t).Item1.F").WithLocation(11, 9),
                 // (11,10): warning CS8619: Nullability of reference types in value of type '(S?, object?)' doesn't match target type '(S, S)'.
@@ -54669,10 +54670,10 @@ class Program
                 // (5,18): warning CS8619: Nullability of reference types in value of type '(object?, object)' doesn't match target type '(string, string)'.
                 //         var u1 = ((string, string))t1; // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "((string, string))t1").WithArguments("(object?, object)", "(string, string)").WithLocation(5, 18),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         u1.Item1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u1.Item1").WithLocation(6, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         u2.Item1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u2.Item1").WithLocation(12, 9));
         }
@@ -55033,7 +55034,7 @@ class Program
                 // (10,41): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         object o = new S() { F = 1, G = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 41),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((S)o).G.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((S)o).G").WithLocation(12, 9));
         }
@@ -55057,7 +55058,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((S)(object)new S() { G = null }).F.ToString(); // 1, 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((S)(object)new S() { G = null }).F").WithLocation(11, 9),
                 // (11,35): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -55088,7 +55089,7 @@ class Program
                 // (10,46): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         object? o = (S?)new S() { F = 1, G = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 46),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((S?)o).Value.G.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((S?)o).Value.G").WithLocation(12, 9));
         }
@@ -55129,19 +55130,19 @@ class Program
                 // (10,42): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         object o1 = new T() { P = 1, Q = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 42),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((T)o1).Q.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((T)o1).Q").WithLocation(12, 9),
                 // (16,42): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         object o2 = new T() { P = 2, Q = null }; // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(16, 42),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((T)o2).Q.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((T)o2).Q").WithLocation(18, 9),
                 // (22,42): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         object o3 = new T() { P = 3, Q = null }; // 5
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(22, 42),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((T)o3).Q.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((T)o3).Q").WithLocation(24, 9));
         }
@@ -55176,19 +55177,19 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((T1)(object)new T1() { Q = null }).Q.ToString(); // 1, 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((T1)(object)new T1() { Q = null }).Q").WithLocation(11, 9),
                 // (11,37): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         ((T1)(object)new T1() { Q = null }).Q.ToString(); // 1, 2
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 37),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((T2)(object)new T2() { Q = null }).Q.ToString(); // 3, 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((T2)(object)new T2() { Q = null }).Q").WithLocation(16, 9),
                 // (16,37): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         ((T2)(object)new T2() { Q = null }).Q.ToString(); // 3, 4
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(16, 37),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((T3)(object)new T3() { Q = null }).Q.ToString(); // 5, 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((T3)(object)new T3() { Q = null }).Q").WithLocation(21, 9),
                 // (21,37): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -55232,19 +55233,19 @@ class Program
                 // (10,65): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (object, object) t1 = (new T() { P = 1 }, new T() { Q = null }); // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 65),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         (((T, T))t1).Item2.Q.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(((T, T))t1).Item2.Q").WithLocation(12, 9),
                 // (16,65): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (object, object) t2 = (new T() { P = 2 }, new T() { Q = null }); // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(16, 65),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         (((T, T))t2).Item2.Q.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(((T, T))t2).Item2.Q").WithLocation(18, 9),
                 // (22,65): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         (object, object) t3 = (new T() { P = 3 }, new T() { Q = null }); // 5
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(22, 65),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         (((T, T))t3).Item2.Q.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(((T, T))t3).Item2.Q").WithLocation(24, 9));
         }
@@ -55273,7 +55274,7 @@ class Program
                 // (10,45): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         object o = (T?)new T() { P = 1, Q = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 45),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         ((T?)o).Value.Q.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "((T?)o).Value.Q").WithLocation(12, 9));
         }
@@ -55326,7 +55327,7 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         F.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F.F").WithLocation(7, 9));
         }
@@ -55347,7 +55348,7 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         F.F.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F.F.F").WithLocation(8, 9));
         }
@@ -55370,7 +55371,7 @@ class Program
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/31395: Nullability of class members should be copied on assignment.
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F.F").WithLocation(9, 9));
         }
@@ -55395,10 +55396,10 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.F").WithLocation(12, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.F.F").WithLocation(12, 9));
         }
@@ -55418,7 +55419,7 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F.F.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.F.F").WithLocation(7, 9));
         }
@@ -55446,7 +55447,7 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.B.A.B.A.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.B.A.B.A").WithLocation(15, 9));
         }
@@ -55655,7 +55656,7 @@ class C
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         s.P.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.P.F").WithLocation(19, 9));
         }
@@ -55685,7 +55686,7 @@ class Program
                 // (11,27): warning CS8625: Cannot convert null literal to non-nullable reference or unconstrained type parameter.
                 //         S<T>.Instance.F = null; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 27),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         S<T>.Instance.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "S<T>.Instance.F").WithLocation(13, 9));
         }
@@ -55724,10 +55725,10 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (22,9): warning CS8602: Possible dereference of a null reference.
+                // (22,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.A1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.A1").WithLocation(22, 9),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.B1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.B1").WithLocation(25, 9));
         }
@@ -55802,7 +55803,7 @@ class B
                 // (11,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         t1 = default; // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(11, 14),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         t2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2").WithLocation(15, 9),
                 // (16,14): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
@@ -55811,10 +55812,10 @@ class B
                 // (21,14): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         t3 = default; // 6
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(21, 14),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         t4.P.ToString(); // 7 and 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t4").WithLocation(25, 9),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         t4.P.ToString(); // 7 and 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t4.P").WithLocation(25, 9),
                 // (26,16): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
@@ -55823,7 +55824,7 @@ class B
                 // (27,14): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         t4 = default; // 10
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(27, 14),
-                // (31,9): warning CS8602: Possible dereference of a null reference.
+                // (31,9): warning CS8602: Dereference of a possibly null reference.
                 //         t5.P.ToString(); // 11 and 12
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t5.P").WithLocation(31, 9),
                 // (32,16): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
@@ -59671,7 +59672,7 @@ class A
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         y3.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y3").WithLocation(18, 9),
                 // (19,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
@@ -62074,7 +62075,7 @@ class A
                 // (9,11): warning CS8604: Possible null reference argument for parameter 'o' in 'void C.F(object o)'.
                 //         F((object)t1);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(object)t1").WithArguments("o", "void C.F(object o)").WithLocation(9, 11),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         t1.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1").WithLocation(10, 9),
                 // (26,11): warning CS8604: Possible null reference argument for parameter 'o' in 'void C.F(object o)'.
@@ -62086,7 +62087,7 @@ class A
                 // (27,11): warning CS8604: Possible null reference argument for parameter 'o' in 'void C.F(object o)'.
                 //         F((object)t4);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(object)t4").WithArguments("o", "void C.F(object o)").WithLocation(27, 11),
-                // (28,9): warning CS8602: Possible dereference of a null reference.
+                // (28,9): warning CS8602: Dereference of a possibly null reference.
                 //         t4.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t4").WithLocation(28, 9)
             );
@@ -62372,10 +62373,10 @@ class C
                 // (12,18): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //             t1 = default; // 1
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(12, 18),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         t1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1").WithLocation(15, 9),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         t2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2").WithLocation(25, 9)
                 );
@@ -62426,22 +62427,22 @@ class C
                 // (29,9): error CS0411: The type arguments for method 'C.CopyOutInherit<T1, T2>(T1, out T2)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         CopyOutInherit(u, out var x7);
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "CopyOutInherit").WithArguments("C.CopyOutInherit<T1, T2>(T1, out T2)").WithLocation(29, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(10, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(13, 9),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         x3.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(16, 9),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         x4.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x4").WithLocation(21, 9),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         x5.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x5").WithLocation(24, 9),
-                // (27,9): warning CS8602: Possible dereference of a null reference.
+                // (27,9): warning CS8602: Dereference of a possibly null reference.
                 //         x6.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x6").WithLocation(27, 9));
         }
@@ -62535,7 +62536,7 @@ class C
                 // (5,9): warning CS8653: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         default(T).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default(T)").WithArguments("T").WithLocation(5, 9),
-                // (5,9): warning CS8602: Possible dereference of a null reference.
+                // (5,9): warning CS8602: Dereference of a possibly null reference.
                 //         default(T).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "default(T)").WithLocation(5, 9),
                 // (6,9): warning CS8653: A default expression introduces a null value when 'T' is a non-nullable reference type.
@@ -62544,22 +62545,22 @@ class C
                 // (10,16): warning CS8653: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         T x1 = default; // 2
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(10, 16),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(11, 9),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         y1.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(16, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         x2.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(20, 9),
-                // (25,9): warning CS8602: Possible dereference of a null reference.
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         y2.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(25, 9),
-                // (26,9): warning CS8602: Possible dereference of a null reference.
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
                 //         a2[0].ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a2[0]").WithLocation(26, 9),
-                // (34,9): warning CS8602: Possible dereference of a null reference.
+                // (34,9): warning CS8602: Dereference of a possibly null reference.
                 //         a3[0].ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a3[0]").WithLocation(34, 9)
                 );
@@ -63721,13 +63722,13 @@ class C4<T, U> : I<T?>, I<U?> where T : class where U : class { }";
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,10): warning CS8602: Possible dereference of a null reference.
+                // (6,10): warning CS8602: Dereference of a possibly null reference.
                 //         (z1 = x1).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z1 = x1").WithLocation(6, 10),
                 // (12,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (z2 = x2).ToString();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x2").WithLocation(12, 15),
-                // (12,10): warning CS8602: Possible dereference of a null reference.
+                // (12,10): warning CS8602: Dereference of a possibly null reference.
                 //         (z2 = x2).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z2 = x2").WithLocation(12, 10));
         }
@@ -64761,10 +64762,10 @@ class B : A
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (13,21): warning CS8602: Possible dereference of a null reference.
+                // (13,21): warning CS8602: Dereference of a possibly null reference.
                 //             int n = this.F.Length; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "this.F").WithLocation(13, 21),
-                // (19,21): warning CS8602: Possible dereference of a null reference.
+                // (19,21): warning CS8602: Dereference of a possibly null reference.
                 //             int n = base.F.Length; // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "base.F").WithLocation(19, 21));
         }
@@ -64799,10 +64800,10 @@ class B : A
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (12,21): warning CS8602: Possible dereference of a null reference.
+                // (12,21): warning CS8602: Dereference of a possibly null reference.
                 //             int n = this.F.Length; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "this.F").WithLocation(12, 21),
-                // (18,21): warning CS8602: Possible dereference of a null reference.
+                // (18,21): warning CS8602: Dereference of a possibly null reference.
                 //             int n = base.F.Length; // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "base.F").WithLocation(18, 21));
         }
@@ -67527,7 +67528,7 @@ static class E
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         obj.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "obj").WithLocation(6, 9));
         }
@@ -67559,16 +67560,16 @@ static class E
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,9): warning CS8602: Possible dereference of a null reference.
+                // (5,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(5, 9),
                 // (7,9): error CS0165: Use of unassigned local variable 'y'
                 //         y.ToString();
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(7, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 9),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(18, 9)
                 );
@@ -67600,7 +67601,7 @@ static class E
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,9): warning CS8602: Possible dereference of a null reference.
+                // (5,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(5, 9),
                 // (7,9): error CS0165: Use of unassigned local variable 'y'
@@ -67609,10 +67610,10 @@ static class E
                 // (8,13): warning CS8653: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         y = default;
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(8, 13),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 9),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(18, 9)
                 );
@@ -67677,13 +67678,13 @@ static class E
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,17): warning CS8602: Possible dereference of a null reference.
+                // (8,17): warning CS8602: Dereference of a possibly null reference.
                 //             n = s/*T:string?*/.Length; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 17),
-                // (12,17): warning CS8602: Possible dereference of a null reference.
+                // (12,17): warning CS8602: Dereference of a possibly null reference.
                 //         n = b ? s/*T:string?*/.Length + // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(12, 17),
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //         n = s/*T:string?*/.Length; // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(14, 13));
             comp.VerifyTypes();
@@ -67726,16 +67727,16 @@ static class E
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,17): warning CS8602: Possible dereference of a null reference.
+                // (8,17): warning CS8602: Dereference of a possibly null reference.
                 //             n = s/*T:string?*/.Length; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(8, 17),
-                // (20,17): warning CS8602: Possible dereference of a null reference.
+                // (20,17): warning CS8602: Dereference of a possibly null reference.
                 //             n = s/*T:string?*/.Length; // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(20, 17),
-                // (24,17): warning CS8602: Possible dereference of a null reference.
+                // (24,17): warning CS8602: Dereference of a possibly null reference.
                 //             n = s/*T:string?*/.Length; // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(24, 17),
-                // (28,17): warning CS8602: Possible dereference of a null reference.
+                // (28,17): warning CS8602: Dereference of a possibly null reference.
                 //             n = s/*T:string?*/.Length; // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(28, 17));
             comp.VerifyTypes();
@@ -67757,7 +67758,7 @@ static class E
             // One warning only, rather than one warning for dereference of c.F
             // and another warning for assignment c.F = c.
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.F = c;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(6, 9));
         }
@@ -67783,10 +67784,10 @@ class C
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/30598: Should report two warnings for x.F(x.y).
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F(x = null); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F(x.y); // 2, 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(11, 9));
         }
@@ -67812,16 +67813,16 @@ class C
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/30598: Should report two warnings for x[x.Length] and y[y.Length].
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8602: Possible dereference of a null reference.
+                // (7,13): warning CS8602: Dereference of a possibly null reference.
                 //         z = x[F(x = null)]; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 13),
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //         z = x[x.Length]; // 2, 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13),
                 // (10,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y[F(y = null)] = 1;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(10, 17),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         y[y.Length] = 2; // 4, 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(11, 9));
         }
@@ -67853,16 +67854,16 @@ class C
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/30598: Should report two warnings for x[x.F] and y[y.F].
             comp.VerifyDiagnostics(
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //         z = x[x = null]; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(13, 13),
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //         z = x[x.F]; // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(14, 13),
                 // (16,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y[y = null] = 1; // 3
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(16, 15),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         y[y.F] = 2; // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(17, 9)
                 );
@@ -67891,13 +67892,13 @@ class C
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/30598: Should report two warnings for y.F = G(y.F).
             comp.VerifyDiagnostics(
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //         o = x.F; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(10, 13),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F = G(y = null); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F = G(y.F); // 3, 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(13, 9));
         }
@@ -67925,13 +67926,13 @@ class C
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/30598: Should report two warnings for y.P = F(y.P).
             comp.VerifyDiagnostics(
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //         o = x.F; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(10, 13),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F = G(y = null); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F = G(y.F); // 3, 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(13, 9));
         }
@@ -67963,22 +67964,22 @@ class C
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/30598: Should report two warnings for y.E += y.F.
             comp.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.E(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(11, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.E += G(y = null); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(13, 9),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.E += y.F; // 3, 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(14, 9),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.E = null; // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(17, 9),
                 // (17,15): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         z.E = null; // 5
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(17, 15),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.E();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z.E").WithLocation(18, 9));
         }
@@ -68008,19 +68009,19 @@ class C
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/30598: Should report two warnings for x[x.F] and y[y.F].
             comp.VerifyDiagnostics(
-                // (5,9): warning CS8602: Possible dereference of a null reference.
+                // (5,9): warning CS8602: Dereference of a possibly null reference.
                 //         d.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "d").WithLocation(5, 9),
-                // (11,13): warning CS8602: Possible dereference of a null reference.
+                // (11,13): warning CS8602: Dereference of a possibly null reference.
                 //         z = x[x = null]; // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(11, 13),
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //         z = x[x.F]; // 3, 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(12, 13),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         y[y = null] = 1;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(14, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         y[y.F] = 2; // 5, 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(15, 9));
         }
@@ -68048,10 +68049,10 @@ static class E
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/30563: Should not report "CS8602: Possible dereference" for y.F2.
             comp.VerifyDiagnostics(
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //         d = x.F1; // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(8, 13),
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //         d = y.F2; // ok
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 13));
         }
@@ -68084,10 +68085,10 @@ static class E
             // https://github.com/dotnet/roslyn/issues/30563: Should not report "CS8602: Possible dereference"
             // for F2(y.F). Should report "CS8604: Possible null reference argument" instead.
             comp.VerifyDiagnostics(
-                // (10,12): warning CS8602: Possible dereference of a null reference.
+                // (10,12): warning CS8602: Dereference of a possibly null reference.
                 //         F1(x.F); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(10, 12),
-                // (12,12): warning CS8602: Possible dereference of a null reference.
+                // (12,12): warning CS8602: Dereference of a possibly null reference.
                 //         F2(y.F); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(12, 12));
         }
@@ -68175,16 +68176,16 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,27): warning CS8602: Possible dereference of a null reference.
+                // (9,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var x in x1) { } // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(9, 27),
-                // (14,27): warning CS8602: Possible dereference of a null reference.
+                // (14,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var y in y1) { } // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(14, 27),
-                // (19,27): warning CS8602: Possible dereference of a null reference.
+                // (19,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var x in x2) { } // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(19, 27),
-                // (24,9): warning CS8602: Possible dereference of a null reference.
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         y2.GetEnumerator(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(24, 9));
         }
@@ -69168,13 +69169,13 @@ class Outer
                 // (10,9): warning CS8631: The type 'T' cannot be used as type parameter 'U' in the generic type or method 'Outer.M2<U>(U)'. Nullability of type argument 'T' doesn't match constraint type 'object'.
                 //         M2(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, "M2").WithArguments("Outer.M2<U>(U)", "object", "U", "T").WithLocation(10, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(x0)").WithLocation(10, 9),
                 // (11,9): warning CS8631: The type 'T' cannot be used as type parameter 'U' in the generic type or method 'Outer.M2<U>(U)'. Nullability of type argument 'T' doesn't match constraint type 'object'.
                 //         M2<T>(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, "M2<T>").WithArguments("Outer.M2<U>(U)", "object", "U", "T").WithLocation(11, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2<T>(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2<T>(x0)").WithLocation(11, 9),
                 // (19,18): warning CS8601: Possible null reference assignment.
@@ -69206,10 +69207,10 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(x0)").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2<T>(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2<T>(x0)").WithLocation(13, 9)
                 );
@@ -69325,7 +69326,7 @@ class Outer
                 // (9,13): warning CS8601: Possible null reference assignment.
                 //         z = (T)x;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(T)x").WithLocation(9, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(10, 9)
                 );
@@ -69358,7 +69359,7 @@ class Outer
                 // (9,13): warning CS8601: Possible null reference assignment.
                 //         z = (T)x;     // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(T)x").WithLocation(9, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(10, 9)
                 );
@@ -69398,7 +69399,7 @@ interface I1{}
                 // (9,13): warning CS8601: Possible null reference assignment.
                 //         z = (T)x;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(T)x").WithLocation(9, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(10, 9)
                 );
@@ -69432,7 +69433,7 @@ interface I1{}
                 // (9,13): warning CS8601: Possible null reference assignment.
                 //         z = (T)x;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(T)x").WithLocation(9, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(10, 9)
                 );
@@ -69472,7 +69473,7 @@ interface I1{}
                 // (9,13): warning CS8601: Possible null reference assignment.
                 //         z = (T)x;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(T)x").WithLocation(9, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(10, 9)
                 );
@@ -69506,7 +69507,7 @@ interface I1{}
                 // (9,13): warning CS8601: Possible null reference assignment.
                 //         z = (T)x;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(T)x").WithLocation(9, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(10, 9)
                 );
@@ -69538,7 +69539,7 @@ class Outer
                 // (8,13): warning CS8601: Possible null reference assignment.
                 //         y = (U)x;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(U)x").WithLocation(8, 13),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 9)
                 );
@@ -69572,7 +69573,7 @@ interface I1 {}
                 // (8,13): warning CS8601: Possible null reference assignment.
                 //         y = (U)x;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(U)x").WithLocation(8, 13),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 9)
                 );
@@ -69606,7 +69607,7 @@ interface I1 {}
                 // (8,13): warning CS8601: Possible null reference assignment.
                 //         y = (U)x;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(U)x").WithLocation(8, 13),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 9)
                 );
@@ -69686,7 +69687,7 @@ class Outer
                 // (9,13): warning CS8601: Possible null reference assignment.
                 //         y = (T)x;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(T)x").WithLocation(9, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(10, 9)
                 );
@@ -69726,7 +69727,7 @@ class Outer
                 // (9,13): warning CS8601: Possible null reference assignment.
                 //         z = (T)x;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(T)x").WithLocation(9, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(10, 9)
                 );
@@ -69790,7 +69791,7 @@ class Outer
                 // (9,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         z = (T)x;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(T)x").WithLocation(9, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(10, 9)
                 );
@@ -69860,7 +69861,7 @@ class Outer
                 // (6,13): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         x = default;
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9)
                 );
@@ -69884,7 +69885,7 @@ class Outer
                 // (6,13): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         x = default(T);
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default(T)").WithArguments("T").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9)
                 );
@@ -69910,7 +69911,7 @@ interface I1 {}
                 // (6,13): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         x = default;
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9)
                 );
@@ -69936,7 +69937,7 @@ interface I1 {}
                 // (6,13): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         x = default(T);
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default(T)").WithArguments("T").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9)
                 );
@@ -69960,7 +69961,7 @@ class Outer
                 // (6,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x = default;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9)
                 );
@@ -69984,7 +69985,7 @@ class Outer
                 // (6,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x = default(T);
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default(T)").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9)
                 );
@@ -70010,7 +70011,7 @@ interface I1 {}
                 // (6,13): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         x = default;
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9)
                 );
@@ -70036,7 +70037,7 @@ interface I1 {}
                 // (6,13): warning CS8652: A default expression introduces a null value when 'T' is a non-nullable reference type.
                 //         x = default(T);
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default(T)").WithArguments("T").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9)
                 );
@@ -70057,7 +70058,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 9)
                 );
@@ -70080,7 +70081,7 @@ interface I1 {}
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 9)
                 );
@@ -70120,7 +70121,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 9)
                 );
@@ -70271,7 +70272,7 @@ class Outer
                 // (6,13): warning CS8654: A null literal introduces a null value when 'T' is a non-nullable reference type.
                 //         x = null;
                 Diagnostic(ErrorCode.WRN_NullLiteralMayIntroduceNullT, "null").WithArguments("T").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9));
         }
@@ -70294,7 +70295,7 @@ class Outer
                 // (6,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9)
                 );
@@ -70318,7 +70319,7 @@ class Outer
                 // (6,13): warning CS8654: A null literal introduces a null value when 'T' is a non-nullable reference type.
                 //         x = null;
                 Diagnostic(ErrorCode.WRN_NullLiteralMayIntroduceNullT, "null").WithArguments("T").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9));
         }
@@ -70341,7 +70342,7 @@ class Outer
                 // (6,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x = null;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(6, 13),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9)
                 );
@@ -70363,7 +70364,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(x, x).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(x, x)").WithLocation(6, 9)
                 );
@@ -70386,7 +70387,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(x, y)").WithLocation(7, 9)
                 );
@@ -70409,7 +70410,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(x, y)").WithLocation(7, 9)
                 );
@@ -70434,10 +70435,10 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(x, y)").WithLocation(8, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1<T>(x, y).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1<T>(x, y)").WithLocation(9, 9)
                 );
@@ -70501,7 +70502,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(x0, y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(x0, y0)").WithLocation(8, 9)
                 );
@@ -70547,7 +70548,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(x0, y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(x0, y0)").WithLocation(11, 9)
                 );
@@ -70658,10 +70659,10 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(out M3(x0), out y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(out M3(x0), out y0)").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2<T>(out M3(x0), out y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2<T>(out M3(x0), out y0)").WithLocation(13, 9)
                 );
@@ -70691,10 +70692,10 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(out x0, out M3(y0)).ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(out x0, out M3(y0))").WithLocation(12, 9),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2<T>(out x0, out M3(y0)).ToString(); // warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2<T>(out x0, out M3(y0))").WithLocation(13, 9)
                 );
@@ -70723,7 +70724,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(out M3(x0), out M3(y0)).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(out M3(x0), out M3(y0))").WithLocation(12, 9)
                 );
@@ -70748,7 +70749,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(out y0, out M3(z0)).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(out y0, out M3(z0))").WithLocation(8, 9)
                 );
@@ -70772,7 +70773,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(y0, z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(y0, z0)").WithLocation(8, 9)
                 );
@@ -70822,7 +70823,7 @@ interface I1<in T> {}
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(M3(x0), M3(y0)).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(M3(x0), M3(y0))").WithLocation(10, 9)
                 );
@@ -70851,7 +70852,7 @@ interface I1<in T> {}
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(M3(x0), M3(y0)).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(M3(x0), M3(y0))").WithLocation(10, 9)
                 );
@@ -70882,7 +70883,7 @@ interface I1<in T> {}
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(M3(x0), M3(y0)).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(M3(x0), M3(y0))").WithLocation(12, 9)
                 );
@@ -70909,7 +70910,7 @@ interface I1<in T> {}
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(y0, M3(z0)).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(y0, M3(z0))").WithLocation(8, 9)
                 );
@@ -71016,7 +71017,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(ref M3(x0), ref y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(ref M3(x0), ref y0)").WithLocation(10, 9)
                 );
@@ -71043,7 +71044,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(ref x0, ref M3(y0)).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(ref x0, ref M3(y0))").WithLocation(10, 9)
                 );
@@ -71416,7 +71417,7 @@ interface I1
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         x0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x0").WithLocation(8, 9)
                 );
@@ -71461,7 +71462,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(10, 9)
                 );
@@ -71481,7 +71482,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (6,10): warning CS8602: Possible dereference of a null reference.
+                // (6,10): warning CS8602: Dereference of a possibly null reference.
                 //         (x0 ?? y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x0 ?? y0").WithLocation(6, 10)
                 );
@@ -71560,10 +71561,10 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,13): warning CS8602: Possible dereference of a null reference.
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
                 //             x0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x0").WithLocation(9, 13),
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //             y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(10, 13)
                 );
@@ -71590,7 +71591,7 @@ class Outer
                 // (6,19): error CS0150: A constant value is expected
                 //         if (x0 is default) return;
                 Diagnostic(ErrorCode.ERR_ConstantExpected, "default").WithLocation(6, 19),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x0").WithLocation(7, 9)
                 );
@@ -71614,7 +71615,7 @@ class Outer
                 // (6,19): error CS0150: A constant value is expected
                 //         if (x0 is default(T)) return;
                 Diagnostic(ErrorCode.ERR_ConstantExpected, "default(T)").WithLocation(6, 19),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x0").WithLocation(7, 9)
                 );
@@ -71640,7 +71641,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(x0)").WithLocation(9, 9)
                 );
@@ -71684,7 +71685,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(x0)").WithLocation(9, 9)
                 );
@@ -71714,10 +71715,10 @@ class Outer
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,13): warning CS8602: Possible dereference of a null reference.
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
                 //             M2(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(x0)").WithLocation(10, 13),
-                // (11,13): warning CS8602: Possible dereference of a null reference.
+                // (11,13): warning CS8602: Dereference of a possibly null reference.
                 //             M2(y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(y0)").WithLocation(11, 13)
                 );
@@ -71751,7 +71752,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(17, 9)
                 );
@@ -71785,7 +71786,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(17, 9)
                 );
@@ -71927,10 +71928,10 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(10, 9));
         }
@@ -71956,7 +71957,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(11, 9)
                 );
@@ -72001,7 +72002,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(v0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(v0)").WithLocation(11, 9)
                 );
@@ -72030,7 +72031,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(v0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(v0)").WithLocation(13, 9)
                 );
@@ -72059,7 +72060,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(v0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(v0)").WithLocation(13, 9)
                 );
@@ -72088,7 +72089,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         a0[0].ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a0[0]").WithLocation(10, 9)
                 );
@@ -72315,7 +72316,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(18, 9)
                 );
@@ -72351,7 +72352,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(20, 9)
                 );
@@ -72387,7 +72388,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(20, 9)
                 );
@@ -72569,7 +72570,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(11, 9)
                 );
@@ -72600,7 +72601,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(11, 9)
                 );
@@ -72650,7 +72651,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(8, 9));
         }
@@ -72769,7 +72770,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (6,10): warning CS8602: Possible dereference of a null reference.
+                // (6,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? x0 : y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x0 : y0").WithLocation(6, 10)
                 );
@@ -72790,7 +72791,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (7,10): warning CS8602: Possible dereference of a null reference.
+                // (7,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? x0 : y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x0 : y0").WithLocation(7, 10)
                 );
@@ -72811,7 +72812,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (7,10): warning CS8602: Possible dereference of a null reference.
+                // (7,10): warning CS8602: Dereference of a possibly null reference.
                 //         (b ? x0 : y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x0 : y0").WithLocation(7, 10)
                 );
@@ -72838,7 +72839,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(11, 9)
                 );
@@ -72932,7 +72933,7 @@ class Outer<T>
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(8, 9)
                 );
@@ -72959,7 +72960,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(8, 9)
                 );
@@ -73000,7 +73001,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (6,10): warning CS8602: Possible dereference of a null reference.
+                // (6,10): warning CS8602: Dereference of a possibly null reference.
                 //         (true ? x0 : y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "true ? x0 : y0").WithLocation(6, 10)
                 );
@@ -73021,7 +73022,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (7,10): warning CS8602: Possible dereference of a null reference.
+                // (7,10): warning CS8602: Dereference of a possibly null reference.
                 //         (true ? x0 : y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "true ? x0 : y0").WithLocation(7, 10)
                 );
@@ -73064,10 +73065,10 @@ class Outer
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(10, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(12, 9));
         }
@@ -73094,7 +73095,7 @@ class Outer<T>
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(10, 9));
         }
@@ -73122,10 +73123,10 @@ class Outer<T>
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(9, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(11, 9));
         }
@@ -73151,7 +73152,7 @@ class Outer<T>
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9));
         }
@@ -73177,7 +73178,7 @@ class Outer<T>
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9));
         }
@@ -73204,7 +73205,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9)
                 );
@@ -73224,7 +73225,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (6,10): warning CS8602: Possible dereference of a null reference.
+                // (6,10): warning CS8602: Dereference of a possibly null reference.
                 //         (false ? x0 : y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "false ? x0 : y0").WithLocation(6, 10)
                 );
@@ -73261,7 +73262,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (7,10): warning CS8602: Possible dereference of a null reference.
+                // (7,10): warning CS8602: Dereference of a possibly null reference.
                 //         (false ? x0 : y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "false ? x0 : y0").WithLocation(7, 10)
                 );
@@ -73288,10 +73289,10 @@ class Outer
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(10, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(12, 9));
         }
@@ -73319,10 +73320,10 @@ class Outer<T>
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(9, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(11, 9));
         }
@@ -73349,7 +73350,7 @@ class Outer<T>
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(10, 9));
         }
@@ -73375,7 +73376,7 @@ class Outer<T>
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9));
         }
@@ -73402,7 +73403,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9)
                 );
@@ -73429,7 +73430,7 @@ class Outer<T>
 }
 ";
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9));
         }
@@ -73456,10 +73457,10 @@ class Outer<T, U> where T : Outer<T, U>? where U : T
                 // (6,16): warning CS8601: Possible null reference assignment.
                 //         U y0 = (U)x0;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(U)x0").WithLocation(6, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(11, 9)
                 );
@@ -73487,10 +73488,10 @@ class Outer<T, U> where T : class? where U : T
                 // (6,16): warning CS8601: Possible null reference assignment.
                 //         U y0 = (U)x0;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(U)x0").WithLocation(6, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(11, 9)
                 );
@@ -73520,10 +73521,10 @@ class Outer<T, U> where T : Outer<T, U>?, U
                 // (6,16): warning CS8638: Conditional access may produce a null value when 'T' is a non-nullable reference type.
                 //         T z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("T").WithLocation(6, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(11, 9)
                 );
@@ -73555,10 +73556,10 @@ class Outer<T, U> where T : Outer<T, U>? where U : T
                 // (7,16): warning CS8601: Possible null reference assignment.
                 //         U y0 = (U)z0;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(U)z0").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(11, 9)
                 );
@@ -73589,10 +73590,10 @@ class Outer<T, U> where T : Outer<T, U>?, U
                 // (7,16): warning CS8638: Conditional access may produce a null value when 'T' is a non-nullable reference type.
                 //         T z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("T").WithLocation(7, 16),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(10, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(12, 9)
                 );
@@ -73622,10 +73623,10 @@ class Outer<T, U> where T : Outer<T, U>?, U
                 // (6,16): warning CS8638: Conditional access may produce a null value when 'T' is a non-nullable reference type.
                 //         T z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("T").WithLocation(6, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(11, 9)
                 );
@@ -73654,10 +73655,10 @@ class Outer<T, U> where T : Outer<T, U>?, U
                 // (6,16): warning CS8638: Conditional access may produce a null value when 'T' is a non-nullable reference type.
                 //         T z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("T").WithLocation(6, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(11, 9)
                 );
@@ -73684,7 +73685,7 @@ class Outer<T> where T : Outer<T>?
                 // (6,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         Outer<T> z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0?.M1()").WithLocation(6, 23),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(8, 9)
                 );
@@ -73712,7 +73713,7 @@ class Outer<T> where T : Outer<T>?
                 // (7,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         Outer<T> z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0?.M1()").WithLocation(7, 23),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9)
                 );
@@ -73739,7 +73740,7 @@ class Outer<T> where T : Outer<T>?
                 // (6,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         Outer<T> z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0?.M1()").WithLocation(6, 23),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(8, 9)
                 );
@@ -73767,7 +73768,7 @@ class Outer<T> where T : Outer<T>?
                 // (7,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         Outer<T> z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0?.M1()").WithLocation(7, 23),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9)
                 );
@@ -73794,7 +73795,7 @@ class Outer<T, U> where T : Outer<T, U>?, U where U : class?
                 // (6,16): warning CS8638: Conditional access may produce a null value when 'U' is a non-nullable reference type.
                 //         U z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("U").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(8, 9)
                 );
@@ -73822,7 +73823,7 @@ class Outer<T, U> where T : Outer<T, U>?, U where U : class?
                 // (7,16): warning CS8638: Conditional access may produce a null value when 'U' is a non-nullable reference type.
                 //         U z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("U").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9)
                 );
@@ -73849,7 +73850,7 @@ class Outer<T, U> where T : U where U : Outer<T, U>?
                 // (6,16): warning CS8638: Conditional access may produce a null value when 'T' is a non-nullable reference type.
                 //         U z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(8, 9)
                 );
@@ -73875,7 +73876,7 @@ class Outer<T, U> where T : U where U : Outer<T, U>?
                 // (6,16): warning CS8638: Conditional access may produce a null value when 'T' is a non-nullable reference type.
                 //         T z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(8, 9)
                 );
@@ -73903,7 +73904,7 @@ class Outer<T, U> where T : U where U : Outer<T, U>?
                 // (7,16): warning CS8638: Conditional access may produce a null value when 'T' is a non-nullable reference type.
                 //         U z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9)
                 );
@@ -73931,7 +73932,7 @@ class Outer<T, U> where T : U where U : Outer<T, U>?
                 // (7,16): warning CS8638: Conditional access may produce a null value when 'T' is a non-nullable reference type.
                 //         T z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9)
                 );
@@ -73958,7 +73959,7 @@ class Outer<T, U> where T : Outer<T, U>? where U : class?
                 // (6,16): warning CS8638: Conditional access may produce a null value when 'U' is a non-nullable reference type.
                 //         U z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("U").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(8, 9)
                 );
@@ -73986,7 +73987,7 @@ class Outer<T, U> where T : Outer<T, U>? where U : class?
                 // (7,16): warning CS8638: Conditional access may produce a null value when 'U' is a non-nullable reference type.
                 //         U z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConditionalAccessMayReturnNull, "x0?.M1()").WithArguments("U").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9)
                 );
@@ -74013,7 +74014,7 @@ class Outer<T, U> where T : Outer<T, U>? where U : class
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         U z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0?.M1()").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(8, 9)
                 );
@@ -74041,7 +74042,7 @@ class Outer<T, U> where T : Outer<T, U>? where U : class
                 // (7,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         U z0 = x0?.M1();
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0?.M1()").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(9, 9)
                 );
@@ -74066,7 +74067,7 @@ class Outer<T>
                 // (6,21): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         object y0 = x0 as object;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as object").WithLocation(6, 21),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74089,7 +74090,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -74114,7 +74115,7 @@ class Outer<T>
                 // (6,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         dynamic y0 = x0 as dynamic;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as dynamic").WithLocation(6, 22),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74137,7 +74138,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -74161,7 +74162,7 @@ class Outer<T> where T : class?
                 // (6,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74185,7 +74186,7 @@ class Outer<T> where T : class?
                 // (6,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74210,7 +74211,7 @@ class Outer<T> where T : class?
                 // (7,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -74234,7 +74235,7 @@ class Outer<T> where T : class?
                 // (6,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74258,7 +74259,7 @@ class Outer<T> where T : class?
                 // (6,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74283,7 +74284,7 @@ class Outer<T> where T : class?
                 // (7,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -74305,7 +74306,7 @@ class Outer<T> where T : object
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74348,7 +74349,7 @@ class Outer<T> where T : class
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74373,7 +74374,7 @@ class Outer<T> where T : class
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74399,7 +74400,7 @@ class Outer<T> where T : class
                 // (7,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -74424,7 +74425,7 @@ class Outer<T> where T : class
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74449,7 +74450,7 @@ class Outer<T> where T : class
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74475,7 +74476,7 @@ class Outer<T> where T : class
                 // (7,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -74500,7 +74501,7 @@ class Outer<T>
                 // (6,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         Outer<T> y0 = x0 as Outer<T>;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as Outer<T>").WithLocation(6, 23),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74526,7 +74527,7 @@ class Outer<T>
                 // (7,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         Outer<T> y0 = x0 as Outer<T>;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as Outer<T>").WithLocation(7, 23),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -74550,7 +74551,7 @@ class Outer<T> where T : class?
                 // (6,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74575,7 +74576,7 @@ class Outer<T> where T : class?
                 // (7,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -74599,7 +74600,7 @@ class Outer<T> where T : class?
                 // (6,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74624,7 +74625,7 @@ class Outer<T> where T : class
                 // (6,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         Outer<T> y0 = x0 as Outer<T>;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as Outer<T>").WithLocation(6, 23),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74649,7 +74650,7 @@ class Outer<T> where T : class
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74675,7 +74676,7 @@ class Outer<T> where T : class
                 // (7,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -74700,7 +74701,7 @@ class Outer<T> where T : class
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74725,7 +74726,7 @@ class Outer<T> where T : Outer<T>?
                 // (6,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         Outer<T> y0 = x0 as Outer<T>;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as Outer<T>").WithLocation(6, 23),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74768,7 +74769,7 @@ class Outer<T> where T : Outer<T>?
                 // (6,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74811,7 +74812,7 @@ class Outer<T> where T : Outer<T>
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74837,7 +74838,7 @@ class Outer<T> where T : Outer<T>
                 // (7,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -74862,7 +74863,7 @@ class Outer<T> where T : Outer<T>
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74889,7 +74890,7 @@ interface I1{}
                 // (6,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         I1 y0 = x0 as I1;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as I1").WithLocation(6, 17),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74936,7 +74937,7 @@ interface I1{}
                 // (6,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -74983,7 +74984,7 @@ interface I1{}
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -75011,7 +75012,7 @@ interface I1{}
                 // (7,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -75038,7 +75039,7 @@ interface I1{}
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -75060,7 +75061,7 @@ class Outer<T> where T : class?
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -75119,7 +75120,7 @@ class Outer<T, U> where T : U where U : class?
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -75196,7 +75197,7 @@ class Outer<T, U> where T : class?, U where U : class?
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -75258,7 +75259,7 @@ class Outer<T, U> where T : class, U where U : class?
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -75284,7 +75285,7 @@ class Outer<T, U> where T : class, U where U : class?
                 // (7,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -75309,7 +75310,7 @@ class Outer<T, U> where T : class, U where U : class
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -75333,7 +75334,7 @@ class Outer<T, U> where T : class?, U where U : class?
                 // (6,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -75358,7 +75359,7 @@ class Outer<T, U> where T : class?, U where U : class?
                 // (7,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -75383,7 +75384,7 @@ class Outer<T, U> where T : class?, U where U : class
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -75407,7 +75408,7 @@ class Outer<T, U> where T : class?, U
                 // (6,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -75432,7 +75433,7 @@ class Outer<T, U> where T : class?, U
                 // (7,16): warning CS8626: The 'as' operator may produce a null value when 'T' is a non-nullable reference type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_AsOperatorMayReturnNull, "x0 as T").WithArguments("T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -75457,7 +75458,7 @@ class Outer<T, U> where T : class, U
                 // (6,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(6, 16),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(8, 9)
                 );
@@ -75483,7 +75484,7 @@ class Outer<T, U> where T : class, U
                 // (7,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y0 = x0 as T;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x0 as T").WithLocation(7, 16),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(9, 9)
                 );
@@ -75510,7 +75511,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(z0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(z0)").WithLocation(10, 9));
         }
@@ -75529,7 +75530,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (6,10): warning CS8602: Possible dereference of a null reference.
+                // (6,10): warning CS8602: Dereference of a possibly null reference.
                 //         (x0 ??= y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x0 ??= y0").WithLocation(6, 10));
         }
@@ -75573,10 +75574,10 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(x0)").WithLocation(8, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x0.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x0").WithLocation(11, 9));
         }
@@ -75602,7 +75603,7 @@ class Outer
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(x0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(x0)").WithLocation(11, 9));
         }
@@ -75632,7 +75633,7 @@ class Outer<T>
 ";
 
             CreateCompilation(source, options: WithNonNullTypesTrue()).VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         M1(y0).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M1(y0)").WithLocation(11, 9));
         }
@@ -76334,7 +76335,7 @@ class B<[Nullable(0)]T01,
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = s.Length; // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(14, 13)
                 );
@@ -76369,7 +76370,7 @@ class B<[Nullable(0)]T01,
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (16,16): warning CS8602: Possible dereference of a null reference.
+                // (16,16): warning CS8602: Dereference of a possibly null reference.
                 //         return s.Length; // warning: possibly null
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(16, 16)
                 );
@@ -76405,7 +76406,7 @@ class B<[Nullable(0)]T01,
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,20): warning CS8602: Possible dereference of a null reference.
+                // (14,20): warning CS8602: Dereference of a possibly null reference.
                 //             return s.Length; // warning: possibly null
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(14, 20)
                 );
@@ -76445,10 +76446,10 @@ class B<[Nullable(0)]T01,
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,17): warning CS8602: Possible dereference of a null reference.
+                // (14,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(14, 17),
-                // (18,17): warning CS8602: Possible dereference of a null reference.
+                // (18,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(18, 17)
                 );
@@ -76488,10 +76489,10 @@ class B<[Nullable(0)]T01,
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,17): warning CS8602: Possible dereference of a null reference.
+                // (14,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(14, 17),
-                // (18,17): warning CS8602: Possible dereference of a null reference.
+                // (18,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(18, 17)
                 );
@@ -76535,13 +76536,13 @@ class B<[Nullable(0)]T01,
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,17): warning CS8602: Possible dereference of a null reference.
+                // (14,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(14, 17),
-                // (18,17): warning CS8602: Possible dereference of a null reference.
+                // (18,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(18, 17),
-                // (22,17): warning CS8602: Possible dereference of a null reference.
+                // (22,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(22, 17)
                 );
@@ -76581,10 +76582,10 @@ class B<[Nullable(0)]T01,
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,17): warning CS8602: Possible dereference of a null reference.
+                // (14,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(14, 17),
-                // (18,17): warning CS8602: Possible dereference of a null reference.
+                // (18,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(18, 17)
                 );
@@ -76623,13 +76624,13 @@ class B<[Nullable(0)]T01,
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,17): warning CS8602: Possible dereference of a null reference.
+                // (9,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(9, 17),
-                // (13,17): warning CS8602: Possible dereference of a null reference.
+                // (13,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(13, 17),
-                // (17,17): warning CS8602: Possible dereference of a null reference.
+                // (17,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(17, 17)
                 );
@@ -76665,7 +76666,7 @@ class B<[Nullable(0)]T01,
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,17): warning CS8602: Possible dereference of a null reference.
+                // (14,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(14, 17)
                 );
@@ -76705,7 +76706,7 @@ class B<[Nullable(0)]T01,
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (18,17): warning CS8602: Possible dereference of a null reference.
+                // (18,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(18, 17)
                 );
@@ -76945,31 +76946,31 @@ class B<[Nullable(0)]T01,
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (27,17): warning CS8602: Possible dereference of a null reference.
+                // (27,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 1a
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(27, 17),
-                // (52,17): warning CS8602: Possible dereference of a null reference.
+                // (52,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 1b
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(52, 17),
-                // (77,17): warning CS8602: Possible dereference of a null reference.
+                // (77,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 1c
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(77, 17),
-                // (100,21): warning CS8602: Possible dereference of a null reference.
+                // (100,21): warning CS8602: Dereference of a possibly null reference.
                 //                 _ = s.Length; // warning 2a
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(100, 21),
-                // (124,21): warning CS8602: Possible dereference of a null reference.
+                // (124,21): warning CS8602: Dereference of a possibly null reference.
                 //                 _ = s.Length; // warning 2b
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(124, 21),
-                // (148,21): warning CS8602: Possible dereference of a null reference.
+                // (148,21): warning CS8602: Dereference of a possibly null reference.
                 //                 _ = s.Length; // warning 2c
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(148, 21),
-                // (174,17): warning CS8602: Possible dereference of a null reference.
+                // (174,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 3a
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(174, 17),
-                // (199,17): warning CS8602: Possible dereference of a null reference.
+                // (199,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 3b
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(199, 17),
-                // (224,17): warning CS8602: Possible dereference of a null reference.
+                // (224,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = s.Length; // warning 3c
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(224, 17)
                 );
@@ -79300,7 +79301,7 @@ class Program
                 // (10,23): warning CS8619: Nullability of reference types in value of type 'C<object?>' doesn't match target type 'C<object>'.
                 //         C<object> x = new C<object?>() { F = null };
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new C<object?>() { F = null }").WithArguments("C<object?>", "C<object>").WithLocation(10, 23),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F/*T:object?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.F").WithLocation(11, 9),
                 // (12,24): warning CS8619: Nullability of reference types in value of type 'C<object>' doesn't match target type 'C<object?>'.
@@ -79334,7 +79335,7 @@ class Program
                 // (10,23): warning CS8619: Nullability of reference types in value of type 'S<object?>' doesn't match target type 'S<object>'.
                 //         S<object> x = new S<object?>();
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new S<object?>()").WithArguments("S<object?>", "S<object>").WithLocation(10, 23),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.F/*T:object?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.F").WithLocation(11, 9),
                 // (12,24): warning CS8619: Nullability of reference types in value of type 'S<object>' doesn't match target type 'S<object?>'.
@@ -79371,10 +79372,10 @@ class Program
                 // (8,14): warning CS8619: Nullability of reference types in value of type '<anonymous type: C<object?> F>' doesn't match target type '<anonymous type: C<object> F>'.
                 //         a1 = new { F = y1 };
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new { F = y1 }").WithArguments("<anonymous type: C<object?> F>", "<anonymous type: C<object> F>").WithLocation(8, 14),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         a1.F/*T:C<object!>?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a1.F").WithLocation(9, 9),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         a2.F/*T:C<object!>?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a2.F").WithLocation(14, 9),
                 // (15,14): warning CS8619: Nullability of reference types in value of type '<anonymous type: C<object?> F>' doesn't match target type '<anonymous type: C<object> F>'.
@@ -79411,10 +79412,10 @@ class Program
                 // (8,14): warning CS8619: Nullability of reference types in value of type '(C<object?>?, C<object?>?)' doesn't match target type '(C<object> x1, C<object?>? y1)'.
                 //         t1 = (y1, y1);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(y1, y1)").WithArguments("(C<object?>?, C<object?>?)", "(C<object> x1, C<object?>? y1)").WithLocation(8, 14),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         t1.Item1/*T:C<object!>?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1.Item1").WithLocation(9, 9),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         t2.Item1/*T:C<object!>?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2.Item1").WithLocation(14, 9),
                 // (15,14): warning CS8619: Nullability of reference types in value of type '(C<object?>, C<object?>)' doesn't match target type '(C<object>? x2, C<object?> y2)'.
@@ -79443,7 +79444,7 @@ class Program
                 // (6,42): warning CS8619: Nullability of reference types in value of type '(C<object> x, C<object?>? y)' doesn't match target type '(C<object?>? a, C<object> b)'.
                 //         (C<object?>? a, C<object> b) t = (x, y);
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(x, y)").WithArguments("(C<object> x, C<object?>? y)", "(C<object?>? a, C<object> b)").WithLocation(6, 42),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.b/*T:C<object!>?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.b").WithLocation(8, 9));
             comp.VerifyTypes();
@@ -80096,13 +80097,13 @@ class Program
                 // (14,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             var o2 = (object)t2; // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(object)t2").WithLocation(14, 22),
-                // (15,13): warning CS8602: Possible dereference of a null reference.
+                // (15,13): warning CS8602: Dereference of a possibly null reference.
                 //             o2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o2").WithLocation(15, 13),
                 // (27,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             var d3 = (dynamic)t3; // 4
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(dynamic)t3").WithLocation(27, 22),
-                // (28,13): warning CS8602: Possible dereference of a null reference.
+                // (28,13): warning CS8602: Dereference of a possibly null reference.
                 //             d3.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "d3").WithLocation(28, 13));
         }
@@ -80306,16 +80307,16 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,13): warning CS8602: Possible dereference of a null reference.
+                // (6,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = z1/*T:object?*/.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z1").WithLocation(6, 13),
-                // (8,13): warning CS8602: Possible dereference of a null reference.
+                // (8,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = w1/*T:dynamic?*/.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w1").WithLocation(8, 13),
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = z2/*T:object!*/.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z2").WithLocation(14, 13),
-                // (16,13): warning CS8602: Possible dereference of a null reference.
+                // (16,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = w2/*T:dynamic!*/.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w2").WithLocation(16, 13)
                 );
@@ -80466,13 +80467,13 @@ class Program
                 // (20,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             var a1 = (object)na1; // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(object)na1").WithLocation(20, 22),
-                // (21,13): warning CS8602: Possible dereference of a null reference.
+                // (21,13): warning CS8602: Dereference of a possibly null reference.
                 //             a1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a1").WithLocation(21, 13),
                 // (33,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             var a2 = (System.ValueType)na2; // 3
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(System.ValueType)na2").WithLocation(33, 22),
-                // (34,13): warning CS8602: Possible dereference of a null reference.
+                // (34,13): warning CS8602: Dereference of a possibly null reference.
                 //             a2.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a2").WithLocation(34, 13),
                 // (47,22): warning CS8629: Nullable value type may be null.
@@ -80481,7 +80482,7 @@ class Program
                 // (48,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             var b3 = (object)a3.B; // 6
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(object)a3.B").WithLocation(48, 22),
-                // (49,13): warning CS8602: Possible dereference of a null reference.
+                // (49,13): warning CS8602: Dereference of a possibly null reference.
                 //             b3.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b3").WithLocation(49, 13),
                 // (62,22): warning CS8629: Nullable value type may be null.
@@ -80490,7 +80491,7 @@ class Program
                 // (63,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             var b4 = (System.ValueType)a4.B; // 9
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(System.ValueType)a4.B").WithLocation(63, 22),
-                // (64,13): warning CS8602: Possible dereference of a null reference.
+                // (64,13): warning CS8602: Dereference of a possibly null reference.
                 //             b4.ToString(); // 10
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b4").WithLocation(64, 13));
         }
@@ -80548,7 +80549,7 @@ class Program
                 // (25,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             var c1 = (C)na1; // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(C)na1").WithLocation(25, 22),
-                // (26,13): warning CS8602: Possible dereference of a null reference.
+                // (26,13): warning CS8602: Dereference of a possibly null reference.
                 //             c1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1").WithLocation(26, 13),
                 // (39,22): warning CS8629: Nullable value type may be null.
@@ -80557,7 +80558,7 @@ class Program
                 // (40,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //             var c2 = (C)a2.B; // 4
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(C)a2.B").WithLocation(40, 22),
-                // (41,13): warning CS8602: Possible dereference of a null reference.
+                // (41,13): warning CS8602: Dereference of a possibly null reference.
                 //             c2.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(41, 13));
         }
@@ -80609,10 +80610,10 @@ class Program
                 // (20,21): warning CS8629: Nullable value type may be null.
                 //             var s = ns.Value; // 1
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "ns").WithLocation(20, 21),
-                // (22,13): warning CS8602: Possible dereference of a null reference.
+                // (22,13): warning CS8602: Dereference of a possibly null reference.
                 //             c.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(22, 13),
-                // (34,22): warning CS8602: Possible dereference of a null reference.
+                // (34,22): warning CS8602: Dereference of a possibly null reference.
                 //             var ns = nc.S; // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "nc").WithLocation(34, 22),
                 // (35,17): warning CS8629: Nullable value type may be null.
@@ -81167,10 +81168,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (31,17): warning CS8602: Possible dereference of a null reference.
+                // (31,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = c3.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c3").WithLocation(31, 17),
-                // (33,17): warning CS8602: Possible dereference of a null reference.
+                // (33,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = c4.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c4").WithLocation(33, 17));
         }
@@ -81217,22 +81218,22 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = c1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1").WithLocation(14, 13),
-                // (16,13): warning CS8602: Possible dereference of a null reference.
+                // (16,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = c2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(16, 13),
-                // (24,17): warning CS8602: Possible dereference of a null reference.
+                // (24,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = c1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1").WithLocation(24, 17),
-                // (26,17): warning CS8602: Possible dereference of a null reference.
+                // (26,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = c2.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(26, 17),
-                // (31,17): warning CS8602: Possible dereference of a null reference.
+                // (31,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = c3.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c3").WithLocation(31, 17),
-                // (33,17): warning CS8602: Possible dereference of a null reference.
+                // (33,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = c4.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c4").WithLocation(33, 17));
         }
@@ -81323,22 +81324,22 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,13): warning CS8602: Possible dereference of a null reference.
+                // (14,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = c1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1").WithLocation(14, 13),
-                // (16,13): warning CS8602: Possible dereference of a null reference.
+                // (16,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = c2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(16, 13),
-                // (24,17): warning CS8602: Possible dereference of a null reference.
+                // (24,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = c1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1").WithLocation(24, 17),
-                // (26,17): warning CS8602: Possible dereference of a null reference.
+                // (26,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = c2.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(26, 17),
-                // (31,17): warning CS8602: Possible dereference of a null reference.
+                // (31,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = c3.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c3").WithLocation(31, 17),
-                // (33,17): warning CS8602: Possible dereference of a null reference.
+                // (33,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = c4.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c4").WithLocation(33, 17));
         }
@@ -81603,19 +81604,19 @@ class C<T>
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,13): warning CS8602: Possible dereference of a null reference.
+                // (11,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = t1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1").WithLocation(11, 13),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = t2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2").WithLocation(13, 13),
-                // (21,17): warning CS8602: Possible dereference of a null reference.
+                // (21,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = t1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1").WithLocation(21, 17),
                 // (25,22): warning CS8601: Possible null reference assignment.
                 //             var t2 = (T)ns; // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "(T)ns").WithLocation(25, 22),
-                // (26,17): warning CS8602: Possible dereference of a null reference.
+                // (26,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = t2.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2").WithLocation(26, 17)
                 );
@@ -81656,16 +81657,16 @@ class C<T>
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,13): warning CS8602: Possible dereference of a null reference.
+                // (11,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = t1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1").WithLocation(11, 13),
-                // (13,13): warning CS8602: Possible dereference of a null reference.
+                // (13,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = t2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2").WithLocation(13, 13),
-                // (21,17): warning CS8602: Possible dereference of a null reference.
+                // (21,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = t1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1").WithLocation(21, 17),
-                // (26,17): warning CS8602: Possible dereference of a null reference.
+                // (26,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = t2.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t2").WithLocation(26, 17));
         }
@@ -81709,10 +81710,10 @@ class C<T> where T : class
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (28,17): warning CS8602: Possible dereference of a null reference.
+                // (28,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = t3.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t3").WithLocation(28, 17),
-                // (30,17): warning CS8602: Possible dereference of a null reference.
+                // (30,17): warning CS8602: Dereference of a possibly null reference.
                 //             _ = t4.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t4").WithLocation(30, 17));
         }
@@ -82413,7 +82414,7 @@ class B2 : A<int?>
                 // (9,15): error CS0029: Cannot implicitly convert type 'int?' to 'U'
                 //         U u = t;
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "t").WithArguments("int?", "U").WithLocation(9, 15),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         o.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(11, 9),
                 // (19,15): error CS0029: Cannot implicitly convert type 'int?' to 'U'
@@ -82450,10 +82451,10 @@ class B2 : A<int?>
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         o.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(11, 9),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         o.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(21, 9)
                 );
@@ -82482,13 +82483,13 @@ class B2 : A<int?>
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,10): warning CS8602: Possible dereference of a null reference.
+                // (6,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((object?)x1).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(object?)x1").WithLocation(6, 10),
-                // (7,10): warning CS8602: Possible dereference of a null reference.
+                // (7,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((object?)y1).ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(object?)y1").WithLocation(7, 10),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         w2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w2").WithLocation(15, 9)
                 );
@@ -82522,13 +82523,13 @@ class B2 : A<int?>
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,10): warning CS8602: Possible dereference of a null reference.
+                // (9,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((object?)x).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(object?)x").WithLocation(9, 10),
-                // (18,10): warning CS8602: Possible dereference of a null reference.
+                // (18,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((object?)x).ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(object?)x").WithLocation(18, 10),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(20, 9)
                 );
@@ -82983,10 +82984,10 @@ class Program
 ";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Value.F.ToString(); // warning baseline
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Value.F").WithLocation(14, 9),
-                // (23,9): warning CS8602: Possible dereference of a null reference.
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Value.F.ToString(); // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Value.F").WithLocation(23, 9)
             );
@@ -83026,13 +83027,13 @@ class Program
                 // (16,32): error CS1503: Argument 1: cannot convert from 'int' to 'S'
                 //         S? y = new Nullable<S>(1);
                 Diagnostic(ErrorCode.ERR_BadArgType, "1").WithArguments("1", "int", "S").WithLocation(16, 32),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Value.F.ToString(); // warning 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Value.F").WithLocation(17, 9),
                 // (19,32): error CS1503: Argument 1: cannot convert from '<null>' to 'S'
                 //         S? z = new Nullable<S>(null);
                 Diagnostic(ErrorCode.ERR_BadArgType, "null").WithArguments("1", "<null>", "S").WithLocation(19, 32),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.Value.F.ToString(); // warning 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z.Value.F").WithLocation(20, 9)
             );
@@ -83072,10 +83073,10 @@ class Program
                 // (17,9): warning CS8629: Nullable value type may be null.
                 //         y.Value.F.ToString(); // warning 1
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "y").WithLocation(17, 9),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Value.F.ToString(); // warning 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Value.F").WithLocation(17, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.Value.F.ToString(); // warning 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z.Value.F").WithLocation(20, 9)
 );
@@ -83240,10 +83241,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,14): warning CS8602: Possible dereference of a null reference.
+                // (5,14): warning CS8602: Dereference of a possibly null reference.
                 //         _ = (t1 as object).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1 as object").WithLocation(5, 14),
-                // (9,18): warning CS8602: Possible dereference of a null reference.
+                // (9,18): warning CS8602: Dereference of a possibly null reference.
                 //             _ = (t1 as object).ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t1 as object").WithLocation(9, 18),
                 // (13,14): warning CS8629: Nullable value type may be null.
@@ -83252,13 +83253,13 @@ class Program
                 // (17,18): warning CS8629: Nullable value type may be null.
                 //             _ = (t2 as T?).Value; // 4
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "t2 as T?").WithLocation(17, 18),
-                // (21,14): warning CS8602: Possible dereference of a null reference.
+                // (21,14): warning CS8602: Dereference of a possibly null reference.
                 //         _ = (t3 as U).ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t3 as U").WithLocation(21, 14),
-                // (23,18): warning CS8602: Possible dereference of a null reference.
+                // (23,18): warning CS8602: Dereference of a possibly null reference.
                 //             _ = (t3 as U).ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t3 as U").WithLocation(23, 18),
-                // (25,18): warning CS8602: Possible dereference of a null reference.
+                // (25,18): warning CS8602: Dereference of a possibly null reference.
                 //             _ = (t3 as U).ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t3 as U").WithLocation(25, 18),
                 // (29,14): warning CS8629: Nullable value type may be null.
@@ -83270,10 +83271,10 @@ class Program
                 // (33,18): warning CS8629: Nullable value type may be null.
                 //             _ = (t4 as U?).Value; // 10
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "t4 as U?").WithLocation(33, 18),
-                // (37,14): warning CS8602: Possible dereference of a null reference.
+                // (37,14): warning CS8602: Dereference of a possibly null reference.
                 //         _ = (t5 as dynamic).ToString(); // 11
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t5 as dynamic").WithLocation(37, 14),
-                // (41,18): warning CS8602: Possible dereference of a null reference.
+                // (41,18): warning CS8602: Dereference of a possibly null reference.
                 //             _ = (t5 as dynamic).ToString(); // 12
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t5 as dynamic").WithLocation(41, 18)
                 );
@@ -83864,16 +83865,16 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.x").WithLocation(8, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.y").WithLocation(9, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.x.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.x").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.y.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.y").WithLocation(11, 9));
             comp.VerifyTypes();
@@ -83898,16 +83899,16 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.x").WithLocation(8, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.y").WithLocation(9, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.x.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.x").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.y.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u.y").WithLocation(11, 9));
             comp.VerifyTypes();
@@ -83934,16 +83935,16 @@ class Program
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/issues/32575: Not handling default for U.
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Item1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Item1").WithLocation(7, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Item2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Item2").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Item1.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Item1").WithLocation(10, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Item2.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Item2").WithLocation(11, 9)
                 );
@@ -84353,7 +84354,7 @@ class C
                 // (8,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         string s6 = (s4 ??= s5); // Warn 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "s4 ??= s5").WithLocation(8, 22),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         s4.ToString(); // Warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s4").WithLocation(9, 9));
         }
@@ -84394,16 +84395,16 @@ class C
 
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         c1.F.ToString(); // Warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1.F").WithLocation(14, 9),
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         c1.F.ToString(); // Warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1.F").WithLocation(19, 9),
-                // (23,9): warning CS8602: Possible dereference of a null reference.
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
                 //         c1.F.ToString(); // Warn 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1.F").WithLocation(23, 9),
-                // (27,9): warning CS8602: Possible dereference of a null reference.
+                // (27,9): warning CS8602: Dereference of a possibly null reference.
                 //         (c1 ??= c3).F.ToString(); // Warn 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(c1 ??= c3).F").WithLocation(27, 9));
         }
@@ -84437,10 +84438,10 @@ class C
 
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         c2.ToString(); // Warn 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(9, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         c2.ToString(); // Warn 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c2").WithLocation(15, 9),
                 // (19,31): warning CS8604: Possible null reference argument for parameter 'c' in 'C C.GetC(C c)'.
@@ -84509,7 +84510,7 @@ class C
 
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         c1[0].ToString(); // Warn
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c1[0]").WithLocation(7, 9));
         }
@@ -84538,7 +84539,7 @@ class C
                 // (6,20): warning CS8601: Possible null reference assignment.
                 //         M2(c1) ??= c2; // Warn 1, 2
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "c2").WithLocation(6, 20),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         M2(c2).ToString(); // Warn 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "M2(c2)").WithLocation(10, 9));
         }
@@ -84651,10 +84652,10 @@ class B : A
                 // (5,22): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (T x, U y) = default((T, U)); // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default((T, U))").WithLocation(5, 22),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(7, 9));
         }
@@ -84680,10 +84681,10 @@ class B : A
                 // (5,32): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (T x, U y) = (default, default); // 1, 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(5, 32),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(7, 9));
         }
@@ -84706,7 +84707,7 @@ class B : A
                 // (5,24): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (T x, T? y) = (null, new T()); // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(5, 24),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 9));
         }
@@ -84729,13 +84730,13 @@ class B : A
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b").WithLocation(7, 9),
                 // (8,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (a, b) = (y, x); // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "y").WithLocation(8, 19),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(9, 9));
         }
@@ -84758,13 +84759,13 @@ class B : A
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b").WithLocation(7, 9),
                 // (8,18): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (b, a) = t; // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "t").WithLocation(8, 18),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(9, 9));
         }
@@ -84791,7 +84792,7 @@ class B : A
                 // (6,23): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (T a, T? b) = t; // 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "t").WithLocation(6, 23),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(7, 9));
         }
@@ -84811,10 +84812,10 @@ class B : A
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(6, 9),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(7, 9));
         }
@@ -84839,7 +84840,7 @@ class B : A
                 // (5,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T x = default; // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "default").WithLocation(5, 15),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(8, 9));
         }
@@ -84863,7 +84864,7 @@ class B : A
                 // (5,21): warning CS8619: Nullability of reference types in value of type '(T?, T)' doesn't match target type '(T, T?)'.
                 //         (T, T?) t = (default, new T()); // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(default, new T())").WithArguments("(T?, T)", "(T, T?)").WithLocation(5, 21),
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(7, 9));
         }
@@ -84888,7 +84889,7 @@ class B : A
                 // (6,19): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         t.Item1 = null; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 19),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(8, 9));
         }
@@ -84909,10 +84910,10 @@ class B : A
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(6, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9));
         }
@@ -84933,10 +84934,10 @@ class B : A
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(6, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9));
         }
@@ -84957,10 +84958,10 @@ class B : A
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(6, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(8, 9));
         }
@@ -84982,10 +84983,10 @@ class B : A
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.Item1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.Item1").WithLocation(6, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(9, 9));
         }
@@ -85013,10 +85014,10 @@ class B : A
                 // (5,62): warning CS8619: Nullability of reference types in value of type '(object y, object? z)' doesn't match target type '(object x, object y)'.
                 //         ((object a, object b), (object x, object y) c) = (x, (y, z)); // 1, 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(y, z)").WithArguments("(object y, object? z)", "(object x, object y)").WithLocation(5, 62),
-                // (6,9): warning CS8602: Possible dereference of a null reference.
+                // (6,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(6, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.y.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.y").WithLocation(9, 9));
         }
@@ -85065,10 +85066,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         u.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "u").WithLocation(11, 9));
         }
@@ -85098,10 +85099,10 @@ class Program
                 // (9,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (T x1, T y1) = new Pair<T, T?>(); // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "T y1").WithLocation(9, 16),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         y1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(11, 9),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         y2.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(14, 9));
         }
@@ -85128,10 +85129,10 @@ class Program
                 // (9,21): error CS0029: Cannot implicitly convert type 'Pair<T, U?>' to '(T, U?)'
                 //         (T, U?) t = new Pair<T, U?>();
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "new Pair<T, U?>()").WithArguments("Pair<T, U?>", "(T, U?)").WithLocation(9, 21),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item1.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item1").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         t.Item2.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Item2").WithLocation(11, 9));
         }
@@ -85159,10 +85160,10 @@ class Program
                 // (9,32): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (T a, (T? b, T? c)) = (x, y); // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "x").WithLocation(9, 32),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(10, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(12, 9));
         }
@@ -85192,7 +85193,7 @@ class Program
                 // (9,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (T a, (T? b, T? c)) = p; // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "T a").WithLocation(9, 10),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(10, 9));
         }
@@ -85222,7 +85223,7 @@ class Program
                 // (9,10): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (T a, (T? b, T? c)) = p; // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "T a").WithLocation(9, 10),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(10, 9));
         }
@@ -85250,7 +85251,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,22): warning CS8602: Possible dereference of a null reference.
+                // (9,22): warning CS8602: Dereference of a possibly null reference.
                 //         var (x, y) = p1; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "p1").WithLocation(9, 22));
         }
@@ -85355,19 +85356,19 @@ class Program
                 // (5,109): warning CS8619: Nullability of reference types in value of type '(object, object, object, object?, object?, (object? y, object x), object, object, object?, object?)' doesn't match target type '(object?, object, object?, object, object?, (object, object?), object, object, object?, object)'.
                 //         (object?, object, object?, object, object?, (object, object?), object, object, object?, object) t = (x, x, x, y, y, (y, x), x, x, y, y); // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(x, x, x, y, y, (y, x), x, x, y, y)").WithArguments("(object, object, object, object?, object?, (object? y, object x), object, object, object?, object?)", "(object?, object, object?, object, object?, (object, object?), object, object, object?, object)").WithLocation(5, 109),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         _4.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "_4").WithLocation(10, 9),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         _5.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "_5").WithLocation(11, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         _6a.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "_6a").WithLocation(12, 9),
-                // (16,9): warning CS8602: Possible dereference of a null reference.
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
                 //         _9.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "_9").WithLocation(16, 9),
-                // (17,9): warning CS8602: Possible dereference of a null reference.
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
                 //         _10.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "_10").WithLocation(17, 9));
         }
@@ -85443,13 +85444,13 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,9): warning CS8602: Possible dereference of a null reference.
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(7, 9),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(8, 9),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         z.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(9, 9));
         }
@@ -85502,7 +85503,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(14, 9));
         }
@@ -85625,22 +85626,22 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,10): warning CS8602: Possible dereference of a null reference.
+                // (11,10): warning CS8602: Dereference of a possibly null reference.
                 //         (x0.F, // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x0").WithLocation(11, 10),
-                // (13,18): warning CS8602: Possible dereference of a null reference.
+                // (13,18): warning CS8602: Dereference of a possibly null reference.
                 //                 (y0.F, // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(13, 18),
-                // (18,10): warning CS8602: Possible dereference of a null reference.
+                // (18,10): warning CS8602: Dereference of a possibly null reference.
                 //         (x1.F, // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(18, 10),
-                // (20,18): warning CS8602: Possible dereference of a null reference.
+                // (20,18): warning CS8602: Dereference of a possibly null reference.
                 //                 (y1.F, // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(20, 18),
-                // (26,13): warning CS8602: Possible dereference of a null reference.
+                // (26,13): warning CS8602: Dereference of a possibly null reference.
                 //             y2.F) = // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(26, 13),
-                // (28,21): warning CS8602: Possible dereference of a null reference.
+                // (28,21): warning CS8602: Dereference of a possibly null reference.
                 //                     x2.F); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(28, 21));
         }
@@ -85696,40 +85697,40 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (11,11): warning CS8602: Possible dereference of a null reference.
+                // (11,11): warning CS8602: Dereference of a possibly null reference.
                 //         ((x0.F, // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x0").WithLocation(11, 11),
-                // (12,13): warning CS8602: Possible dereference of a null reference.
+                // (12,13): warning CS8602: Dereference of a possibly null reference.
                 //             y0.F), // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(12, 13),
-                // (13,17): warning CS8602: Possible dereference of a null reference.
+                // (13,17): warning CS8602: Dereference of a possibly null reference.
                 //                 z0.F) = // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z0").WithLocation(13, 17),
-                // (20,11): warning CS8602: Possible dereference of a null reference.
+                // (20,11): warning CS8602: Dereference of a possibly null reference.
                 //         ((x1.F, // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(20, 11),
-                // (23,23): warning CS8602: Possible dereference of a null reference.
+                // (23,23): warning CS8602: Dereference of a possibly null reference.
                 //                     ((y1.F, // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(23, 23),
-                // (24,25): warning CS8602: Possible dereference of a null reference.
+                // (24,25): warning CS8602: Dereference of a possibly null reference.
                 //                         z1.F), // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z1").WithLocation(24, 25),
-                // (31,17): warning CS8602: Possible dereference of a null reference.
+                // (31,17): warning CS8602: Dereference of a possibly null reference.
                 //                 x2.F) = // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(31, 17),
-                // (33,25): warning CS8602: Possible dereference of a null reference.
+                // (33,25): warning CS8602: Dereference of a possibly null reference.
                 //                         y2.F), // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(33, 25),
-                // (34,29): warning CS8602: Possible dereference of a null reference.
+                // (34,29): warning CS8602: Dereference of a possibly null reference.
                 //                             z2.F); // 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z2").WithLocation(34, 29),
-                // (38,10): warning CS8602: Possible dereference of a null reference.
+                // (38,10): warning CS8602: Dereference of a possibly null reference.
                 //         (x3.F, // 10
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(38, 10),
-                // (40,17): warning CS8602: Possible dereference of a null reference.
+                // (40,17): warning CS8602: Dereference of a possibly null reference.
                 //                 y3.F)) = // 11
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y3").WithLocation(40, 17),
-                // (42,26): warning CS8602: Possible dereference of a null reference.
+                // (42,26): warning CS8602: Dereference of a possibly null reference.
                 //                         (z3.F, // 12
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z3").WithLocation(42, 26));
         }
@@ -85774,16 +85775,16 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (14,17): warning CS8602: Possible dereference of a null reference.
+                // (14,17): warning CS8602: Dereference of a possibly null reference.
                 //                 p0; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "p0").WithLocation(14, 17),
-                // (19,13): warning CS8602: Possible dereference of a null reference.
+                // (19,13): warning CS8602: Dereference of a possibly null reference.
                 //             p1.Second) = // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "p1").WithLocation(19, 13),
-                // (24,10): warning CS8602: Possible dereference of a null reference.
+                // (24,10): warning CS8602: Dereference of a possibly null reference.
                 //         (p2.First, // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "p2").WithLocation(24, 10),
-                // (30,10): warning CS8602: Possible dereference of a null reference.
+                // (30,10): warning CS8602: Dereference of a possibly null reference.
                 //         (p3.First, // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "p3").WithLocation(30, 10));
         }
@@ -85845,34 +85846,34 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (13,11): warning CS8602: Possible dereference of a null reference.
+                // (13,11): warning CS8602: Dereference of a possibly null reference.
                 //         ((x0.First, // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x0").WithLocation(13, 11),
-                // (15,17): warning CS8602: Possible dereference of a null reference.
+                // (15,17): warning CS8602: Dereference of a possibly null reference.
                 //                 y0.First) = // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y0").WithLocation(15, 17),
-                // (22,13): warning CS8602: Possible dereference of a null reference.
+                // (22,13): warning CS8602: Dereference of a possibly null reference.
                 //             y1.First), // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(22, 13),
-                // (24,22): warning CS8602: Possible dereference of a null reference.
+                // (24,22): warning CS8602: Dereference of a possibly null reference.
                 //                     (x1, // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(24, 22),
-                // (31,17): warning CS8602: Possible dereference of a null reference.
+                // (31,17): warning CS8602: Dereference of a possibly null reference.
                 //                 x2.First) = // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x2").WithLocation(31, 17),
-                // (33,25): warning CS8602: Possible dereference of a null reference.
+                // (33,25): warning CS8602: Dereference of a possibly null reference.
                 //                         y2.Second); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2").WithLocation(33, 25),
-                // (37,10): warning CS8602: Possible dereference of a null reference.
+                // (37,10): warning CS8602: Dereference of a possibly null reference.
                 //         (x3.First, // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(37, 10),
-                // (39,17): warning CS8602: Possible dereference of a null reference.
+                // (39,17): warning CS8602: Dereference of a possibly null reference.
                 //                 y3.First)) = // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y3").WithLocation(39, 17),
-                // (46,14): warning CS8602: Possible dereference of a null reference.
+                // (46,14): warning CS8602: Dereference of a possibly null reference.
                 //             (x4.First, // 9
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x4").WithLocation(46, 14),
-                // (49,25): warning CS8602: Possible dereference of a null reference.
+                // (49,25): warning CS8602: Dereference of a possibly null reference.
                 //                         y4); // 10
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y4").WithLocation(49, 25));
         }
@@ -85901,10 +85902,10 @@ class Program
                 // (7,42): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (object a, object b, object c) = t; // 1, 2
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "t").WithLocation(7, 42),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(8, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(10, 9));
         }
@@ -85926,7 +85927,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b").WithLocation(8, 9));
         }
@@ -85957,7 +85958,7 @@ class Program
                 // (3,21): warning CS0649: Field 'S.F' is never assigned to, and will always have its default value null
                 //     internal object F;
                 Diagnostic(ErrorCode.WRN_UnassignedInternalField, "F").WithArguments("S.F", "null").WithLocation(3, 21),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Value.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Value.F").WithLocation(13, 9),
                 // (14,13): warning CS8629: Nullable value type may be null.
@@ -85989,7 +85990,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.Value.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.Value.F").WithLocation(15, 9));
         }
@@ -86021,7 +86022,7 @@ class Program
                 // (10,31): warning CS8619: Nullability of reference types in value of type 'S<T>' doesn't match target type 'S<T?>?'.
                 //         (S<T>? x, S<T?>? y) = t; // 1, 2
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "t").WithArguments("S<T>", "S<T?>?").WithLocation(10, 31),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         x.Value.F.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x.Value.F").WithLocation(11, 9));
         }
@@ -86070,7 +86071,7 @@ class Program
                 // (5,53): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         (object? a, object? b, object? c) = (x, y = null);
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(5, 53),
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(9, 9));
         }
@@ -86260,7 +86261,7 @@ class Program
                 // (6,13): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         y = null; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(6, 13),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(8, 9));
         }
@@ -86287,7 +86288,7 @@ class Program
                 // (8,13): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         y = null; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 13),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(10, 9));
         }
@@ -86363,7 +86364,7 @@ class Program
                 // (11,27): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         y = new C() { F = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 27),
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(13, 9));
         }
@@ -86390,7 +86391,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (13,9): warning CS8602: Possible dereference of a null reference.
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(13, 9));
         }
@@ -86422,7 +86423,7 @@ class Program
                 // (13,27): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         y = new C() { F = null }; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(13, 27),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(15, 9));
         }
@@ -86451,7 +86452,7 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         y.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y.F").WithLocation(15, 9));
         }
@@ -86533,7 +86534,7 @@ class Program
                 // (11,9): warning CS1717: Assignment made to same variable; did you mean to assign something else?
                 //         a = a;
                 Diagnostic(ErrorCode.WRN_AssignmentToSelf, "a = a").WithLocation(11, 9),
-                // (12,9): warning CS8602: Possible dereference of a null reference.
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
                 //         a.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.F").WithLocation(12, 9),
                 // (13,43): warning CS8625: Cannot convert null literal to non-nullable reference type.
@@ -86542,7 +86543,7 @@ class Program
                 // (14,9): warning CS1717: Assignment made to same variable; did you mean to assign something else?
                 //         b.F = b.F;
                 Diagnostic(ErrorCode.WRN_AssignmentToSelf, "b.F = b.F").WithLocation(14, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         b.F.F.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b.F.F").WithLocation(15, 9));
         }
@@ -86604,7 +86605,7 @@ class Program
                 // (10,9): warning CS1717: Assignment made to same variable; did you mean to assign something else?
                 //         c.F = c.F; // 1
                 Diagnostic(ErrorCode.WRN_AssignmentToSelf, "c.F = c.F").WithLocation(10, 9),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         c.F = c.F; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(10, 9));
         }
@@ -86684,10 +86685,10 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         C<T1>.F.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<T1>.F").WithLocation(10, 9),
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         C<T2?>.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<T2?>.F").WithLocation(15, 9),
                 // (25,13): warning CS8629: Nullable value type may be null.
@@ -86753,19 +86754,19 @@ class Program
                 // (10,19): warning CS8653: A default expression introduces a null value when 'T1' is a non-nullable reference type.
                 //         C<T1>.F = default; // 1
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T1").WithLocation(10, 19),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         C<T1>.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<T1>.F").WithLocation(11, 9),
                 // (25,19): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         C<T4>.F = null; // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(25, 19),
-                // (26,9): warning CS8602: Possible dereference of a null reference.
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
                 //         C<T4>.F.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<T4>.F").WithLocation(26, 9),
                 // (40,23): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         C<string>.F = null; // 5
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(40, 23),
-                // (41,13): warning CS8602: Possible dereference of a null reference.
+                // (41,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = C<string>.F.Length; // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<string>.F").WithLocation(41, 13));
         }
@@ -86831,19 +86832,19 @@ class Program
                 // (13,19): warning CS8653: A default expression introduces a null value when 'T1' is a non-nullable reference type.
                 //         C<T1>.P = default; // 1
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T1").WithLocation(13, 19),
-                // (14,9): warning CS8602: Possible dereference of a null reference.
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         C<T1>.P.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<T1>.P").WithLocation(14, 9),
                 // (28,19): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         C<T4>.P = null; // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(28, 19),
-                // (29,9): warning CS8602: Possible dereference of a null reference.
+                // (29,9): warning CS8602: Dereference of a possibly null reference.
                 //         C<T4>.P.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<T4>.P").WithLocation(29, 9),
                 // (43,23): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         C<string>.P = null; // 5
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(43, 23),
-                // (44,13): warning CS8602: Possible dereference of a null reference.
+                // (44,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = C<string>.P.Length; // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<string>.P").WithLocation(44, 13));
         }
@@ -86881,13 +86882,13 @@ class Program
                 // (10,19): warning CS8653: A default expression introduces a null value when 'T1' is a non-nullable reference type.
                 //         S<T1>.F = default; // 1
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T1").WithLocation(10, 19),
-                // (11,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
                 //         S<T1>.F.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "S<T1>.F").WithLocation(11, 9),
                 // (20,19): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         S<T3>.F = null; // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(20, 19),
-                // (21,9): warning CS8602: Possible dereference of a null reference.
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
                 //         S<T3>.F.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "S<T3>.F").WithLocation(21, 9));
         }
@@ -86924,13 +86925,13 @@ class Program
                 // (9,19): warning CS8653: A default expression introduces a null value when 'T1' is a non-nullable reference type.
                 //         S<T1>.P = default; // 1
                 Diagnostic(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT, "default").WithArguments("T1").WithLocation(9, 19),
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         S<T1>.P.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "S<T1>.P").WithLocation(10, 9),
                 // (19,19): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         S<T3>.P = null; // 3
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(19, 19),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         S<T3>.P.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "S<T3>.P").WithLocation(20, 9));
         }
@@ -87123,19 +87124,19 @@ class Program
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (19,9): warning CS8602: Possible dereference of a null reference.
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
                 //         y1.A.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1.A").WithLocation(19, 9),
-                // (20,9): warning CS8602: Possible dereference of a null reference.
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
                 //         y1.B.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1.B").WithLocation(20, 9),
                 // (24,16): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T x2 = null; // 3
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(24, 16),
-                // (27,9): warning CS8602: Possible dereference of a null reference.
+                // (27,9): warning CS8602: Dereference of a possibly null reference.
                 //         y2.A.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2.A").WithLocation(27, 9),
-                // (28,9): warning CS8602: Possible dereference of a null reference.
+                // (28,9): warning CS8602: Dereference of a possibly null reference.
                 //         y2.B.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y2.B").WithLocation(28, 9),
                 // (41,13): warning CS8629: Nullable value type may be null.
@@ -87193,10 +87194,10 @@ class Program
                 // (23,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         T y = null; // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(23, 15),
-                // (26,9): warning CS8602: Possible dereference of a null reference.
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
                 //         xy.B.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "xy.B").WithLocation(26, 9),
-                // (28,9): warning CS8602: Possible dereference of a null reference.
+                // (28,9): warning CS8602: Dereference of a possibly null reference.
                 //         yx.A.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "yx.A").WithLocation(28, 9));
         }
@@ -87311,10 +87312,10 @@ class Program
                 // (23,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         U y = null; // 1
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(23, 15),
-                // (26,9): warning CS8602: Possible dereference of a null reference.
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
                 //         ix.A(y).ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ix.A(y)").WithLocation(26, 9),
-                // (29,9): warning CS8602: Possible dereference of a null reference.
+                // (29,9): warning CS8602: Dereference of a possibly null reference.
                 //         iy.B(x).ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "iy.B(x)").WithLocation(29, 9));
         }
@@ -87349,13 +87350,13 @@ public class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,27): warning CS8602: Possible dereference of a null reference.
+                // (5,27): warning CS8602: Dereference of a possibly null reference.
                 //     void Test1(C? c) => c?.f.M(c.f.ToString()); // nested use of `c.f` is safe
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, ".f").WithLocation(5, 27),
-                // (6,25): warning CS8602: Possible dereference of a null reference.
+                // (6,25): warning CS8602: Dereference of a possibly null reference.
                 //     void Test2(C? c) => c.f.M(c.f.ToString());
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(6, 25),
-                // (6,25): warning CS8602: Possible dereference of a null reference.
+                // (6,25): warning CS8602: Dereference of a possibly null reference.
                 //     void Test2(C? c) => c.f.M(c.f.ToString());
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.f").WithLocation(6, 25)
                 );
@@ -87397,7 +87398,7 @@ public class C
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,25): warning CS8602: Possible dereference of a null reference.
+                // (7,25): warning CS8602: Dereference of a possibly null reference.
                 //     void Test2(C? c) => c.Nested?.M(c.Nested.ToString());
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c").WithLocation(7, 25)
                 );
@@ -87431,16 +87432,16 @@ interface I
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (5,14): warning CS8602: Possible dereference of a null reference.
+                // (5,14): warning CS8602: Dereference of a possibly null reference.
                 //         _ = (c?.S).Length;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c?.S").WithLocation(5, 14),
-                // (6,14): warning CS8602: Possible dereference of a null reference.
+                // (6,14): warning CS8602: Dereference of a possibly null reference.
                 //         _ = (a?[0]).P;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a?[0]").WithLocation(6, 14),
-                // (11,14): warning CS8602: Possible dereference of a null reference.
+                // (11,14): warning CS8602: Dereference of a possibly null reference.
                 //         _ = (t?.S).Length;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t?.S").WithLocation(11, 14),
-                // (12,14): warning CS8602: Possible dereference of a null reference.
+                // (12,14): warning CS8602: Dereference of a possibly null reference.
                 //         _ = (t?[0]).P;
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t?[0]").WithLocation(12, 14)
                 );
@@ -87673,28 +87674,28 @@ class G<T>
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             // https://github.com/dotnet/roslyn/pull/33929: Once we report one of the (NOT YET) warnings, we should report the other
             comp.VerifyDiagnostics(
-                // (15,9): warning CS8602: Possible dereference of a null reference.
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
                 //         node.Next.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "node.Next").WithLocation(15, 9),
-                // (29,9): warning CS8602: Possible dereference of a null reference.
+                // (29,9): warning CS8602: Dereference of a possibly null reference.
                 //         node.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "node").WithLocation(29, 9),
-                // (43,9): warning CS8602: Possible dereference of a null reference.
+                // (43,9): warning CS8602: Dereference of a possibly null reference.
                 //         node.ToString(); // 3
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "node").WithLocation(43, 9),
-                // (63,9): warning CS8602: Possible dereference of a null reference.
+                // (63,9): warning CS8602: Dereference of a possibly null reference.
                 //         node.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "node").WithLocation(63, 9),
-                // (83,9): warning CS8602: Possible dereference of a null reference.
+                // (83,9): warning CS8602: Dereference of a possibly null reference.
                 //         node.ToString(); // 5
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "node").WithLocation(83, 9),
-                // (97,9): warning CS8602: Possible dereference of a null reference.
+                // (97,9): warning CS8602: Dereference of a possibly null reference.
                 //         node.ToString(); // 6
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "node").WithLocation(97, 9),
-                // (104,9): warning CS8602: Possible dereference of a null reference.
+                // (104,9): warning CS8602: Dereference of a possibly null reference.
                 //         node.ToString(); // 7
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "node").WithLocation(104, 9),
-                // (118,9): warning CS8602: Possible dereference of a null reference.
+                // (118,9): warning CS8602: Dereference of a possibly null reference.
                 //         node.ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "node").WithLocation(118, 9));
         }
@@ -87731,7 +87732,7 @@ public class C
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (7,13): warning CS8602: Possible dereference of a null reference.
+                // (7,13): warning CS8602: Dereference of a possibly null reference.
                 //         _ = __refvalue(r, string?).Length; // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "__refvalue(r, string?)").WithLocation(7, 13)
                 );
@@ -87974,7 +87975,7 @@ class C
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(() => o).ToString(); // warning: maybe null
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => o)").WithLocation(8, 9));
         }
@@ -87999,7 +88000,7 @@ class C
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(() => o, M(1)).ToString(); // warning: maybe null
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => o, M(1))").WithLocation(9, 9));
         }
@@ -88031,10 +88032,10 @@ class C
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (10,9): warning CS8602: Possible dereference of a null reference.
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
                 //         fa1[0]().ToString(); // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "fa1[0]()").WithLocation(10, 9),
-                // (18,9): warning CS8602: Possible dereference of a null reference.
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
                 //         fa3[0]().ToString(); // warning
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "fa3[0]()").WithLocation(18, 9));
         }
@@ -88085,7 +88086,7 @@ class C
 ";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
                 //         F(() => o).ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => o)").WithLocation(9, 9));
         }


### PR DESCRIPTION
Search & replace change.
Fixes https://github.com/dotnet/roslyn/issues/34408