### PR TITLE
Classify Catch variables as locals

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -3412,5 +3412,19 @@ class True
                 Class("True"),
                 Class("True"));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestCatchDeclarationVariable()
+        {
+            await TestInMethodAsync(@"
+try
+{
+}
+catch (Exception ex)
+{
+    throw ex;
+}",
+                Local("ex"));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -4709,5 +4709,23 @@ foreach (var (x, y) in new[] { (1, 2) });
                 Punctuation.CloseParen,
                 Punctuation.Semicolon);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task CatchDeclarationStatement()
+        {
+            await TestInMethodAsync(@"
+try { } catch (Exception ex) { }
+",
+                ControlKeyword("try"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                ControlKeyword("catch"),
+                Punctuation.OpenParen,
+                Identifier("Exception"),
+                Local("ex"),
+                Punctuation.CloseParen,
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
@@ -808,5 +808,20 @@ End Class"
                 [Class]("C"),
                 [Class]("C"))
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Classification)>
+        Public Async Function TestCatchStatement() As Task
+            Dim code =
+"Try
+
+Catch ex As Exception
+    Throw ex
+End Try"
+
+            Await TestInMethodAsync(code,
+                Local("ex"),
+                [Class]("Exception"),
+                Local("ex"))
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
@@ -5221,5 +5221,23 @@ End Sub"
                 Keyword("Sub"))
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Classification)>
+        Public Async Function TestCatchStatement() As Task
+            Dim code =
+"Try
+
+Catch ex As Exception
+
+End Try"
+
+            Await TestInMethodAsync(code,
+                ControlKeyword("Try"),
+                ControlKeyword("Catch"),
+                Local("ex"),
+                Keyword("As"),
+                Identifier("Exception"),
+                ControlKeyword("End"),
+                ControlKeyword("Try"))
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -228,6 +228,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             {
                 return ClassificationTypeNames.EnumMemberName;
             }
+            else if (token.Parent is CatchDeclarationSyntax catchDeclaration && catchDeclaration.Identifier == token)
+            {
+                return ClassificationTypeNames.LocalName;
+            }
             else if (token.Parent is VariableDeclaratorSyntax variableDeclarator && variableDeclarator.Identifier == token)
             {
                 var varDecl = variableDeclarator.Parent as VariableDeclarationSyntax;

--- a/src/Workspaces/VisualBasic/Portable/Classification/ClassificationHelpers.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/ClassificationHelpers.vb
@@ -212,6 +212,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
                 Return ClassificationTypeNames.EnumMemberName
             ElseIf TypeOf parent Is LabelStatementSyntax AndAlso DirectCast(parent, LabelStatementSyntax).LabelToken = identifier Then
                 Return ClassificationTypeNames.LabelName
+            ElseIf TypeOf parent?.Parent Is CatchStatementSyntax AndAlso DirectCast(parent.Parent, CatchStatementSyntax).IdentifierName.Identifier = identifier Then
+                Return ClassificationTypeNames.LocalName
             ElseIf TryClassifyModifiedIdentifer(parent, identifier, classification) Then
                 Return classification
             ElseIf (identifier.ToString() = "IsTrue" OrElse identifier.ToString() = "IsFalse") AndAlso


### PR DESCRIPTION
As noticed by @jmarolf, catch variables were not being classified as locals in the catch declaration. The semantic classifier was already classifying them within the catch body appropriately.