### PR TITLE
Move to BYOC pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,9 @@ pr:
 
 jobs:
 - job: Windows_Desktop_Unit_Tests
-  pool: dotnet-external-temp-vs2019
+  pool:
+    name: NetCorePublic-Int-Pool
+    queue: BuildPool.Windows.10.Amd64.VS2017.Open
   strategy:
     maxParallel: 4
     matrix:
@@ -90,7 +92,9 @@ jobs:
       condition: not(succeeded())
 
 - job: Windows_CoreClr_Unit_Tests
-  pool: dotnet-external-temp-vs2019
+  pool:
+    name: NetCorePublic-Int-Pool
+    queue: BuildPool.Windows.10.Amd64.VS2017.Open
   strategy:
     maxParallel: 2
     matrix:
@@ -123,7 +127,9 @@ jobs:
       condition: not(succeeded())
            
 - job: Windows_Determinism_Test
-  pool: dotnet-external-temp-vs2019
+  pool:
+    name: NetCorePublic-Int-Pool
+    queue: BuildPool.Windows.10.Amd64.VS2017.Open
   timeoutInMinutes: 90
   steps:
     - script: eng/test-determinism.cmd -configuration Debug
@@ -139,7 +145,9 @@ jobs:
       condition: not(succeeded())
 
 - job: Windows_Correctness_Test
-  pool: dotnet-external-temp-vs2019
+  pool:
+    name: NetCorePublic-Int-Pool
+    queue: BuildPool.Windows.10.Amd64.VS2017.Open
   timeoutInMinutes: 90
   steps:
     - script: eng/test-build-correctness.cmd -configuration Release

--- a/src/Tools/ExternalAccess/Xamarin.Remote/Microsoft.CodeAnalysis.ExternalAccess.Xamarin.Remote.csproj
+++ b/src/Tools/ExternalAccess/Xamarin.Remote/Microsoft.CodeAnalysis.ExternalAccess.Xamarin.Remote.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Remote\ServiceHub\Microsoft.CodeAnalysis.Remote.ServiceHub.csproj" />    
   </ItemGroup>


### PR DESCRIPTION
This changes our pipelines to use the BYOC (Bring Your Own Cloud) pools
hosed by the core engineering team. This is a dynamic queue which should
scale better for our uses than the static pools we are using today.