### PR TITLE
Fix usage of ConcurrentDictionary.AddOrUpdate

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
@@ -92,9 +92,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     RaiseProjectAnalyzerReferenceChangedIfNeeded(project, newAnalyzersPerReference, newMap);
 
                     // update cache. 
-                    // add and update is same since this method will not be called concurrently.
-                    var entry = _stateMap.AddOrUpdate(project.Id,
-                        _ => new Entry(project.AnalyzerReferences, newAnalyzersPerReference, newMap), (_1, _2) => new Entry(project.AnalyzerReferences, newAnalyzersPerReference, newMap));
+                    var entry = new Entry(project.AnalyzerReferences, newAnalyzersPerReference, newMap);
+                    _stateMap[project.Id] = entry;
 
                     VerifyDiagnosticStates(entry.AnalyzerMap.Values);
 

--- a/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
                             document.Project, cancellationToken).ConfigureAwait(false);
 
                         var newInfo = cachedInfo.WithChecksum(checksum);
-                        _projectToInfo.AddOrUpdate(document.Project.Id, newInfo, (_1, _2) => newInfo);
+                        _projectToInfo[document.Project.Id] = newInfo;
                         return;
                     }
                 }
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
 
                     // Mark that we're up to date with this project.  Future calls with the same 
                     // semantic version can bail out immediately.
-                    _projectToInfo.AddOrUpdate(project.Id, projectInfo, (_1, _2) => projectInfo);
+                    _projectToInfo[project.Id] = projectInfo;
                 }
             }
 
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
                     // We still want to cache that result so that don't try to continuously produce
                     // this info over and over again.
                     metadataInfo = new MetadataInfo(info, metadataInfo.ReferencingProjects ?? new HashSet<ProjectId>());
-                    _metadataPathToInfo.AddOrUpdate(key, metadataInfo, (_1, _2) => metadataInfo);
+                    _metadataPathToInfo[key] = metadataInfo;
                 }
 
                 // Keep track that this dll is referenced by this project.

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -515,8 +515,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
             }
 
             var state = new ProjectState(isEnabled, installedPackages);
-            _projectToInstalledPackageAndVersion.AddOrUpdate(
-                projectId, state, (_1, _2) => state);
+            _projectToInstalledPackageAndVersion[projectId] = state;
         }
 
         public bool IsInstalled(Workspace workspace, ProjectId projectId, string packageName)


### PR DESCRIPTION
The lambda here is used in the update scenario. Given we always want to
update and discard the existing value, we don't need to go through this
method.

Looking over the implementation, there's a few things to note:
* The indexer always adds or updates the value
* AddOrUpdate does a bit more logic so that it spins on the collection
checking if the value already exists while retrying the factory logic

This makes the code safe to switch to indexer and avoid the allocation

Fixes #33179

Contained squashed changes from other PR:
https://github.com/dotnet/roslyn/pull/33173/commits/8f64a8790283a32c786b35c65072df84cfc65f75
https://github.com/dotnet/roslyn/pull/33173/commits/a70422ed7c813e3679cbd3d7eeada84663877d11