### PR TITLE
Allow overriding members with nullable variance

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1436,6 +1436,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return !source.NullableAnnotation.IsAnnotated();
         }
 
+        /// <summary>
+        /// Returns false if the source does not have an implicit conversion to the destination
+        /// because of either incompatible top level or nested nullability.
+        /// </summary>
+        public bool HasAnyNullabilityImplicitConversion(TypeWithAnnotations source, TypeWithAnnotations destination)
+        {
+            Debug.Assert(IncludeNullability);
+            HashSet<DiagnosticInfo> discardedDiagnostics = null;
+            return HasTopLevelNullabilityImplicitConversion(source, destination) &&
+                ClassifyImplicitConversionFromType(source.Type, destination.Type, ref discardedDiagnostics).Kind != ConversionKind.NoConversion;
+        }
+
         public static bool HasIdentityConversionToAny<T>(T type, ArrayBuilder<T> targetTypes)
             where T : TypeSymbol
         {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -15557,24 +15557,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Nullability of reference types in type doesn&apos;t match overridden member..
-        /// </summary>
-        internal static string WRN_NullabilityMismatchInTypeOnOverride {
-            get {
-                return ResourceManager.GetString("WRN_NullabilityMismatchInTypeOnOverride", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Nullability of reference types in type doesn&apos;t match overridden member..
-        /// </summary>
-        internal static string WRN_NullabilityMismatchInTypeOnOverride_Title {
-            get {
-                return ResourceManager.GetString("WRN_NullabilityMismatchInTypeOnOverride_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The type &apos;{3}&apos; cannot be used as type parameter &apos;{2}&apos; in the generic type or method &apos;{0}&apos;. Nullability of type argument &apos;{3}&apos; doesn&apos;t match constraint type &apos;{1}&apos;..
         /// </summary>
         internal static string WRN_NullabilityMismatchInTypeParameterConstraint {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5325,12 +5325,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_UnboxPossibleNull_Title" xml:space="preserve">
     <value>Unboxing a possibly null value.</value>
   </data>
-  <data name="WRN_NullabilityMismatchInTypeOnOverride" xml:space="preserve">
-    <value>Nullability of reference types in type doesn't match overridden member.</value>
-  </data>
-  <data name="WRN_NullabilityMismatchInTypeOnOverride_Title" xml:space="preserve">
-    <value>Nullability of reference types in type doesn't match overridden member.</value>
-  </data>
   <data name="WRN_NullabilityMismatchInReturnTypeOnOverride" xml:space="preserve">
     <value>Nullability of reference types in return type doesn't match overridden member.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1635,7 +1635,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_NullReferenceArgument = 8604,
         WRN_UnboxPossibleNull = 8605,
         WRN_NullReferenceIterationVariable = 8606,
-        // Unused 8607
+        // Unused 8607-8608
         WRN_NullabilityMismatchInReturnTypeOnOverride = 8609,
         WRN_NullabilityMismatchInParameterTypeOnOverride = 8610,
         WRN_NullabilityMismatchInParameterTypeOnPartial = 8611,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1636,7 +1636,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_UnboxPossibleNull = 8605,
         WRN_NullReferenceIterationVariable = 8606,
         // Unused 8607
-        WRN_NullabilityMismatchInTypeOnOverride = 8608,
         WRN_NullabilityMismatchInReturnTypeOnOverride = 8609,
         WRN_NullabilityMismatchInParameterTypeOnOverride = 8610,
         WRN_NullabilityMismatchInParameterTypeOnPartial = 8611,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -372,7 +372,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_NullReferenceReturn:
                 case ErrorCode.WRN_NullReferenceArgument:
                 case ErrorCode.WRN_NullReferenceIterationVariable:
-                case ErrorCode.WRN_NullabilityMismatchInTypeOnOverride:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial:

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -195,7 +195,6 @@
                 case ErrorCode.WRN_NullReferenceArgument:
                 case ErrorCode.WRN_UnboxPossibleNull:
                 case ErrorCode.WRN_NullReferenceIterationVariable:
-                case ErrorCode.WRN_NullabilityMismatchInTypeOnOverride:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1018,7 +1018,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return;
 
-            bool isOrContainsErrorType(TypeSymbol typeSymbol)
+            static bool isOrContainsErrorType(TypeSymbol typeSymbol)
             {
                 return (object)typeSymbol.VisitType((currentTypeSymbol, unused1, unused2) => currentTypeSymbol.IsErrorType(), (object)null) != null;
             }
@@ -1076,33 +1076,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             new FormattedSymbol(overridingParameters[i], SymbolDisplayFormat.ShortFormat));
                     }
                 }
+            }
 
-                return;
-
-                static bool isValidNullableConversion(
-                    ConversionsBase conversions,
-                    RefKind refKind,
-                    TypeWithAnnotations sourceType,
-                    TypeWithAnnotations targetType)
+            static bool isValidNullableConversion(
+                ConversionsBase conversions,
+                RefKind refKind,
+                TypeWithAnnotations sourceType,
+                TypeWithAnnotations targetType)
+            {
+                switch (refKind)
                 {
-                    switch (refKind)
-                    {
-                        case RefKind.Ref:
-                            // ref variables are invariant
-                            return sourceType.Equals(
-                                targetType,
-                                TypeCompareKind.AllIgnoreOptions & ~(TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
+                    case RefKind.Ref:
+                        // ref variables are invariant
+                        return sourceType.Equals(
+                            targetType,
+                            TypeCompareKind.AllIgnoreOptions & ~(TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
 
-                        case RefKind.Out:
-                            // out variables have inverted variance
-                            (sourceType, targetType) = (targetType, sourceType);
-                            break;
+                    case RefKind.Out:
+                        // out variables have inverted variance
+                        (sourceType, targetType) = (targetType, sourceType);
+                        break;
 
-                        default:
-                            break;
-                    }
-                    return conversions.HasAnyNullabilityImplicitConversion(sourceType, targetType);
+                    default:
+                        break;
                 }
+                return conversions.HasAnyNullabilityImplicitConversion(sourceType, targetType);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1034,8 +1034,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (overriddenMethod is null ||
                     overridingMethod is null ||
                     compilation is null ||
-                    ((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)
-                        ?.IsFeatureEnabled(MessageID.IDS_FeatureNullableReferenceTypes) != true)
+                    !compilation.IsFeatureEnabled(MessageID.IDS_FeatureNullableReferenceTypes))
                 {
                     // Don't do any validation if the nullable feature is not enabled or
                     // the override is not written directly in source

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -871,13 +871,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             }
                             else
                             {
-                                // Don't check parameters on the getter because they will be a subset of the setter
-                                checkValidNullableMethodOverride(
-                                    overridingProperty.GetMethod.Locations[0],
-                                    overriddenProperty.GetMethod,
-                                    overridingProperty.GetMethod,
-                                    diagnostics,
-                                    checkParameters: overridingProperty.SetMethod is null);
+                                if (overridingProperty.GetMethod is object)
+                                {
+                                    checkValidNullableMethodOverride(
+                                        overridingProperty.GetMethod.Locations[0],
+                                        overriddenProperty.GetMethod,
+                                        overridingProperty.GetMethod,
+                                        diagnostics,
+                                        // Don't check parameters on the getter if there is a setter
+                                        // because they will be a subset of the setter
+                                        checkParameters: overridingProperty.SetMethod is null);
+                                }
 
                                 if (overridingProperty.SetMethod is object)
                                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1007,7 +1007,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (overriddenMethod is null ||
                     overridingMethod is null ||
                     compilation is null ||
-                    overridingMethod.IsImplicitlyDeclared ||
                     ((CSharpParseOptions)overridingMemberLocation.SourceTree?.Options)
                         ?.IsFeatureEnabled(MessageID.IDS_FeatureNullableReferenceTypes) != true)
                 {

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1637,16 +1637,6 @@
         <target state="translated">Typ odkazu s možnou hodnotou null v typu neodpovídá implicitně implementovanému členu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Typ odkazu s možnou hodnotou null v typu neodpovídá přepsanému členu.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Typ odkazu s možnou hodnotou null v typu neodpovídá přepsanému členu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">Typ {3} nejde použít jako parametr typu {2} v obecném typu nebo metodě {0}. Typ argumentu {3} s možnou hodnotou null neodpovídá typu omezení {1}.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1637,16 +1637,6 @@
         <target state="translated">Die NULL-Zulässigkeit von Verweistypen im Typ entspricht nicht dem implizit implementierten Member.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Die NULL-Zulässigkeit von Verweistypen im Typ entspricht nicht dem außer Kraft gesetzten Member.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Die NULL-Zulässigkeit von Verweistypen im Typ entspricht nicht dem außer Kraft gesetzten Member.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">Der Typ "{3}" kann nicht als Typparameter "{2}" im generischen Typ oder in der generischen Methode "{0}" verwendet werden. Die NULL-Zulässigkeit des Typarguments "{3}" entspricht nicht dem Einschränkungstyp "{1}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1639,16 +1639,6 @@
         <target state="translated">La nulabilidad de los tipos de referencia del tipo no coincide con el miembro implementado de forma implícita</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">La nulabilidad de los tipos de referencia del tipo no coincide con el miembro reemplazado.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">La nulabilidad de los tipos de referencia del tipo no coincide con el miembro reemplazado</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">El tipo "{3}" no se puede usar como parámetro de tipo "{2}" en el tipo o método genérico "{0}". La nulabilidad del argumento de tipo "{3}" no coincide con el tipo de restricción "{1}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1638,16 +1638,6 @@
         <target state="translated">La nullabilité des types référence dans le type ne correspond pas au membre implémenté implicitement.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">La nullabilité des types référence dans le type ne correspond pas au membre substitué.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">La nullabilité des types référence dans le type ne correspond pas au membre substitué.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">Impossible d'utiliser le type '{3}' en tant que paramètre de type '{2}' dans le type ou la méthode générique '{0}'. La nullabilité de l'argument de type '{3}' ne correspond pas au type de contrainte '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1637,16 +1637,6 @@
         <target state="translated">Il supporto dei valori Null dei tipi riferimento nel tipo non corrisponde al membro implementato in modo implicito.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Il supporto dei valori Null dei tipi riferimento nel tipo non corrisponde al membro di cui è stato eseguito l'override.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Il supporto dei valori Null dei tipi riferimento nel tipo non corrisponde al membro di cui è stato eseguito l'override.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">Non è possibile usare il tipo '{3}' come parametro di tipo '{2}' nel metodo o nel tipo generico '{0}'. Il supporto dei valori Null dell'argomento di tipo '{3}' non corrisponde al tipo di vincolo '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1637,16 +1637,6 @@
         <target state="translated">型における参照型の Null 許容性が、暗黙的に実装されるメンバーと一致しません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">型における参照型の Null 許容性が、オーバーライドされるメンバーと一致しません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">型における参照型の Null 許容性が、オーバーライドされるメンバーと一致しません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">型 '{3}' を、ジェネリック型またはメソッド '{0}' 内で型パラメーター '{2}' として使用することはできません。型引数 '{3}' の Null 許容性が制約型 '{1}' と一致しません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1637,16 +1637,6 @@
         <target state="translated">형식에 있는 참조 형식 Null 허용 여부가 암시적으로 구현된 멤버와 일치하지 않습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">형식에 있는 참조 형식 Null 허용 여부가 재정의된 멤버와 일치하지 않습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">형식에 있는 참조 형식 Null 허용 여부가 재정의된 멤버와 일치하지 않습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">'{3}' 형식은 제네릭 형식 또는 '{0}' 메서드에서 '{2}' 형식 매개 변수로 사용할 수 없습니다. '{3}' 형식 인수의 Null 허용 여부가 '{1}' 제약 조건 형식과 일치하지 않습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1637,16 +1637,6 @@
         <target state="translated">Obsługa wartości null dla typów referencyjnych w typie jest niezgodna z niejawnie implementowaną składową.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Obsługa wartości null dla typów referencyjnych w typie jest niezgodna z przesłoniętą składową.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Obsługa wartości null dla typów referencyjnych w typie jest niezgodna z przesłoniętą składową.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">Nie można użyć typu „{3}” jako parametru typu „{2}” w typie ogólnym lub metodzie „{0}”. Obsługa wartości null w argumencie typu „{3}” jest niezgodna z typem ograniczenia „{1}”.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1637,16 +1637,6 @@
         <target state="translated">A anulabilidade de tipos de referência em tipo não corresponde ao membro implicitamente implementado.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">A anulabilidade de tipos de referência em tipo não corresponde ao membro substituído.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">A anulabilidade de tipos de referência em tipo não corresponde ao membro substituído.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">O tipo '{3}' não pode ser usado como parâmetro de tipo '{2}' no tipo ou método genérico '{0}'. A anulabilidade do argumento de tipo '{3}' não corresponde ao tipo de restrição '{1}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1637,16 +1637,6 @@
         <target state="translated">Допустимость значения NULL для ссылочных типов в типе не совпадает с явно реализованным членом.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Допустимость значения NULL для ссылочных типов в типе не совпадает с переопределенным членом.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Допустимость значения NULL для ссылочных типов в типе не совпадает с переопределенным членом.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">Тип "{3}" не может быть использован как параметр типа "{2}" в универсальном типе или методе "{0}". Допустимость значения NULL для аргумента типа "{3}" не соответствует типу ограничения "{1}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1638,16 +1638,6 @@
         <target state="translated">Türdeki başvuru türlerinin boş değer atanabilirliği, örtük olarak uygulanan üye ile eşleşmiyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Türdeki başvuru türlerinin boş değer atanabilirliği, geçersiz kılınan üye ile eşleşmiyor.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">Türdeki başvuru türlerinin boş değer atanabilirliği, geçersiz kılınan üye ile eşleşmiyor.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">{3}' türü '{0}' genel türü veya metodu için '{2}' tür parametresi olarak kullanılamıyor. '{3}' tür bağımsız değişkeninin boş değer atanabilirliği, '{1}' kısıtlama türüyle eşleşmiyor.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1678,16 +1678,6 @@
         <target state="translated">类型中引用类型的为 Null 性与隐式实现的成员不匹配。</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">类型中引用类型的为 Null 性与重写成员不匹配。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">类型中引用类型的为 Null 性与重写成员不匹配。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">类型“{3}”不能用作泛型类型或方法“{0}”中的类型参数“{2}”。类型参数“{3}”的为 Null 性与约束类型“{1}”不匹配。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1637,16 +1637,6 @@
         <target state="translated">型別中參考型別的可 Null 性與隱含實作的成員不符合。</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">型別中參考型別的可 Null 性與覆寫的成員不符合。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_NullabilityMismatchInTypeOnOverride_Title">
-        <source>Nullability of reference types in type doesn't match overridden member.</source>
-        <target state="translated">型別中參考型別的可 Null 性與覆寫的成員不符合。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_NullabilityMismatchInTypeParameterConstraint">
         <source>The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.</source>
         <target state="translated">型別 '{3}' 無法作為型別參數 '{2}' 用於泛型型別或方法 '{0}' 中。型別引數 '{3}' 的可 Null 性與條件約束型別 '{1}' 不符合。</target>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -13640,6 +13640,37 @@ class F : A<object?>
         }
 
         [Fact]
+        public void NullableVarianceConsumer()
+        {
+            var comp = CreateCompilation(@"
+class A
+{
+    public virtual object? M() => null;
+}
+class B : A
+{
+    public override object M() => null; // warn
+}
+class C
+{
+    void M()
+    {
+        var b = new B();
+        b.M().ToString();
+        A a = b;
+        a.M().ToString(); // warn
+    }
+}", options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (8,35): warning CS8603: Possible null reference return.
+                //     public override object M() => null;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null").WithLocation(8, 35),
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
+                //         a.M().ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a.M()").WithLocation(17, 9));
+        }
+
+        [Fact]
         public void Implementing_07()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -13561,6 +13561,41 @@ class E : D
         }
 
         [Fact]
+        public void OverrideConstraintVariance()
+        {
+            var src = @"
+using System.Collections.Generic;
+class A
+{
+    public virtual List<T>? M<T>(List<T>? t) => null!;
+}
+class B : A
+{
+    public override List<T> M<T>(List<T> t) => null!;
+}
+class C : B
+{
+    public override List<T>? M<T>(List<T>? t) => null!;
+}
+class D : C
+{
+    public override List<T> M<T>(List<T> t) => null!;
+}
+";
+            var comp = CreateCompilation(src, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (9,29): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
+                //     public override List<T> M<T>(List<T> t) => null!;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("t").WithLocation(9, 29),
+                // (13,30): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override List<T>? M<T>(List<T>? t) => null!;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M").WithLocation(13, 30),
+                // (17,29): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
+                //     public override List<T> M<T>(List<T> t) => null!;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("t").WithLocation(17, 29));
+        }
+
+        [Fact]
         public void Implementing_07()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -13431,6 +13431,7 @@ class A
     public virtual void M4(ref object o) { }
     public virtual void M5(out object o) => throw null!;
     public virtual void M6(in object o) { }
+    public virtual object this[object o] { get => null!; set { } }
 }
 class B : A
 {
@@ -13440,6 +13441,7 @@ class B : A
     public override void M4(ref object? o) { } // warn
     public override void M5(out object? o) => throw null!; // warn
     public override void M6(in object? o) { }
+    public override object? this[object? o] { get => null!; set { } }
 }
 class C : B
 {
@@ -13449,6 +13451,7 @@ class C : B
     public override void M4(ref object o) { } // warn
     public override void M5(out object o) => throw null!;
     public override void M6(in object o) { } // warn
+    public override object this[object o] { get => null!; set { } }
 }
 class D : C
 {
@@ -13458,6 +13461,7 @@ class D : C
     public override void M4(ref object? o) { } // warn
     public override void M5(out object? o) => throw null!; // warn
     public override void M6(in object? o) { }
+    public override object? this[object? o] { get => null!; set { } }
 }
 class E : D
 {
@@ -13467,51 +13471,70 @@ class E : D
     public override void M4(ref object o) { } // warn
     public override void M5(out object o) => throw null!;
     public override void M6(in object o) { } // warn
+    public override object this[object o] { get => null!; set { } }
 }";
             var comp = CreateCompilation(src, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (17,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
-                //     public override void M4(ref object? o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(17, 26),
                 // (18,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
-                //     public override void M5(out object? o) => throw null!; // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("o").WithLocation(18, 26),
-                // (23,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
-                //     public override void M(object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("o").WithLocation(23, 26),
-                // (24,26): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
-                //     public override void M2((object, object) t) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("t").WithLocation(24, 26),
-                // (25,26): warning CS8610: Nullability of reference types in type of parameter 'i' doesn't match overridden member.
-                //     public override void M3(I<object> i) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("i").WithLocation(25, 26),
-                // (26,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
-                //     public override void M4(ref object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(26, 26),
-                // (28,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
-                //     public override void M6(in object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M6").WithArguments("o").WithLocation(28, 26),
-                // (35,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M4(ref object? o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(35, 26),
-                // (36,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(18, 26),
+                // (19,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M5(out object? o) => throw null!; // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("o").WithLocation(36, 26),
-                // (41,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("o").WithLocation(19, 26),
+                // (21,47): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override object? this[object? o] { get => null!; set { } }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(21, 47),
+                // (25,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M(object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("o").WithLocation(41, 26),
-                // (42,26): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("o").WithLocation(25, 26),
+                // (26,26): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
                 //     public override void M2((object, object) t) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("t").WithLocation(42, 26),
-                // (43,26): warning CS8610: Nullability of reference types in type of parameter 'i' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("t").WithLocation(26, 26),
+                // (27,26): warning CS8610: Nullability of reference types in type of parameter 'i' doesn't match overridden member.
                 //     public override void M3(I<object> i) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("i").WithLocation(43, 26),
-                // (44,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("i").WithLocation(27, 26),
+                // (28,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M4(ref object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(44, 26),
-                // (46,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(28, 26),
+                // (30,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M6(in object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M6").WithArguments("o").WithLocation(46, 26)
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M6").WithArguments("o").WithLocation(30, 26),
+                // (31,59): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override object this[object o] { get => null!; set { } }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("o").WithLocation(31, 59),
+                // (31,59): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override object this[object o] { get => null!; set { } }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(31, 59),
+                // (38,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M4(ref object? o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(38, 26),
+                // (39,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M5(out object? o) => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("o").WithLocation(39, 26),
+                // (41,47): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override object? this[object? o] { get => null!; set { } }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(41, 47),
+                // (45,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M(object o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("o").WithLocation(45, 26),
+                // (46,26): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
+                //     public override void M2((object, object) t) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("t").WithLocation(46, 26),
+                // (47,26): warning CS8610: Nullability of reference types in type of parameter 'i' doesn't match overridden member.
+                //     public override void M3(I<object> i) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("i").WithLocation(47, 26),
+                // (48,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M4(ref object o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(48, 26),
+                // (50,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M6(in object o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M6").WithArguments("o").WithLocation(50, 26),
+                // (51,59): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override object this[object o] { get => null!; set { } }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("o").WithLocation(51, 59),
+                // (51,59): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override object this[object o] { get => null!; set { } }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(51, 59)
                 );
         }
 
@@ -13661,15 +13684,15 @@ abstract class A3
 
 class B1 : A1
 {
-    public override int this[string[] x] // 1
+    public override int this[string[] x]
     {
         get {throw new System.NotImplementedException();}
-        set {}
+        set {} // 1
     } 
 }
 class B2 : A2
 {
-    public override int this[string[]? x] // 2
+    public override int this[string[]? x]
     {
         get {throw new System.NotImplementedException();}
         set {}
@@ -13677,7 +13700,7 @@ class B2 : A2
 }
 class B3 : A3
 {
-    public override int this[string?[]? x] // 3
+    public override int this[string?[]? x]
     {
         get {throw new System.NotImplementedException();}
         set {}
@@ -13687,11 +13710,8 @@ class B3 : A3
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                // (26,9): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                //         get {throw new System.NotImplementedException();}
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "get").WithArguments("x").WithLocation(26, 9),
                 // (27,9): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                //         set {}
+                //         set {} // 1
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("x").WithLocation(27, 9)
                 );
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -13432,6 +13432,8 @@ class A
     public virtual void M5(out object o) => throw null!;
     public virtual void M6(in object o) { }
     public virtual object this[object o] { get => null!; set { } }
+    public virtual string this[string s] => null!;
+    public virtual string this[int[] a] { set { } }
 }
 class B : A
 {
@@ -13442,6 +13444,8 @@ class B : A
     public override void M5(out object? o) => throw null!; // warn
     public override void M6(in object? o) { }
     public override object? this[object? o] { get => null!; set { } }
+    public override string this[string? s] => null!;
+    public override string this[int[]? a] { set { } }
 }
 class C : B
 {
@@ -13452,6 +13456,8 @@ class C : B
     public override void M5(out object o) => throw null!;
     public override void M6(in object o) { } // warn
     public override object this[object o] { get => null!; set { } }
+    public override string this[string s] => null!;
+    public override string this[int[] a] { set { } }
 }
 class D : C
 {
@@ -13462,6 +13468,8 @@ class D : C
     public override void M5(out object? o) => throw null!; // warn
     public override void M6(in object? o) { }
     public override object? this[object? o] { get => null!; set { } }
+    public override string this[string? s] => null!;
+    public override string this[int[]? a] { set { } }
 }
 class E : D
 {
@@ -13472,69 +13480,83 @@ class E : D
     public override void M5(out object o) => throw null!;
     public override void M6(in object o) { } // warn
     public override object this[object o] { get => null!; set { } }
+    public override string this[string s] => null!;
+    public override string this[int[] a] { set { } }
 }";
             var comp = CreateCompilation(src, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
-                // (18,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                // (20,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M4(ref object? o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(18, 26),
-                // (19,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(20, 26),
+                // (21,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M5(out object? o) => throw null!; // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("o").WithLocation(19, 26),
-                // (21,47): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("o").WithLocation(21, 26),
+                // (23,47): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
                 //     public override object? this[object? o] { get => null!; set { } }
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(21, 47),
-                // (25,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(23, 47),
+                // (29,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M(object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("o").WithLocation(25, 26),
-                // (26,26): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("o").WithLocation(29, 26),
+                // (30,26): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
                 //     public override void M2((object, object) t) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("t").WithLocation(26, 26),
-                // (27,26): warning CS8610: Nullability of reference types in type of parameter 'i' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("t").WithLocation(30, 26),
+                // (31,26): warning CS8610: Nullability of reference types in type of parameter 'i' doesn't match overridden member.
                 //     public override void M3(I<object> i) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("i").WithLocation(27, 26),
-                // (28,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("i").WithLocation(31, 26),
+                // (32,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M4(ref object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(28, 26),
-                // (30,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(32, 26),
+                // (34,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M6(in object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M6").WithArguments("o").WithLocation(30, 26),
-                // (31,59): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M6").WithArguments("o").WithLocation(34, 26),
+                // (35,59): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override object this[object o] { get => null!; set { } }
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("o").WithLocation(31, 59),
-                // (31,59): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("o").WithLocation(35, 59),
+                // (35,59): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
                 //     public override object this[object o] { get => null!; set { } }
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(31, 59),
-                // (38,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(35, 59),
+                // (36,46): warning CS8610: Nullability of reference types in type of parameter 's' doesn't match overridden member.
+                //     public override string this[string s] => null!;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "null!").WithArguments("s").WithLocation(36, 46),
+                // (37,44): warning CS8610: Nullability of reference types in type of parameter 'a' doesn't match overridden member.
+                //     public override string this[int[] a] { set { } }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("a").WithLocation(37, 44),
+                // (44,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M4(ref object? o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(38, 26),
-                // (39,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
-                //     public override void M5(out object? o) => throw null!; // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("o").WithLocation(39, 26),
-                // (41,47): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
-                //     public override object? this[object? o] { get => null!; set { } }
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(41, 47),
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(44, 26),
                 // (45,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M5(out object? o) => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("o").WithLocation(45, 26),
+                // (47,47): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override object? this[object? o] { get => null!; set { } }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(47, 47),
+                // (53,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M(object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("o").WithLocation(45, 26),
-                // (46,26): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("o").WithLocation(53, 26),
+                // (54,26): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
                 //     public override void M2((object, object) t) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("t").WithLocation(46, 26),
-                // (47,26): warning CS8610: Nullability of reference types in type of parameter 'i' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("t").WithLocation(54, 26),
+                // (55,26): warning CS8610: Nullability of reference types in type of parameter 'i' doesn't match overridden member.
                 //     public override void M3(I<object> i) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("i").WithLocation(47, 26),
-                // (48,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("i").WithLocation(55, 26),
+                // (56,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M4(ref object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(48, 26),
-                // (50,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(56, 26),
+                // (58,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override void M6(in object o) { } // warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M6").WithArguments("o").WithLocation(50, 26),
-                // (51,59): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M6").WithArguments("o").WithLocation(58, 26),
+                // (59,59): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
                 //     public override object this[object o] { get => null!; set { } }
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("o").WithLocation(51, 59),
-                // (51,59): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("o").WithLocation(59, 59),
+                // (59,59): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
                 //     public override object this[object o] { get => null!; set { } }
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(51, 59)
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(59, 59),
+                // (60,46): warning CS8610: Nullability of reference types in type of parameter 's' doesn't match overridden member.
+                //     public override string this[string s] => null!;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "null!").WithArguments("s").WithLocation(60, 46),
+                // (61,44): warning CS8610: Nullability of reference types in type of parameter 'a' doesn't match overridden member.
+                //     public override string this[int[] a] { set { } }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("a").WithLocation(61, 44)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -10857,24 +10857,21 @@ class B : A
 ";
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             compilation.VerifyDiagnostics(
-                 // (32,29): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
-                 //     public override string? M1()
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M1").WithLocation(32, 29),
-                 // (42,28): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
-                 //     public override string M3()
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M3").WithLocation(42, 28),
-                 // (47,29): error CS0508: 'B.M4()': return type must be 'string?' to match overridden member 'A.M4()'
-                 //     public override string? M4()
-                 Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "M4").WithArguments("B.M4()", "A.M4()", "string?").WithLocation(47, 29),
-                 // (52,29): error CS0506: 'B.M5()': cannot override inherited member 'A.M5()' because it is not marked virtual, abstract, or override
-                 //     public override string? M5()
-                 Diagnostic(ErrorCode.ERR_CantOverrideNonVirtual, "M5").WithArguments("B.M5()", "A.M5()").WithLocation(52, 29),
-                 // (19,44): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                 //     public virtual System.Nullable<string> M4()
-                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M4").WithArguments("System.Nullable<T>", "T", "string").WithLocation(19, 44),
-                 // (24,36): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                 //     public System.Nullable<string> M5()
-                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M5").WithArguments("System.Nullable<T>", "T", "string").WithLocation(24, 36)
+                // (47,29): error CS0508: 'B.M4()': return type must be 'string?' to match overridden member 'A.M4()'
+                //     public override string? M4()
+                Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "M4").WithArguments("B.M4()", "A.M4()", "string?").WithLocation(47, 29),
+                // (52,29): error CS0506: 'B.M5()': cannot override inherited member 'A.M5()' because it is not marked virtual, abstract, or override
+                //     public override string? M5()
+                Diagnostic(ErrorCode.ERR_CantOverrideNonVirtual, "M5").WithArguments("B.M5()", "A.M5()").WithLocation(52, 29),
+                // (32,29): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override string? M1()
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M1").WithLocation(32, 29),
+                // (19,44): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
+                //     public virtual System.Nullable<string> M4()
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M4").WithArguments("System.Nullable<T>", "T", "string").WithLocation(19, 44),
+                // (24,36): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
+                //     public System.Nullable<string> M5()
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M5").WithArguments("System.Nullable<T>", "T", "string").WithLocation(24, 36)
                 );
 
             var b = compilation.GetTypeByMetadataName("B");
@@ -10943,24 +10940,21 @@ class B : A
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                 // (27,26): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                 //     public override void M1(string? x)
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M1").WithArguments("x").WithLocation(27, 26),
-                 // (35,26): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                 //     public override void M3(string x)
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("x").WithLocation(35, 26),
-                 // (39,26): error CS0115: 'B.M4(string)': no suitable method found to override
-                 //     public override void M4(string? x)
-                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M4").WithArguments("B.M4(string?)").WithLocation(39, 26),
-                 // (43,26): error CS0115: 'B.M5(string)': no suitable method found to override
-                 //     public override void M5(string? x)
-                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M5").WithArguments("B.M5(string?)").WithLocation(43, 26),
-                 // (16,52): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                 //     public virtual void M4(System.Nullable<string> x)
-                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "x").WithArguments("System.Nullable<T>", "T", "string").WithLocation(16, 52),
-                 // (20,44): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                 //     public void M5(System.Nullable<string> x)
-                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "x").WithArguments("System.Nullable<T>", "T", "string").WithLocation(20, 44)
+                // (16,52): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
+                //     public virtual void M4(System.Nullable<string> x)
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "x").WithArguments("System.Nullable<T>", "T", "string").WithLocation(16, 52),
+                // (20,44): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
+                //     public void M5(System.Nullable<string> x)
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "x").WithArguments("System.Nullable<T>", "T", "string").WithLocation(20, 44),
+                // (35,26): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
+                //     public override void M3(string x)
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("x").WithLocation(35, 26),
+                // (39,26): error CS0115: 'B.M4(string?)': no suitable method found to override
+                //     public override void M4(string? x)
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M4").WithArguments("B.M4(string?)").WithLocation(39, 26),
+                // (43,26): error CS0115: 'B.M5(string?)': no suitable method found to override
+                //     public override void M5(string? x)
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M5").WithArguments("B.M5(string?)").WithLocation(43, 26)
                 );
 
             var b = compilation.GetTypeByMetadataName("B");
@@ -11173,19 +11167,12 @@ class B2 : A
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                 // (19,49): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                 //     public override event System.Action<string> E2;
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "E2").WithLocation(19, 49),
-                 // (18,50): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                 //     public override event System.Action<string?> E1;
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "E1").WithLocation(18, 50),
-                 // (26,49): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                 //     public override event System.Action<string> E2; // 2
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "E2").WithLocation(26, 49),
-                 // (25,50): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                 //     public override event System.Action<string?> E1; // 2
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "E1").WithLocation(25, 50)
-                );
+                // (18,50): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override event System.Action<string?> E1 {add {} remove{}}
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "E1").WithArguments("value").WithLocation(18, 50),
+                // (19,49): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override event System.Action<string> E2 {add {} remove{}}
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "E2").WithArguments("value").WithLocation(19, 49));
 
             foreach (string typeName in new[] { "B1", "B2" })
             {
@@ -11257,31 +11244,18 @@ public class B2 : A
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                // (18,44): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
-                //     public override System.Action<string?> Oblivious2(System.Action<string?> x) => throw null!; // warn 3 and 4 // https://github.com/dotnet/roslyn/issues/29851: Should not warn
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "Oblivious2").WithLocation(18, 44),
                 // (18,44): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
                 //     public override System.Action<string?> Oblivious2(System.Action<string?> x) => throw null!; // warn 3 and 4 // https://github.com/dotnet/roslyn/issues/29851: Should not warn
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "Oblivious2").WithArguments("x").WithLocation(18, 44),
-                // (19,44): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
-                //     public override System.Action<string?> M3(System.Action<string?> x) => throw null!; // warn 5 and 6
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M3").WithLocation(19, 44),
                 // (19,44): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
                 //     public override System.Action<string?> M3(System.Action<string?> x) => throw null!; // warn 5 and 6
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("x").WithLocation(19, 44),
-                // (20,44): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
-                //     public override System.Action<string?> M4(System.Action<string?> x) => throw null!; // warn 7 and 8
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M4").WithLocation(20, 44),
                 // (20,44): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
                 //     public override System.Action<string?> M4(System.Action<string?> x) => throw null!; // warn 7 and 8
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("x").WithLocation(20, 44),
-                // (21,44): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
-                //     public override System.Action<string?> M5(System.Action<string?> x) => throw null!; // warn 9 and 10
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M5").WithLocation(21, 44),
                 // (21,44): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
                 //     public override System.Action<string?> M5(System.Action<string?> x) => throw null!; // warn 9 and 10
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("x").WithLocation(21, 44)
-                );
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("x").WithLocation(21, 44));
 
             var b1 = compilation.GetTypeByMetadataName("B1");
             verifyMethodMatchesOverridden(expectMatch: false, b1, "Oblivious1");
