### PR TITLE
Avoid a first-chance FileNotFoundException when a ruleset include is not found.

### DIFF
--- a/src/Compilers/Core/Portable/RuleSet/RuleSetInclude.cs
+++ b/src/Compilers/Core/Portable/RuleSet/RuleSetInclude.cs
@@ -55,6 +55,11 @@ namespace Microsoft.CodeAnalysis
             try
             {
                 path = GetIncludePath(parent);
+                if (path == null)
+                {
+                    return null;
+                }
+
                 ruleSet = RuleSetProcessor.LoadFromFile(path);
             }
             catch (FileNotFoundException)
@@ -78,11 +83,9 @@ namespace Microsoft.CodeAnalysis
         private string GetIncludePath(RuleSet parent)
         {
             var resolvedIncludePath = ResolveIncludePath(_includePath, parent?.FilePath);
-
-            // If we still couldn't find it then throw an exception;
             if (resolvedIncludePath == null)
             {
-                throw new FileNotFoundException(string.Format(CodeAnalysisResources.FailedToResolveRuleSetName, _includePath), _includePath);
+                return null;
             }
 
             // Return the canonical full path


### PR DESCRIPTION
When a .ruleset file includes a non-existing ruleset reference we receive null from ResolveIncludePath and throw a FileNotFoundException, which is the immediately caught in LoadRuleSet.

We can avoid the first-chance exception and the associated allocations if we just return null. A missing ruleset is not an exceptional situation so no need to use exceptions for control flow here if we can avoid it.

This is not blocking anything and not urgent, I was just passing by and noticed this and decided to fix.