### PR TITLE
Move to 16.0 RTM build tools

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
     "vs": {
       "version": "16.0"
     },
-    "xcopy-msbuild": "16.0.0-rc1-alpha"
+    "xcopy-msbuild": "16.0.0-alpha"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19171.3"


### PR DESCRIPTION
This changes our build tools to be 16.0 RTM.