@@ -11456,7 +11430,7 @@ abstract class A
 class B1 : A
 {
 " + NonNullTypesOff() + @"
-    public override event System.Action<string?> E1 {add {} remove{}} // 1, 2
+    public override event System.Action<string?> E1 {add {} remove{}} // 1
 " + NonNullTypesOff() + @"
     public override event System.Action<string> E2 {add {} remove{}}
 }
@@ -11464,7 +11438,7 @@ class B1 : A
 class B2 : A
 {
 " + NonNullTypesOff() + @"
-    public override event System.Action<string?> E1; // 3, 4
+    public override event System.Action<string?> E1; // 3
 " + NonNullTypesOff() + @"
     public override event System.Action<string> E2;
 " + NonNullTypesOn() + @"
@@ -11478,19 +11452,15 @@ class B2 : A
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                // (19,50): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                //     public override event System.Action<string?> E1 {add {} remove{}} // 1, 2
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "E1").WithLocation(19, 50),
-                // (27,50): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                //     public override event System.Action<string?> E1; // 3, 4
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "E1").WithLocation(27, 50),
-                // (27,47): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
-                //     public override event System.Action<string?> E1; // 3, 4
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(27, 47),
                 // (19,47): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
-                //     public override event System.Action<string?> E1 {add {} remove{}} // 1, 2
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(19, 47)
-                );
+                //     public override event System.Action<string?> E1 {add {} remove{}} // 1
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(19, 47),
+                // (19,50): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override event System.Action<string?> E1 {add {} remove{}} // 1
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "E1").WithArguments("value").WithLocation(19, 50),
+                // (27,47): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
+                //     public override event System.Action<string?> E1; // 3
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(27, 47));
         }
 
         [Fact]
