### PR TITLE
Use correct Solution snapshot in call to UpdateSolutionForBatch

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -358,7 +358,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         solutionChanges,
                         documentFileNamesAdded,
                         documentsToOpen,
-                        (s, documents) => solution.AddDocuments(documents),
+                        (s, documents) => s.AddDocuments(documents),
                         WorkspaceChangeKind.DocumentAdded,
                         (s, id) =>
                         {


### PR DESCRIPTION
This was accidentally using the solution local variable in the containing method rather than the solution instance that's passed to the lambda. It happens to work only because no other mutations have yet happened, so s and solution will point to the same instance. But if anything else got reordered in this method stuff would break.