### PR TITLE
Add cancellationToken local symbol

### DIFF
--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -117,7 +117,8 @@ But it contains additional state:
 - a promise of a value-or-end,
 - a current yielded value of type `T`,
 - an `int` capturing the id of the thread that created it,
-- a `bool` flag indicating "dispose mode".
+- a `bool` flag indicating "dispose mode",
+- a `CancellationToken` field.
 
 The central method of the state machine is `MoveNext()`. It gets run by `MoveNextAsync()`, or as a background continuation initiated from these from an `await` in the method.
 
@@ -195,6 +196,11 @@ Similarly, the kick-off method is much like those of regular iterator methods:
     return result;
 }
 ```
+
+#### `cancellationToken` pseudo-local
+
+A variable named `cancellationToken` and of type `System.Threading.CancellationToken` exists in the body of an async-iterator method that returns `IAsyncEnumerable`.
+That variable is initialized with the token received by `GetAsyncEnumerator`. The compiler treats this variable as a local that is implicitly declared and is hoisted into a field.
 
 #### Disposal
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1561,6 +1561,10 @@ moreArguments:
             {
                 cause = MessageID.IDS_FIXEDLOCAL;
             }
+            else if (local.SynthesizedKind == SynthesizedLocalKind.AsyncIteratorCancellationToken)
+            {
+                cause = MessageID.IDS_CANCELLATIONTOKENLOCAL;
+            }
             else
             {
                 Error(diagnostics, GetStandardLvalueError(kind), node);

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
@@ -145,6 +145,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         method = method ?? GetMethodSymbol(methodDecl, resultBinder);
                         resultBinder = new InMethodBinder(method, resultBinder);
+                        if (method.IsAsync)
+                        {
+                            resultBinder = new CancellationTokenLocalScopeBinder(method, resultBinder);
+                        }
                     }
 
                     resultBinder = resultBinder.WithUnsafeRegionIfNecessary(methodDecl.Modifiers);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_NameConflicts.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_NameConflicts.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ValidateNameConflictsInScope(symbol, location, symbol.Name, diagnostics);
         }
 
-        private static Location GetLocation(Symbol symbol)
+        internal static Location GetLocation(Symbol symbol)
         {
             var locations = symbol.Locations;
             return locations.Length != 0 ? locations[0] : symbol.ContainingSymbol.Locations[0];

--- a/src/Compilers/CSharp/Portable/Binder/CancellationTokenLocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/CancellationTokenLocalScopeBinder.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    /// <summary>
+    /// This binder is responsible for introducing the 'cancellationToken' variable
+    /// in async-iterator methods.
+    /// </summary>
+    internal sealed class CancellationTokenLocalScopeBinder : LocalScopeBinder
+    {
+        private readonly SourceMethodSymbol _methodSymbol;
+
+        public CancellationTokenLocalScopeBinder(SourceMethodSymbol owner, Binder enclosing)
+            : base(enclosing, enclosing.Flags & ~BinderFlags.AllClearedAtExecutableCodeBoundary)
+        {
+            Debug.Assert(!enclosing.Flags.Includes(BinderFlags.InCatchFilter));
+            Debug.Assert((object)owner != null);
+            Debug.Assert(enclosing is InMethodBinder);
+            _methodSymbol = owner;
+        }
+
+        protected override SourceLocalSymbol LookupLocal(SyntaxToken nameToken)
+            => throw ExceptionUtilities.Unreachable;
+
+        protected override LocalFunctionSymbol LookupLocalFunction(SyntaxToken nameToken)
+            => null;
+
+        internal override uint LocalScopeDepth
+            => Binder.TopLevelScope;
+
+        protected override bool InExecutableBinder
+            => true;
+
+        internal override Symbol ContainingMemberOrLambda
+            => _methodSymbol;
+
+        internal override bool IsInMethodBody
+            => true;
+
+        internal override bool IsNestedFunctionBinder
+            => _methodSymbol.MethodKind == MethodKind.LocalFunction;
+
+        internal override bool IsDirectlyInIterator
+            => Next.IsDirectlyInIterator;
+
+        internal override bool IsIndirectlyInIterator
+            => Next.IsIndirectlyInIterator;
+
+        internal override GeneratedLabelSymbol BreakLabel
+            => null;
+
+        internal override GeneratedLabelSymbol ContinueLabel
+            => null;
+
+        internal override TypeWithAnnotations GetIteratorElementType(YieldStatementSyntax node, DiagnosticBag diagnostics)
+            => Next.GetIteratorElementType(node, diagnostics);
+
+        protected override ImmutableArray<LocalSymbol> BuildLocals()
+        {
+            if (_methodSymbol.GetCancellationTokenLocal() is { } cancellationTokenLocal)
+            {
+                return ImmutableArray.Create<LocalSymbol>(cancellationTokenLocal);
+            }
+            return ImmutableArray<LocalSymbol>.Empty;
+        }
+
+        internal override void LookupSymbolsInSingleBinder(
+            LookupResult result, string name, int arity, ConsList<TypeSymbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            Debug.Assert(result.IsClear);
+
+            if (name != SourceOrdinaryMethodSymbol.AsyncIteratorCancellationTokenLocal ||
+                (options & LookupOptions.NamespaceAliasesOnly) != 0)
+            {
+                return;
+            }
+
+            if (_methodSymbol.GetCancellationTokenLocal() is { } cancellationTokenLocal)
+            {
+                result.MergeEqual(originalBinder.CheckViability(cancellationTokenLocal, arity, options, null, diagnose, ref useSiteDiagnostics));
+            }
+        }
+
+        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        {
+            if (options.CanConsiderLocals() && _methodSymbol.GetCancellationTokenLocal() is { } cancellationTokenLocal)
+            {
+                if (originalBinder.CanAddLookupSymbolInfo(cancellationTokenLocal, options, result, null))
+                {
+                    result.AddSymbol(cancellationTokenLocal, cancellationTokenLocal.Name, 0);
+                }
+            }
+        }
+
+        internal override bool EnsureSingleDefinition(Symbol symbol, string name, Location location, DiagnosticBag diagnostics)
+        {
+            if (name == SourceOrdinaryMethodSymbol.AsyncIteratorCancellationTokenLocal &&
+                _methodSymbol.GetCancellationTokenLocal() is { } existingSymbol)
+            {
+                if (symbol == existingSymbol)
+                {
+                    return false;
+                }
+
+                return ReportConflictWithLocal(existingSymbol, symbol, name, location, diagnostics);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -234,6 +234,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 binder = binder.WithUnsafeRegionIfNecessary(node.Modifiers);
                 binder = new InMethodBinder(match, binder);
+
+                if (match.IsAsync)
+                {
+                    binder = new CancellationTokenLocalScopeBinder(match, binder);
+                }
             }
 
             BlockSyntax blockBody = node.Body;

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -473,7 +473,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private bool ReportConflictWithLocal(Symbol local, Symbol newSymbol, string name, Location newLocation, DiagnosticBag diagnostics)
+        protected bool ReportConflictWithLocal(Symbol local, Symbol newSymbol, string name, Location newLocation, DiagnosticBag diagnostics)
         {
             // Quirk of the way we represent lambda parameters.
             SymbolKind newSymbolKind = (object)newSymbol == null ? SymbolKind.Parameter : newSymbol.Kind;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private void CheckDeclared(LocalSymbol local)
             {
-                if (!DeclaredLocals.Contains(local))
+                if (!DeclaredLocals.Contains(local) && local.SynthesizedKind != SynthesizedLocalKind.AsyncIteratorCancellationToken)
                 {
                     Debug.Assert(false, "undeclared local " + local.GetDebuggerDisplay());
                 }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -7225,6 +7225,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Parameters and type parameters of async iterator methods cannot be named &apos;cancellationToken&apos;..
+        /// </summary>
+        internal static string ERR_NoCancellationTokenParameterInAsyncIterator {
+            get {
+                return ResourceManager.GetString("ERR_NoCancellationTokenParameterInAsyncIterator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot find the interop type that matches the embedded interop type &apos;{0}&apos;. Are you missing an assembly reference?.
         /// </summary>
         internal static string ERR_NoCanonicalView {
@@ -10857,6 +10866,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string IDS_BaseTypeInBaseExpression {
             get {
                 return ResourceManager.GetString("IDS_BaseTypeInBaseExpression", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to cancellation token variable.
+        /// </summary>
+        internal static string IDS_CANCELLATIONTOKENLOCAL {
+            get {
+                return ResourceManager.GetString("IDS_CANCELLATIONTOKENLOCAL", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2536,6 +2536,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Local functions and lambdas may not use or capture the &apos;cancellationToken&apos; variable..
+        /// </summary>
+        internal static string ERR_CannotUseOrCaptureCancellationToken_ {
+            get {
+                return ResourceManager.GetString("ERR_CannotUseOrCaptureCancellationToken ", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos;: cannot explicitly call operator or accessor.
         /// </summary>
         internal static string ERR_CantCallSpecialMethod {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5829,4 +5829,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_NoCancellationTokenParameterInAsyncIterator" xml:space="preserve">
     <value>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</value>
   </data>
+  <data name="ERR_CannotUseOrCaptureCancellationToken " xml:space="preserve">
+    <value>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -315,6 +315,9 @@
   <data name="IDS_FOREACHLOCAL" xml:space="preserve">
     <value>foreach iteration variable</value>
   </data>
+  <data name="IDS_CANCELLATIONTOKENLOCAL" xml:space="preserve">
+    <value>cancellation token variable</value>
+  </data>
   <data name="IDS_FIXEDLOCAL" xml:space="preserve">
     <value>fixed variable</value>
   </data>
@@ -5822,5 +5825,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_DefaultInterfaceImplementationInNoPIAType" xml:space="preserve">
     <value>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</value>
+  </data>
+  <data name="ERR_NoCancellationTokenParameterInAsyncIterator" xml:space="preserve">
+    <value>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1585,6 +1585,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_DefaultLiteralConvertedToNullIsNotIntended = 8402,
         ERR_IteratorMustBeAsync = 8403,
         ERR_NoCancellationTokenParameterInAsyncIterator = 8404,
+        ERR_CannotUseOrCaptureCancellationToken = 8405,
 
         ERR_NoConvToIAsyncDisp = 8410,
         ERR_AwaitForEachMissingMember = 8411,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1584,6 +1584,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AltInterpolatedVerbatimStringsNotAvailable = 8401,
         WRN_DefaultLiteralConvertedToNullIsNotIntended = 8402,
         ERR_IteratorMustBeAsync = 8403,
+        ERR_NoCancellationTokenParameterInAsyncIterator = 8404,
 
         ERR_NoConvToIAsyncDisp = 8410,
         ERR_AwaitForEachMissingMember = 8411,

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -98,6 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_PathList = MessageBase + 12686,
         IDS_Text = MessageBase + 12687,
 
+        IDS_CANCELLATIONTOKENLOCAL = MessageBase + 12688,
         // available
 
         IDS_FeatureNullPropagatingOperator = MessageBase + 12690,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -429,6 +429,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        protected LocalSymbol MethodCancellationTokenLocal
+        {
+            get
+            {
+                if (_symbol is SourceMethodSymbol method)
+                {
+                    return method.GetCancellationTokenLocal();
+                }
+                return null;
+            }
+        }
+
         /// <summary>
         /// Specifies whether or not method's out parameters should be analyzed. If there's more
         /// than one location in the method being analyzed, then the method is partial and we prefer

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractRegionDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractRegionDataFlowPass.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             MakeSlots(MethodParameters);
             if ((object)MethodThisParameter != null) GetOrCreateSlot(MethodThisParameter);
+            if (MethodCancellationTokenLocal is { } cancellationTokenLocal) GetOrCreateSlot(cancellationTokenLocal);
             var result = base.Scan(ref badRegion);
             return result;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -202,6 +202,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            if (MethodCancellationTokenLocal is { } cancellationTokenLocal)
+            {
+                int slot = base.GetOrCreateSlot(MethodCancellationTokenLocal);
+                SetSlotState(slot, true);
+                NoteWrite(cancellationTokenLocal, value: null, read: false);
+            }
+
             ImmutableArray<PendingBranch> pendingReturns = base.Scan(ref badRegion);
 
             // check that each out parameter is definitely assigned at the end of the method.  If

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -294,6 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 EnterParameter(methodThisParameter, methodThisParameter.TypeWithAnnotations);
             }
+            // Note: no need to analyze the 'cancellationToken' local in async-iterator methods
 
             ImmutableArray<PendingBranch> pendingReturns = base.Scan(ref badRegion);
             return pendingReturns;

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -332,7 +332,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     if (((SourceMethodSymbol)_topLevelMethod).GetCancellationTokenLocal() is { } cancellationToken)
                     {
-                        // TODO2 need to confirm this
+                        // need to confirm this
+                        // See https://github.com/dotnet/roslyn/issues/34708
+
                         DeclareLocals(_currentScope, ImmutableArray.Create<Symbol>(cancellationToken));
                     }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -330,6 +330,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         DeclareLocals(_currentScope, ImmutableArray.Create<Symbol>(thisParam));
                     }
+                    if (((SourceMethodSymbol)_topLevelMethod).GetCancellationTokenLocal() is { } cancellationToken)
+                    {
+                        // TODO2 need to confirm this
+                        DeclareLocals(_currentScope, ImmutableArray.Create<Symbol>(cancellationToken));
+                    }
 
                     Visit(_currentScope.BoundNode);
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
@@ -53,6 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool badRegion = false;
             walker.Analyze(ref badRegion);
+
             Debug.Assert(!badRegion);
 
             if (!method.IsStatic && method.ContainingType.TypeKind == TypeKind.Struct)
@@ -60,6 +61,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // It is possible that the enclosing method only *writes* to the enclosing struct, but in that
                 // case it should be considered captured anyway so that we have a proxy for it to write to.
                 walker.CaptureVariable(method.ThisParameter, node.Syntax);
+            }
+
+            if (method is SourceMethodSymbol sourceMethod)
+            {
+                // We capture the variable and create a field regardless of usage
+                if (sourceMethod.GetCancellationTokenLocal() is { } local)
+                {
+                    walker.CaptureVariable(local, node.Syntax);
+                }
             }
 
             var variablesToHoist = walker._variablesToHoist;

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -501,7 +501,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 #endif
             )
         {
-            return new SynthesizedLocal(CurrentFunction, TypeWithAnnotations.Create(type), kind, syntax, isPinned, refKind
+            return new SynthesizedLocal(CurrentFunction, TypeWithAnnotations.Create(type), kind, syntax, isPinned, refKind, name: null
 #if DEBUG
                 , createdAtLineNumber, createdAtFilePath
 #endif

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {

--- a/src/Compilers/CSharp/Portable/Symbols/SentinenlLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SentinenlLocalSymbol.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class SentinenlLocalSymbol : LocalSymbol
+    {
+        internal static readonly SentinenlLocalSymbol Instance = new SentinenlLocalSymbol();
+        private SentinenlLocalSymbol() { }
+
+        public override TypeWithAnnotations TypeWithAnnotations => throw ExceptionUtilities.Unreachable;
+        public override RefKind RefKind => throw ExceptionUtilities.Unreachable;
+        public override Symbol ContainingSymbol => throw ExceptionUtilities.Unreachable;
+        public override ImmutableArray<Location> Locations => throw ExceptionUtilities.Unreachable;
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => throw ExceptionUtilities.Unreachable;
+        internal override LocalDeclarationKind DeclarationKind => throw ExceptionUtilities.Unreachable;
+        internal override SynthesizedLocalKind SynthesizedKind => throw ExceptionUtilities.Unreachable;
+        internal override SyntaxNode ScopeDesignatorOpt => throw ExceptionUtilities.Unreachable;
+        internal override bool IsImportedFromMetadata => throw ExceptionUtilities.Unreachable;
+        internal override SyntaxToken IdentifierToken => throw ExceptionUtilities.Unreachable;
+        internal override bool IsPinned => throw ExceptionUtilities.Unreachable;
+        internal override bool IsCompilerGenerated => throw ExceptionUtilities.Unreachable;
+        internal override uint RefEscapeScope => throw ExceptionUtilities.Unreachable;
+        internal override uint ValEscapeScope => throw ExceptionUtilities.Unreachable;
+        internal override ConstantValue GetConstantValue(SyntaxNode node, LocalSymbol inProgress, DiagnosticBag diagnostics = null) => throw ExceptionUtilities.Unreachable;
+        internal override ImmutableArray<Diagnostic> GetConstantValueDiagnostics(BoundExpression boundInitValue) => throw ExceptionUtilities.Unreachable;
+        internal override SyntaxNode GetDeclaratorSyntax() => throw ExceptionUtilities.Unreachable;
+        internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax) => throw ExceptionUtilities.Unreachable;
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -402,5 +402,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override SynthesizedLocal GetCancellationTokenLocal()
+            => null;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -21,6 +21,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public abstract ImmutableArray<TypeParameterConstraintClause> GetTypeParameterConstraintClauses(bool early);
 
+        /// <summary>
+        /// Async-iterator methods and local functions introduce a pseudo-local called 'cancellationToken'.
+        /// </summary>
+        internal abstract SynthesizedLocal GetCancellationTokenLocal();
+
         protected static void ReportBadRefToken(TypeSyntax returnTypeSyntax, DiagnosticBag diagnostics)
         {
             if (!returnTypeSyntax.HasErrors)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static string MakeHoistedLocalFieldName(SynthesizedLocalKind kind, int slotIndex, string localNameOpt = null)
         {
-            Debug.Assert((localNameOpt != null) == (kind == SynthesizedLocalKind.UserDefined));
+            Debug.Assert((localNameOpt != null) == (kind == SynthesizedLocalKind.UserDefined) || kind == SynthesizedLocalKind.AsyncIteratorCancellationToken);
             Debug.Assert(slotIndex >= 0);
             Debug.Assert(kind.IsLongLived());
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly SyntaxNode _syntaxOpt;
         private readonly bool _isPinned;
         private readonly RefKind _refKind;
+        private readonly string _name;
 
 #if DEBUG
         private readonly int _createdAtLineNumber;
@@ -33,7 +34,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             SynthesizedLocalKind kind,
             SyntaxNode syntaxOpt = null,
             bool isPinned = false,
-            RefKind refKind = RefKind.None
+            RefKind refKind = RefKind.None,
+            string name = null
 #if DEBUG
             ,
             [CallerLineNumber]int createdAtLineNumber = 0,
@@ -51,6 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _syntaxOpt = syntaxOpt;
             _isPinned = isPinned;
             _refKind = refKind;
+            _name = name;
 
 #if DEBUG
             _createdAtLineNumber = createdAtLineNumber;
@@ -77,6 +80,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override RefKind RefKind
         {
             get { return _refKind; }
+        }
+
+        internal override bool IsWritableVariable
+        {
+            get
+            {
+                if (SynthesizedKind == SynthesizedLocalKind.AsyncIteratorCancellationToken)
+                {
+                    return false;
+                }
+
+                return base.IsWritableVariable;
+            }
         }
 
         internal override bool IsImportedFromMetadata
@@ -111,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override string Name
         {
-            get { return null; }
+            get { return _name; }
         }
 
         public override TypeWithAnnotations TypeWithAnnotations

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Omezení new() nejde používat s omezením unmanaged.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">{0}: typ použitý v příkazu async using musí být implicitně převoditelný na System.IAsyncDisposable nebo implementovat odpovídající metodu DisposeAsync. Neměli jste v úmyslu použít using místo await using?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">Název souboru {0} je prázdný, obsahuje neplatné znaky, má specifikaci jednotky bez absolutní cesty nebo je moc dlouhý.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Neplatný operand pro porovnávací vzorek. Vyžaduje se hodnota, ale nalezeno: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">__arglist nemůže mít argument předávaný pomocí in nebo out</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Ungültiger Operand für die Musterübereinstimmung. Ein Wert ist erforderlich, gefunden wurde aber "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">"__arglist" darf kein über "in" oder "out" übergebenes Argument umfassen.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Die new()-Einschränkung kann nicht mit der unmanaged-Einschränkung verwendet werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">"{0}": Der in einer asynchronen using-Anweisung verwendete Typ muss implizit in "System.IAsyncDisposable" konvertiert werden können oder eine geeignete DisposeAsync-Methode implementieren. Meinten Sie "using" anstelle von "await using"?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">Der Dateiname "{0}" ist leer, enthält ungültige Zeichen, weist eine Laufwerkangabe ohne absoluten Pfad auf oder ist zu lang.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -217,6 +217,11 @@
         <target state="translated">La restricción "new()" no se puede utilizar con la restricción "unmanaged"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">"{0}": el tipo usado en una instrucción using asincrónica debe poder convertirse de forma implícita en "System.IAsyncDisposable" o implemente un método "DisposeAsync" adecuado. ¿Quiso decir "using" en lugar de "await using"?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">El nombre de archivo '{0}' está vacío, contiene caracteres no válidos, tiene una especificación de unidad sin ruta de acceso absoluta o es demasiado largo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Operando no válido para la coincidencia de patrones. Se requería un valor, pero se encontró '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">__arglist no puede tener un argumento que se ha pasado con "in" o "out"</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -217,6 +217,11 @@
         <target state="translated">La contrainte 'new()' ne peut pas être utilisée avec la contrainte 'unmanaged'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">'{0}' : le type utilisé dans une instruction using asynchrone doit être implicitement convertible en 'System.IAsyncDisposable' ou implémenter une méthode 'DisposeAsync' appropriée. Vouliez-vous dire 'using' plutôt que 'await using' ?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">Le nom de fichier '{0}' est vide, contient des caractères non valides, spécifie un lecteur sans chemin d'accès absolu ou est trop long</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Opérande non valide pour les critères spéciaux ; la valeur nécessaire n'est pas celle trouvée, '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">__arglist ne peut pas avoir un argument passé par 'in' ou 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Non è possibile usare il vincolo 'new()' con il vincolo 'unmanaged'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">'{0}': il tipo usato in un'istruzione using asincrona deve essere convertibile in modo implicito in 'System.IAsyncDisposable' o implementare un metodo 'DisposeAsync' adatto. Si intendeva 'using' invece di 'await using'?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">Il nome file '{0}' è vuoto, contiene caratteri non validi, include una specifica di unità senza percorso assoluto oppure è troppo lungo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">L'operando non è valido per i criteri di ricerca. È richiesto un valore ma è stato trovato '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">__arglist non può contenere un argomento passato da 'in' o 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">パターン マッチには使用できないオペランドです。値が必要ですが、'{0}' が見つかりました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">__arglist では、'in' や 'out' で引数を渡すことができません</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -217,6 +217,11 @@
         <target state="translated">new()' 制約は 'unmanaged' 制約と一緒には使用できません</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">'{0}': 非同期 using ステートメントで使用される型は、暗黙的に 'System.IAsyncDisposable' に変換可能であるか、適切な 'DisposeAsync' メソッドを実装する必要があります。'await using' ではなく 'using' ですか?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">ファイル名 '{0}' は、空である、無効な文字を含んでいる、絶対パスが指定されていないドライブ指定がある、または長すぎるかのいずれかです。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">패턴 일치에 대한 피연산자가 잘못되었습니다. 값이 필요하지만 '{0}'을(를) 찾았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">__arglist는 'in' 또는 'out'으로 전달되는 인수를 가질 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -217,6 +217,11 @@
         <target state="translated">new()' 제약 조건은 'unmanaged' 제약 조건과 함께 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">'{0}': 비동기 using 문에 사용된 형식은 암시적으로 'System.IAsyncDisposable'로 변환할 수 있거나 적합한 'DisposeAsync' 메서드를 구현해야 합니다. 'await using' 대신 'using'을 사용하시겠습니까?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">{0}' 파일 이름이 비어 있거나, 잘못된 문자가 있거나, 절대 경로가 없는 드라이브 사양이 있거나, 너무 깁니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Ograniczenie „new()” nie może być używane z ograniczeniem „unmanaged”</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">„{0}”: Typ użyty w asynchronicznej instrukcji using musi być jawnie konwertowalny na typ „System.IAsyncDisposable” lub musi implementować odpowiednią metodę „DisposeAsync”. Czy chodziło Ci o użycie instrukcji „using”, a nie „await using”?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">Nazwa pliku „{0}” jest pusta, zawiera nieprawidłowe znaki, zawiera specyfikację dysku bez bezwzględnej ścieżki lub jest za długa</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Nieprawidłowy operand dla dopasowania wzorca; wymagana jest wartość, a znaleziono „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">Element __arglist nie może mieć argumentu przekazywanego przez parametr „in” ani „out”</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -217,6 +217,11 @@
         <target state="translated">A restrição 'new()' não pode ser usada com a restrição 'unmanaged'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">'{0}': o tipo usado em uma instrução async using deve ser implicitamente conversível em 'System.IAsyncDisposable' ou implementar um método 'DisposeAsync' adequado. Você quis dizer 'using' em vez de 'await using'?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">Nome do arquivo "{0}" está vazio, contém caracteres inválidos, tem uma especificação de unidade sem um caminho absoluto ou é muito longo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Operando inválido para correspondência de padrão. Um valor era obrigatório, mas '{0}' foi encontrado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">__arglist não pode ter um argumento passado por 'in' ou 'out'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Ограничение "new()" невозможно использовать вместе с ограничением "unmanaged"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">"{0}": тип, используемый в асинхронном операторе using, должен допускать неявное преобразование в тип "System.IAsyncDisposable" или реализовывать подходящий метод "DisposeAsync". Возможно, вы имели в виду "using", а не "await using"?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">Имя файла "{0}" пустое, содержит недопустимые символы, имеет имя диска без абсолютного пути или слишком длинное.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Недопустимый операнд для сопоставления с шаблоном. Требуется значение, но найдено "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">В __arglist невозможно передать аргумент с помощью in или out</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -217,6 +217,11 @@
         <target state="translated">'new()' kısıtlaması, 'unmanaged' kısıtlamasıyla kullanılamaz</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">'{0}': Zaman uyumsuz bir using deyiminde kullanılan tür örtük olarak 'System.IAsyncDisposable' arabirimine dönüştürebilir olmalı veya uygun bir 'DisposeAsync' yöntemi uygulamalıdır. 'await using' yerine 'using' mi kullanmak istediniz?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Desen eşleşmesi için işlenen geçersiz. Değer gerekiyordu ancak '{0}' bulundu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">__arglist, 'in' veya 'out' tarafından geçirilen bir bağımsız değişkene sahip olamaz</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">用于模式匹配的操作数无效；需要值，但找到的是“{0}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">__arglist 不能有 "in" 或 "out" 传递的参数</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -242,6 +242,11 @@
         <target state="translated">"new()" 约束不能与 "unmanaged" 约束一起使用</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">“{0}”: 异步 using 语句中使用的类型必须可隐式转换为 "System.IAsyncDisposable" 或实现适用的 "DisposeAsync" 方法。是否希望使用 "using" 而非 "await using"?</target>
@@ -420,6 +425,11 @@
       <trans-unit id="IDS_BaseTypeInBaseExpression">
         <source>specifying base type in base expression</source>
         <target state="new">specifying base type in base expression</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -217,6 +217,11 @@
         <target state="translated">new()' 條件約束不能和 'unmanaged' 條件約束一起使用</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_NoCancellationTokenParameterInAsyncIterator">
+        <source>Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</source>
+        <target state="new">Parameters and type parameters of async iterator methods cannot be named 'cancellationToken'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoConvToIAsyncDispWrongAsync">
         <source>'{0}': type used in an async using statement must be implicitly convertible to 'System.IAsyncDisposable' or implement a suitable 'DisposeAsync' method. Did you mean 'using' rather than 'await using'?</source>
         <target state="translated">'{0}': 在非同步 using 陳述式中使用的類型，必須可隱含地轉換為 'System.IAsyncDisposable' 或實作合適的 'DisposeAsync' 方法。您指的是 'using' 而不是 'await using' 嗎?</target>
@@ -380,6 +385,11 @@
       <trans-unit id="FTL_InvalidInputFileName">
         <source>File name '{0}' is empty, contains invalid characters, has a drive specification without an absolute path, or is too long</source>
         <target state="translated">檔案名稱 '{0}' 是空的、包含了無效字元、指定了磁碟機但不是絕對路徑，或太長了。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_CANCELLATIONTOKENLOCAL">
+        <source>cancellation token variable</source>
+        <target state="new">cancellation token variable</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_CSCHelp">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">模式比對運算元無效; 需要值，但找到 '{0}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_CannotUseOrCaptureCancellationToken ">
+        <source>Local functions and lambdas may not use or capture the 'cancellationToken' variable.</source>
+        <target state="new">Local functions and lambdas may not use or capture the 'cancellationToken' variable.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_CantUseInOrOutInArglist">
         <source>__arglist cannot have an argument passed by 'in' or 'out'</source>
         <target state="translated">__arglist 不得包含 'in' 或 'out' 傳遞的引數</target>

--- a/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
+++ b/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
@@ -230,6 +230,13 @@ namespace Microsoft.CodeAnalysis
         /// TODO: Avoid using lambdas and display classes for implementation of relaxation stubs and remove this kind.
         /// </summary>
         DelegateRelaxationReceiver = 0x101,
+
+        /// <summary>
+        /// The variable used in async-iterator methods to refer to the CancellationToken
+        /// from `GetAsyncEnumerator(CancellationToken)`.
+        /// Never actually created as a local variable. Its usages are lowered to refer to that parameter instead.
+        /// </summary>
+        AsyncIteratorCancellationToken = 0x102,
     }
 
     internal static class SynthesizedLocalKindExtensions
@@ -276,6 +283,10 @@ namespace Microsoft.CodeAnalysis
                 case SynthesizedLocalKind.UserDefined:
                 case SynthesizedLocalKind.LambdaDisplayClass:
                 case SynthesizedLocalKind.With:
+                    return false;
+
+                // The cancellationToken variable needs a dedicated slot/field
+                case SynthesizedLocalKind.AsyncIteratorCancellationToken:
                     return false;
 
                 default:

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -409,6 +409,93 @@ namespace System.Runtime.CompilerServices
 }
 ";
 
+        // from https://github.com/dotnet/coreclr/pull/21939
+        public const string AsyncEnumerableWithCancellation = @"
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+namespace System.Threading.Tasks
+{
+    /// <summary>Provides a set of static methods for working with specific kinds of <see cref=""Task""/> instances.</summary>
+    public static class TaskExtensions
+    {
+        public static ConfiguredCancelableAsyncEnumerable<T> WithCancellation<T>(
+            this IAsyncEnumerable<T> source, CancellationToken cancellationToken) =>
+            new ConfiguredCancelableAsyncEnumerable<T>(source, continueOnCapturedContext: true, cancellationToken);
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Provides an awaitable async enumerable that enables cancelable iteration and configured awaits.</summary>
+    [StructLayout(LayoutKind.Auto)]
+    public readonly struct ConfiguredCancelableAsyncEnumerable<T>
+    {
+        private readonly IAsyncEnumerable<T> _enumerable;
+        private readonly CancellationToken _cancellationToken;
+        private readonly bool _continueOnCapturedContext;
+
+        internal ConfiguredCancelableAsyncEnumerable(IAsyncEnumerable<T> enumerable, bool continueOnCapturedContext, CancellationToken cancellationToken)
+        {
+            _enumerable = enumerable;
+            _continueOnCapturedContext = continueOnCapturedContext;
+            _cancellationToken = cancellationToken;
+        }
+
+        /// <summary>Configures how awaits on the tasks returned from an async iteration will be performed.</summary>
+        /// <param name=""continueOnCapturedContext"">Whether to capture and marshal back to the current context.</param>
+        /// <returns>The configured enumerable.</returns>
+        /// <remarks>This will replace any previous value set by <see cref=""ConfigureAwait(bool)""/> for this iteration.</remarks>
+        public ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait(bool continueOnCapturedContext) =>
+            new ConfiguredCancelableAsyncEnumerable<T>(_enumerable, continueOnCapturedContext, _cancellationToken);
+
+        /// <summary>Sets the <see cref=""CancellationToken""/> to be passed to <see cref=""IAsyncEnumerable{T}.GetAsyncEnumerator(CancellationToken)""/> when iterating.</summary>
+        /// <param name=""cancellationToken"">The <see cref=""CancellationToken""/> to use.</param>
+        /// <returns>The configured enumerable.</returns>
+        /// <remarks>This will replace any previous <see cref=""CancellationToken""/> set by <see cref=""WithCancellation(CancellationToken)""/> for this iteration.</remarks>
+        public ConfiguredCancelableAsyncEnumerable<T> WithCancellation(CancellationToken cancellationToken) =>
+            new ConfiguredCancelableAsyncEnumerable<T>(_enumerable, _continueOnCapturedContext, cancellationToken);
+
+        public Enumerator GetAsyncEnumerator() =>
+           // as with other ""configured"" awaitable-related type in CompilerServices, we don't null check to defend against
+           // misuse like `default(ConfiguredCancelableAsyncEnumerable<T>).GetAsyncEnumerator()`, which will null ref by design.
+           new Enumerator(_enumerable.GetAsyncEnumerator(_cancellationToken), _continueOnCapturedContext);
+
+        /// <summary>Provides an awaitable async enumerator that enables cancelable iteration and configured awaits.</summary>
+        [StructLayout(LayoutKind.Auto)]
+        public readonly struct Enumerator
+        {
+            private readonly IAsyncEnumerator<T> _enumerator;
+            private readonly bool _continueOnCapturedContext;
+
+            internal Enumerator(IAsyncEnumerator<T> enumerator, bool continueOnCapturedContext)
+            {
+                _enumerator = enumerator;
+                _continueOnCapturedContext = continueOnCapturedContext;
+            }
+
+            /// <summary>Advances the enumerator asynchronously to the next element of the collection.</summary>
+            /// <returns>
+            /// A <see cref=""ConfiguredValueTaskAwaitable{Boolean}""/> that will complete with a result of <c>true</c>
+            /// if the enumerator was successfully advanced to the next element, or <c>false</c> if the enumerator has
+            /// passed the end of the collection.
+            /// </returns>
+            public ConfiguredValueTaskAwaitable<bool> MoveNextAsync() =>
+                _enumerator.MoveNextAsync().ConfigureAwait(_continueOnCapturedContext);
+
+            /// <summary>Gets the element in the collection at the current position of the enumerator.</summary>
+            public T Current => _enumerator.Current;
+
+            /// <summary>
+            /// Performs application-defined tasks associated with freeing, releasing, or
+            /// resetting unmanaged resources asynchronously.
+            /// </summary>
+            public ConfiguredValueTaskAwaitable DisposeAsync() =>
+                _enumerator.DisposeAsync().ConfigureAwait(_continueOnCapturedContext);
+        }
+    }
+}";
+
         protected static CSharpCompilationOptions WithNonNullTypesTrue(CSharpCompilationOptions options = null)
         {
             return WithNonNullTypes(options, NullableContextOptions.Enable);

--- a/src/Test/Utilities/Portable/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Portable/Assert/AssertEx.cs
@@ -176,6 +176,24 @@ namespace Roslyn.Test.Utilities
             Equal(expected, (IEnumerable<T>)actual, comparer, message, itemSeparator);
         }
 
+        public static void Equal(string expected, string actual)
+        {
+            if (expected == actual)
+            {
+                return;
+            }
+
+            var message = new StringBuilder();
+            message.AppendLine();
+            message.AppendLine("Expected:");
+            message.AppendLine(expected);
+            message.AppendLine("Actual:");
+            message.AppendLine(actual);
+            message.AppendLine("Differences:");
+
+            Assert.False(true, message.ToString());
+        }
+
         public static void Equal<T>(
             IEnumerable<T> expected,
             IEnumerable<T> actual,

--- a/src/Test/Utilities/Portable/Metadata/MetadataReaderUtils.cs
+++ b/src/Test/Utilities/Portable/Metadata/MetadataReaderUtils.cs
@@ -327,6 +327,14 @@ namespace Roslyn.Test.Utilities
                         TypeDefinition type = reader.GetTypeDefinition((TypeDefinitionHandle)handle);
                         return getQualifiedName(type.Namespace, type.Name);
                     }
+                case HandleKind.FieldDefinition:
+                    {
+                        FieldDefinition field = reader.GetFieldDefinition((FieldDefinitionHandle)handle);
+                        var blob = reader.GetBlobReader(field.Signature);
+                        var decoder = new SignatureDecoder<string, object>(ConstantSignatureVisualizer.Instance, reader, genericContext: null);
+                        var signature = decoder.DecodeFieldSignature(ref blob);
+                        return $"{signature} {reader.GetString(field.Name)}";
+                    }
                 case HandleKind.MethodDefinition:
                     {
                         MethodDefinition method = reader.GetMethodDefinition((MethodDefinitionHandle)handle);


### PR DESCRIPTION
Inside an async-iterator method that returns `IAsyncEnumerable` (but not `IAsyncEnumerator`), a variable `cancellationToken` exists. It is implemented as a field on the state machine. We initialize it with the token passed as a parameter into `GetAsyncEnumerator(CancellationToken)`.

Parameters and type parameters of this name are disallowed on such async-iterators.
There is discussion of providing a warning on parameters of type `CancellationToken` as well, but I will do that in a follow-up (see below).
I temporarily blocked usage and capture of `cancellationToken` in local functions and lambdas due to time constraints.

Fixes https://github.com/dotnet/roslyn/issues/34407

- [x] Add a binder just after the InMethodBinder
- [x] Stored the synthesized local in the method. 
- [x] Checking IsIterator early is trouble (we need to determine if the local exists before binding the body of the method, but binding the body is currently required to determine if a method is an iterator) so I'm using the return type instead. The two are equivalent (otherwise an error is produced).
- [x] AsyncRewriter hoists the synthesized local.
- [x] GetAsyncEnumerator assigns the corresponding field with value from parameter.
- [x] Made local readonly. Don't assign a debug slot to this local. Add diagnostics for conflicts.
- [x] Report an error if the `CancellationToken` type is missing (filed https://github.com/dotnet/roslyn/issues/34709)
- [x] When a local function captures `cancellationToken` the async method should use that local function's environment, rather than its own field. (temporarily blocked this scenario. Filed https://github.com/dotnet/roslyn/issues/34708 to enable)
- [x] Add a warning for parameters of type `CancellationToken` (email thread with LDM, filed https://github.com/dotnet/roslyn/issues/34710)
- [ ] test EE (see comment in DefineUserDefinedStateMachineHoistedLocal) and EnC (add a declaration for 'cancellationToken', add a write statement)

Relates to https://github.com/dotnet/roslyn/issues/24037 (async-streams umbrella)