### PR TITLE
Add asyncInfo.catchHandlerOffset for async Main implementation

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly PEModuleBuilder _moduleBeingBuiltOpt; // Null if compiling for diagnostics
         private readonly Predicate<Symbol> _filterOpt;         // If not null, limit analysis to specific symbols
         private readonly DebugDocumentProvider _debugDocumentProvider;
+        private readonly MethodSymbol _entryPointOpt;
 
         //
         // MethodCompiler employs concurrency by following flattened fork/join pattern.
@@ -77,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         // Internal for testing only.
         internal MethodCompiler(CSharpCompilation compilation, PEModuleBuilder moduleBeingBuiltOpt, bool emittingPdb, bool emitTestCoverageData, bool hasDeclarationErrors,
-            DiagnosticBag diagnostics, Predicate<Symbol> filterOpt, CancellationToken cancellationToken)
+            DiagnosticBag diagnostics, Predicate<Symbol> filterOpt, MethodSymbol entryPointOpt, CancellationToken cancellationToken)
         {
             Debug.Assert(compilation != null);
             Debug.Assert(diagnostics != null);
@@ -88,6 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _cancellationToken = cancellationToken;
             _diagnostics = diagnostics;
             _filterOpt = filterOpt;
+            _entryPointOpt = entryPointOpt;
 
             _hasDeclarationErrors = hasDeclarationErrors;
             SetGlobalErrorIfTrue(hasDeclarationErrors);
@@ -124,7 +126,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // TODO: revise to use a loop instead of a recursion
             }
 
-            MethodCompiler methodCompiler = new MethodCompiler(
+            MethodSymbol entryPoint = null;
+            if (filterOpt is null)
+            {
+                entryPoint = GetEntryPoint(compilation, moduleBeingBuiltOpt, hasDeclarationErrors, diagnostics, cancellationToken);
+            }
+
+            var methodCompiler = new MethodCompiler(
                 compilation,
                 moduleBeingBuiltOpt,
                 emittingPdb,
@@ -132,6 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasDeclarationErrors,
                 diagnostics,
                 filterOpt,
+                entryPoint,
                 cancellationToken);
 
             if (compilation.Options.ConcurrentBuild)
@@ -182,7 +191,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 WarnUnusedFields(compilation, diagnostics, cancellationToken);
 
-                MethodSymbol entryPoint = GetEntryPoint(compilation, moduleBeingBuiltOpt, hasDeclarationErrors, diagnostics, cancellationToken);
                 if (moduleBeingBuiltOpt != null && entryPoint != null && compilation.Options.OutputKind.IsApplication())
                 {
                     moduleBeingBuiltOpt.SetPEEntryPoint(entryPoint, diagnostics);
@@ -282,7 +290,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     importChainOpt: null,
                     emittingPdb: false,
                     emitTestCoverageData: false,
-                    dynamicAnalysisSpans: ImmutableArray<SourceSpan>.Empty);
+                    dynamicAnalysisSpans: ImmutableArray<SourceSpan>.Empty,
+                    entryPointOpt: null);
                 moduleBeingBuilt.SetMethodBody(synthesizedEntryPoint, emittedBody);
             }
 
@@ -707,7 +716,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 method.GenerateDebugInfo ? importChain : null,
                                 emittingPdb: _emittingPdb,
                                 emitTestCoverageData: _emitTestCoverageData,
-                                dynamicAnalysisSpans: ImmutableArray<SourceSpan>.Empty);
+                                dynamicAnalysisSpans: ImmutableArray<SourceSpan>.Empty,
+                                _entryPointOpt);
                         }
                     }
                     catch (BoundTreeVisitor.CancelledByStackGuardException ex)
@@ -813,7 +823,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         importChainOpt: null,
                         emittingPdb: false,
                         emitTestCoverageData: _emitTestCoverageData,
-                        dynamicAnalysisSpans: ImmutableArray<SourceSpan>.Empty);
+                        dynamicAnalysisSpans: ImmutableArray<SourceSpan>.Empty,
+                        entryPointOpt: null);
 
                     _moduleBeingBuiltOpt.SetMethodBody(accessor, emittedBody);
                     // Definition is already in the symbol table, so don't call moduleBeingBuilt.AddCompilerGeneratedDefinition
@@ -1207,7 +1218,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             importChain,
                             _emittingPdb,
                             _emitTestCoverageData,
-                            dynamicAnalysisSpans);
+                            dynamicAnalysisSpans,
+                            entryPointOpt: null);
 
                         _moduleBeingBuiltOpt.SetMethodBody(methodSymbol.PartialDefinitionPart ?? methodSymbol, emittedBody);
                     }
