### PR TITLE
Assert MaybeNull is not used for value types other than Nullable<T>

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -841,7 +841,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 case SyntaxKind.SingleVariableDesignation:
                     {
-                        var declType = new TypeWithState(inputType, NullableFlowState.MaybeNull).ToTypeWithAnnotations();
+                        var declType = TypeWithState.ForType(inputType).ToTypeWithAnnotations();
                         BindPatternDesignation(
                             designation: node, declType: declType, inputValEscape: inputValEscape, typeSyntax: null, diagnostics: diagnostics, hasErrors: ref hasErrors,
                             variableSymbol: out Symbol variableSymbol, variableAccess: out BoundExpression variableAccess);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2231,13 +2231,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             var accessExpressionType = VisitRvalueWithState(node.AccessExpression);
             Join(ref this.State, ref receiverState);
 
+            // Per LDM 2019-02-13 decision, the result of a conditional access might be null even if
+            // both the receiver and right-hand-side are believed not to be null.
+            NullableFlowState resultState = NullableFlowState.MaybeNull;
+
             // https://github.com/dotnet/roslyn/issues/29956 Use flow analysis type rather than node.Type
             // so that nested nullability is inferred from flow analysis. See VisitConditionalOperator.
             TypeSymbol type = node.Type;
-
-            // Per LDM 2019-02-13 decision, the result of a conditional access might be null even if
-            // both the receiver and right-hand-side are believed not to be null.
-            NullableFlowState resultState = type.CanContainNull() ? NullableFlowState.MaybeNull : NullableFlowState.NotNull;
 
             // If the result type does not allow annotations, then we produce a warning because
             // the result may be null.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4013,7 +4013,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         canConvertNestedNullability = conversion.Exists;
                     }
 
-                    resultState = operandType.State;
+                    resultState = getTargetStateFromOperand(operandType, targetType);
                     break;
 
                 case ConversionKind.ImplicitNullable:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4155,7 +4155,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return resultType;
 
             static NullableFlowState getTargetStateFromOperand(TypeWithState operandType, TypeSymbol targetType) =>
-                (operandType.State == NullableFlowState.MaybeNull && (!targetType.IsValueType || targetType.IsNullableTypeOrTypeParameter())) ? NullableFlowState.MaybeNull : NullableFlowState.NotNull;
+                (operandType.State == NullableFlowState.MaybeNull && TypeWithState.CanContainNull(targetType)) ? NullableFlowState.MaybeNull : NullableFlowState.NotNull;
         }
 
         private TypeWithState ApplyUserDefinedConversion(

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Invalid type, used only to catch Visit methods that do not set
         /// _result.Type. See VisitExpressionWithoutStackGuard.
         /// </summary>
-        private static readonly TypeWithState _invalidType = new TypeWithState(ErrorTypeSymbol.UnknownResultType, NullableFlowState.NotNull);
+        private static readonly TypeWithState _invalidType = TypeWithState.Create(ErrorTypeSymbol.UnknownResultType, NullableFlowState.NotNull);
 
         /// <summary>
         /// The result and l-value type of the last visited expression.
@@ -1409,7 +1409,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitObjectCreationInitializer(null, slot, initializerOpt);
             }
 
-            ResultType = new TypeWithState(type, resultState);
+            ResultType = TypeWithState.Create(type, resultState);
         }
 
         private void VisitObjectCreationInitializer(Symbol containingSymbol, int containingSlot, BoundExpression node)
@@ -1502,7 +1502,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void SetNotNullResult(BoundExpression node)
         {
-            ResultType = new TypeWithState(node.Type, NullableFlowState.NotNull);
+            ResultType = TypeWithState.Create(node.Type, NullableFlowState.NotNull);
         }
 
         private int GetOrCreatePlaceholderSlot(BoundExpression node)
@@ -1552,7 +1552,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            ResultType = new TypeWithState(anonymousType, NullableFlowState.NotNull);
+            ResultType = TypeWithState.Create(anonymousType, NullableFlowState.NotNull);
             return null;
         }
 
@@ -1563,7 +1563,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitRvalue(expr);
             }
             TypeSymbol resultType = (node.InitializerOpt == null) ? node.Type : VisitArrayInitializer(node);
