### PR TITLE
Fix wrong package name for VS debugger

### DIFF
--- a/src/Tools/ExternalAccess/Debugger/Microsoft.CodeAnalysis.ExternalAccess.Debugger.csproj
+++ b/src/Tools/ExternalAccess/Debugger/Microsoft.CodeAnalysis.ExternalAccess.Debugger.csproj
@@ -19,7 +19,7 @@
     <!--
       ⚠ ONLY VISUAL STUDIO DEBUGGER ASSEMBLIES MAY BE ADDED HERE ⚠
     -->
-    <InternalsVisibleTo Include="Microsoft.VisualStudio.Debugger.VsDebugPresentationPackage" Key="$(VisualStudioDebuggerKey)" />
+    <InternalsVisibleTo Include="VsDebugPresentationPackage" Key="$(VisualStudioDebuggerKey)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The VsDebugPresentationPackage does not follow the same
naming convention as the other packages. So the previous name
is wrong.