@@ -1346,6 +1358,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        // entryPointOpt is only considered for synthesized methods (to recognize the synthesized MoveNext method for async Main)
         private static MethodBody GenerateMethodBody(
             PEModuleBuilder moduleBuilder,
             MethodSymbol method,
@@ -1360,7 +1373,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImportChain importChainOpt,
             bool emittingPdb,
             bool emitTestCoverageData,
-            ImmutableArray<SourceSpan> dynamicAnalysisSpans)
+            ImmutableArray<SourceSpan> dynamicAnalysisSpans,
+            MethodSymbol entryPointOpt)
         {
             // Note: don't call diagnostics.HasAnyErrors() in release; could be expensive if compilation has many warnings.
             Debug.Assert(!diagnostics.HasAnyErrors(), "Running code generator when errors exist might be dangerous; code generator not expecting errors");
@@ -1413,9 +1427,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // but without anything useful on the call stack. Async Task methods on the other hand return exceptions as the result of the Task.
                     // So it is undesirable to consider these exceptions "user unhandled" since there may well be user code that is awaiting the task.
                     // This is a heuristic since it's possible that there is no user code awaiting the task.
+
+                    // We do the same for async Main methods, since it is unlikely that user code will be awaiting the Task:
+                    // AsyncForwardEntryPoint <Main> -> kick-off method Main -> MoveNext.
+
+                    bool isAsyncMainMoveNext = kickoffMethod.IsEntryPointCandidate &&
+                        entryPointOpt is SynthesizedEntryPointSymbol.AsyncForwardEntryPoint asyncForwardEntryPoint &&
+                        kickoffMethod.Equals(asyncForwardEntryPoint.UserMain);
+
                     moveNextBodyDebugInfoOpt = new AsyncMoveNextBodyDebugInfo(
                         kickoffMethod,
-                        catchHandlerOffset: kickoffMethod.ReturnsVoid ? asyncCatchHandlerOffset : -1,
+                        catchHandlerOffset: (kickoffMethod.ReturnsVoid || isAsyncMainMoveNext) ? asyncCatchHandlerOffset : -1,
                         asyncYieldPoints,
                         asyncResumePoints);
                 }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1358,7 +1358,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        // entryPointOpt is only considered for synthesized methods (to recognize the synthesized MoveNext method for async Main)
