### PR TITLE
Test helpers utilized by Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders.ExplicitInterfaceMemberCompletionProviderTests do not handle ```<Workspace>``` markup

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
@@ -365,8 +365,8 @@ interface IGoo
     </Project>
 </Workspace>";
 
-            await VerifyItemExistsAsync(markup, "Goo1()"); // https://github.com/dotnet/roslyn/issues/34456: Should use VerifyItemIsAbsentAsync instead after test infrastructure is changed to actually build two distinct projects from the XML 
-            await VerifyItemExistsAsync(markup, "Prop1"); // https://github.com/dotnet/roslyn/issues/34456: Should use VerifyItemIsAbsentAsync instead after test infrastructure is changed to actually build two distinct projects from the XML 
+            await VerifyItemIsAbsentAsync(markup, "Goo1()");
+            await VerifyItemIsAbsentAsync(markup, "Prop1");
             await VerifyItemExistsAsync(markup, "Goo2()");
             await VerifyItemExistsAsync(markup, "Prop2");
         }
@@ -401,8 +401,8 @@ interface IGoo
     </Project>
 </Workspace>";
 
-            await VerifyItemExistsAsync(markup, "Goo1()"); // https://github.com/dotnet/roslyn/issues/34456: Should use VerifyItemIsAbsentAsync instead after test infrastructure is changed to actually build two distinct projects from the XML 
-            await VerifyItemExistsAsync(markup, "Prop1"); // https://github.com/dotnet/roslyn/issues/34456: Should use VerifyItemIsAbsentAsync instead after test infrastructure is changed to actually build two distinct projects from the XML 
+            await VerifyItemIsAbsentAsync(markup, "Goo1()");
+            await VerifyItemIsAbsentAsync(markup, "Prop1");
             await VerifyItemExistsAsync(markup, "Goo2()");
             await VerifyItemExistsAsync(markup, "Prop2");
         }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
@@ -354,7 +354,7 @@ class Bar : IGoo
     </Project>
     <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"" LanguageVersion=""Preview"">
         <Document FilePath=""Test2.cs"">
-interface IGoo
+public interface IGoo
 {
     internal void Goo1() {}
     internal int Prop1 { get => 0; }
@@ -390,7 +390,7 @@ interface IBar : IGoo
     </Project>
     <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"" LanguageVersion=""Preview"">
         <Document FilePath=""Test2.cs"">
-interface IGoo
+public interface IGoo
 {
     internal void Goo1() {}
     internal int Prop1 { get => 0; }

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             }
             catch(XmlException)
             {
-                output = default;
+                output = null;
                 return false;
             }
         }

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml;
-using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion;
@@ -303,42 +301,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         /// <summary>
         /// Override this to change parameters or return without verifying anything, e.g. for script sources. Or to test in other code contexts.
         /// </summary>
-        /// <param name="codeBeforeCommit">The source code (not markup).</param>
+        /// <param name="codeBeforeCommit">The source code or markup.</param>
         /// <param name="position">Position where intellisense is invoked.</param>
         /// <param name="itemToCommit">The item to commit from the completion provider.</param>
         /// <param name="expectedCodeAfterCommit">The expected code after commit.</param>
         protected virtual async Task VerifyCustomCommitProviderWorkerAsync(string codeBeforeCommit, int position, string itemToCommit, string expectedCodeAfterCommit, SourceCodeKind sourceCodeKind, char? commitChar = null)
         {
-            Document document1;
-            if (TryParseXElement(codeBeforeCommit, out var workspaceElement) && workspaceElement.Name == "Workspace")
-            {
-                document1 = WorkspaceFixture.CreateWorkspaceAndGetDocument(workspaceElement);
-            }
-            else
-            {
-                document1 = WorkspaceFixture.UpdateDocument(codeBeforeCommit, sourceCodeKind);
-            }
-
+            var document1 = WorkspaceFixture.UpdateDocument(codeBeforeCommit, sourceCodeKind);
             await VerifyCustomCommitProviderCheckResultsAsync(document1, codeBeforeCommit, position, itemToCommit, expectedCodeAfterCommit, commitChar);
 
             if (await CanUseSpeculativeSemanticModelAsync(document1, position))
             {
                 var document2 = WorkspaceFixture.UpdateDocument(codeBeforeCommit, sourceCodeKind, cleanBeforeUpdate: false);
                 await VerifyCustomCommitProviderCheckResultsAsync(document2, codeBeforeCommit, position, itemToCommit, expectedCodeAfterCommit, commitChar);
-            }
-        }
-
-        private bool TryParseXElement(string input, out XElement output)
-        {
-            try
-            {
-                output = XElement.Parse(input);
-                return true;
-            }
-            catch(XmlException)
-            {
-                output = null;
-                return false;
             }
         }
 
