### PR TITLE
Fix version comparison

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -60,7 +60,7 @@
     
     TODO: Inline the import when we no longer need to support earlier versions of MSBuild.
     -->
-  <Import Project="Microsoft.Managed.EditorConfig.targets" Condition="$(MSBuildVersion) >= 16.1" />
+  <Import Project="Microsoft.Managed.EditorConfig.targets" Condition="$(MSBuildVersion) >= 16.1.0" />
 
   <!--
     ========================


### PR DESCRIPTION
In Microsoft.Managed.Core.targets we import Microsoft.Managed.EditorConfig.targets, but only if we're running in a version of MSBuild greater than or equal to 16.1. The problem with this is that the `MSBuildVersion` property is a three-part version (like 16.1.27) but is being compared to a two-part version (16.1). This sort of comparison can have unexpected behavior. For example, the expression `Version.Parse("16.1.0") == Version.Parse("16.1")` evaluates to `false`, and `Version.Parse("16.1.0") > Version.Parse("16.1")` evaluates to `true`.

To avoid any such weirdness, here we make sure to compare to a three-part version number.