### PR TITLE
use new CPS API to report designer attribute

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -213,9 +213,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             var updateService = await GetUpdateServiceIfCpsProjectAsync(document.Project, cancellationToken).ConfigureAwait(false);
             if (updateService != null)
             {
-                // we track work by async token but doesn't explicitly wait for it
+                // we track work by async token but doesn't explicitly wait for it. and update service is free-thread service,
+                // no need to switch to UI thread to use it
                 var asyncToken = _listener.BeginAsyncOperation("RegisterDesignerAttribute");
-                _ = updateService.SetProjectItemDesignerTypeAsync(document.FilePath, designerAttributeArgument).CompletesAsyncOperation(asyncToken);
+                _ = updateService.SetProjectItemDesignerTypeAsync(document.FilePath, designerAttributeArgument)
+                                 .ReportNonFatalErrorAsync().CompletesAsyncOperation(asyncToken);
             }
             else
             {

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -84,7 +84,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                 return;
             }
 
-            // use tree version so that things like compiler option changes are considered
+            // use text and project dependent versions so that we can detect changes on this file and its dependent files
+            // in current project or projects this depends on transitively
             var textVersion = await document.GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
             var projectVersion = await document.Project.GetDependentVersionAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzerProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzerProvider.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Services;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribute
 {
@@ -20,7 +19,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 
         private readonly IThreadingContext _threadingContext;
         private readonly IServiceProvider _serviceProvider;
-        private readonly IProjectItemDesignerTypeUpdateService _projectItemDesignerTypeUpdateService;
         private readonly IForegroundNotificationService _notificationService;
         private readonly IAsynchronousOperationListenerProvider _listenerProvider;
 
@@ -29,13 +27,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
         public DesignerAttributeIncrementalAnalyzerProvider(
             IThreadingContext threadingContext,
             SVsServiceProvider serviceProvider,
-            IProjectItemDesignerTypeUpdateService projectItemDesignerTypeUpdateService,
             IForegroundNotificationService notificationService,
             IAsynchronousOperationListenerProvider listenerProvider)
         {
             _threadingContext = threadingContext;
             _serviceProvider = serviceProvider;
-            _projectItemDesignerTypeUpdateService = projectItemDesignerTypeUpdateService;
             _notificationService = notificationService;
             _listenerProvider = listenerProvider;
         }
@@ -43,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
         public IIncrementalAnalyzer CreateIncrementalAnalyzer(CodeAnalysis.Workspace workspace)
         {
             return new DesignerAttributeIncrementalAnalyzer(
-                _threadingContext, _serviceProvider, _projectItemDesignerTypeUpdateService, _notificationService, _listenerProvider);
+                _threadingContext, _serviceProvider, _notificationService, _listenerProvider);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzerProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzerProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Services;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribute
 {
@@ -19,6 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 
         private readonly IThreadingContext _threadingContext;
         private readonly IServiceProvider _serviceProvider;
+        private readonly IProjectItemDesignerTypeUpdateService _projectItemDesignerTypeUpdateService;
         private readonly IForegroundNotificationService _notificationService;
         private readonly IAsynchronousOperationListenerProvider _listenerProvider;
 
@@ -27,18 +29,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
         public DesignerAttributeIncrementalAnalyzerProvider(
             IThreadingContext threadingContext,
             SVsServiceProvider serviceProvider,
+            IProjectItemDesignerTypeUpdateService projectItemDesignerTypeUpdateService,
             IForegroundNotificationService notificationService,
             IAsynchronousOperationListenerProvider listenerProvider)
         {
             _threadingContext = threadingContext;
             _serviceProvider = serviceProvider;
+            _projectItemDesignerTypeUpdateService = projectItemDesignerTypeUpdateService;
             _notificationService = notificationService;
             _listenerProvider = listenerProvider;
         }
 
         public IIncrementalAnalyzer CreateIncrementalAnalyzer(CodeAnalysis.Workspace workspace)
         {
-            return new DesignerAttributeIncrementalAnalyzer(_threadingContext, _serviceProvider, _notificationService, _listenerProvider);
+            return new DesignerAttributeIncrementalAnalyzer(
+                _threadingContext, _serviceProvider, _projectItemDesignerTypeUpdateService, _notificationService, _listenerProvider);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/TaskExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/TaskExtensions.cs
@@ -478,5 +478,15 @@ namespace Roslyn.Utilities
             // > !dso     // dump stack objects
             FatalError.Report(exception);
         }
+
+        public static Task ReportNonFatalErrorAsync(this Task task)
+        {
+            task.ContinueWith(p => FatalError.ReportWithoutCrashUnlessCanceled(p.Exception),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            return task;
+        }
     }
 }


### PR DESCRIPTION
fix https://github.com/dotnet/roslyn/issues/33854

....

![image](https://user-images.githubusercontent.com/1333179/55761034-d6226400-5a12-11e9-9a1d-ca7155761ccd.png)

vs

.net framework 
![image](https://user-images.githubusercontent.com/1333179/55761075-f3efc900-5a12-11e9-9e9e-6a7607d19fe9.png)

...

.net core put this in csproj
![image](https://user-images.githubusercontent.com/1333179/55761089-01a54e80-5a13-11e9-9170-1204f3b51e73.png)

whereas .net framework put this in csproj
![image](https://user-images.githubusercontent.com/1333179/55761124-1f72b380-5a13-11e9-9f3b-014551c2028e.png)

it looks like
legacy "IVSMDDesignerService.RegisterDesignViewAttribute" will ignore designerAttribute "Form" for designer.cs file but new API "IProjectItemDesignerTypeUpdateService.SetProjectItemDesignerTypeAsync" accept it and change csproj file.

it looks like a bug on the IProjectItemDesignerTypeUpdateService side. 