-            ResultType = new TypeWithState(resultType, NullableFlowState.NotNull);
+            ResultType = TypeWithState.Create(resultType, NullableFlowState.NotNull);
             return null;
         }
 
@@ -1802,7 +1802,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 resultState = leftType.State.Join(rightType.State);
             }
 
-            return new TypeWithState(resultType, resultState);
+            return TypeWithState.Create(resultType, resultState);
         }
 
         protected override void AfterLeftChildHasBeenVisited(BoundBinaryOperator binary)
@@ -2104,7 +2104,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rightResult = VisitRvalueWithState(rightOperand);
                 // Should be able to use rightResult for the result of the operator but
                 // binding may have generated a different result type in the case of errors.
-                ResultType = new TypeWithState(node.Type, rightResult.State);
+                ResultType = TypeWithState.Create(node.Type, rightResult.State);
                 return null;
             }
 
@@ -2202,7 +2202,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static TypeWithState GetNullCoalescingResultType(TypeWithState rightResult, TypeSymbol resultType)
         {
             NullableFlowState resultState = rightResult.State;
-            return new TypeWithState(resultType, resultState);
+            return TypeWithState.Create(resultType, resultState);
         }
 
         public override BoundNode VisitConditionalAccess(BoundConditionalAccess node)
@@ -2248,7 +2248,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             _currentConditionalReceiverVisitResult = default;
             _lastConditionalAccessSlot = previousConditionalAccessSlot;
-            ResultType = new TypeWithState(type, resultState);
+            ResultType = TypeWithState.Create(type, resultState);
             return null;
         }
 
@@ -2285,7 +2285,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var lValueAnnotation = consequenceLValue.NullableAnnotation.EnsureCompatible(alternativeLValue.NullableAnnotation);
                 var rValueState = consequenceRValue.State.Join(alternativeRValue.State);
 
-                SetResult(new TypeWithState(refResultType, rValueState), TypeWithAnnotations.Create(refResultType, lValueAnnotation));
+                SetResult(TypeWithState.Create(refResultType, rValueState), TypeWithAnnotations.Create(refResultType, lValueAnnotation));
                 return null;
             }
 
@@ -2380,7 +2380,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 resultState = convertedConsequenceResult.State.Join(convertedAlternativeResult.State);
             }
 
-            ResultType = new TypeWithState(resultType, resultState);
+            ResultType = TypeWithState.Create(resultType, resultState);
             return null;
 
             (BoundExpression, Conversion, TypeWithState) visitConditionalOperand(LocalState state, BoundExpression operand)
@@ -2445,7 +2445,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 rvalueType = rvalueType.GetNullableUnderlyingType();
             }
-            ResultType = new TypeWithState(rvalueType, NullableFlowState.NotNull);
+            ResultType = TypeWithState.Create(rvalueType, NullableFlowState.NotNull);
             return null;
         }
 
@@ -3374,7 +3374,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (slot > 0 && slot < this.State.Capacity)
             {
                 NullableFlowState state = this.State[slot];
-                return new TypeWithState(type.Type, state);
+                return TypeWithState.Create(type.Type, state);
             }
 
             return type;
@@ -3609,7 +3609,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 tupleOpt = tupleOpt.WithElementTypes(elementTypesWithAnnotations);
                 var locations = tupleOpt.TupleElements.SelectAsArray((element, location) => element.Locations.FirstOrDefault() ?? location, node.Syntax.Location);
                 tupleOpt.CheckConstraints(_conversions, includeNullability: true, node.Syntax, locations, compilation, diagnosticsOpt: null, nullabilityDiagnosticsOpt: Diagnostics);
-                ResultType = new TypeWithState(tupleOpt, NullableFlowState.NotNull);
+                ResultType = TypeWithState.Create(tupleOpt, NullableFlowState.NotNull);
             }
         }
 
@@ -3940,7 +3940,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ReportNullabilityMismatchWithTargetDelegate(node.Syntax, delegateType, unboundLambda);
                         }
 
