### PR TITLE
Add telemetry to toggle block comment.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CommentSelection/AbstractToggleBlockCommentBase.cs
+++ b/src/EditorFeatures/Core/Implementation/CommentSelection/AbstractToggleBlockCommentBase.cs
@@ -31,8 +31,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
         private static readonly CommentSelectionResult s_emptyCommentSelectionResult =
             new CommentSelectionResult(new List<TextChange>(), new List<CommentTrackingSpan>(), Operation.Uncomment);
 
-        private const string ContentTypeString = "ContentType";
-        private const string SubjectBufferLengthString = "subjectBufferLength";
+        private const string LanguageNameString = "languagename";
+        private const string LengthString = "length";
 
         private readonly ITextStructureNavigatorSelectorService _navigatorSelectorService;
 
@@ -89,8 +89,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
         {
             using (Logger.LogBlock(FunctionId.CommandHandler_ToggleBlockComment, KeyValueLogMessage.Create(LogType.UserAction, m =>
             {
-                m[ContentTypeString] = subjectBuffer.ContentType.DisplayName;
-                m[SubjectBufferLengthString] = subjectBuffer.CurrentSnapshot.Length;
+                m[LanguageNameString] = document.Project.Language;
+                m[LengthString] = subjectBuffer.CurrentSnapshot.Length;
             }), cancellationToken))
             {
                 var experimentationService = document.Project.Solution.Workspace.Services.GetRequiredService<IExperimentationService>();

--- a/src/EditorFeatures/Core/Implementation/CommentSelection/AbstractToggleBlockCommentBase.cs
+++ b/src/EditorFeatures/Core/Implementation/CommentSelection/AbstractToggleBlockCommentBase.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CommentSelection;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Experiments;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -29,6 +30,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
     {
         private static readonly CommentSelectionResult s_emptyCommentSelectionResult =
             new CommentSelectionResult(new List<TextChange>(), new List<CommentTrackingSpan>(), Operation.Uncomment);
+
+        private const string ContentTypeString = "ContentType";
+        private const string SubjectBufferLengthString = "subjectBufferLength";
 
         private readonly ITextStructureNavigatorSelectorService _navigatorSelectorService;
 
@@ -83,21 +87,28 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
         internal async override Task<CommentSelectionResult> CollectEditsAsync(Document document, ICommentSelectionService service,
             ITextBuffer subjectBuffer, NormalizedSnapshotSpanCollection selectedSpans, ValueTuple command, CancellationToken cancellationToken)
         {
-            var experimentationService = document.Project.Solution.Workspace.Services.GetRequiredService<IExperimentationService>();
-            if (!experimentationService.IsExperimentEnabled(WellKnownExperimentNames.RoslynToggleBlockComment))
+            using (Logger.LogBlock(FunctionId.CommandHandler_ToggleBlockComment, KeyValueLogMessage.Create(LogType.UserAction, m =>
             {
+                m[ContentTypeString] = subjectBuffer.ContentType.DisplayName;
+                m[SubjectBufferLengthString] = subjectBuffer.CurrentSnapshot.Length;
+            }), cancellationToken))
+            {
+                var experimentationService = document.Project.Solution.Workspace.Services.GetRequiredService<IExperimentationService>();
+                if (!experimentationService.IsExperimentEnabled(WellKnownExperimentNames.RoslynToggleBlockComment))
+                {
+                    return s_emptyCommentSelectionResult;
+                }
+
+                var navigator = _navigatorSelectorService.GetTextStructureNavigator(subjectBuffer);
+
+                var commentInfo = await service.GetInfoAsync(document, selectedSpans.First().Span.ToTextSpan(), cancellationToken).ConfigureAwait(false);
+                if (commentInfo.SupportsBlockComment)
+                {
+                    return await ToggleBlockCommentsAsync(document, commentInfo, navigator, selectedSpans, cancellationToken).ConfigureAwait(false);
+                }
+
                 return s_emptyCommentSelectionResult;
             }
-
-            var navigator = _navigatorSelectorService.GetTextStructureNavigator(subjectBuffer);
-
-            var commentInfo = await service.GetInfoAsync(document, selectedSpans.First().Span.ToTextSpan(), cancellationToken).ConfigureAwait(false);
-            if (commentInfo.SupportsBlockComment)
-            {
-                return await ToggleBlockCommentsAsync(document, commentInfo, navigator, selectedSpans, cancellationToken).ConfigureAwait(false);
-            }
-
-            return s_emptyCommentSelectionResult;
         }
 
         private async Task<CommentSelectionResult> ToggleBlockCommentsAsync(Document document, CommentSelectionInfo commentInfo,

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -61,6 +61,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         CommandHandler_GetCommandState,
         CommandHandler_ExecuteHandlers,
         CommandHandler_FormatCommand,
+        CommandHandler_ToggleBlockComment,
 
         Workspace_SourceText_GetChangeRanges,
         Workspace_Recoverable_RecoverRootAsync,


### PR DESCRIPTION
Add some telemetry for toggle block comment.

Can retrieve data like # invocations (total, per user, etc...), split it up by content type (language).  Can also look at the performance in relation to the document size.