@@ -11741,18 +11711,18 @@ class B2 : A2
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                 // (28,31): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                 //     public override string[]? P2 {get; set;}
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "P2").WithLocation(28, 31),
-                 // (30,30): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                 //     public override string[] this[int x] // 1
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "this").WithLocation(30, 30),
-                 // (36,31): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                 //     public override string[]? this[short x] // 2
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "this").WithLocation(36, 31),
-                 // (27,30): warning CS8608: Nullability of reference types in type doesn't match overridden member.
-                 //     public override string[] P1 {get; set;}
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride, "P1").WithLocation(27, 30)
+                // (27,39): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override string[] P1 {get; set;} 
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(27, 39),
+                // (28,35): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override string[]? P2 {get; set;} 
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(28, 35),
+                // (33,9): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //         set {}
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(33, 9),
+                // (38,9): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //         get {throw new System.NotImplementedException();}
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(38, 9)
                 );
 
             foreach (var member in compilation.GetTypeByMetadataName("B1").GetMembers().OfType<PropertySymbol>())
@@ -12543,9 +12513,6 @@ class B : A
                 // (26,26): error CS0115: 'B.M3<T>(T?[]?)': no suitable method found to override
                 //     public override void M3<T>(T?[]? x)
                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M3").WithArguments("B.M3<T>(T?[]?)").WithLocation(26, 26),