+        /// <summary>
+        /// entryPointOpt is only considered for synthesized methods (to recognize the synthesized MoveNext method for async Main)
+        /// </summary>
         private static MethodBody GenerateMethodBody(
             PEModuleBuilder moduleBuilder,
             MethodSymbol method,

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -302,12 +302,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary> A synthesized entrypoint that forwards all calls to an async Main Method </summary>
         internal sealed class AsyncForwardEntryPoint : SynthesizedEntryPointSymbol
         {
-            /// <summary> The user-defined asynchronous main method. </summary>
+            /// <summary> The syntax for the user-defined asynchronous main method. </summary>
             private readonly CSharpSyntaxNode _userMainReturnTypeSyntax;
 
             private readonly BoundExpression _getAwaiterGetResultCall;
 
             private readonly ImmutableArray<ParameterSymbol> _parameters;
+
+            /// <summary> The user-defined asynchronous main method. </summary>
+            internal MethodSymbol UserMain { get; }
 
             internal AsyncForwardEntryPoint(CSharpCompilation compilation, NamedTypeSymbol containingType, MethodSymbol userMain) :
                 base(containingType)
@@ -316,6 +319,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // parameter checks for determining entrypoint validity.
                 Debug.Assert(userMain.ParameterCount == 0 || userMain.ParameterCount == 1);
 
+                UserMain = userMain;
                 _userMainReturnTypeSyntax = userMain.ExtractReturnTypeSyntax();
                 var binder = compilation.GetBinder(_userMainReturnTypeSyntax);
                 _parameters = SynthesizedParameterSymbol.DeriveParameters(userMain, this);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             private readonly ImmutableArray<ParameterSymbol> _parameters;
 
             /// <summary> The user-defined asynchronous main method. </summary>
-            internal MethodSymbol UserMain { get; }
+            internal readonly MethodSymbol UserMain;
 
             internal AsyncForwardEntryPoint(CSharpCompilation compilation, NamedTypeSymbol containingType, MethodSymbol userMain) :
                 base(containingType)

--- a/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
@@ -88,6 +88,11 @@ public class C
             var expectedIssues = string.Format(@"
       ""results"": [
         {{
+          ""ruleId"": ""CS5001"",
+          ""level"": ""error"",
+          ""message"": ""Program does not contain a static 'Main' method suitable for an entry point""
+        }},
+        {{
           ""ruleId"": ""CS0169"",
           ""level"": ""warning"",
           ""message"": ""The field 'C.x' is never used"",
@@ -107,11 +112,6 @@ public class C
           ""properties"": {{
             ""warningLevel"": 3
           }}
-        }},
-        {{
-          ""ruleId"": ""CS5001"",
-          ""level"": ""error"",
-          ""message"": ""Program does not contain a static 'Main' method suitable for an entry point""
         }}
       ],
       ""rules"": {{
@@ -185,6 +185,11 @@ public class C
             var expectedIssues = string.Format(@"
       ""results"": [
         {{
+          ""ruleId"": ""CS5001"",
+          ""level"": ""error"",
+          ""message"": ""Program does not contain a static 'Main' method suitable for an entry point""
+        }},
+        {{
           ""ruleId"": ""CS0169"",
           ""level"": ""warning"",
           ""message"": ""The field 'C.x' is never used"",
@@ -207,11 +212,6 @@ public class C
           ""properties"": {{
             ""warningLevel"": 3
           }}
-        }},
-        {{
-          ""ruleId"": ""CS5001"",
-          ""level"": ""error"",
-          ""message"": ""Program does not contain a static 'Main' method suitable for an entry point""
         }}
       ],
       ""rules"": {{

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncMainTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncMainTests.cs
@@ -694,7 +694,7 @@ class A
                 Diagnostic(ErrorCode.ERR_NoEntryPoint).WithLocation(1, 1));
         }
 
-        [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [Fact]
         public void MainCanReturnTask()
         {
             var source = @"
@@ -726,8 +726,12 @@ class A
                 => metadataReader.GetMethodDefinition(handle).GetCustomAttributes()
                     .Select(a => metadataReader.Dump(metadataReader.GetCustomAttribute(a).Constructor));
 
-            // Verify asyncInfo.catchHandler
-            compilation.VerifyPdb("A+<Main>d__0.MoveNext",
+            if (ExecutionConditionUtil.IsWindows)
+            {
+                _ = ConditionalSkipReason.NativePdbRequiresDesktop;
+
+                // Verify asyncInfo.catchHandler
+                compilation.VerifyPdb("A+<Main>d__0.MoveNext",
 @"<symbols>
   <files>
     <file id=""1"" name="""" language=""C#"" />
@@ -762,6 +766,7 @@ class A
     </method>
   </methods>
 </symbols>", options: PdbValidationOptions.SkipConversionValidation);
+            }
             // The PDB conversion from portable to windows drops the entryPoint node
             // Tracked by https://github.com/dotnet/roslyn/issues/34561
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncMainTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncMainTests.cs
@@ -751,17 +751,17 @@ class A
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xd"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""48"" document=""1"" />
-        <entry offset=""0x3c"" hidden=""true"" document=""1"" />
-        <entry offset=""0x8f"" hidden=""true"" document=""1"" />
-        <entry offset=""0xa7"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xaf"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""48"" document=""1"" />
+        <entry offset=""0x3e"" hidden=""true"" document=""1"" />
+        <entry offset=""0x91"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa9"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xb1"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
-        <catchHandler offset=""0x8f"" />
+        <catchHandler offset=""0x91"" />
         <kickoffMethod declaringType=""A"" methodName=""Main"" />
-        <await yield=""0x4e"" resume=""0x69"" declaringType=""A+&lt;Main&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x50"" resume=""0x6b"" declaringType=""A+&lt;Main&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -2585,7 +2585,7 @@ public class C
   }
   catch System.Exception
   {
-    // sequence point: <hidden>
+    // async: catch handler, sequence point: <hidden>
     IL_00d7:  stloc.s    V_4
     IL_00d9:  ldarg.0
     IL_00da:  ldc.i4.s   -2
@@ -4292,7 +4292,7 @@ class C
   }
   catch System.Exception
   {
-    // sequence point: <hidden>
+    // async: catch handler, sequence point: <hidden>
     IL_00d3:  stloc.s    V_4
     IL_00d5:  ldarg.0
     IL_00d6:  ldc.i4.s   -2

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
@@ -603,6 +603,9 @@ public abstract class C
             var source = "System.Console.WriteLine(1);";
             var compilation = CreateCompilationWithMscorlib40(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
             compilation.VerifyEmitDiagnostics(
+                // error CS1061: 'Task<object>' does not contain a definition for 'GetAwaiter' and no accessible extension method 'GetAwaiter' accepting a first argument of type 'Task<object>' could be found (are you missing a using directive or an assembly reference?)
+                //
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "").WithArguments("System.Threading.Tasks.Task<object>", "GetAwaiter").WithLocation(1, 1),
                 // (1,1): error CS0518: Predefined type 'System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1' is not defined or imported
                 // System.Console.WriteLine(1);
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "System.Console.WriteLine(1);").WithArguments("System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1").WithLocation(1, 1),

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -13237,6 +13237,7 @@ expectedOutput: "-100");
                 hasDeclarationErrors: false,
                 diagnostics: diagnostics,
                 filterOpt: null,
+                entryPointOpt: null,
                 cancellationToken: CancellationToken.None);
 
             // Add diagnostic to MethodBodyCompiler bag, as if


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/29143 (exception thrown in async Main).

```C#
using System;
using System.Threading.Tasks;

internal class Program
{
    private static async Task Main(string[] args)
    {
        throw new Exception(); 
    }
}
```

I was able to verify the fix on a desktop project (shown below). 
I was not able to verify on a Core project because of a Roslyn deployment issue (https://github.com/dotnet/roslyn/issues/34321).

![image](https://user-images.githubusercontent.com/12466233/55185312-4dbddc80-5151-11e9-84d7-8725d9ffcbf2.png)

