### PR TITLE
Async Completion - Ctrl+Space isn't filtering the list (when non-unique)

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         {
             switch (trigger.Reason)
             {
+                case AsyncCompletionData.CompletionTriggerReason.InvokeAndCommitIfUnique:
+                    return new RoslynTrigger(CompletionTriggerKind.InvokeAndCommitIfUnique);
                 case AsyncCompletionData.CompletionTriggerReason.Insertion:
                     return RoslynTrigger.CreateInsertionTrigger(trigger.Character);
                 case AsyncCompletionData.CompletionTriggerReason.Deletion:

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -4884,6 +4884,27 @@ namespace ThenIncludeIntellisenseBug
             End Using
         End Function
 
+        <MemberData(NameOf(AllCompletionImplementations))>
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCommitIfUniqueFiltersIfNotUnique(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+                              <Document>
+class C
+{
+    void Method()
+    {
+        Me$$
+    }
+}
+                              </Document>)
+
+                state.SendCommitUniqueCompletionListItem()
+                Await state.AssertCompletionSession()
+                state.AssertCompletionItemsContainAll(displayText:={"MemberwiseClone", "Method"})
+                state.AssertCompletionItemsDoNotContainAny(displayText:={"int", "ToString()", "Microsoft", "Math"})
+            End Using
+        End Function
+
         Private Class MultipleChangeCompletionProvider
             Inherits CompletionProvider
 


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/34601