-                // (18,26): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                //     public override void M1(string?[] x)
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M1").WithArguments("x").WithLocation(18, 26),
                 // (16,7): error CS0534: 'B' does not implement inherited abstract member 'A.M3<T>(T?[]?)'
                 // class B : A
                 Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "B").WithArguments("B", "A.M3<T>(T?[]?)").WithLocation(16, 7),
@@ -12611,9 +12578,6 @@ class B : A
                 // (18,26): error CS0115: 'B.M2<T>(T?[])': no suitable method found to override
                 //     public override void M2<T>(T?[] x)
                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M2").WithArguments("B.M2<T>(T?[])").WithLocation(18, 26),
-                // (13,26): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                //     public override void M1(string?[] x)
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M1").WithArguments("x").WithLocation(13, 26),
                 // (10,7): error CS0534: 'B' does not implement inherited abstract member 'A.M2<T>(T[])'
                 // class B : A
                 Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "B").WithArguments("B", "A.M2<T>(T[])").WithLocation(10, 7),
@@ -13007,12 +12971,6 @@ class B : A
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                 // (22,26): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                 //     public override void M2<T>(T?[] x)
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("x").WithLocation(22, 26),
-                 // (18,26): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                 //     public override void M1(string?[] x)
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M1").WithArguments("x").WithLocation(18, 26)
                 );
 
             var b = compilation.GetTypeByMetadataName("B");
