### PR TITLE
Report a better error for an attempt to access protected member of object class within an interface.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -684,6 +684,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool diagnose,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
+            LookupMembersInClass(result, type, name, arity, basesBeingResolved, options, originalBinder, type, diagnose, ref useSiteDiagnostics);
+        }
+
+        // Lookup member in a class, struct, enum, delegate.
+        private void LookupMembersInClass(
+            LookupResult result,
+            TypeSymbol type,
+            string name,
+            int arity,
+            ConsList<TypeSymbol> basesBeingResolved,
+            LookupOptions options,
+            Binder originalBinder,
+            TypeSymbol accessThroughType,
+            bool diagnose,
+            ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
             Debug.Assert((object)type != null);
             Debug.Assert(!type.IsInterfaceType() && type.TypeKind != TypeKind.TypeParameter);
 
@@ -694,7 +710,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             while ((object)currentType != null)
             {
                 tmp.Clear();
-                LookupMembersWithoutInheritance(tmp, currentType, name, arity, options, originalBinder, type, diagnose, ref useSiteDiagnostics, basesBeingResolved);
+                LookupMembersWithoutInheritance(tmp, currentType, name, arity, options, originalBinder, accessThroughType, diagnose, ref useSiteDiagnostics, basesBeingResolved);
 
                 MergeHidingLookupResults(result, tmp, ref useSiteDiagnostics);
 
@@ -951,7 +967,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var tmp = LookupResult.GetInstance();
                 // NB: we assume use-site-errors on System.Object, if any, have been reported earlier.
-                this.LookupMembersInClass(tmp, this.Compilation.GetSpecialType(SpecialType.System_Object), name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteDiagnostics);
+                this.LookupMembersInClass(tmp, this.Compilation.GetSpecialType(SpecialType.System_Object), name, arity, basesBeingResolved, options, originalBinder, type, diagnose, ref useSiteDiagnostics);
                 MergeHidingLookupResults(current, tmp, ref useSiteDiagnostics);
                 tmp.Free();
             }

--- a/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
@@ -252,8 +252,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 case TypeKind.Class:
                 case TypeKind.Error:
-                case TypeKind.Interface:
                     return compilation.Assembly.GetSpecialType(SpecialType.System_Object);
+                case TypeKind.Interface:
+                    return null;
                 case TypeKind.Struct:
                     return compilation.Assembly.GetSpecialType(SpecialType.System_ValueType);
                 default:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
@@ -441,8 +441,6 @@ public abstract `class C`<T`> : NS.I
                     "System.Boolean System.Object.Equals(System.Object objA, System.Object objB)",
                     "System.Boolean System.Object.ReferenceEquals(System.Object objA, System.Object objB)",
                     "System.Int32 System.Object.GetHashCode()",
-                    "System.Object System.Object.MemberwiseClone()",
-                    "void System.Object.Finalize()",
                     "System.String System.Object.ToString()",
                     "System.Type System.Object.GetType()"),
                 s_pop, //NS.I

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -1276,7 +1276,7 @@ namespace System
             var someMemberInC = (MemberDeclarationSyntax)typeDeclC.Members[0];
 
             var namesInC = model.LookupNames(someMemberInC.SpanStart);
-            Assert.Equal(15, namesInC.Count); // everything in System.Object is included, with an uncertain count
+            Assert.Equal(13, namesInC.Count); // everything with exception of protected members in System.Object is included, with an uncertain count
             Assert.Contains("A", namesInC);
             Assert.Contains("B", namesInC);
             Assert.Contains("C", namesInC);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -58407,5 +58407,46 @@ I1.M1
 ");
         }
 
+        [Fact]
+        public void MemberwiseClone_01()
+        {
+            var source0 = @"
+interface I1
+{
+    object M1(I2 x, I3 y)
+    {
+        x.MemberwiseClone();
+        y.MemberwiseClone();
+        this.MemberwiseClone();
+        return ((I1)this).MemberwiseClone();
+    }
+}
+
+interface I2
+{
+}
+
+interface I3 : I1
+{
+}
+";
+
+            var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll, targetFramework: TargetFramework.NetStandardLatest);
+            compilation0.VerifyDiagnostics(
+                // (6,11): error CS0122: 'object.MemberwiseClone()' is inaccessible due to its protection level
+                //         x.MemberwiseClone();
+                Diagnostic(ErrorCode.ERR_BadAccess, "MemberwiseClone").WithArguments("object.MemberwiseClone()").WithLocation(6, 11),
+                // (7,11): error CS0122: 'object.MemberwiseClone()' is inaccessible due to its protection level
+                //         y.MemberwiseClone();
+                Diagnostic(ErrorCode.ERR_BadAccess, "MemberwiseClone").WithArguments("object.MemberwiseClone()").WithLocation(7, 11),
+                // (8,14): error CS0122: 'object.MemberwiseClone()' is inaccessible due to its protection level
+                //         this.MemberwiseClone();
+                Diagnostic(ErrorCode.ERR_BadAccess, "MemberwiseClone").WithArguments("object.MemberwiseClone()").WithLocation(8, 14),
+                // (9,27): error CS0122: 'object.MemberwiseClone()' is inaccessible due to its protection level
+                //         return ((I1)this).MemberwiseClone();
+                Diagnostic(ErrorCode.ERR_BadAccess, "MemberwiseClone").WithArguments("object.MemberwiseClone()").WithLocation(9, 27)
+                );
+        }
+
     }
 }


### PR DESCRIPTION
Before this change, the following confusing error was reported for all error locations in the added test scenario:
CS1540 Cannot access protected member 'object.MemberwiseClone()' via a qualifier of type 'object'; the qualifier must be of type 'I1' (or derived from it)