### PR TITLE
using partial load platform API

### DIFF
--- a/src/VisualStudio/Core/Def/Experimentation/ExperimentationOptions.cs
+++ b/src/VisualStudio/Core/Def/Experimentation/ExperimentationOptions.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Options.Providers;
 
@@ -16,6 +15,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Experimentation
     [ExportOptionProvider, Shared]
     internal class ExperimentationOptionsProvider : IOptionProvider
     {
-        public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>();
+        public ImmutableArray<IOption> Options { get; } = ImmutableArray<IOption>.Empty;
     }
 }

--- a/src/VisualStudio/Core/Def/Experimentation/ExperimentationOptions.cs
+++ b/src/VisualStudio/Core/Def/Experimentation/ExperimentationOptions.cs
@@ -11,19 +11,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Experimentation
     internal static class ExperimentationOptions
     {
         internal const string LocalRegistryPath = @"Roslyn\Internal\Experiment\";
-
-        public static readonly Option<bool> SolutionStatusService_ForceDelay = new Option<bool>(nameof(ExperimentationOptions), nameof(SolutionStatusService_ForceDelay), defaultValue: false,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "SolutionStatusService_ForceDelay"));
-
-        public static readonly Option<int> SolutionStatusService_DelayInMS = new Option<int>(nameof(ExperimentationOptions), nameof(SolutionStatusService_DelayInMS), defaultValue: 10000,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "SolutionStatusService_DelayInMS"));
     }
 
     [ExportOptionProvider, Shared]
     internal class ExperimentationOptionsProvider : IOptionProvider
     {
-        public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
-            ExperimentationOptions.SolutionStatusService_ForceDelay,
-            ExperimentationOptions.SolutionStatusService_DelayInMS);
+        public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>();
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeWatcherProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeWatcherProvider.cs
@@ -1,7 +1,10 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using IVsAsyncFileChangeEx = Microsoft.VisualStudio.Shell.IVsAsyncFileChangeEx;
@@ -14,6 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private readonly TaskCompletionSource<IVsAsyncFileChangeEx> _fileChangeService = new TaskCompletionSource<IVsAsyncFileChangeEx>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public FileChangeWatcherProvider(IThreadingContext threadingContext, [Import(typeof(SVsServiceProvider))] Shell.IAsyncServiceProvider serviceProvider)
         {
             // We do not want background work to implicitly block on the availability of the SVsFileChangeEx to avoid any deadlock risk,

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.OperationProgress;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
 using Task = System.Threading.Tasks.Task;
 
@@ -84,8 +85,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     return;
                 }
 
-                // TODO: this should have cancellation token
-                await status.WaitForCompletionAsync().ConfigureAwait(false);
+                // TODO: WaitForCompletionAsync should accept cancellation directly.
+                //       for now, use WithCancellation to indirectly add cancellation
+                await status.WaitForCompletionAsync().WithCancellation(cancellationToken).ConfigureAwait(false);
             }
 
             public async Task<bool> IsFullyLoadedAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 await EnsureInitializationAsync(cancellationToken).ConfigureAwait(false);
 
-                var status = await GetProgressStageStatusAsync().ConfigureAwait(false);
+                var status = await GetProgressStageStatusAsync(cancellationToken).ConfigureAwait(false);
                 if (status == null)
                 {
                     return;
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 await EnsureInitializationAsync(cancellationToken).ConfigureAwait(false);
 
-                var status = await GetProgressStageStatusAsync().ConfigureAwait(false);
+                var status = await GetProgressStageStatusAsync(cancellationToken).ConfigureAwait(false);
                 if (status == null)
                 {
                     return false;
@@ -103,9 +103,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 return !status.Status.IsInProgress;
             }
 
-            private async Task<IVsOperationProgressStageStatus> GetProgressStageStatusAsync()
+            private async Task<IVsOperationProgressStageStatus> GetProgressStageStatusAsync(CancellationToken cancellationToken)
             {
-                var service = await _serviceProvider.GetServiceAsync<SVsOperationProgress, IVsOperationProgressStatusService>(throwOnFailure: false).ConfigureAwait(false);
+                var service = await _serviceProvider.GetServiceAsync<SVsOperationProgress, IVsOperationProgressStatusService>(throwOnFailure: false)
+                                                    .WithCancellation(cancellationToken).ConfigureAwait(false);
+
                 return service?.GetStageStatus(CommonOperationProgressStageIds.Intellisense);
             }
 
@@ -122,7 +124,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                     // with IAsyncServiceProvider, to get a service from BG, there is not much else
                     // we can do to avoid this pattern to subscribe to events
-                    var status = await GetProgressStageStatusAsync().ConfigureAwait(false);
+                    var status = await GetProgressStageStatusAsync(cancellationToken).ConfigureAwait(false);
                     if (status == null)
                     {
                         return;

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Editor.GoToDefinition;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Undo;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Composition;
@@ -31,6 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices
         private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _streamingPresenters;
 
         [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         private RoslynVisualStudioWorkspace(
             ExportProvider exportProvider,
             [ImportMany] IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters,


### PR DESCRIPTION
connect IWorkspaceStatusService to the first version of IOperationStatusService from platform.

all test related code is also removed and now it is using one from platform which one can get from
"\\vspfs3\Public\AdrianV\Tools\Operation Progress\OperationProgressTestVsix.vsix"

the test window is located at
view->Other windows->OperationProgressToolWindow

![image](https://user-images.githubusercontent.com/1333179/55614801-accbb480-5742-11e9-8732-3b7b9eb2fd2c.png)
