### PR TITLE
Format `{}`

### DIFF
--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -388,7 +388,7 @@ class C
 {
     void M()
     {
-        _ = this is { }
+        _ = this is {}
     }
 }";
 
@@ -431,7 +431,7 @@ class C
 {
     void M()
     {
-        _ = this is { }
+        _ = this is {}
         M();
     }
 }";
@@ -476,7 +476,7 @@ class C
 {
     void M()
     {
-        _ = this is (1, 2) { }
+        _ = this is (1, 2) {}
         M();
     }
 }";

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // empty {} in pattern
             if (previousToken.Kind() == SyntaxKind.OpenBraceToken &&
                 currentToken.Kind() == SyntaxKind.CloseBraceToken &&
-                !currentToken.Parent.IsKind(SyntaxKind.Block, SyntaxKind.ArrayInitializerExpression, SyntaxKind.NamespaceDeclaration, SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration))
+                currentToken.Parent.IsKind(SyntaxKindEx.PropertyPatternClause))
             {
                 return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -257,6 +257,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }
 
+            // empty {} in pattern
+            if (previousToken.Kind() == SyntaxKind.OpenBraceToken &&
+                currentToken.Kind() == SyntaxKind.CloseBraceToken &&
+                !currentToken.Parent.IsKind(SyntaxKind.Block, SyntaxKind.ArrayInitializerExpression, SyntaxKind.NamespaceDeclaration, SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration))
+            {
+                return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+            }
+
             // attribute case
             // , [
             if (previousToken.Kind() == SyntaxKind.CommaToken && currentToken.Kind() == SyntaxKind.OpenBracketToken && currentToken.Parent is AttributeListSyntax)

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5142,7 +5142,7 @@ _ = this is  C( 1 , 2 ){}  ; }
 {
     void M()
     {
-        _ = this is C(1, 2) { };
+        _ = this is C(1, 2) {};
     }
 }";
             // no space separates the type and the positional pattern
@@ -5165,7 +5165,7 @@ _ = this is  C( 1 , 2 ){}  ; }
 {
     void M()
     {
-        _ = this is C (1, 2) { };
+        _ = this is C (1, 2) {};
     }
 }";
             await AssertFormatAsync(expectedCode, code, changedOptionSet: changingOptions);
@@ -5188,8 +5188,8 @@ _ = this is  C(  ){}  ; }
 {
     void M()
     {
-        _ = this is C( 1, 2 ) { };
-        _ = this is C() { };
+        _ = this is C( 1, 2 ) {};
+        _ = this is C() {};
     }
 }";
             await AssertFormatAsync(expectedCode, code, changedOptionSet: changingOptions);
@@ -5212,8 +5212,8 @@ _ = this is  C(  ){}  ; }
 {
     void M()
     {
-        _ = this is C(1, 2) { };
-        _ = this is C( ) { };
+        _ = this is C(1, 2) {};
+        _ = this is C( ) {};
     }
 }";
             await AssertFormatAsync(expectedCode, code, changedOptionSet: changingOptions);
@@ -5290,7 +5290,7 @@ M();
 {
     void M()
     {
-        _ = this is { }
+        _ = this is {}
         M();
     }
 }";
@@ -5313,7 +5313,7 @@ M();
 {
     void M()
     {
-        _ = this is (1, 2) { }
+        _ = this is (1, 2) {}
         M();
     }
 }";
@@ -9067,6 +9067,91 @@ public class Test
         );
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task EmptyIsPropertyPattern()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        _ = x is { }
+    }
+}
+";
+            var expected = @"
+class C
+{
+    void M()
+    {
+        _ = x is {}
+    }
+}
+";
+
+            await AssertFormatAsync(expected, code);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task EmptySwitchCasePropertyPattern()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        switch (x)
+        {
+            case { }
+        }
+    }
+}
+";
+            var expected = @"
+class C
+{
+    void M()
+    {
+        switch (x)
+        {
+            case {}
+        }
+    }
+}
+";
+
+            await AssertFormatAsync(expected, code);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task EmptySwitchExpressionCasePropertyPattern()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        _ = x switch
+        {
+            { } =>
+    }
+}
+";
+            var expected = @"
+class C
+{
+    void M()
+    {
+        _ = x switch
+        {
+            {} =>
+    }
+}
+";
+
+            await AssertFormatAsync(expected, code);
         }
 
         [Theory, Trait(Traits.Feature, Traits.Features.Formatting)]


### PR DESCRIPTION
Formats empty curly braces of a property pattern without a space.