### PR TITLE
Emit DebuggerStepThrough attribute on async Main stub

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -5,7 +5,9 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -343,6 +345,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(
                     ReturnType.SpecialType == SpecialType.System_Void ||
                     ReturnType.SpecialType == SpecialType.System_Int32);
+            }
+
+            internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+            {
+                base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+
+                AddSynthesizedAttribute(ref attributes, this.DeclaringCompilation.SynthesizeDebuggerStepThroughAttribute());
             }
 
             public override string Name => MainName;


### PR DESCRIPTION
When you have an `static async Task Main` method, we synthesize an entry point `static void <Main>`. That method should be annotated so that the debugger doesn't try to stop there, but rather in the user's `Main` method.

I manually verified that this fix is effective: launching the debugger with F11 results in the debugger stopping on the open brace of the user's `Main` method.

Fixes https://github.com/dotnet/roslyn/issues/32101

@tmat FYI