### PR TITLE
Fix the pull member up failure

### DIFF
--- a/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -2191,7 +2191,7 @@ namespace PushUpTest
 
     public class Testclass2 : Base2
     {
-        private static event EventHandler Event1, Eve[||]nt3, Event4;
+        private event EventHandler Event1, Eve[||]nt3, Event4;
     }
 }";
             var expected = @"
@@ -2200,12 +2200,12 @@ namespace PushUpTest
 {
     public abstract class Base2
     {
-        private static abstract event EventHandler Event3;
+        private abstract event EventHandler Event3;
     }
 
     public class Testclass2 : Base2
     {
-        private static event EventHandler Event1, Eve[||]nt3, Event4;
+        private event EventHandler Event1, Eve[||]nt3, Event4;
     }
 }";
             await TestWithPullMemberDialogAsync(testText, expected, selection: new[] { ("Event3", true) }, index: 1);

--- a/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp.Dialog;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Test.Utilities.PullMemberUp;
+using Roslyn.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
 {
@@ -2149,6 +2150,120 @@ namespace PushUpTest
 }";
 
             await TestWithPullMemberDialogAsync(testText, expected);
+        }
+
+        [WorkItem(34268, "https://github.com/dotnet/roslyn/issues/34268")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
+        public async Task TestPullPropertyToAbstractClassViaDialogWithMakeAbstractOption()
+        {
+            var testText = @"
+abstract class B
+{
+}
+
+class D : B
+{
+    int [||]X => 7;
+}";
+            var expected = @"
+abstract class B
+{
+    private abstract int X { get; }
+}
+
+class D : B
+{
+    int X => 7;
+}";
+            await TestWithPullMemberDialogAsync(testText, expected, selection: new[] { ("X", true) }, index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
+        public async Task PullEventUpToAbstractClassViaDialogWithMakeAbstractOption()
+        {
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+    }
+
+    public class Testclass2 : Base2
+    {
+        private static event EventHandler Event1, Eve[||]nt3, Event4;
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public abstract class Base2
+    {
+        private static abstract event EventHandler Event3;
+    }
+
+    public class Testclass2 : Base2
+    {
+        private static event EventHandler Event1, Eve[||]nt3, Event4;
+    }
+}";
+            await TestWithPullMemberDialogAsync(testText, expected, selection: new[] { ("Event3", true) }, index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
+        public async Task TestPullEventWithAddAndRemoveMethodToClassViaDialogWithMakeAbstractOption()
+        {
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public class BaseClass
+    {
+    }
+
+    public class TestClass : BaseClass
+    {
+        public event EventHandler Eve[||]nt1
+        {
+            add
+            {
+                System.Console.Writeline(""This is add"");
+            }
+            remove
+            {
+                System.Console.Writeline(""This is remove"");
+            }
+        }
+    }
+}";
+
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public abstract class BaseClass
+    {
+        public abstract event EventHandler Event1;
+    }
+
+    public class TestClass : BaseClass
+    {
+        public event EventHandler Event1
+        {
+            add
+            {
+                System.Console.Writeline(""This is add"");
+            }
+            remove
+            {
+                System.Console.Writeline(""This is remove"");
+            }
+        }
+    }
+}";
+
+            await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("Event1", true) }, index: 1);
         }
 
         #endregion Dialog

--- a/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
             }
             else if (member is IPropertySymbol propertySymbol)
             {
-                return CodeGenerationSymbolFactory.CreatePropertySymbol(propertySymbol, modifiers: modifier);
+                return CodeGenerationSymbolFactory.CreatePropertySymbol(propertySymbol, modifiers: modifier, getMethod: propertySymbol.GetMethod, setMethod: propertySymbol.SetMethod);
             }
             else if (member is IEventSymbol eventSymbol)
             {


### PR DESCRIPTION
Related [issue](https://github.com/dotnet/roslyn/issues/34268)
So, null pointer exception happens when you try to make a property abstract like
```
abstract class B { }

class D : B
{
    int $$X => 7;
}
```
If try to make it abstract via the pull member up dialog, it will fail.

Reason:
It is due to CodeGenerationSymbolFactory.CreatePropertySymbol() takes SetMethod and GetMethod and the default value are both null.

I also add two additional tests to cover the cases which makes events abstract.