@@ -13057,12 +13015,6 @@ class B : A
             var compilation = CreateCompilation(new[] { source });
 
             compilation.VerifyDiagnostics(
-                // (13,26): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                //     public override void M1(string?[] x)
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M1").WithArguments("x").WithLocation(13, 26),
-                // (18,26): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                //     public override void M2<T>(T?[] x)
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("x").WithLocation(18, 26),
                 // (18,33): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
                 //     public override void M2<T>(T?[] x)
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(18, 33),
@@ -13300,6 +13252,247 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         }
 
         [Fact]
+        public void Override_NullabilityCovariance()
+        {
+            var src = @"
+using System;
+
+interface I<out T> {}
+class A
+{
+    public virtual object? M() => null;
+    public virtual (object?, object?) M2() => throw null!;
+    public virtual I<object?> M3() => throw null!;
+    public virtual ref object? M4() => throw null!;
+    public virtual ref readonly object? M5() => throw null!;
+    public virtual Func<object>? P1 { get; set; } = null!;
+    public virtual Func<object?> P2 { get; set; } = null!;
+    public virtual event Func<object>? E1 { add {} remove {} }
+    public virtual event Func<object?> E2 { add {} remove {} }
+}
+class B : A
+{
+    public override object M() => null!;
+    public override (object, object) M2() => throw null!;
+    public override I<object> M3() => throw null!;
+    public override ref object M4() => throw null!; // warn
+    public override ref readonly object M5() => throw null!;
+    public override Func<object> P1 { get; set; } = null!; // warn
+    public override Func<object> P2 { get; set; } = null!; // warn
+    public override event Func<object> E1 { add {} remove {} }
+    public override event Func<object> E2 { add {} remove {} }
+}
+class C : B
+{
+    public override object? M() => null; // warn
+    public override (object?, object?) M2() => throw null!; // warn
+    public override I<object?> M3() => throw null!; // warn
+    public override ref object? M4() => throw null!; // warn
+    public override ref readonly object? M5() => throw null!; // warn
+    public override Func<object>? P1 { get; set; } = null!; // warn
+    public override Func<object?> P2 { get; set; } = null!; // warn
+    public override event Func<object>? E1 { add {} remove {} } // warn
+    public override event Func<object?> E2 { add {} remove {} } // warn
+}
+class D : C
+{
+    public override object M() => null!;
+    public override (object, object) M2() => throw null!;
+    public override I<object> M3() => throw null!;
+    public override ref object M4() => throw null!; // warn
+    public override ref readonly object M5() => throw null!;
+    public override Func<object> P1 { get; set; } = null!; // warn
+    public override Func<object> P2 { get; set; } = null!; // warn
+    public override event Func<object> E1 { add {} remove {} }
+    public override event Func<object> E2 { add {} remove {} }
+}
+class E : D
+{
+    public override object? M() => null; // warn
+    public override (object?, object?) M2() => throw null!; // warn
+    public override I<object?> M3() => throw null!; // warn
+    public override ref object? M4() => throw null!; // warn
+    public override ref readonly object? M5() => throw null!; // warn
+    public override Func<object>? P1 { get; set; } = null!; // warn
+    public override Func<object?> P2 { get; set; } = null!; // warn
+    public override event Func<object>? E1 { add {} remove {} } // warn
+    public override event Func<object?> E2 { add {} remove {} } // warn
+}";
+            var comp = CreateCompilation(src, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (22,32): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override ref object M4() => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M4").WithLocation(22, 32),
+                // (24,44): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override Func<object> P1 { get; set; } = null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(24, 44),
+                // (25,44): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override Func<object> P2 { get; set; } = null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(25, 44),
+                // (26,40): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override event Func<object> E1 { add {} remove {} }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "E1").WithArguments("value").WithLocation(26, 40),
+                // (27,40): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override event Func<object> E2 { add {} remove {} }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "E2").WithArguments("value").WithLocation(27, 40),
+                // (31,29): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override object? M() => null; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M").WithLocation(31, 29),
+                // (32,40): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override (object?, object?) M2() => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M2").WithLocation(32, 40),
+                // (33,32): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override I<object?> M3() => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M3").WithLocation(33, 32),
+                // (34,33): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override ref object? M4() => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M4").WithLocation(34, 33),
+                // (35,42): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override ref readonly object? M5() => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M5").WithLocation(35, 42),
+                // (36,40): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override Func<object>? P1 { get; set; } = null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(36, 40),
+                // (37,40): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override Func<object?> P2 { get; set; } = null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(37, 40),
+                // (46,32): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override ref object M4() => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M4").WithLocation(46, 32),
+                // (48,44): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override Func<object> P1 { get; set; } = null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(48, 44),
+                // (49,44): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override Func<object> P2 { get; set; } = null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(49, 44),
+                // (50,40): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override event Func<object> E1 { add {} remove {} }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "E1").WithArguments("value").WithLocation(50, 40),
+                // (51,40): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
+                //     public override event Func<object> E2 { add {} remove {} }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "E2").WithArguments("value").WithLocation(51, 40),
+                // (55,29): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override object? M() => null; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M").WithLocation(55, 29),
+                // (56,40): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override (object?, object?) M2() => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M2").WithLocation(56, 40),
+                // (57,32): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override I<object?> M3() => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M3").WithLocation(57, 32),
+                // (58,33): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override ref object? M4() => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M4").WithLocation(58, 33),
+                // (59,42): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override ref readonly object? M5() => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "M5").WithLocation(59, 42),
+                // (60,40): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override Func<object>? P1 { get; set; } = null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(60, 40),
+                // (61,40): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
+                //     public override Func<object?> P2 { get; set; } = null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(61, 40)
+                );
+        }
+
+        [Fact]
+        public void Override_NullabilityContravariance()
+        {
+            var src = @"
+interface I<out T> {}
+class A
+{
+    public virtual void M(object o) { }
+    public virtual void M2((object, object) t) { }
+    public virtual void M3(I<object> i) { }
+    public virtual void M4(ref object o) { }
+    public virtual void M5(out object o) => throw null!;
+    public virtual void M6(in object o) { }
+}
+class B : A
+{
+    public override void M(object? o) { }
+    public override void M2((object?, object?) t) { }
+    public override void M3(I<object?> i) { }
+    public override void M4(ref object? o) { } // warn
+    public override void M5(out object? o) => throw null!; // warn
+    public override void M6(in object? o) { }
+}
+class C : B
+{
+    public override void M(object o) { } // warn
+    public override void M2((object, object) t) { } // warn
+    public override void M3(I<object> i) { } // warn
+    public override void M4(ref object o) { } // warn
+    public override void M5(out object o) => throw null!;
+    public override void M6(in object o) { } // warn
+}
+class D : C
+{
+    public override void M(object? o) { }
+    public override void M2((object?, object?) t) { }
+    public override void M3(I<object?> i) { }
+    public override void M4(ref object? o) { } // warn
+    public override void M5(out object? o) => throw null!; // warn
+    public override void M6(in object? o) { }
+}
+class E : D
+{
+    public override void M(object o) { } // warn
+    public override void M2((object, object) t) { } // warn
+    public override void M3(I<object> i) { } // warn
+    public override void M4(ref object o) { } // warn
+    public override void M5(out object o) => throw null!;
+    public override void M6(in object o) { } // warn
+}";
+            var comp = CreateCompilation(src, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (17,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M4(ref object? o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(17, 26),
+                // (18,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M5(out object? o) => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("o").WithLocation(18, 26),
+                // (23,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M(object o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("o").WithLocation(23, 26),
+                // (24,26): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
+                //     public override void M2((object, object) t) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("t").WithLocation(24, 26),
+                // (25,26): warning CS8610: Nullability of reference types in type of parameter 'i' doesn't match overridden member.
+                //     public override void M3(I<object> i) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("i").WithLocation(25, 26),
+                // (26,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M4(ref object o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(26, 26),
+                // (28,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M6(in object o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M6").WithArguments("o").WithLocation(28, 26),
+                // (35,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M4(ref object? o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(35, 26),
+                // (36,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M5(out object? o) => throw null!; // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M5").WithArguments("o").WithLocation(36, 26),
+                // (41,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M(object o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M").WithArguments("o").WithLocation(41, 26),
+                // (42,26): warning CS8610: Nullability of reference types in type of parameter 't' doesn't match overridden member.
+                //     public override void M2((object, object) t) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M2").WithArguments("t").WithLocation(42, 26),
+                // (43,26): warning CS8610: Nullability of reference types in type of parameter 'i' doesn't match overridden member.
+                //     public override void M3(I<object> i) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M3").WithArguments("i").WithLocation(43, 26),
+                // (44,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M4(ref object o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M4").WithArguments("o").WithLocation(44, 26),
+                // (46,26): warning CS8610: Nullability of reference types in type of parameter 'o' doesn't match overridden member.
+                //     public override void M6(in object o) { } // warn
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "M6").WithArguments("o").WithLocation(46, 26)
+                );
+        }
+
+        [Fact]
         public void Implementing_07()
         {
             var source = @"
@@ -13471,12 +13664,12 @@ class B3 : A3
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                 // (24,25): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                 //     public override int this[string[] x] // 1
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "this").WithArguments("x").WithLocation(24, 25),
-                 // (32,25): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
-                 //     public override int this[string[]? x] // 2
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "this").WithArguments("x").WithLocation(32, 25)
+                // (26,9): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
+                //         get {throw new System.NotImplementedException();}
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "get").WithArguments("x").WithLocation(26, 9),
+                // (27,9): warning CS8610: Nullability of reference types in type of parameter 'x' doesn't match overridden member.
+                //         set {}
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("x").WithLocation(27, 9)
                 );
 
             foreach (string typeName in new[] { "B1", "B2" })

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -270,7 +270,6 @@ class X
                         case ErrorCode.WRN_NullReferenceReturn:
                         case ErrorCode.WRN_NullReferenceArgument:
                         case ErrorCode.WRN_NullReferenceIterationVariable:
-                        case ErrorCode.WRN_NullabilityMismatchInTypeOnOverride:
                         case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride:
                         case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride:
                         case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial:


### PR DESCRIPTION
Implements a design change where overrides are allowed to change the
type of the member as long as there is an implicit nullable reference
conversion from the overriding type to the overridden type according to
the nullable variance rules.

Fixes #23268
Fixes #30958