### PR TITLE
Support `inlineDescription` parameter for `AssertSelectedCompletionIt…em` in ModernCompletionTestState

### DIFF
--- a/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
@@ -212,7 +212,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                                     Optional shouldFormatOnCommit As Boolean? = Nothing,
                                                     Optional inlineDescription As String = Nothing,
                                                     Optional projectionsView As ITextView = Nothing) As Task
-            ' inlineDescription is not used in this implementation.
 
             Dim view = If(projectionsView, TextView)
 


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/33913

The actual fix was https://github.com/dotnet/roslyn/pull/34275