-                        return new TypeWithState(targetType, NullableFlowState.NotNull);
+                        return TypeWithState.Create(targetType, NullableFlowState.NotNull);
                     }
                     break;
 
@@ -3956,14 +3956,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ImplicitDynamic:
                 case ConversionKind.Unboxing:
                 case ConversionKind.Boxing:
-                    resultState = getTargetStateFromOperand(operandType, targetType);
+                    resultState = operandType.State;
                     break;
 
                 case ConversionKind.ImplicitThrow:
                     break;
 
                 case ConversionKind.NoConversion:
-                    resultState = getTargetStateFromOperand(operandType, targetType);
+                    resultState = operandType.State;
                     break;
 
                 case ConversionKind.DefaultOrNullLiteral:
@@ -4013,7 +4013,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         canConvertNestedNullability = conversion.Exists;
                     }
 
-                    resultState = getTargetStateFromOperand(operandType, targetType);
+                    resultState = operandType.State;
                     break;
 
                 case ConversionKind.ImplicitNullable:
@@ -4039,7 +4039,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         canConvertNestedNullability = conversion.Exists;
                     }
 
-                    resultState = getTargetStateFromOperand(operandType, targetType);
+                    resultState = operandType.State;
                     break;
 
                 case ConversionKind.ExplicitNullable:
@@ -4121,7 +4121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 resultState = NullableFlowState.MaybeNull;
             }
 
-            var resultType = new TypeWithState(targetType, resultState);
+            var resultType = TypeWithState.Create(targetType, resultState);
 
             if (operandType.Type?.IsErrorType() != true && !targetType.IsErrorType())
             {
@@ -4153,9 +4153,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return resultType;
-
-            static NullableFlowState getTargetStateFromOperand(TypeWithState operandType, TypeSymbol targetType) =>
-                (operandType.State == NullableFlowState.MaybeNull && TypeWithState.CanContainNull(targetType)) ? NullableFlowState.MaybeNull : NullableFlowState.NotNull;
         }
 
         private TypeWithState ApplyUserDefinedConversion(
@@ -4182,7 +4179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // cf. Binder.CreateUserDefinedConversion
             if (!conversion.IsValid)
             {
-                return new TypeWithState(targetType, NullableFlowState.NotNull);
+                return TypeWithState.Create(targetType, NullableFlowState.NotNull);
             }
 
             // operand -> conversion "from" type
@@ -4261,7 +4258,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ? compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(ImmutableArray.Create(returnType))
                 : returnType.Type;
             NullableFlowState state = returnType.ToTypeWithState().State.Join(operandState);
-            return new TypeWithState(type, state);
+            return TypeWithState.Create(type, state);
         }
 
         private TypeWithState ClassifyAndApplyConversion(
@@ -4381,7 +4378,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void VisitThisOrBaseReference(BoundExpression node)
         {
-            var rvalueResult = new TypeWithState(node.Type, NullableFlowState.NotNull);
+            var rvalueResult = TypeWithState.Create(node.Type, NullableFlowState.NotNull);
             var lvalueResult = TypeWithAnnotations.Create(node.Type, NullableAnnotation.NotAnnotated);
             SetResult(rvalueResult, lvalueResult);
         }
@@ -4425,7 +4422,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 TrackNullableStateForAssignment(right, leftLValueType, MakeSlot(left), rightType, MakeSlot(right));
-                SetResult(new TypeWithState(leftLValueType.Type, rightType.State), leftLValueType);
+                SetResult(TypeWithState.Create(leftLValueType.Type, rightType.State), leftLValueType);
             }
 
             return null;
@@ -4585,7 +4582,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             valueSlot = MakeSlot(rightPart);
                             if (valueSlot > 0)
                             {
-                                var valueBeforeNullableWrapping = new TypeWithState(underlyingType.Type, NullableFlowState.NotNull);
+                                var valueBeforeNullableWrapping = TypeWithState.Create(underlyingType.Type, NullableFlowState.NotNull);
                                 TrackNullableStateOfNullableValue(targetSlot, targetType.Type, rightPart, valueBeforeNullableWrapping, valueSlot);
                             }
                         }