@@ -434,7 +409,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         /// <summary>
         /// Override this to change parameters or return without verifying anything, e.g. for script sources. Or to test in other code contexts.
         /// </summary>
-        /// <param name="codeBeforeCommit">The source code (not markup).</param>
+        /// <param name="codeBeforeCommit">The source code or markup.</param>
         /// <param name="position">Position where intellisense is invoked.</param>
         /// <param name="itemToCommit">The item to commit from the completion provider.</param>
         /// <param name="expectedCodeAfterCommit">The expected code after commit.</param>

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -148,7 +148,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             SourceCodeKind sourceCodeKind, bool usePreviousCharAsTrigger, bool checkForAbsence,
             int? glyph, int? matchPriority, bool? hasSuggestionModeItem, string displayTextSuffix)
         {
-            MarkupTestFile.GetPosition(markup.NormalizeLineEndings(), out var code, out int position);
+            WorkspaceFixture.GetWorkspace(markup);
+            var code = WorkspaceFixture.Code;
+            var position = WorkspaceFixture.Position;
 
             return VerifyWorkerAsync(
                 code, position, expectedItemOrNull, expectedDescriptionOrNull,
@@ -158,9 +160,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         protected async Task VerifyCustomCommitProviderAsync(string markupBeforeCommit, string itemToCommit, string expectedCodeAfterCommit, SourceCodeKind? sourceCodeKind = null, char? commitChar = null)
         {
-            using (WorkspaceFixture.GetWorkspace())
+            using (WorkspaceFixture.GetWorkspace(markupBeforeCommit))
             {
-                MarkupTestFile.GetPosition(markupBeforeCommit.NormalizeLineEndings(), out var code, out int position);
+                var code = WorkspaceFixture.Code;
+                var position = WorkspaceFixture.Position;
 
                 if (sourceCodeKind.HasValue)
                 {
@@ -177,7 +180,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         protected async Task VerifyProviderCommitAsync(string markupBeforeCommit, string itemToCommit, string expectedCodeAfterCommit,
             char? commitChar, string textTypedSoFar, SourceCodeKind? sourceCodeKind = null)
         {
-            MarkupTestFile.GetPosition(markupBeforeCommit.NormalizeLineEndings(), out var code, out int position);
+            WorkspaceFixture.GetWorkspace(markupBeforeCommit);
+
+            var code = WorkspaceFixture.Code;
+            var position = WorkspaceFixture.Position;
 
             expectedCodeAfterCommit = expectedCodeAfterCommit.NormalizeLineEndings();
             if (sourceCodeKind.HasValue)
@@ -321,7 +327,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         {
             var workspace = WorkspaceFixture.GetWorkspace();
             SetWorkspaceOptions(workspace);
-            var textBuffer = workspace.Documents.Single().TextBuffer;
+            var textBuffer = WorkspaceFixture.CurrentDocument.TextBuffer;
 
             var service = GetCompletionService(workspace);
             var items = (await GetCompletionListAsync(service, document, position, RoslynCompletion.CompletionTrigger.Invoke)).Items;
@@ -330,7 +336,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             if (service.ExclusiveProviders?[0] is ICustomCommitCompletionProvider customCommitCompletionProvider)
             {
                 var completionRules = GetCompletionHelper(document);
-                var textView = (WorkspaceFixture.GetWorkspace()).Documents.Single().GetTextView();
+                var textView = WorkspaceFixture.CurrentDocument.GetTextView();
                 VerifyCustomCommitWorker(service, customCommitCompletionProvider, firstItem, completionRules, textView, textBuffer, codeBeforeCommit, expectedCodeAfterCommit, commitChar);
             }
             else
@@ -367,8 +373,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             var newDoc = document.WithText(newText);
             document.Project.Solution.Workspace.TryApplyChanges(newDoc.Project.Solution);
 
-            var textBuffer = (WorkspaceFixture.GetWorkspace()).Documents.Single().TextBuffer;
-            var textView = (WorkspaceFixture.GetWorkspace()).Documents.Single().GetTextView();
+            var textBuffer = WorkspaceFixture.CurrentDocument.TextBuffer;
+            var textView = WorkspaceFixture.CurrentDocument.GetTextView();
 
             string actualCodeAfterCommit = textBuffer.CurrentSnapshot.AsText().ToString();
             var caretPosition = commit.NewPosition != null ? commit.NewPosition.Value : textView.Caret.Position.BufferPosition.Position;
@@ -430,7 +436,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             Document document, int position, string itemToCommit, string expectedCodeAfterCommit, char? commitCharOpt, string textTypedSoFar)
         {
             var workspace = WorkspaceFixture.GetWorkspace();
-            var textBuffer = workspace.Documents.Single().TextBuffer;
+            var textBuffer = WorkspaceFixture.CurrentDocument.TextBuffer;
             var textSnapshot = textBuffer.CurrentSnapshot.AsText();
 
             var service = GetCompletionService(workspace);
@@ -833,7 +839,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         protected async Task<ImmutableArray<CompletionItem>> GetCompletionItemsAsync(
             string markup, SourceCodeKind sourceCodeKind, bool usePreviousCharAsTrigger = false)
         {
-            MarkupTestFile.GetPosition(markup.NormalizeLineEndings(), out var code, out int position);
+            WorkspaceFixture.GetWorkspace(markup);
+            var code = WorkspaceFixture.Code;
+            var position = WorkspaceFixture.Position;
             var document = WorkspaceFixture.UpdateDocument(code, sourceCodeKind);
 
             var trigger = usePreviousCharAsTrigger

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         /// <summary>
         /// Override this to change parameters or return without verifying anything, e.g. for script sources. Or to test in other code contexts.
         /// </summary>
-        /// <param name="codeBeforeCommit">The source code or markup.</param>
+        /// <param name="codeBeforeCommit">The source code (not markup).</param>
         /// <param name="position">Position where intellisense is invoked.</param>
         /// <param name="itemToCommit">The item to commit from the completion provider.</param>
         /// <param name="expectedCodeAfterCommit">The expected code after commit.</param>
@@ -415,7 +415,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         /// <summary>
         /// Override this to change parameters or return without verifying anything, e.g. for script sources. Or to test in other code contexts.
         /// </summary>
-        /// <param name="codeBeforeCommit">The source code or markup.</param>
+        /// <param name="codeBeforeCommit">The source code (not markup).</param>
         /// <param name="position">Position where intellisense is invoked.</param>
         /// <param name="itemToCommit">The item to commit from the completion provider.</param>
         /// <param name="expectedCodeAfterCommit">The expected code after commit.</param>

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml;
-using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion;
@@ -309,36 +307,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         /// <param name="expectedCodeAfterCommit">The expected code after commit.</param>
         protected virtual async Task VerifyCustomCommitProviderWorkerAsync(string codeBeforeCommit, int position, string itemToCommit, string expectedCodeAfterCommit, SourceCodeKind sourceCodeKind, char? commitChar = null)
         {
-            Document document1;
-            if (TryParseXElement(codeBeforeCommit, out var workspaceElement) && workspaceElement.Name == "Workspace")
-            {
-                document1 = WorkspaceFixture.CreateWorkspaceAndGetDocument(workspaceElement);
-            }
-            else
-            {
-                document1 = WorkspaceFixture.UpdateDocument(codeBeforeCommit, sourceCodeKind);
-            }
-
+            var document1 = WorkspaceFixture.UpdateDocument(codeBeforeCommit, sourceCodeKind);
             await VerifyCustomCommitProviderCheckResultsAsync(document1, codeBeforeCommit, position, itemToCommit, expectedCodeAfterCommit, commitChar);
 
             if (await CanUseSpeculativeSemanticModelAsync(document1, position))
             {
                 var document2 = WorkspaceFixture.UpdateDocument(codeBeforeCommit, sourceCodeKind, cleanBeforeUpdate: false);
                 await VerifyCustomCommitProviderCheckResultsAsync(document2, codeBeforeCommit, position, itemToCommit, expectedCodeAfterCommit, commitChar);
-            }
-        }
-
-        private bool TryParseXElement(string input, out XElement output)
-        {
-            try
-            {
-                output = XElement.Parse(input);
-                return true;
-            }
-            catch(XmlException)
-            {
-                output = null;
-                return false;
             }
         }
 

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion;
@@ -307,13 +309,36 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         /// <param name="expectedCodeAfterCommit">The expected code after commit.</param>
         protected virtual async Task VerifyCustomCommitProviderWorkerAsync(string codeBeforeCommit, int position, string itemToCommit, string expectedCodeAfterCommit, SourceCodeKind sourceCodeKind, char? commitChar = null)
         {
-            var document1 = WorkspaceFixture.UpdateDocument(codeBeforeCommit, sourceCodeKind);
+            Document document1;
+            if (TryParseXElement(codeBeforeCommit, out var workspaceElement) && workspaceElement.Name == "Workspace")
+            {
+                document1 = WorkspaceFixture.CreateWorkspaceAndGetDocument(workspaceElement);
+            }
+            else
+            {
+                document1 = WorkspaceFixture.UpdateDocument(codeBeforeCommit, sourceCodeKind);
+            }
+
             await VerifyCustomCommitProviderCheckResultsAsync(document1, codeBeforeCommit, position, itemToCommit, expectedCodeAfterCommit, commitChar);
 
             if (await CanUseSpeculativeSemanticModelAsync(document1, position))
             {
                 var document2 = WorkspaceFixture.UpdateDocument(codeBeforeCommit, sourceCodeKind, cleanBeforeUpdate: false);
                 await VerifyCustomCommitProviderCheckResultsAsync(document2, codeBeforeCommit, position, itemToCommit, expectedCodeAfterCommit, commitChar);
+            }
+        }
+
+        private bool TryParseXElement(string input, out XElement output)
+        {
+            try
+            {
+                output = XElement.Parse(input);
+                return true;
+            }
+            catch(XmlException)
+            {
+                output = default;
+                return false;
             }
         }
 

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
@@ -3,8 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Text;
+using System.Xml.Linq;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
@@ -33,10 +32,16 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             }
         }
 
+        public Document CreateWorkspaceAndGetDocument(XElement workspaceElement)
+        {
+            _workspace = TestWorkspace.CreateWorkspace(workspaceElement);
+            var hostDocument = _workspace.Documents.First(d => d.CursorPosition.HasValue);
+            return _workspace.CurrentSolution.GetDocument(hostDocument.Id);
+        }
+
         public Document UpdateDocument(string text, SourceCodeKind sourceCodeKind, bool cleanBeforeUpdate = true)
         {
             var hostDocument = (GetWorkspace()).Documents.Single();
-            var textBuffer = hostDocument.TextBuffer;
 
             // clear the document
             if (cleanBeforeUpdate)

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
@@ -33,19 +33,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             }
         }
 
-        public Document CreateWorkspaceAndGetDocument(XElement workspaceElement)
-        {
-            _workspace = TestWorkspace.CreateWorkspace(workspaceElement);
-            var hostDocument = _workspace.Documents.First(d => d.CursorPosition.HasValue);
-            return _workspace.CurrentSolution.GetDocument(hostDocument.Id);
-        }
-
         public Document UpdateDocument(string text, SourceCodeKind sourceCodeKind, bool cleanBeforeUpdate = true)
         {
-            var hostDocument = (GetWorkspace()).Documents.Single();
-
-            // clear the document
-            if (cleanBeforeUpdate)
+            TestHostDocument hostDocument;
+            if (TryParseXElement(text, out var workspaceElement) && workspaceElement.Name == "Workspace")
             {
                 _workspace = TestWorkspace.CreateWorkspace(workspaceElement);
                 hostDocument = _workspace.Documents.First(d => d.CursorPosition.HasValue);

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
@@ -33,10 +33,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             }
         }
 
+        public Document CreateWorkspaceAndGetDocument(XElement workspaceElement)
+        {
+            _workspace = TestWorkspace.CreateWorkspace(workspaceElement);
+            var hostDocument = _workspace.Documents.First(d => d.CursorPosition.HasValue);
+            return _workspace.CurrentSolution.GetDocument(hostDocument.Id);
+        }
+
         public Document UpdateDocument(string text, SourceCodeKind sourceCodeKind, bool cleanBeforeUpdate = true)
         {
-            TestHostDocument hostDocument;
-            if (TryParseXElement(text, out var workspaceElement) && workspaceElement.Name == "Workspace")
+            var hostDocument = (GetWorkspace()).Documents.Single();
+
+            // clear the document
+            if (cleanBeforeUpdate)
             {
                 _workspace = TestWorkspace.CreateWorkspace(workspaceElement);
                 hostDocument = _workspace.Documents.First(d => d.CursorPosition.HasValue);


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/34456