### PR TITLE
Fix commit tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpIntelliSense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpIntelliSense.cs
@@ -270,7 +270,23 @@ class Class1
                 'M',
                 Shift(VirtualKey.Enter));
 
-            VisualStudio.Editor.Verify.TextContains(@"
+            if (LegacyCompletionCondition.Instance.ShouldSkip)
+            {
+                // Async completion commits the item and inserts a blank line
+                VisualStudio.Editor.Verify.TextContains(@"
+class Class1
+{
+    void Main(string[] args)
+    {
+        Main
+$$
+    }
+}",
+assertCaretPosition: true);
+            }
+            else
+            {
+                VisualStudio.Editor.Verify.TextContains(@"
 class Class1
 {
     void Main(string[] args)
@@ -279,6 +295,7 @@ class Class1
     }
 }",
 assertCaretPosition: true);
+            }
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -299,7 +316,23 @@ class Class1
                 'M',
                 Shift(VirtualKey.Enter));
 
-            VisualStudio.Editor.Verify.TextContains(@"
+            if (LegacyCompletionCondition.Instance.ShouldSkip)
+            {
+                // Async completion commits the item (even in suggestion mode) and inserts a blank line
+                VisualStudio.Editor.Verify.TextContains(@"
+class Class1
+{
+    void Main(string[] args)
+    {
+        Main
+$$
+    }
+}",
+assertCaretPosition: true);
+            }
+            else
+            {
+                VisualStudio.Editor.Verify.TextContains(@"
 class Class1
 {
     void Main(string[] args)
@@ -309,6 +342,7 @@ $$
     }
 }",
 assertCaretPosition: true);
+            }
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]


### PR DESCRIPTION
The editor made a change for 16.0 RTM which invalidated a workaround we applied in #33828. When the CI was upgraded to this release, the tests started failing. This change ~~removes the workaround~~ and updates the tests to assert the behavior which is shipping in 16.1.P1.

The removal of the workaround will be sent as a separate PR to **master**.