@@ -4830,7 +4827,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                resultType = new TypeWithState(node.Type, NullableFlowState.NotNull);
+                resultType = TypeWithState.Create(node.Type, NullableFlowState.NotNull);
             }
 
             TrackNullableStateForAssignment(node, leftLValueType, MakeSlot(node.Left), resultType);
@@ -4975,7 +4972,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (slot > 0 && slot < this.State.Capacity)
                 {
                     var state = this.State[slot];
-                    resultType = new TypeWithState(resultType.Type, state);
+                    resultType = TypeWithState.Create(resultType.Type, state);
                 }
             }
 
@@ -5154,7 +5151,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                resultType = new TypeWithState(node.Type, node.OperatorKind.IsLifted() ? argumentResult.State : NullableFlowState.NotNull);
+                resultType = TypeWithState.Create(node.Type, node.OperatorKind.IsLifted() ? argumentResult.State : NullableFlowState.NotNull);
             }
 
             ResultType = resultType;
@@ -5205,7 +5202,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // https://github.com/dotnet/roslyn/issues/33879 Conversions: Lifted operator
                 // Should this use the updated flow type and state?  How should it compute nullability?
-                return new TypeWithState(node.Type, NullableFlowState.NotNull);
+                return TypeWithState.Create(node.Type, NullableFlowState.NotNull);
             }
 
             // Update method based on inferred operand types: see https://github.com/dotnet/roslyn/issues/29605.
@@ -5309,7 +5306,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitTypeOfOperator(BoundTypeOfOperator node)
         {
             var result = base.VisitTypeOfOperator(node);
-            ResultType = new TypeWithState(node.Type, NullableFlowState.NotNull);
+            ResultType = TypeWithState.Create(node.Type, NullableFlowState.NotNull);
             return result;
         }
 
@@ -5409,7 +5406,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            ResultType = new TypeWithState(type, resultState);
+            ResultType = TypeWithState.Create(type, resultState);
             return null;
         }
 
@@ -5441,7 +5438,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = base.VisitLiteral(node);
 
             Debug.Assert(!IsConditionalState);
-            ResultType = new TypeWithState(node.Type, node.Type?.CanContainNull() != false && node.ConstantValue?.IsNull == true ? NullableFlowState.MaybeNull : NullableFlowState.NotNull);
+            ResultType = TypeWithState.Create(node.Type, node.Type?.CanContainNull() != false && node.ConstantValue?.IsNull == true ? NullableFlowState.MaybeNull : NullableFlowState.NotNull);
 
             return result;
         }
@@ -5577,7 +5574,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitNoPiaObjectCreationExpression(BoundNoPiaObjectCreationExpression node)
         {
             var result = base.VisitNoPiaObjectCreationExpression(node);
-            ResultType = new TypeWithState(node.Type, NullableFlowState.NotNull);
+            ResultType = TypeWithState.Create(node.Type, NullableFlowState.NotNull);
             return result;
         }
 
@@ -5686,7 +5683,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitNameOfOperator(BoundNameOfOperator node)
         {
             var result = base.VisitNameOfOperator(node);
-            ResultType = new TypeWithState(node.Type, NullableFlowState.NotNull);
+            ResultType = TypeWithState.Create(node.Type, NullableFlowState.NotNull);
             return result;
         }
 
@@ -5700,7 +5697,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitInterpolatedString(BoundInterpolatedString node)
         {
             var result = base.VisitInterpolatedString(node);
-            ResultType = new TypeWithState(node.Type, NullableFlowState.NotNull);
+            ResultType = TypeWithState.Create(node.Type, NullableFlowState.NotNull);
             return result;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                 break;
                                         }
                                         State[outputSlot] = NullableFlowState.NotNull;
-                                        var outputType = new TypeWithState(e.Type, inputState);
+                                        var outputType = TypeWithState.Create(e.Type, inputState);
                                         addToTempMap(output, outputSlot, outputType.Type);
                                         break;
                                     }
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             var tempState = this.State[tempSlot];
                             if (variableAccess is BoundLocal { LocalSymbol: SourceLocalSymbol { IsVar: true } local })
                             {
-                                var inferredType = new TypeWithState(tempType, tempState).ToTypeWithAnnotations();
+                                var inferredType = TypeWithState.Create(tempType, tempState).ToTypeWithAnnotations();
                                 if (_variableTypes.TryGetValue(local, out var existingType))
                                 {
                                     // merge inferred nullable annotation from different branches of the decision tree

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -711,7 +711,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Reading from a variable of a type parameter (that could be substituted with a nullable type), but which
             // cannot itself be annotated (because it isn't known to be a reference type), may yield a null value
             // even though the type parameter isn't annotated.
-            return new TypeWithState(
+            return TypeWithState.Create(
                 Type,
                 IsPossiblyNullableTypeTypeParameter() || NullableAnnotation.IsAnnotated() ? NullableFlowState.MaybeNull : NullableFlowState.NotNull);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
@@ -16,14 +16,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public bool MayBeNull => State == NullableFlowState.MaybeNull;
         public bool IsNotNull => State == NullableFlowState.NotNull;
 
-        public static bool CanContainNull(TypeSymbol type)
+        private static bool CanContainNull(TypeSymbol type)
         {
             return type is null || !type.IsValueType || type.IsNullableTypeOrTypeParameter();
         }
 
-        public static TypeWithState ForType(TypeSymbol type) => new TypeWithState(type, CanContainNull(type) ? NullableFlowState.MaybeNull : NullableFlowState.NotNull);
+        public static TypeWithState ForType(TypeSymbol type)
+        {
+            var state = CanContainNull(type) ? NullableFlowState.MaybeNull : NullableFlowState.NotNull;
+            return new TypeWithState(type, state);
+        }
 
-        public TypeWithState(TypeSymbol type, NullableFlowState state)
+        public static TypeWithState Create(TypeSymbol type, NullableFlowState defaultState)
+        {
+            var state = defaultState == NullableFlowState.MaybeNull && CanContainNull(type) ? NullableFlowState.MaybeNull : NullableFlowState.NotNull;
+            return new TypeWithState(type, state);
+        }
+
+        private TypeWithState(TypeSymbol type, NullableFlowState state)
         {
             Debug.Assert(state == NullableFlowState.NotNull || CanContainNull(type));
             Type = type;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
@@ -16,7 +16,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public bool MayBeNull => State == NullableFlowState.MaybeNull;
         public bool IsNotNull => State == NullableFlowState.NotNull;
         public static TypeWithState ForType(TypeSymbol type) => new TypeWithState(type, type?.CanContainNull() == true ? NullableFlowState.MaybeNull : NullableFlowState.NotNull);
-        public TypeWithState(TypeSymbol type, NullableFlowState state) => (Type, State) = (type, state);
+        public TypeWithState(TypeSymbol type, NullableFlowState state)
+        {
+            Debug.Assert(state == NullableFlowState.NotNull || type is null || !type.IsValueType || type.IsNullableTypeOrTypeParameter());
+            Type = type;
+            State = state;
+        }
         public void Deconstruct(out TypeSymbol type, out NullableFlowState state) => (type, state) = (Type, State);
         public string GetDebuggerDisplay() => $"{{Type:{Type?.GetDebuggerDisplay()}, State:{State}{"}"}";
         public override string ToString() => GetDebuggerDisplay();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -79998,7 +79998,7 @@ class Program
         }
         else
         {
-            _ = (S)ni; // 1
+            _ = (S)ni; // 3
         }
     }
 }";
@@ -80011,7 +80011,7 @@ class Program
                 //             _ = s4.Value; // 2
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "s4").WithLocation(33, 17),
                 // (45,20): warning CS8629: Nullable value type may be null.
-                //             _ = (S)ni; // 1
+                //             _ = (S)ni; // 3
                 Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "ni").WithLocation(45, 20)
                 );
         }
@@ -81721,9 +81721,8 @@ class B2 : A<int?>
                 //         o.ToString(); // 1
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(11, 9),
                 // (21,9): warning CS8602: Dereference of a possibly null reference.
-                //         o.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(21, 9)
-                );
+                //         o.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "o").WithLocation(21, 9));
         }
 
         [Fact]


### PR DESCRIPTION
Added assert to `TypeWithState` constructor and fixed several call sites.