### PR TITLE
Avoid optimizing goto in SyntheticBoundNodeFactory.Switch()

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -884,18 +884,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             statements.Add(null); // placeholder at statements[0] for the dispatch
             foreach (var section in sections)
             {
-                LabelSymbol sectionLabel;
-                // If the section only contains a goto statement, use that label.
-                if (section.Statements.Length == 1 && section.Statements[0] is BoundGotoStatement bgoto)
-                {
-                    sectionLabel = bgoto.Label;
-                }
-                else
-                {
-                    sectionLabel = new GeneratedLabelSymbol("case " + section.Values[0]);
-                    statements.Add(Label(sectionLabel));
-                    statements.AddRange(section.Statements);
-                }
+                LabelSymbol sectionLabel = new GeneratedLabelSymbol("case " + section.Values[0]);
+                statements.Add(Label(sectionLabel));
+                statements.AddRange(section.Statements);
 
                 foreach (var value in section.Values)
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -3,8 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -896,7 +894,6 @@ class Test
             CompileAndVerify(source, expectedOutput: expected);
         }
 
-
         [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void AsyncInFinally003()
         {
@@ -978,9 +975,9 @@ class Test
 </symbols>
 ");
 
-            v.VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
-{
-  // Code size      455 (0x1c7)
+            v.VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
+@"{
+  // Code size      461 (0x1cd)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -996,194 +993,197 @@ class Test
   .try
   {
    ~IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_002b
+    IL_0008:  brfalse.s  IL_0012
     IL_000a:  br.s       IL_000c
     IL_000c:  ldloc.0
     IL_000d:  ldc.i4.1
-    IL_000e:  beq        IL_010f
-    IL_0013:  br.s       IL_0015
-   -IL_0015:  nop
-   -IL_0016:  ldarg.0
-    IL_0017:  ldc.i4.0
-    IL_0018:  stfld      ""int Test.<G>d__1.<x>5__1""
-   ~IL_001d:  ldarg.0
-    IL_001e:  ldnull
-    IL_001f:  stfld      ""object Test.<G>d__1.<>s__2""
-    IL_0024:  ldarg.0
-    IL_0025:  ldc.i4.0
-    IL_0026:  stfld      ""int Test.<G>d__1.<>s__3""
-   ~IL_002b:  nop
+    IL_000e:  beq.s      IL_0014
+    IL_0010:  br.s       IL_0019
+    IL_0012:  br.s       IL_002f
+    IL_0014:  br         IL_0115
+   -IL_0019:  nop
+   -IL_001a:  ldarg.0
+    IL_001b:  ldc.i4.0
+    IL_001c:  stfld      ""int Test.<G>d__1.<x>5__1""
+   ~IL_0021:  ldarg.0
+    IL_0022:  ldnull
+    IL_0023:  stfld      ""object Test.<G>d__1.<>s__2""
+    IL_0028:  ldarg.0
+    IL_0029:  ldc.i4.0
+    IL_002a:  stfld      ""int Test.<G>d__1.<>s__3""
+   ~IL_002f:  nop
     .try
     {
-     ~IL_002c:  ldloc.0
-      IL_002d:  brfalse.s  IL_006d
-      IL_002f:  br.s       IL_0031
-     -IL_0031:  nop
-     -IL_0032:  call       ""System.Threading.Tasks.Task<int> Test.F()""
-      IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-      IL_003c:  stloc.2
-     ~IL_003d:  ldloca.s   V_2
-      IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-      IL_0044:  brtrue.s   IL_0089
-      IL_0046:  ldarg.0
-      IL_0047:  ldc.i4.0
-      IL_0048:  dup
-      IL_0049:  stloc.0
-      IL_004a:  stfld      ""int Test.<G>d__1.<>1__state""
-     <IL_004f:  ldarg.0
-      IL_0050:  ldloc.2
-      IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-      IL_0056:  ldarg.0
-      IL_0057:  stloc.3
-      IL_0058:  ldarg.0
-      IL_0059:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-      IL_005e:  ldloca.s   V_2
-      IL_0060:  ldloca.s   V_3
-      IL_0062:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
-      IL_0067:  nop
-      IL_0068:  leave      IL_01c6
-     >IL_006d:  ldarg.0
-      IL_006e:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-      IL_0073:  stloc.2
-      IL_0074:  ldarg.0
-      IL_0075:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-      IL_007a:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-      IL_0080:  ldarg.0
-      IL_0081:  ldc.i4.m1
-      IL_0082:  dup
-      IL_0083:  stloc.0
-      IL_0084:  stfld      ""int Test.<G>d__1.<>1__state""
-      IL_0089:  ldarg.0
-      IL_008a:  ldloca.s   V_2
-      IL_008c:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-      IL_0091:  stfld      ""int Test.<G>d__1.<>s__5""
-      IL_0096:  ldarg.0
-      IL_0097:  ldarg.0
-      IL_0098:  ldfld      ""int Test.<G>d__1.<>s__5""
-      IL_009d:  stfld      ""int Test.<G>d__1.<x>5__1""
-     -IL_00a2:  ldarg.0
-      IL_00a3:  ldarg.0
-      IL_00a4:  ldfld      ""int Test.<G>d__1.<x>5__1""
-      IL_00a9:  stfld      ""int Test.<G>d__1.<>s__4""
-      IL_00ae:  br.s       IL_00b0
-      IL_00b0:  ldarg.0
-      IL_00b1:  ldc.i4.1
-      IL_00b2:  stfld      ""int Test.<G>d__1.<>s__3""
-      IL_00b7:  leave.s    IL_00c5
+     ~IL_0030:  ldloc.0
+      IL_0031:  brfalse.s  IL_0035
+      IL_0033:  br.s       IL_0037
+      IL_0035:  br.s       IL_0073
+     -IL_0037:  nop
+     -IL_0038:  call       ""System.Threading.Tasks.Task<int> Test.F()""
+      IL_003d:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+      IL_0042:  stloc.2
+     ~IL_0043:  ldloca.s   V_2
+      IL_0045:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+      IL_004a:  brtrue.s   IL_008f
+      IL_004c:  ldarg.0
+      IL_004d:  ldc.i4.0
+      IL_004e:  dup
+      IL_004f:  stloc.0
+      IL_0050:  stfld      ""int Test.<G>d__1.<>1__state""
+     <IL_0055:  ldarg.0
+      IL_0056:  ldloc.2
+      IL_0057:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+      IL_005c:  ldarg.0
+      IL_005d:  stloc.3
+      IL_005e:  ldarg.0
+      IL_005f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+      IL_0064:  ldloca.s   V_2
+      IL_0066:  ldloca.s   V_3
+      IL_0068:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
+      IL_006d:  nop
+      IL_006e:  leave      IL_01cc
+     >IL_0073:  ldarg.0
+      IL_0074:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+      IL_0079:  stloc.2
+      IL_007a:  ldarg.0
+      IL_007b:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+      IL_0080:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+      IL_0086:  ldarg.0
+      IL_0087:  ldc.i4.m1
+      IL_0088:  dup
+      IL_0089:  stloc.0
+      IL_008a:  stfld      ""int Test.<G>d__1.<>1__state""
+      IL_008f:  ldarg.0
+      IL_0090:  ldloca.s   V_2
+      IL_0092:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+      IL_0097:  stfld      ""int Test.<G>d__1.<>s__5""
+      IL_009c:  ldarg.0
+      IL_009d:  ldarg.0
+      IL_009e:  ldfld      ""int Test.<G>d__1.<>s__5""
+      IL_00a3:  stfld      ""int Test.<G>d__1.<x>5__1""
+     -IL_00a8:  ldarg.0
+      IL_00a9:  ldarg.0
+      IL_00aa:  ldfld      ""int Test.<G>d__1.<x>5__1""
+      IL_00af:  stfld      ""int Test.<G>d__1.<>s__4""
+      IL_00b4:  br.s       IL_00b6
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.1
+      IL_00b8:  stfld      ""int Test.<G>d__1.<>s__3""
+      IL_00bd:  leave.s    IL_00cb
     }
     catch object
     {
-     ~IL_00b9:  stloc.s    V_4
-      IL_00bb:  ldarg.0
-      IL_00bc:  ldloc.s    V_4
-      IL_00be:  stfld      ""object Test.<G>d__1.<>s__2""
-      IL_00c3:  leave.s    IL_00c5
+     ~IL_00bf:  stloc.s    V_4
+      IL_00c1:  ldarg.0
+      IL_00c2:  ldloc.s    V_4
+      IL_00c4:  stfld      ""object Test.<G>d__1.<>s__2""
+      IL_00c9:  leave.s    IL_00cb
     }
-   -IL_00c5:  nop
-   -IL_00c6:  ldarg.0
-    IL_00c7:  ldarg.0
-    IL_00c8:  ldfld      ""int Test.<G>d__1.<x>5__1""
-    IL_00cd:  stfld      ""int Test.<G>d__1.<>s__6""
-    IL_00d2:  call       ""System.Threading.Tasks.Task<int> Test.F()""
-    IL_00d7:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00dc:  stloc.s    V_5
-   ~IL_00de:  ldloca.s   V_5
-    IL_00e0:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_00e5:  brtrue.s   IL_012c
-    IL_00e7:  ldarg.0
-    IL_00e8:  ldc.i4.1
-    IL_00e9:  dup
-    IL_00ea:  stloc.0
-    IL_00eb:  stfld      ""int Test.<G>d__1.<>1__state""
-   <IL_00f0:  ldarg.0
-    IL_00f1:  ldloc.s    V_5
-    IL_00f3:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-    IL_00f8:  ldarg.0
-    IL_00f9:  stloc.3
-    IL_00fa:  ldarg.0
-    IL_00fb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-    IL_0100:  ldloca.s   V_5
-    IL_0102:  ldloca.s   V_3
-    IL_0104:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
-    IL_0109:  nop
-    IL_010a:  leave      IL_01c6
-   >IL_010f:  ldarg.0
-    IL_0110:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-    IL_0115:  stloc.s    V_5
-    IL_0117:  ldarg.0
-    IL_0118:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-    IL_011d:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0123:  ldarg.0
-    IL_0124:  ldc.i4.m1
-    IL_0125:  dup
-    IL_0126:  stloc.0
-    IL_0127:  stfld      ""int Test.<G>d__1.<>1__state""
-    IL_012c:  ldarg.0
-    IL_012d:  ldloca.s   V_5
-    IL_012f:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0134:  stfld      ""int Test.<G>d__1.<>s__7""
-    IL_0139:  ldarg.0
-    IL_013a:  ldarg.0
-    IL_013b:  ldfld      ""int Test.<G>d__1.<>s__6""
+   -IL_00cb:  nop
+   -IL_00cc:  ldarg.0
+    IL_00cd:  ldarg.0
+    IL_00ce:  ldfld      ""int Test.<G>d__1.<x>5__1""
+    IL_00d3:  stfld      ""int Test.<G>d__1.<>s__6""
+    IL_00d8:  call       ""System.Threading.Tasks.Task<int> Test.F()""
+    IL_00dd:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_00e2:  stloc.s    V_5
+   ~IL_00e4:  ldloca.s   V_5
+    IL_00e6:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_00eb:  brtrue.s   IL_0132
+    IL_00ed:  ldarg.0
+    IL_00ee:  ldc.i4.1
+    IL_00ef:  dup
+    IL_00f0:  stloc.0
+    IL_00f1:  stfld      ""int Test.<G>d__1.<>1__state""
+   <IL_00f6:  ldarg.0
+    IL_00f7:  ldloc.s    V_5
+    IL_00f9:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+    IL_00fe:  ldarg.0
+    IL_00ff:  stloc.3
+    IL_0100:  ldarg.0
+    IL_0101:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+    IL_0106:  ldloca.s   V_5
+    IL_0108:  ldloca.s   V_3
+    IL_010a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
+    IL_010f:  nop
+    IL_0110:  leave      IL_01cc
+   >IL_0115:  ldarg.0
+    IL_0116:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+    IL_011b:  stloc.s    V_5
+    IL_011d:  ldarg.0
+    IL_011e:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+    IL_0123:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0129:  ldarg.0
+    IL_012a:  ldc.i4.m1
+    IL_012b:  dup
+    IL_012c:  stloc.0
+    IL_012d:  stfld      ""int Test.<G>d__1.<>1__state""
+    IL_0132:  ldarg.0
+    IL_0133:  ldloca.s   V_5
+    IL_0135:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_013a:  stfld      ""int Test.<G>d__1.<>s__7""
+    IL_013f:  ldarg.0
     IL_0140:  ldarg.0
-    IL_0141:  ldfld      ""int Test.<G>d__1.<>s__7""
-    IL_0146:  add
-    IL_0147:  stfld      ""int Test.<G>d__1.<x>5__1""
-   -IL_014c:  nop
-   ~IL_014d:  ldarg.0
-    IL_014e:  ldfld      ""object Test.<G>d__1.<>s__2""
-    IL_0153:  stloc.s    V_4
-    IL_0155:  ldloc.s    V_4
-    IL_0157:  brfalse.s  IL_0176
-    IL_0159:  ldloc.s    V_4
-    IL_015b:  isinst     ""System.Exception""
-    IL_0160:  stloc.s    V_6
-    IL_0162:  ldloc.s    V_6
-    IL_0164:  brtrue.s   IL_0169
-    IL_0166:  ldloc.s    V_4
-    IL_0168:  throw
-    IL_0169:  ldloc.s    V_6
-    IL_016b:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_0170:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_0175:  nop
-    IL_0176:  ldarg.0
-    IL_0177:  ldfld      ""int Test.<G>d__1.<>s__3""
-    IL_017c:  stloc.s    V_7
-    IL_017e:  ldloc.s    V_7
-    IL_0180:  ldc.i4.1
-    IL_0181:  beq.s      IL_0185
-    IL_0183:  br.s       IL_018e
-    IL_0185:  ldarg.0
-    IL_0186:  ldfld      ""int Test.<G>d__1.<>s__4""
-    IL_018b:  stloc.1
-    IL_018c:  leave.s    IL_01b1
-    IL_018e:  ldarg.0
-    IL_018f:  ldnull
-    IL_0190:  stfld      ""object Test.<G>d__1.<>s__2""
-    IL_0195:  leave.s    IL_01b1
+    IL_0141:  ldfld      ""int Test.<G>d__1.<>s__6""
+    IL_0146:  ldarg.0
+    IL_0147:  ldfld      ""int Test.<G>d__1.<>s__7""
+    IL_014c:  add
+    IL_014d:  stfld      ""int Test.<G>d__1.<x>5__1""
+   -IL_0152:  nop
+   ~IL_0153:  ldarg.0
+    IL_0154:  ldfld      ""object Test.<G>d__1.<>s__2""
+    IL_0159:  stloc.s    V_4
+    IL_015b:  ldloc.s    V_4
+    IL_015d:  brfalse.s  IL_017c
+    IL_015f:  ldloc.s    V_4
+    IL_0161:  isinst     ""System.Exception""
+    IL_0166:  stloc.s    V_6
+    IL_0168:  ldloc.s    V_6
+    IL_016a:  brtrue.s   IL_016f
+    IL_016c:  ldloc.s    V_4
+    IL_016e:  throw
+    IL_016f:  ldloc.s    V_6
+    IL_0171:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_0176:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_017b:  nop
+    IL_017c:  ldarg.0
+    IL_017d:  ldfld      ""int Test.<G>d__1.<>s__3""
+    IL_0182:  stloc.s    V_7
+    IL_0184:  ldloc.s    V_7
+    IL_0186:  ldc.i4.1
+    IL_0187:  beq.s      IL_018b
+    IL_0189:  br.s       IL_0194
+    IL_018b:  ldarg.0
+    IL_018c:  ldfld      ""int Test.<G>d__1.<>s__4""
+    IL_0191:  stloc.1
+    IL_0192:  leave.s    IL_01b7
+    IL_0194:  ldarg.0
+    IL_0195:  ldnull
+    IL_0196:  stfld      ""object Test.<G>d__1.<>s__2""
+    IL_019b:  leave.s    IL_01b7
   }
   catch System.Exception
   {
-   ~IL_0197:  stloc.s    V_6
-    IL_0199:  ldarg.0
-    IL_019a:  ldc.i4.s   -2
-    IL_019c:  stfld      ""int Test.<G>d__1.<>1__state""
-    IL_01a1:  ldarg.0
-    IL_01a2:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-    IL_01a7:  ldloc.s    V_6
-    IL_01a9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_01ae:  nop
-    IL_01af:  leave.s    IL_01c6
+   ~IL_019d:  stloc.s    V_6
+    IL_019f:  ldarg.0
+    IL_01a0:  ldc.i4.s   -2
+    IL_01a2:  stfld      ""int Test.<G>d__1.<>1__state""
+    IL_01a7:  ldarg.0
+    IL_01a8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+    IL_01ad:  ldloc.s    V_6
+    IL_01af:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_01b4:  nop
+    IL_01b5:  leave.s    IL_01cc
   }
- -IL_01b1:  ldarg.0
-  IL_01b2:  ldc.i4.s   -2
-  IL_01b4:  stfld      ""int Test.<G>d__1.<>1__state""
- ~IL_01b9:  ldarg.0
-  IL_01ba:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-  IL_01bf:  ldloc.1
-  IL_01c0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_01c5:  nop
-  IL_01c6:  ret
+ -IL_01b7:  ldarg.0
+  IL_01b8:  ldc.i4.s   -2
+  IL_01ba:  stfld      ""int Test.<G>d__1.<>1__state""
+ ~IL_01bf:  ldarg.0
+  IL_01c0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+  IL_01c5:  ldloc.1
+  IL_01c6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_01cb:  nop
+  IL_01cc:  ret
 }", sequencePoints: "Test+<G>d__1.MoveNext");
         }
 
@@ -1785,7 +1785,6 @@ Attempted to divide by zero.
 ";
             CompileAndVerify(source, expectedOutput: expected);
         }
-
 
         [Fact]
         public void AsyncInCatchFilter()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -2054,9 +2054,9 @@ class C
 }");
                 if (options == TestOptions.DebugExe)
                 {
-                    verifier.VerifyIL("C.<M>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
-{
-  // Code size      289 (0x121)
+                    verifier.VerifyIL("C.<M>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
+@"{
+  // Code size      298 (0x12a)
   .maxstack  3
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter V_1,
@@ -2073,131 +2073,133 @@ class C
     IL_0008:  ldc.i4.s   -4
     IL_000a:  sub
     IL_000b:  switch    (
-        IL_00c5,
         IL_0026,
-        IL_0026,
-        IL_0026,
-        IL_0083)
-    IL_0024:  br.s       IL_0026
-    IL_0026:  ldarg.0
-    IL_0027:  ldfld      ""bool C.<M>d__0.<>w__disposeMode""
-    IL_002c:  brfalse.s  IL_0033
-    IL_002e:  leave      IL_00fd
-    IL_0033:  ldarg.0
-    IL_0034:  ldc.i4.m1
-    IL_0035:  dup
-    IL_0036:  stloc.0
-    IL_0037:  stfld      ""int C.<M>d__0.<>1__state""
+        IL_002b,
+        IL_002f,
+        IL_002f,
+        IL_002d)
+    IL_0024:  br.s       IL_002f
+    IL_0026:  br         IL_00ce
+    IL_002b:  br.s       IL_002f
+    IL_002d:  br.s       IL_008c
+    IL_002f:  ldarg.0
+    IL_0030:  ldfld      ""bool C.<M>d__0.<>w__disposeMode""
+    IL_0035:  brfalse.s  IL_003c
+    IL_0037:  leave      IL_0106
+    IL_003c:  ldarg.0
+    IL_003d:  ldc.i4.m1
+    IL_003e:  dup
+    IL_003f:  stloc.0
+    IL_0040:  stfld      ""int C.<M>d__0.<>1__state""
     // sequence point: {
-    IL_003c:  nop
+    IL_0045:  nop
     // sequence point: Write(""1 "");
-    IL_003d:  ldstr      ""1 ""
-    IL_0042:  call       ""void System.Console.Write(string)""
-    IL_0047:  nop
+    IL_0046:  ldstr      ""1 ""
+    IL_004b:  call       ""void System.Console.Write(string)""
+    IL_0050:  nop
     // sequence point: await System.Threading.Tasks.Task.CompletedTask;
-    IL_0048:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get""
-    IL_004d:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
-    IL_0052:  stloc.1
+    IL_0051:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get""
+    IL_0056:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
+    IL_005b:  stloc.1
     // sequence point: <hidden>
-    IL_0053:  ldloca.s   V_1
-    IL_0055:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
-    IL_005a:  brtrue.s   IL_009f
-    IL_005c:  ldarg.0
-    IL_005d:  ldc.i4.0
-    IL_005e:  dup
-    IL_005f:  stloc.0
-    IL_0060:  stfld      ""int C.<M>d__0.<>1__state""
-    // async: yield
+    IL_005c:  ldloca.s   V_1
+    IL_005e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
+    IL_0063:  brtrue.s   IL_00a8
     IL_0065:  ldarg.0
-    IL_0066:  ldloc.1
-    IL_0067:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<M>d__0.<>u__1""
-    IL_006c:  ldarg.0
-    IL_006d:  stloc.2
+    IL_0066:  ldc.i4.0
+    IL_0067:  dup
+    IL_0068:  stloc.0
+    IL_0069:  stfld      ""int C.<M>d__0.<>1__state""
+    // async: yield
     IL_006e:  ldarg.0
-    IL_006f:  ldflda     ""System.Runtime.CompilerServices.AsyncIteratorMethodBuilder C.<M>d__0.<>t__builder""
-    IL_0074:  ldloca.s   V_1
-    IL_0076:  ldloca.s   V_2
-    IL_0078:  call       ""void System.Runtime.CompilerServices.AsyncIteratorMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<M>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<M>d__0)""
-    IL_007d:  nop
-    IL_007e:  leave      IL_0120
+    IL_006f:  ldloc.1
+    IL_0070:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<M>d__0.<>u__1""
+    IL_0075:  ldarg.0
+    IL_0076:  stloc.2
+    IL_0077:  ldarg.0
+    IL_0078:  ldflda     ""System.Runtime.CompilerServices.AsyncIteratorMethodBuilder C.<M>d__0.<>t__builder""
+    IL_007d:  ldloca.s   V_1
+    IL_007f:  ldloca.s   V_2
+    IL_0081:  call       ""void System.Runtime.CompilerServices.AsyncIteratorMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<M>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<M>d__0)""
+    IL_0086:  nop
+    IL_0087:  leave      IL_0129
     // async: resume
-    IL_0083:  ldarg.0
-    IL_0084:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<M>d__0.<>u__1""
-    IL_0089:  stloc.1
-    IL_008a:  ldarg.0
-    IL_008b:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<M>d__0.<>u__1""
-    IL_0090:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0096:  ldarg.0
-    IL_0097:  ldc.i4.m1
-    IL_0098:  dup
-    IL_0099:  stloc.0
-    IL_009a:  stfld      ""int C.<M>d__0.<>1__state""
-    IL_009f:  ldloca.s   V_1
-    IL_00a1:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_00a6:  nop
+    IL_008c:  ldarg.0
+    IL_008d:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<M>d__0.<>u__1""
+    IL_0092:  stloc.1
+    IL_0093:  ldarg.0
+    IL_0094:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<M>d__0.<>u__1""
+    IL_0099:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_009f:  ldarg.0
+    IL_00a0:  ldc.i4.m1
+    IL_00a1:  dup
+    IL_00a2:  stloc.0
+    IL_00a3:  stfld      ""int C.<M>d__0.<>1__state""
+    IL_00a8:  ldloca.s   V_1
+    IL_00aa:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+    IL_00af:  nop
     // sequence point: Write(""2 "");
-    IL_00a7:  ldstr      ""2 ""
-    IL_00ac:  call       ""void System.Console.Write(string)""
-    IL_00b1:  nop
+    IL_00b0:  ldstr      ""2 ""
+    IL_00b5:  call       ""void System.Console.Write(string)""
+    IL_00ba:  nop
     // sequence point: yield return 3;
-    IL_00b2:  ldarg.0
-    IL_00b3:  ldc.i4.3
-    IL_00b4:  stfld      ""int C.<M>d__0.<>2__current""
-    IL_00b9:  ldarg.0
-    IL_00ba:  ldc.i4.s   -4
-    IL_00bc:  dup
-    IL_00bd:  stloc.0
-    IL_00be:  stfld      ""int C.<M>d__0.<>1__state""
-    IL_00c3:  leave.s    IL_0113
+    IL_00bb:  ldarg.0
+    IL_00bc:  ldc.i4.3
+    IL_00bd:  stfld      ""int C.<M>d__0.<>2__current""
+    IL_00c2:  ldarg.0
+    IL_00c3:  ldc.i4.s   -4
+    IL_00c5:  dup
+    IL_00c6:  stloc.0
+    IL_00c7:  stfld      ""int C.<M>d__0.<>1__state""
+    IL_00cc:  leave.s    IL_011c
     // sequence point: <hidden>
-    IL_00c5:  ldarg.0
-    IL_00c6:  ldc.i4.m1
-    IL_00c7:  dup
-    IL_00c8:  stloc.0
-    IL_00c9:  stfld      ""int C.<M>d__0.<>1__state""
     IL_00ce:  ldarg.0
-    IL_00cf:  ldfld      ""bool C.<M>d__0.<>w__disposeMode""
-    IL_00d4:  brfalse.s  IL_00d8
-    IL_00d6:  leave.s    IL_00fd
+    IL_00cf:  ldc.i4.m1
+    IL_00d0:  dup
+    IL_00d1:  stloc.0
+    IL_00d2:  stfld      ""int C.<M>d__0.<>1__state""
+    IL_00d7:  ldarg.0
+    IL_00d8:  ldfld      ""bool C.<M>d__0.<>w__disposeMode""
+    IL_00dd:  brfalse.s  IL_00e1
+    IL_00df:  leave.s    IL_0106
     // sequence point: Write("" 4 "");
-    IL_00d8:  ldstr      "" 4 ""
-    IL_00dd:  call       ""void System.Console.Write(string)""
-    IL_00e2:  nop
-    IL_00e3:  leave.s    IL_00fd
+    IL_00e1:  ldstr      "" 4 ""
+    IL_00e6:  call       ""void System.Console.Write(string)""
+    IL_00eb:  nop
+    IL_00ec:  leave.s    IL_0106
   }
   catch System.Exception
   {
     // sequence point: <hidden>
-    IL_00e5:  stloc.3
-    IL_00e6:  ldarg.0
-    IL_00e7:  ldc.i4.s   -2
-    IL_00e9:  stfld      ""int C.<M>d__0.<>1__state""
-    IL_00ee:  ldarg.0
-    IL_00ef:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-    IL_00f4:  ldloc.3
-    IL_00f5:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetException(System.Exception)""
-    IL_00fa:  nop
-    IL_00fb:  leave.s    IL_0120
+    IL_00ee:  stloc.3
+    IL_00ef:  ldarg.0
+    IL_00f0:  ldc.i4.s   -2
+    IL_00f2:  stfld      ""int C.<M>d__0.<>1__state""
+    IL_00f7:  ldarg.0
+    IL_00f8:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+    IL_00fd:  ldloc.3
+    IL_00fe:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetException(System.Exception)""
+    IL_0103:  nop
+    IL_0104:  leave.s    IL_0129
   }
   // sequence point: }
-  IL_00fd:  ldarg.0
-  IL_00fe:  ldc.i4.s   -2
-  IL_0100:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_0106:  ldarg.0
+  IL_0107:  ldc.i4.s   -2
+  IL_0109:  stfld      ""int C.<M>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_0105:  ldarg.0
-  IL_0106:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-  IL_010b:  ldc.i4.0
-  IL_010c:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
-  IL_0111:  nop
-  IL_0112:  ret
-  IL_0113:  ldarg.0
-  IL_0114:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-  IL_0119:  ldc.i4.1
-  IL_011a:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
-  IL_011f:  nop
-  IL_0120:  ret
-}
-", sequencePoints: "C+<M>d__0.MoveNext", source: source);
+  IL_010e:  ldarg.0
+  IL_010f:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+  IL_0114:  ldc.i4.0
+  IL_0115:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
+  IL_011a:  nop
+  IL_011b:  ret
+  IL_011c:  ldarg.0
+  IL_011d:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+  IL_0122:  ldc.i4.1
+  IL_0123:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
+  IL_0128:  nop
+  IL_0129:  ret
+}", sequencePoints: "C+<M>d__0.MoveNext", source: source);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -1291,7 +1291,8 @@ class C
 }";
             var verifier = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput: @"1", verify: Verification.Fails);
             verifier.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"{
+@"
+{
   // Code size      198 (0xc6)
   .maxstack  3
   .locals init (int V_0,
@@ -1395,7 +1396,8 @@ class C
 }");
             verifier = CompileAndVerify(text, options: TestOptions.UnsafeDebugExe, expectedOutput: @"1", verify: Verification.Fails);
             verifier.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"{
+@"
+{
   // Code size      227 (0xe3)
   .maxstack  3
   .locals init (int V_0,
@@ -1549,7 +1551,8 @@ class Test
             // NOTE: only one hoisted int local:  
             //       int Test.<MainAsync>d__1.<a>5__2
             verifier.VerifyIL("Test.<MainAsync>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"{
+@"
+{
   // Code size      292 (0x124)
   .maxstack  3
   .locals init (int V_0,
@@ -1682,7 +1685,8 @@ class Test
             //       int Test.<MainAsync>d__1.<a>5__1  and  
             //       int Test.<MainAsync>d__1.<b>5__2
             verifier.VerifyIL("Test.<MainAsync>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"{
+@"
+{
   // Code size      331 (0x14b)
   .maxstack  3
   .locals init (int V_0,
@@ -1872,7 +1876,8 @@ class Test
             // NOTE: only one hoisted int local:  
             //       int Test.<MainAsync>d__1.<a>5__2
             verifier.VerifyIL("Test.<MainAsync>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"{
+@"
+{
   // Code size      292 (0x124)
   .maxstack  3
   .locals init (int V_0,
@@ -2005,7 +2010,8 @@ class Test
             //       int Test.<MainAsync>d__1.<a>5__1  and  
             //       int Test.<MainAsync>d__1.<b>5__2
             verifier.VerifyIL("Test.<MainAsync>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"{
+@"
+{
   // Code size      331 (0x14b)
   .maxstack  3
   .locals init (int V_0,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -145,7 +144,6 @@ a
 ";
             CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expected);
             CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expected);
-
         }
 
         [Fact]
@@ -592,7 +590,6 @@ class Test
   IL_00be:  ret
 }
 ");
-
         }
 
         [Fact]
@@ -880,7 +877,6 @@ class Test
   IL_0263:  ret
 }
 ");
-
         }
 
         [Fact]
@@ -1295,8 +1291,7 @@ class C
 }";
             var verifier = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput: @"1", verify: Verification.Fails);
             verifier.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"
-{
+@"{
   // Code size      198 (0xc6)
   .maxstack  3
   .locals init (int V_0,
@@ -1400,9 +1395,8 @@ class C
 }");
             verifier = CompileAndVerify(text, options: TestOptions.UnsafeDebugExe, expectedOutput: @"1", verify: Verification.Fails);
             verifier.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"
-{
-  // Code size      225 (0xe1)
+@"{
+  // Code size      227 (0xe3)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -1417,106 +1411,107 @@ class C
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0084
-    IL_000a:  br.s       IL_000c
-    IL_000c:  nop
-    IL_000d:  nop
-    IL_000e:  ldarg.0
-    IL_000f:  ldfld      ""byte[] C.<F>d__0.b""
-    IL_0014:  dup
-    IL_0015:  stloc.2
-    IL_0016:  brfalse.s  IL_001d
-    IL_0018:  ldloc.2
-    IL_0019:  ldlen
-    IL_001a:  conv.i4
-    IL_001b:  brtrue.s   IL_0027
-    IL_001d:  ldarg.0
-    IL_001e:  ldc.i4.0
-    IL_001f:  conv.u
-    IL_0020:  stfld      ""byte* C.<F>d__0.<p>5__2""
-    IL_0025:  br.s       IL_0035
-    IL_0027:  ldarg.0
-    IL_0028:  ldloc.2
-    IL_0029:  ldc.i4.0
-    IL_002a:  ldelema    ""byte""
-    IL_002f:  conv.u
-    IL_0030:  stfld      ""byte* C.<F>d__0.<p>5__2""
-    IL_0035:  nop
-    IL_0036:  ldarg.0
-    IL_0037:  ldarg.0
-    IL_0038:  ldfld      ""byte* C.<F>d__0.<p>5__2""
-    IL_003d:  ldind.u1
-    IL_003e:  stfld      ""int C.<F>d__0.<i>5__1""
-    IL_0043:  nop
-    IL_0044:  ldnull
-    IL_0045:  stloc.2
-    IL_0046:  nop
-    IL_0047:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_004c:  stloc.s    V_4
-    IL_004e:  ldloca.s   V_4
-    IL_0050:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_0055:  stloc.3
-    IL_0056:  ldloca.s   V_3
-    IL_0058:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_005d:  brtrue.s   IL_00a0
-    IL_005f:  ldarg.0
-    IL_0060:  ldc.i4.0
-    IL_0061:  dup
-    IL_0062:  stloc.0
-    IL_0063:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0068:  ldarg.0
-    IL_0069:  ldloc.3
-    IL_006a:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
-    IL_006f:  ldarg.0
-    IL_0070:  stloc.s    V_5
-    IL_0072:  ldarg.0
-    IL_0073:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_0078:  ldloca.s   V_3
-    IL_007a:  ldloca.s   V_5
-    IL_007c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__0)""
-    IL_0081:  nop
-    IL_0082:  leave.s    IL_00e0
-    IL_0084:  ldarg.0
-    IL_0085:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
-    IL_008a:  stloc.3
-    IL_008b:  ldarg.0
-    IL_008c:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
-    IL_0091:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0097:  ldarg.0
-    IL_0098:  ldc.i4.m1
-    IL_0099:  dup
-    IL_009a:  stloc.0
-    IL_009b:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_00a0:  ldloca.s   V_3
-    IL_00a2:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_00a7:  nop
-    IL_00a8:  ldarg.0
-    IL_00a9:  ldfld      ""int C.<F>d__0.<i>5__1""
-    IL_00ae:  stloc.1
-    IL_00af:  leave.s    IL_00cb
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_0086
+    IL_000e:  nop
+    IL_000f:  nop
+    IL_0010:  ldarg.0
+    IL_0011:  ldfld      ""byte[] C.<F>d__0.b""
+    IL_0016:  dup
+    IL_0017:  stloc.2
+    IL_0018:  brfalse.s  IL_001f
+    IL_001a:  ldloc.2
+    IL_001b:  ldlen
+    IL_001c:  conv.i4
+    IL_001d:  brtrue.s   IL_0029
+    IL_001f:  ldarg.0
+    IL_0020:  ldc.i4.0
+    IL_0021:  conv.u
+    IL_0022:  stfld      ""byte* C.<F>d__0.<p>5__2""
+    IL_0027:  br.s       IL_0037
+    IL_0029:  ldarg.0
+    IL_002a:  ldloc.2
+    IL_002b:  ldc.i4.0
+    IL_002c:  ldelema    ""byte""
+    IL_0031:  conv.u
+    IL_0032:  stfld      ""byte* C.<F>d__0.<p>5__2""
+    IL_0037:  nop
+    IL_0038:  ldarg.0
+    IL_0039:  ldarg.0
+    IL_003a:  ldfld      ""byte* C.<F>d__0.<p>5__2""
+    IL_003f:  ldind.u1
+    IL_0040:  stfld      ""int C.<F>d__0.<i>5__1""
+    IL_0045:  nop
+    IL_0046:  ldnull
+    IL_0047:  stloc.2
+    IL_0048:  nop
+    IL_0049:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_004e:  stloc.s    V_4
+    IL_0050:  ldloca.s   V_4
+    IL_0052:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_0057:  stloc.3
+    IL_0058:  ldloca.s   V_3
+    IL_005a:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_005f:  brtrue.s   IL_00a2
+    IL_0061:  ldarg.0
+    IL_0062:  ldc.i4.0
+    IL_0063:  dup
+    IL_0064:  stloc.0
+    IL_0065:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_006a:  ldarg.0
+    IL_006b:  ldloc.3
+    IL_006c:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
+    IL_0071:  ldarg.0
+    IL_0072:  stloc.s    V_5
+    IL_0074:  ldarg.0
+    IL_0075:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_007a:  ldloca.s   V_3
+    IL_007c:  ldloca.s   V_5
+    IL_007e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__0)""
+    IL_0083:  nop
+    IL_0084:  leave.s    IL_00e2
+    IL_0086:  ldarg.0
+    IL_0087:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
+    IL_008c:  stloc.3
+    IL_008d:  ldarg.0
+    IL_008e:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
+    IL_0093:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_0099:  ldarg.0
+    IL_009a:  ldc.i4.m1
+    IL_009b:  dup
+    IL_009c:  stloc.0
+    IL_009d:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_00a2:  ldloca.s   V_3
+    IL_00a4:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_00a9:  nop
+    IL_00aa:  ldarg.0
+    IL_00ab:  ldfld      ""int C.<F>d__0.<i>5__1""
+    IL_00b0:  stloc.1
+    IL_00b1:  leave.s    IL_00cd
   }
   catch System.Exception
   {
-    IL_00b1:  stloc.s    V_6
-    IL_00b3:  ldarg.0
-    IL_00b4:  ldc.i4.s   -2
-    IL_00b6:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_00bb:  ldarg.0
-    IL_00bc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_00c1:  ldloc.s    V_6
-    IL_00c3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00c8:  nop
-    IL_00c9:  leave.s    IL_00e0
+    IL_00b3:  stloc.s    V_6
+    IL_00b5:  ldarg.0
+    IL_00b6:  ldc.i4.s   -2
+    IL_00b8:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_00bd:  ldarg.0
+    IL_00be:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_00c3:  ldloc.s    V_6
+    IL_00c5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00ca:  nop
+    IL_00cb:  leave.s    IL_00e2
   }
-  IL_00cb:  ldarg.0
-  IL_00cc:  ldc.i4.s   -2
-  IL_00ce:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_00d3:  ldarg.0
-  IL_00d4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00d9:  ldloc.1
-  IL_00da:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00df:  nop
-  IL_00e0:  ret
+  IL_00cd:  ldarg.0
+  IL_00ce:  ldc.i4.s   -2
+  IL_00d0:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_00d5:  ldarg.0
+  IL_00d6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00db:  ldloc.1
+  IL_00dc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00e1:  nop
+  IL_00e2:  ret
 }");
         }
 
@@ -1551,12 +1546,10 @@ class Test
 }";
             var verifier = CompileAndVerify(text, options: TestOptions.ReleaseExe, expectedOutput: @"2");
 
-
             // NOTE: only one hoisted int local:  
             //       int Test.<MainAsync>d__1.<a>5__2
             verifier.VerifyIL("Test.<MainAsync>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"
-{
+@"{
   // Code size      292 (0x124)
   .maxstack  3
   .locals init (int V_0,
@@ -1683,16 +1676,14 @@ class Test
   IL_0123:  ret
 }");
 
-
             verifier = CompileAndVerify(text, options: TestOptions.DebugExe, expectedOutput: @"2");
 
             // NOTE: two separate hoisted int locals: 
             //       int Test.<MainAsync>d__1.<a>5__1  and  
             //       int Test.<MainAsync>d__1.<b>5__2
             verifier.VerifyIL("Test.<MainAsync>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"
-{
-  // Code size      327 (0x147)
+@"{
+  // Code size      331 (0x14b)
   .maxstack  3
   .locals init (int V_0,
                 bool V_1,
@@ -1707,141 +1698,143 @@ class Test
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_006b
+    IL_0008:  brfalse.s  IL_0012
     IL_000a:  br.s       IL_000c
     IL_000c:  ldloc.0
     IL_000d:  ldc.i4.1
-    IL_000e:  beq        IL_00e4
-    IL_0013:  br.s       IL_0015
-    IL_0015:  nop
-    IL_0016:  ldarg.0
-    IL_0017:  ldfld      ""string[] Test.<MainAsync>d__1.args""
-    IL_001c:  ldlen
-    IL_001d:  ldc.i4.0
-    IL_001e:  cgt.un
-    IL_0020:  stloc.1
-    IL_0021:  ldloc.1
-    IL_0022:  brfalse.s  IL_009e
-    IL_0024:  nop
-    IL_0025:  ldarg.0
-    IL_0026:  ldc.i4.1
-    IL_0027:  stfld      ""int Test.<MainAsync>d__1.<a>5__1""
-    IL_002c:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_0031:  stloc.3
-    IL_0032:  ldloca.s   V_3
-    IL_0034:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_0039:  stloc.2
-    IL_003a:  ldloca.s   V_2
-    IL_003c:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_0041:  brtrue.s   IL_0087
-    IL_0043:  ldarg.0
-    IL_0044:  ldc.i4.0
-    IL_0045:  dup
-    IL_0046:  stloc.0
-    IL_0047:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-    IL_004c:  ldarg.0
-    IL_004d:  ldloc.2
-    IL_004e:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_0053:  ldarg.0
-    IL_0054:  stloc.s    V_4
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
-    IL_005c:  ldloca.s   V_2
-    IL_005e:  ldloca.s   V_4
-    IL_0060:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<MainAsync>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<MainAsync>d__1)""
-    IL_0065:  nop
-    IL_0066:  leave      IL_0146
-    IL_006b:  ldarg.0
-    IL_006c:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_0071:  stloc.2
-    IL_0072:  ldarg.0
-    IL_0073:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_0078:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_007e:  ldarg.0
-    IL_007f:  ldc.i4.m1
-    IL_0080:  dup
-    IL_0081:  stloc.0
-    IL_0082:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-    IL_0087:  ldloca.s   V_2
-    IL_0089:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_008e:  nop
-    IL_008f:  ldarg.0
-    IL_0090:  ldfld      ""int Test.<MainAsync>d__1.<a>5__1""
-    IL_0095:  call       ""void System.Console.WriteLine(int)""
-    IL_009a:  nop
-    IL_009b:  nop
-    IL_009c:  br.s       IL_0116
+    IL_000e:  beq.s      IL_0014
+    IL_0010:  br.s       IL_0019
+    IL_0012:  br.s       IL_006f
+    IL_0014:  br         IL_00e8
+    IL_0019:  nop
+    IL_001a:  ldarg.0
+    IL_001b:  ldfld      ""string[] Test.<MainAsync>d__1.args""
+    IL_0020:  ldlen
+    IL_0021:  ldc.i4.0
+    IL_0022:  cgt.un
+    IL_0024:  stloc.1
+    IL_0025:  ldloc.1
+    IL_0026:  brfalse.s  IL_00a2
+    IL_0028:  nop
+    IL_0029:  ldarg.0
+    IL_002a:  ldc.i4.1
+    IL_002b:  stfld      ""int Test.<MainAsync>d__1.<a>5__1""
+    IL_0030:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_0035:  stloc.3
+    IL_0036:  ldloca.s   V_3
+    IL_0038:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_003d:  stloc.2
+    IL_003e:  ldloca.s   V_2
+    IL_0040:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_0045:  brtrue.s   IL_008b
+    IL_0047:  ldarg.0
+    IL_0048:  ldc.i4.0
+    IL_0049:  dup
+    IL_004a:  stloc.0
+    IL_004b:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+    IL_0050:  ldarg.0
+    IL_0051:  ldloc.2
+    IL_0052:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_0057:  ldarg.0
+    IL_0058:  stloc.s    V_4
+    IL_005a:  ldarg.0
+    IL_005b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
+    IL_0060:  ldloca.s   V_2
+    IL_0062:  ldloca.s   V_4
+    IL_0064:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<MainAsync>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<MainAsync>d__1)""
+    IL_0069:  nop
+    IL_006a:  leave      IL_014a
+    IL_006f:  ldarg.0
+    IL_0070:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_0075:  stloc.2
+    IL_0076:  ldarg.0
+    IL_0077:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_007c:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_0082:  ldarg.0
+    IL_0083:  ldc.i4.m1
+    IL_0084:  dup
+    IL_0085:  stloc.0
+    IL_0086:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+    IL_008b:  ldloca.s   V_2
+    IL_008d:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_0092:  nop
+    IL_0093:  ldarg.0
+    IL_0094:  ldfld      ""int Test.<MainAsync>d__1.<a>5__1""
+    IL_0099:  call       ""void System.Console.WriteLine(int)""
     IL_009e:  nop
-    IL_009f:  ldarg.0
-    IL_00a0:  ldc.i4.2
-    IL_00a1:  stfld      ""int Test.<MainAsync>d__1.<b>5__2""
-    IL_00a6:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_00ab:  stloc.3
-    IL_00ac:  ldloca.s   V_3
-    IL_00ae:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_00b3:  stloc.s    V_5
-    IL_00b5:  ldloca.s   V_5
-    IL_00b7:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_00bc:  brtrue.s   IL_0101
-    IL_00be:  ldarg.0
-    IL_00bf:  ldc.i4.1
-    IL_00c0:  dup
-    IL_00c1:  stloc.0
-    IL_00c2:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-    IL_00c7:  ldarg.0
-    IL_00c8:  ldloc.s    V_5
-    IL_00ca:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_00cf:  ldarg.0
-    IL_00d0:  stloc.s    V_4
-    IL_00d2:  ldarg.0
-    IL_00d3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
-    IL_00d8:  ldloca.s   V_5
-    IL_00da:  ldloca.s   V_4
-    IL_00dc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<MainAsync>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<MainAsync>d__1)""
-    IL_00e1:  nop
-    IL_00e2:  leave.s    IL_0146
-    IL_00e4:  ldarg.0
-    IL_00e5:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_00ea:  stloc.s    V_5
-    IL_00ec:  ldarg.0
-    IL_00ed:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_00f2:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_00f8:  ldarg.0
-    IL_00f9:  ldc.i4.m1
-    IL_00fa:  dup
-    IL_00fb:  stloc.0
-    IL_00fc:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-    IL_0101:  ldloca.s   V_5
-    IL_0103:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0108:  nop
-    IL_0109:  ldarg.0
-    IL_010a:  ldfld      ""int Test.<MainAsync>d__1.<b>5__2""
-    IL_010f:  call       ""void System.Console.WriteLine(int)""
-    IL_0114:  nop
-    IL_0115:  nop
-    IL_0116:  leave.s    IL_0132
+    IL_009f:  nop
+    IL_00a0:  br.s       IL_011a
+    IL_00a2:  nop
+    IL_00a3:  ldarg.0
+    IL_00a4:  ldc.i4.2
+    IL_00a5:  stfld      ""int Test.<MainAsync>d__1.<b>5__2""
+    IL_00aa:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_00af:  stloc.3
+    IL_00b0:  ldloca.s   V_3
+    IL_00b2:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_00b7:  stloc.s    V_5
+    IL_00b9:  ldloca.s   V_5
+    IL_00bb:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_00c0:  brtrue.s   IL_0105
+    IL_00c2:  ldarg.0
+    IL_00c3:  ldc.i4.1
+    IL_00c4:  dup
+    IL_00c5:  stloc.0
+    IL_00c6:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+    IL_00cb:  ldarg.0
+    IL_00cc:  ldloc.s    V_5
+    IL_00ce:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_00d3:  ldarg.0
+    IL_00d4:  stloc.s    V_4
+    IL_00d6:  ldarg.0
+    IL_00d7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
+    IL_00dc:  ldloca.s   V_5
+    IL_00de:  ldloca.s   V_4
+    IL_00e0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<MainAsync>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<MainAsync>d__1)""
+    IL_00e5:  nop
+    IL_00e6:  leave.s    IL_014a
+    IL_00e8:  ldarg.0
+    IL_00e9:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_00ee:  stloc.s    V_5
+    IL_00f0:  ldarg.0
+    IL_00f1:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_00f6:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_00fc:  ldarg.0
+    IL_00fd:  ldc.i4.m1
+    IL_00fe:  dup
+    IL_00ff:  stloc.0
+    IL_0100:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+    IL_0105:  ldloca.s   V_5
+    IL_0107:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_010c:  nop
+    IL_010d:  ldarg.0
+    IL_010e:  ldfld      ""int Test.<MainAsync>d__1.<b>5__2""
+    IL_0113:  call       ""void System.Console.WriteLine(int)""
+    IL_0118:  nop
+    IL_0119:  nop
+    IL_011a:  leave.s    IL_0136
   }
   catch System.Exception
   {
-    IL_0118:  stloc.s    V_6
-    IL_011a:  ldarg.0
-    IL_011b:  ldc.i4.s   -2
-    IL_011d:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-    IL_0122:  ldarg.0
-    IL_0123:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
-    IL_0128:  ldloc.s    V_6
-    IL_012a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_012f:  nop
-    IL_0130:  leave.s    IL_0146
+    IL_011c:  stloc.s    V_6
+    IL_011e:  ldarg.0
+    IL_011f:  ldc.i4.s   -2
+    IL_0121:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+    IL_0126:  ldarg.0
+    IL_0127:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
+    IL_012c:  ldloc.s    V_6
+    IL_012e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0133:  nop
+    IL_0134:  leave.s    IL_014a
   }
-  IL_0132:  ldarg.0
-  IL_0133:  ldc.i4.s   -2
-  IL_0135:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-  IL_013a:  ldarg.0
-  IL_013b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
-  IL_0140:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0145:  nop
-  IL_0146:  ret
+  IL_0136:  ldarg.0
+  IL_0137:  ldc.i4.s   -2
+  IL_0139:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+  IL_013e:  ldarg.0
+  IL_013f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
+  IL_0144:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0149:  nop
+  IL_014a:  ret
 }");
         }
 
@@ -1876,12 +1869,10 @@ class Test
 }";
             var verifier = CompileAndVerify(text, options: TestOptions.ReleaseExe, expectedOutput: @"2");
 
-
             // NOTE: only one hoisted int local:  
             //       int Test.<MainAsync>d__1.<a>5__2
             verifier.VerifyIL("Test.<MainAsync>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"
-{
+@"{
   // Code size      292 (0x124)
   .maxstack  3
   .locals init (int V_0,
@@ -2008,16 +1999,14 @@ class Test
   IL_0123:  ret
 }");
 
-
             verifier = CompileAndVerify(text, options: TestOptions.DebugExe, expectedOutput: @"2");
 
             // NOTE: two separate hoisted int locals: 
             //       int Test.<MainAsync>d__1.<a>5__1  and  
             //       int Test.<MainAsync>d__1.<b>5__2
             verifier.VerifyIL("Test.<MainAsync>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"
-{
-  // Code size      327 (0x147)
+@"{
+  // Code size      331 (0x14b)
   .maxstack  3
   .locals init (int V_0,
                 bool V_1,
@@ -2032,143 +2021,144 @@ class Test
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_006b
+    IL_0008:  brfalse.s  IL_0012
     IL_000a:  br.s       IL_000c
     IL_000c:  ldloc.0
     IL_000d:  ldc.i4.1
-    IL_000e:  beq        IL_00e4
-    IL_0013:  br.s       IL_0015
-    IL_0015:  nop
-    IL_0016:  ldarg.0
-    IL_0017:  ldfld      ""string[] Test.<MainAsync>d__1.args""
-    IL_001c:  ldlen
-    IL_001d:  ldc.i4.0
-    IL_001e:  cgt.un
-    IL_0020:  stloc.1
-    IL_0021:  ldloc.1
-    IL_0022:  brfalse.s  IL_009e
-    IL_0024:  nop
-    IL_0025:  ldarg.0
-    IL_0026:  ldc.i4.1
-    IL_0027:  stfld      ""int Test.<MainAsync>d__1.<a>5__1""
-    IL_002c:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_0031:  stloc.3
-    IL_0032:  ldloca.s   V_3
-    IL_0034:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_0039:  stloc.2
-    IL_003a:  ldloca.s   V_2
-    IL_003c:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_0041:  brtrue.s   IL_0087
-    IL_0043:  ldarg.0
-    IL_0044:  ldc.i4.0
-    IL_0045:  dup
-    IL_0046:  stloc.0
-    IL_0047:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-    IL_004c:  ldarg.0
-    IL_004d:  ldloc.2
-    IL_004e:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_0053:  ldarg.0
-    IL_0054:  stloc.s    V_4
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
-    IL_005c:  ldloca.s   V_2
-    IL_005e:  ldloca.s   V_4
-    IL_0060:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<MainAsync>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<MainAsync>d__1)""
-    IL_0065:  nop
-    IL_0066:  leave      IL_0146
-    IL_006b:  ldarg.0
-    IL_006c:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_0071:  stloc.2
-    IL_0072:  ldarg.0
-    IL_0073:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_0078:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_007e:  ldarg.0
-    IL_007f:  ldc.i4.m1
-    IL_0080:  dup
-    IL_0081:  stloc.0
-    IL_0082:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-    IL_0087:  ldloca.s   V_2
-    IL_0089:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_008e:  nop
-    IL_008f:  ldarg.0
-    IL_0090:  ldfld      ""int Test.<MainAsync>d__1.<a>5__1""
-    IL_0095:  call       ""void System.Console.WriteLine(int)""
-    IL_009a:  nop
-    IL_009b:  nop
-    IL_009c:  br.s       IL_0116
+    IL_000e:  beq.s      IL_0014
+    IL_0010:  br.s       IL_0019
+    IL_0012:  br.s       IL_006f
+    IL_0014:  br         IL_00e8
+    IL_0019:  nop
+    IL_001a:  ldarg.0
+    IL_001b:  ldfld      ""string[] Test.<MainAsync>d__1.args""
+    IL_0020:  ldlen
+    IL_0021:  ldc.i4.0
+    IL_0022:  cgt.un
+    IL_0024:  stloc.1
+    IL_0025:  ldloc.1
+    IL_0026:  brfalse.s  IL_00a2
+    IL_0028:  nop
+    IL_0029:  ldarg.0
+    IL_002a:  ldc.i4.1
+    IL_002b:  stfld      ""int Test.<MainAsync>d__1.<a>5__1""
+    IL_0030:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_0035:  stloc.3
+    IL_0036:  ldloca.s   V_3
+    IL_0038:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_003d:  stloc.2
+    IL_003e:  ldloca.s   V_2
+    IL_0040:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_0045:  brtrue.s   IL_008b
+    IL_0047:  ldarg.0
+    IL_0048:  ldc.i4.0
+    IL_0049:  dup
+    IL_004a:  stloc.0
+    IL_004b:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+    IL_0050:  ldarg.0
+    IL_0051:  ldloc.2
+    IL_0052:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_0057:  ldarg.0
+    IL_0058:  stloc.s    V_4
+    IL_005a:  ldarg.0
+    IL_005b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
+    IL_0060:  ldloca.s   V_2
+    IL_0062:  ldloca.s   V_4
+    IL_0064:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<MainAsync>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<MainAsync>d__1)""
+    IL_0069:  nop
+    IL_006a:  leave      IL_014a
+    IL_006f:  ldarg.0
+    IL_0070:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_0075:  stloc.2
+    IL_0076:  ldarg.0
+    IL_0077:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_007c:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_0082:  ldarg.0
+    IL_0083:  ldc.i4.m1
+    IL_0084:  dup
+    IL_0085:  stloc.0
+    IL_0086:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+    IL_008b:  ldloca.s   V_2
+    IL_008d:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_0092:  nop
+    IL_0093:  ldarg.0
+    IL_0094:  ldfld      ""int Test.<MainAsync>d__1.<a>5__1""
+    IL_0099:  call       ""void System.Console.WriteLine(int)""
     IL_009e:  nop
-    IL_009f:  ldarg.0
-    IL_00a0:  ldc.i4.2
-    IL_00a1:  stfld      ""int Test.<MainAsync>d__1.<b>5__2""
-    IL_00a6:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_00ab:  stloc.3
-    IL_00ac:  ldloca.s   V_3
-    IL_00ae:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_00b3:  stloc.s    V_5
-    IL_00b5:  ldloca.s   V_5
-    IL_00b7:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_00bc:  brtrue.s   IL_0101
-    IL_00be:  ldarg.0
-    IL_00bf:  ldc.i4.1
-    IL_00c0:  dup
-    IL_00c1:  stloc.0
-    IL_00c2:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-    IL_00c7:  ldarg.0
-    IL_00c8:  ldloc.s    V_5
-    IL_00ca:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_00cf:  ldarg.0
-    IL_00d0:  stloc.s    V_4
-    IL_00d2:  ldarg.0
-    IL_00d3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
-    IL_00d8:  ldloca.s   V_5
-    IL_00da:  ldloca.s   V_4
-    IL_00dc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<MainAsync>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<MainAsync>d__1)""
-    IL_00e1:  nop
-    IL_00e2:  leave.s    IL_0146
-    IL_00e4:  ldarg.0
-    IL_00e5:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_00ea:  stloc.s    V_5
-    IL_00ec:  ldarg.0
-    IL_00ed:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
-    IL_00f2:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_00f8:  ldarg.0
-    IL_00f9:  ldc.i4.m1
-    IL_00fa:  dup
-    IL_00fb:  stloc.0
-    IL_00fc:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-    IL_0101:  ldloca.s   V_5
-    IL_0103:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0108:  nop
-    IL_0109:  ldarg.0
-    IL_010a:  ldfld      ""int Test.<MainAsync>d__1.<b>5__2""
-    IL_010f:  call       ""void System.Console.WriteLine(int)""
-    IL_0114:  nop
-    IL_0115:  nop
-    IL_0116:  leave.s    IL_0132
+    IL_009f:  nop
+    IL_00a0:  br.s       IL_011a
+    IL_00a2:  nop
+    IL_00a3:  ldarg.0
+    IL_00a4:  ldc.i4.2
+    IL_00a5:  stfld      ""int Test.<MainAsync>d__1.<b>5__2""
+    IL_00aa:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_00af:  stloc.3
+    IL_00b0:  ldloca.s   V_3
+    IL_00b2:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_00b7:  stloc.s    V_5
+    IL_00b9:  ldloca.s   V_5
+    IL_00bb:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_00c0:  brtrue.s   IL_0105
+    IL_00c2:  ldarg.0
+    IL_00c3:  ldc.i4.1
+    IL_00c4:  dup
+    IL_00c5:  stloc.0
+    IL_00c6:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+    IL_00cb:  ldarg.0
+    IL_00cc:  ldloc.s    V_5
+    IL_00ce:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_00d3:  ldarg.0
+    IL_00d4:  stloc.s    V_4
+    IL_00d6:  ldarg.0
+    IL_00d7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
+    IL_00dc:  ldloca.s   V_5
+    IL_00de:  ldloca.s   V_4
+    IL_00e0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<MainAsync>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<MainAsync>d__1)""
+    IL_00e5:  nop
+    IL_00e6:  leave.s    IL_014a
+    IL_00e8:  ldarg.0
+    IL_00e9:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_00ee:  stloc.s    V_5
+    IL_00f0:  ldarg.0
+    IL_00f1:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<MainAsync>d__1.<>u__1""
+    IL_00f6:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_00fc:  ldarg.0
+    IL_00fd:  ldc.i4.m1
+    IL_00fe:  dup
+    IL_00ff:  stloc.0
+    IL_0100:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+    IL_0105:  ldloca.s   V_5
+    IL_0107:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_010c:  nop
+    IL_010d:  ldarg.0
+    IL_010e:  ldfld      ""int Test.<MainAsync>d__1.<b>5__2""
+    IL_0113:  call       ""void System.Console.WriteLine(int)""
+    IL_0118:  nop
+    IL_0119:  nop
+    IL_011a:  leave.s    IL_0136
   }
   catch System.Exception
   {
-    IL_0118:  stloc.s    V_6
-    IL_011a:  ldarg.0
-    IL_011b:  ldc.i4.s   -2
-    IL_011d:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-    IL_0122:  ldarg.0
-    IL_0123:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
-    IL_0128:  ldloc.s    V_6
-    IL_012a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_012f:  nop
-    IL_0130:  leave.s    IL_0146
+    IL_011c:  stloc.s    V_6
+    IL_011e:  ldarg.0
+    IL_011f:  ldc.i4.s   -2
+    IL_0121:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+    IL_0126:  ldarg.0
+    IL_0127:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
+    IL_012c:  ldloc.s    V_6
+    IL_012e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0133:  nop
+    IL_0134:  leave.s    IL_014a
   }
-  IL_0132:  ldarg.0
-  IL_0133:  ldc.i4.s   -2
-  IL_0135:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
-  IL_013a:  ldarg.0
-  IL_013b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
-  IL_0140:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0145:  nop
-  IL_0146:  ret
+  IL_0136:  ldarg.0
+  IL_0137:  ldc.i4.s   -2
+  IL_0139:  stfld      ""int Test.<MainAsync>d__1.<>1__state""
+  IL_013e:  ldarg.0
+  IL_013f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<MainAsync>d__1.<>t__builder""
+  IL_0144:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0149:  nop
+  IL_014a:  ret
 }");
         }
-
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncMainTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncMainTests.cs
@@ -1479,5 +1479,439 @@ static class Program {
                 //     static Task Main() {
                 Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Task").WithArguments("MyExtensions.GetAwaiter(System.Threading.Tasks.Task)", "test").WithLocation(31, 12));
         }
+
+        [Fact]
+        [WorkItem(33542, "https://github.com/dotnet/roslyn/issues/33542")]
+        public void AwaitInFinallyInNestedTry_01()
+        {
+            string source =
+@"using System.Threading.Tasks;
+class Program
+{
+    static async Task Main()
+    {
+        try
+        {
+            try
+            {
+                return;
+            }
+            finally
+            {
+                await Task.CompletedTask;
+            }
+        }
+        catch
+        {
+        }
+        finally
+        {
+            await Task.CompletedTask;
+        }
+    }
+}";
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe.WithOptimizationLevel(OptimizationLevel.Release));
+            var verifier = CompileAndVerify(comp, expectedOutput: "");
+            verifier.VerifyIL("Program.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
+@"{
+  // Code size      426 (0x1aa)
+  .maxstack  3
+  .locals init (int V_0,
+                object V_1,
+                System.Runtime.CompilerServices.TaskAwaiter V_2,
+                int V_3,
+                System.Exception V_4)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int Program.<Main>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_001f
+    IL_000a:  ldloc.0
+    IL_000b:  ldc.i4.1
+    IL_000c:  beq        IL_0125
+    IL_0011:  ldarg.0
+    IL_0012:  ldnull
+    IL_0013:  stfld      ""object Program.<Main>d__0.<>7__wrap1""
+    IL_0018:  ldarg.0
+    IL_0019:  ldc.i4.0
+    IL_001a:  stfld      ""int Program.<Main>d__0.<>7__wrap2""
+    IL_001f:  nop
+    .try
+    {
+      IL_0020:  ldloc.0
+      IL_0021:  pop
+      IL_0022:  nop
+      .try
+      {
+        IL_0023:  ldloc.0
+        IL_0024:  brfalse.s  IL_007e
+        IL_0026:  ldarg.0
+        IL_0027:  ldnull
+        IL_0028:  stfld      ""object Program.<Main>d__0.<>7__wrap3""
+        IL_002d:  ldarg.0
+        IL_002e:  ldc.i4.0
+        IL_002f:  stfld      ""int Program.<Main>d__0.<>7__wrap4""
+        .try
+        {
+          IL_0034:  ldarg.0
+          IL_0035:  ldc.i4.1
+          IL_0036:  stfld      ""int Program.<Main>d__0.<>7__wrap4""
+          IL_003b:  leave.s    IL_0047
+        }
+        catch object
+        {
+          IL_003d:  stloc.1
+          IL_003e:  ldarg.0
+          IL_003f:  ldloc.1
+          IL_0040:  stfld      ""object Program.<Main>d__0.<>7__wrap3""
+          IL_0045:  leave.s    IL_0047
+        }
+        IL_0047:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get""
+        IL_004c:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
+        IL_0051:  stloc.2
+        IL_0052:  ldloca.s   V_2
+        IL_0054:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
+        IL_0059:  brtrue.s   IL_009a
+        IL_005b:  ldarg.0
+        IL_005c:  ldc.i4.0
+        IL_005d:  dup
+        IL_005e:  stloc.0
+        IL_005f:  stfld      ""int Program.<Main>d__0.<>1__state""
+        IL_0064:  ldarg.0
+        IL_0065:  ldloc.2
+        IL_0066:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+        IL_006b:  ldarg.0
+        IL_006c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+        IL_0071:  ldloca.s   V_2
+        IL_0073:  ldarg.0
+        IL_0074:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, Program.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref Program.<Main>d__0)""
+        IL_0079:  leave      IL_01a9
+        IL_007e:  ldarg.0
+        IL_007f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+        IL_0084:  stloc.2
+        IL_0085:  ldarg.0
+        IL_0086:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+        IL_008b:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+        IL_0091:  ldarg.0
+        IL_0092:  ldc.i4.m1
+        IL_0093:  dup
+        IL_0094:  stloc.0
+        IL_0095:  stfld      ""int Program.<Main>d__0.<>1__state""
+        IL_009a:  ldloca.s   V_2
+        IL_009c:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+        IL_00a1:  ldarg.0
+        IL_00a2:  ldfld      ""object Program.<Main>d__0.<>7__wrap3""
+        IL_00a7:  stloc.1
+        IL_00a8:  ldloc.1
+        IL_00a9:  brfalse.s  IL_00c0
+        IL_00ab:  ldloc.1
+        IL_00ac:  isinst     ""System.Exception""
+        IL_00b1:  dup
+        IL_00b2:  brtrue.s   IL_00b6
+        IL_00b4:  ldloc.1
+        IL_00b5:  throw
+        IL_00b6:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+        IL_00bb:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+        IL_00c0:  ldarg.0
+        IL_00c1:  ldfld      ""int Program.<Main>d__0.<>7__wrap4""
+        IL_00c6:  stloc.3
+        IL_00c7:  ldloc.3
+        IL_00c8:  ldc.i4.1
+        IL_00c9:  bne.un.s   IL_00cd
+        IL_00cb:  leave.s    IL_00db
+        IL_00cd:  ldarg.0
+        IL_00ce:  ldnull
+        IL_00cf:  stfld      ""object Program.<Main>d__0.<>7__wrap3""
+        IL_00d4:  leave.s    IL_00d9
+      }
+      catch object
+      {
+        IL_00d6:  pop
+        IL_00d7:  leave.s    IL_00d9
+      }
+      IL_00d9:  leave.s    IL_00ee
+      IL_00db:  ldarg.0
+      IL_00dc:  ldc.i4.1
+      IL_00dd:  stfld      ""int Program.<Main>d__0.<>7__wrap2""
+      IL_00e2:  leave.s    IL_00ee
+    }
+    catch object
+    {
+      IL_00e4:  stloc.1
+      IL_00e5:  ldarg.0
+      IL_00e6:  ldloc.1
+      IL_00e7:  stfld      ""object Program.<Main>d__0.<>7__wrap1""
+      IL_00ec:  leave.s    IL_00ee
+    }
+    IL_00ee:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.CompletedTask.get""
+    IL_00f3:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
+    IL_00f8:  stloc.2
+    IL_00f9:  ldloca.s   V_2
+    IL_00fb:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
+    IL_0100:  brtrue.s   IL_0141
+    IL_0102:  ldarg.0
+    IL_0103:  ldc.i4.1
+    IL_0104:  dup
+    IL_0105:  stloc.0
+    IL_0106:  stfld      ""int Program.<Main>d__0.<>1__state""
+    IL_010b:  ldarg.0
+    IL_010c:  ldloc.2
+    IL_010d:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+    IL_0112:  ldarg.0
+    IL_0113:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+    IL_0118:  ldloca.s   V_2
+    IL_011a:  ldarg.0
+    IL_011b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, Program.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref Program.<Main>d__0)""
+    IL_0120:  leave      IL_01a9
+    IL_0125:  ldarg.0
+    IL_0126:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+    IL_012b:  stloc.2
+    IL_012c:  ldarg.0
+    IL_012d:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+    IL_0132:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_0138:  ldarg.0
+    IL_0139:  ldc.i4.m1
+    IL_013a:  dup
+    IL_013b:  stloc.0
+    IL_013c:  stfld      ""int Program.<Main>d__0.<>1__state""
+    IL_0141:  ldloca.s   V_2
+    IL_0143:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+    IL_0148:  ldarg.0
+    IL_0149:  ldfld      ""object Program.<Main>d__0.<>7__wrap1""
+    IL_014e:  stloc.1
+    IL_014f:  ldloc.1
+    IL_0150:  brfalse.s  IL_0167
+    IL_0152:  ldloc.1
+    IL_0153:  isinst     ""System.Exception""
+    IL_0158:  dup
+    IL_0159:  brtrue.s   IL_015d
+    IL_015b:  ldloc.1
+    IL_015c:  throw
+    IL_015d:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_0162:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_0167:  ldarg.0
+    IL_0168:  ldfld      ""int Program.<Main>d__0.<>7__wrap2""
+    IL_016d:  stloc.3
+    IL_016e:  ldloc.3
+    IL_016f:  ldc.i4.1
+    IL_0170:  bne.un.s   IL_0174
+    IL_0172:  leave.s    IL_0196
+    IL_0174:  ldarg.0
+    IL_0175:  ldnull
+    IL_0176:  stfld      ""object Program.<Main>d__0.<>7__wrap1""
+    IL_017b:  leave.s    IL_0196
+  }
+  catch System.Exception
+  {
+    IL_017d:  stloc.s    V_4
+    IL_017f:  ldarg.0
+    IL_0180:  ldc.i4.s   -2
+    IL_0182:  stfld      ""int Program.<Main>d__0.<>1__state""
+    IL_0187:  ldarg.0
+    IL_0188:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+    IL_018d:  ldloc.s    V_4
+    IL_018f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0194:  leave.s    IL_01a9
+  }
+  IL_0196:  ldarg.0
+  IL_0197:  ldc.i4.s   -2
+  IL_0199:  stfld      ""int Program.<Main>d__0.<>1__state""
+  IL_019e:  ldarg.0
+  IL_019f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+  IL_01a4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_01a9:  ret
+}");
+        }
+
+        [Fact]
+        [WorkItem(34720, "https://github.com/dotnet/roslyn/issues/34720")]
+        public void AwaitInFinallyInNestedTry_02()
+        {
+            string source =
+@"using System.IO;
+using System.Threading.Tasks;
+class Program
+{
+    static async Task Main()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            using (new MemoryStream())
+            {
+                try
+                {
+                    continue;
+                }
+                finally
+                {
+                    await Task.Delay(1);
+                }
+            }
+        }
+    }
+}";
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe.WithOptimizationLevel(OptimizationLevel.Release));
+            var verifier = CompileAndVerify(comp, expectedOutput: "");
+            verifier.VerifyIL("Program.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
+@"{
+  // Code size      320 (0x140)
+  .maxstack  3
+  .locals init (int V_0,
+                object V_1,
+                System.Runtime.CompilerServices.TaskAwaiter V_2,
+                int V_3,
+                System.Exception V_4)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int Program.<Main>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_0021
+    IL_000a:  ldarg.0
+    IL_000b:  ldc.i4.0
+    IL_000c:  stfld      ""int Program.<Main>d__0.<i>5__2""
+    IL_0011:  br         IL_0105
+    IL_0016:  ldarg.0
+    IL_0017:  newobj     ""System.IO.MemoryStream..ctor()""
+    IL_001c:  stfld      ""System.IO.MemoryStream Program.<Main>d__0.<>7__wrap2""
+    IL_0021:  nop
+    .try
+    {
+      IL_0022:  ldloc.0
+      IL_0023:  brfalse.s  IL_007e
+      IL_0025:  ldarg.0
+      IL_0026:  ldnull
+      IL_0027:  stfld      ""object Program.<Main>d__0.<>7__wrap3""
+      IL_002c:  ldarg.0
+      IL_002d:  ldc.i4.0
+      IL_002e:  stfld      ""int Program.<Main>d__0.<>7__wrap4""
+      .try
+      {
+        IL_0033:  ldarg.0
+        IL_0034:  ldc.i4.1
+        IL_0035:  stfld      ""int Program.<Main>d__0.<>7__wrap4""
+        IL_003a:  leave.s    IL_0046
+      }
+      catch object
+      {
+        IL_003c:  stloc.1
+        IL_003d:  ldarg.0
+        IL_003e:  ldloc.1
+        IL_003f:  stfld      ""object Program.<Main>d__0.<>7__wrap3""
+        IL_0044:  leave.s    IL_0046
+      }
+      IL_0046:  ldc.i4.1
+      IL_0047:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.Delay(int)""
+      IL_004c:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
+      IL_0051:  stloc.2
+      IL_0052:  ldloca.s   V_2
+      IL_0054:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
+      IL_0059:  brtrue.s   IL_009a
+      IL_005b:  ldarg.0
+      IL_005c:  ldc.i4.0
+      IL_005d:  dup
+      IL_005e:  stloc.0
+      IL_005f:  stfld      ""int Program.<Main>d__0.<>1__state""
+      IL_0064:  ldarg.0
+      IL_0065:  ldloc.2
+      IL_0066:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+      IL_006b:  ldarg.0
+      IL_006c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+      IL_0071:  ldloca.s   V_2
+      IL_0073:  ldarg.0
+      IL_0074:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, Program.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref Program.<Main>d__0)""
+      IL_0079:  leave      IL_013f
+      IL_007e:  ldarg.0
+      IL_007f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+      IL_0084:  stloc.2
+      IL_0085:  ldarg.0
+      IL_0086:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter Program.<Main>d__0.<>u__1""
+      IL_008b:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+      IL_0091:  ldarg.0
+      IL_0092:  ldc.i4.m1
+      IL_0093:  dup
+      IL_0094:  stloc.0
+      IL_0095:  stfld      ""int Program.<Main>d__0.<>1__state""
+      IL_009a:  ldloca.s   V_2
+      IL_009c:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+      IL_00a1:  ldarg.0
+      IL_00a2:  ldfld      ""object Program.<Main>d__0.<>7__wrap3""
+      IL_00a7:  stloc.1
+      IL_00a8:  ldloc.1
+      IL_00a9:  brfalse.s  IL_00c0
+      IL_00ab:  ldloc.1
+      IL_00ac:  isinst     ""System.Exception""
+      IL_00b1:  dup
+      IL_00b2:  brtrue.s   IL_00b6
+      IL_00b4:  ldloc.1
+      IL_00b5:  throw
+      IL_00b6:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+      IL_00bb:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+      IL_00c0:  ldarg.0
+      IL_00c1:  ldfld      ""int Program.<Main>d__0.<>7__wrap4""
+      IL_00c6:  stloc.3
+      IL_00c7:  ldloc.3
+      IL_00c8:  ldc.i4.1
+      IL_00c9:  bne.un.s   IL_00cd
+      IL_00cb:  leave.s    IL_00f5
+      IL_00cd:  ldarg.0
+      IL_00ce:  ldnull
+      IL_00cf:  stfld      ""object Program.<Main>d__0.<>7__wrap3""
+      IL_00d4:  leave.s    IL_00ee
+    }
+    finally
+    {
+      IL_00d6:  ldloc.0
+      IL_00d7:  ldc.i4.0
+      IL_00d8:  bge.s      IL_00ed
+      IL_00da:  ldarg.0
+      IL_00db:  ldfld      ""System.IO.MemoryStream Program.<Main>d__0.<>7__wrap2""
+      IL_00e0:  brfalse.s  IL_00ed
+      IL_00e2:  ldarg.0
+      IL_00e3:  ldfld      ""System.IO.MemoryStream Program.<Main>d__0.<>7__wrap2""
+      IL_00e8:  callvirt   ""void System.IDisposable.Dispose()""
+      IL_00ed:  endfinally
+    }
+    IL_00ee:  ldarg.0
+    IL_00ef:  ldnull
+    IL_00f0:  stfld      ""System.IO.MemoryStream Program.<Main>d__0.<>7__wrap2""
+    IL_00f5:  ldarg.0
+    IL_00f6:  ldfld      ""int Program.<Main>d__0.<i>5__2""
+    IL_00fb:  stloc.3
+    IL_00fc:  ldarg.0
+    IL_00fd:  ldloc.3
+    IL_00fe:  ldc.i4.1
+    IL_00ff:  add
+    IL_0100:  stfld      ""int Program.<Main>d__0.<i>5__2""
+    IL_0105:  ldarg.0
+    IL_0106:  ldfld      ""int Program.<Main>d__0.<i>5__2""
+    IL_010b:  ldc.i4.5
+    IL_010c:  blt        IL_0016
+    IL_0111:  leave.s    IL_012c
+  }
+  catch System.Exception
+  {
+    IL_0113:  stloc.s    V_4
+    IL_0115:  ldarg.0
+    IL_0116:  ldc.i4.s   -2
+    IL_0118:  stfld      ""int Program.<Main>d__0.<>1__state""
+    IL_011d:  ldarg.0
+    IL_011e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+    IL_0123:  ldloc.s    V_4
+    IL_0125:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_012a:  leave.s    IL_013f
+  }
+  IL_012c:  ldarg.0
+  IL_012d:  ldc.i4.s   -2
+  IL_012f:  stfld      ""int Program.<Main>d__0.<>1__state""
+  IL_0134:  ldarg.0
+  IL_0135:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Main>d__0.<>t__builder""
+  IL_013a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_013f:  ret
+}");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -594,9 +594,9 @@ public class Test
 ";
             var v = CompileAndVerify(source, options: TestOptions.DebugDll);
 
-            v.VerifyIL("Test.<F>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
-{
-  // Code size      271 (0x10f)
+            v.VerifyIL("Test.<F>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
+@"{
+  // Code size      273 (0x111)
   .maxstack  5
   .locals init (int V_0,
                 int V_1,
@@ -610,122 +610,123 @@ public class Test
   .try
   {
    ~IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0086
-    IL_000a:  br.s       IL_000c
-   -IL_000c:  nop
-   -IL_000d:  ldarg.0
-    IL_000e:  ldarg.0
-    IL_000f:  ldfld      ""int[] Test.<F>d__2.array""
-    IL_0014:  ldc.i4.1
-    IL_0015:  ldelema    ""int""
-    IL_001a:  dup
-    IL_001b:  ldind.i4
-    IL_001c:  ldc.i4.2
-    IL_001d:  add
-    IL_001e:  dup
-    IL_001f:  stloc.2
-    IL_0020:  stind.i4
-    IL_0021:  ldloc.2
-    IL_0022:  stfld      ""int Test.<F>d__2.<>s__1""
-    IL_0027:  ldarg.0
-    IL_0028:  ldarg.0
-    IL_0029:  ldfld      ""int[] Test.<F>d__2.array""
-    IL_002e:  stfld      ""int[] Test.<F>d__2.<>s__4""
-    IL_0033:  ldarg.0
-    IL_0034:  ldfld      ""int[] Test.<F>d__2.<>s__4""
-    IL_0039:  ldc.i4.3
-    IL_003a:  ldelem.i4
-    IL_003b:  pop
-    IL_003c:  ldarg.0
-    IL_003d:  ldarg.0
-    IL_003e:  ldfld      ""int[] Test.<F>d__2.<>s__4""
-    IL_0043:  ldc.i4.3
-    IL_0044:  ldelem.i4
-    IL_0045:  stfld      ""int Test.<F>d__2.<>s__2""
-    IL_004a:  call       ""System.Threading.Tasks.Task<int> Test.G()""
-    IL_004f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0054:  stloc.3
-   ~IL_0055:  ldloca.s   V_3
-    IL_0057:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_005c:  brtrue.s   IL_00a2
-    IL_005e:  ldarg.0
-    IL_005f:  ldc.i4.0
-    IL_0060:  dup
-    IL_0061:  stloc.0
-    IL_0062:  stfld      ""int Test.<F>d__2.<>1__state""
-   <IL_0067:  ldarg.0
-    IL_0068:  ldloc.3
-    IL_0069:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
-    IL_006e:  ldarg.0
-    IL_006f:  stloc.s    V_4
-    IL_0071:  ldarg.0
-    IL_0072:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-    IL_0077:  ldloca.s   V_3
-    IL_0079:  ldloca.s   V_4
-    IL_007b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__2>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__2)""
-    IL_0080:  nop
-    IL_0081:  leave      IL_010e
-   >IL_0086:  ldarg.0
-    IL_0087:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
-    IL_008c:  stloc.3
-    IL_008d:  ldarg.0
-    IL_008e:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
-    IL_0093:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0099:  ldarg.0
-    IL_009a:  ldc.i4.m1
-    IL_009b:  dup
-    IL_009c:  stloc.0
-    IL_009d:  stfld      ""int Test.<F>d__2.<>1__state""
-    IL_00a2:  ldarg.0
-    IL_00a3:  ldloca.s   V_3
-    IL_00a5:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00aa:  stfld      ""int Test.<F>d__2.<>s__3""
-    IL_00af:  ldarg.0
-    IL_00b0:  ldfld      ""int Test.<F>d__2.<>s__1""
-    IL_00b5:  ldarg.0
-    IL_00b6:  ldfld      ""int[] Test.<F>d__2.<>s__4""
-    IL_00bb:  ldc.i4.3
-    IL_00bc:  ldarg.0
-    IL_00bd:  ldfld      ""int Test.<F>d__2.<>s__2""
-    IL_00c2:  ldarg.0
-    IL_00c3:  ldfld      ""int Test.<F>d__2.<>s__3""
-    IL_00c8:  add
-    IL_00c9:  dup
-    IL_00ca:  stloc.2
-    IL_00cb:  stelem.i4
-    IL_00cc:  ldloc.2
-    IL_00cd:  ldc.i4.4
-    IL_00ce:  call       ""int Test.H(int, int, int)""
-    IL_00d3:  pop
-    IL_00d4:  ldarg.0
-    IL_00d5:  ldnull
-    IL_00d6:  stfld      ""int[] Test.<F>d__2.<>s__4""
-   -IL_00db:  ldc.i4.1
-    IL_00dc:  stloc.1
-    IL_00dd:  leave.s    IL_00f9
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_0088
+   -IL_000e:  nop
+   -IL_000f:  ldarg.0
+    IL_0010:  ldarg.0
+    IL_0011:  ldfld      ""int[] Test.<F>d__2.array""
+    IL_0016:  ldc.i4.1
+    IL_0017:  ldelema    ""int""
+    IL_001c:  dup
+    IL_001d:  ldind.i4
+    IL_001e:  ldc.i4.2
+    IL_001f:  add
+    IL_0020:  dup
+    IL_0021:  stloc.2
+    IL_0022:  stind.i4
+    IL_0023:  ldloc.2
+    IL_0024:  stfld      ""int Test.<F>d__2.<>s__1""
+    IL_0029:  ldarg.0
+    IL_002a:  ldarg.0
+    IL_002b:  ldfld      ""int[] Test.<F>d__2.array""
+    IL_0030:  stfld      ""int[] Test.<F>d__2.<>s__4""
+    IL_0035:  ldarg.0
+    IL_0036:  ldfld      ""int[] Test.<F>d__2.<>s__4""
+    IL_003b:  ldc.i4.3
+    IL_003c:  ldelem.i4
+    IL_003d:  pop
+    IL_003e:  ldarg.0
+    IL_003f:  ldarg.0
+    IL_0040:  ldfld      ""int[] Test.<F>d__2.<>s__4""
+    IL_0045:  ldc.i4.3
+    IL_0046:  ldelem.i4
+    IL_0047:  stfld      ""int Test.<F>d__2.<>s__2""
+    IL_004c:  call       ""System.Threading.Tasks.Task<int> Test.G()""
+    IL_0051:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0056:  stloc.3
+   ~IL_0057:  ldloca.s   V_3
+    IL_0059:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_005e:  brtrue.s   IL_00a4
+    IL_0060:  ldarg.0
+    IL_0061:  ldc.i4.0
+    IL_0062:  dup
+    IL_0063:  stloc.0
+    IL_0064:  stfld      ""int Test.<F>d__2.<>1__state""
+   <IL_0069:  ldarg.0
+    IL_006a:  ldloc.3
+    IL_006b:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
+    IL_0070:  ldarg.0
+    IL_0071:  stloc.s    V_4
+    IL_0073:  ldarg.0
+    IL_0074:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+    IL_0079:  ldloca.s   V_3
+    IL_007b:  ldloca.s   V_4
+    IL_007d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__2>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__2)""
+    IL_0082:  nop
+    IL_0083:  leave      IL_0110
+   >IL_0088:  ldarg.0
+    IL_0089:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
+    IL_008e:  stloc.3
+    IL_008f:  ldarg.0
+    IL_0090:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
+    IL_0095:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_009b:  ldarg.0
+    IL_009c:  ldc.i4.m1
+    IL_009d:  dup
+    IL_009e:  stloc.0
+    IL_009f:  stfld      ""int Test.<F>d__2.<>1__state""
+    IL_00a4:  ldarg.0
+    IL_00a5:  ldloca.s   V_3
+    IL_00a7:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00ac:  stfld      ""int Test.<F>d__2.<>s__3""
+    IL_00b1:  ldarg.0
+    IL_00b2:  ldfld      ""int Test.<F>d__2.<>s__1""
+    IL_00b7:  ldarg.0
+    IL_00b8:  ldfld      ""int[] Test.<F>d__2.<>s__4""
+    IL_00bd:  ldc.i4.3
+    IL_00be:  ldarg.0
+    IL_00bf:  ldfld      ""int Test.<F>d__2.<>s__2""
+    IL_00c4:  ldarg.0
+    IL_00c5:  ldfld      ""int Test.<F>d__2.<>s__3""
+    IL_00ca:  add
+    IL_00cb:  dup
+    IL_00cc:  stloc.2
+    IL_00cd:  stelem.i4
+    IL_00ce:  ldloc.2
+    IL_00cf:  ldc.i4.4
+    IL_00d0:  call       ""int Test.H(int, int, int)""
+    IL_00d5:  pop
+    IL_00d6:  ldarg.0
+    IL_00d7:  ldnull
+    IL_00d8:  stfld      ""int[] Test.<F>d__2.<>s__4""
+   -IL_00dd:  ldc.i4.1
+    IL_00de:  stloc.1
+    IL_00df:  leave.s    IL_00fb
   }
   catch System.Exception
   {
-   ~IL_00df:  stloc.s    V_5
-    IL_00e1:  ldarg.0
-    IL_00e2:  ldc.i4.s   -2
-    IL_00e4:  stfld      ""int Test.<F>d__2.<>1__state""
-    IL_00e9:  ldarg.0
-    IL_00ea:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-    IL_00ef:  ldloc.s    V_5
-    IL_00f1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00f6:  nop
-    IL_00f7:  leave.s    IL_010e
+   ~IL_00e1:  stloc.s    V_5
+    IL_00e3:  ldarg.0
+    IL_00e4:  ldc.i4.s   -2
+    IL_00e6:  stfld      ""int Test.<F>d__2.<>1__state""
+    IL_00eb:  ldarg.0
+    IL_00ec:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+    IL_00f1:  ldloc.s    V_5
+    IL_00f3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00f8:  nop
+    IL_00f9:  leave.s    IL_0110
   }
- -IL_00f9:  ldarg.0
-  IL_00fa:  ldc.i4.s   -2
-  IL_00fc:  stfld      ""int Test.<F>d__2.<>1__state""
- ~IL_0101:  ldarg.0
-  IL_0102:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-  IL_0107:  ldloc.1
-  IL_0108:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_010d:  nop
-  IL_010e:  ret
+ -IL_00fb:  ldarg.0
+  IL_00fc:  ldc.i4.s   -2
+  IL_00fe:  stfld      ""int Test.<F>d__2.<>1__state""
+ ~IL_0103:  ldarg.0
+  IL_0104:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+  IL_0109:  ldloc.1
+  IL_010a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_010f:  nop
+  IL_0110:  ret
 }", sequencePoints: "Test+<F>d__2.MoveNext");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -598,7 +597,6 @@ class TestCase
         if ((int)(object)y == 1)
             count++;
     }
-
 }
 
 class Driver
@@ -783,7 +781,6 @@ class TestCase
             Driver.CompleteSignal.Set();
         }
     }
-
 }
 
 class Driver
@@ -2259,7 +2256,6 @@ class Test
 ");
         }
 
-
         [Fact]
         public void AsyncStateMachineIL_Class_TaskT()
         {
@@ -2315,7 +2311,7 @@ class Test
 
             c.VerifyIL("Test.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      203 (0xcb)
+  // Code size      205 (0xcd)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -2328,84 +2324,85 @@ class Test
   .try
   {
    ~IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0069
-    IL_000a:  br.s       IL_000c
-   -IL_000c:  nop
-   -IL_000d:  call       ""System.Threading.Tasks.TaskFactory System.Threading.Tasks.Task.Factory.get""
-    IL_0012:  ldsfld     ""System.Func<int> Test.<>c.<>9__0_0""
-    IL_0017:  dup
-    IL_0018:  brtrue.s   IL_0031
-    IL_001a:  pop
-    IL_001b:  ldsfld     ""Test.<>c Test.<>c.<>9""
-    IL_0020:  ldftn      ""int Test.<>c.<F>b__0_0()""
-    IL_0026:  newobj     ""System.Func<int>..ctor(object, System.IntPtr)""
-    IL_002b:  dup
-    IL_002c:  stsfld     ""System.Func<int> Test.<>c.<>9__0_0""
-    IL_0031:  callvirt   ""System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)""
-    IL_0036:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003b:  stloc.2
-   ~IL_003c:  ldloca.s   V_2
-    IL_003e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0043:  brtrue.s   IL_0085
-    IL_0045:  ldarg.0
-    IL_0046:  ldc.i4.0
-    IL_0047:  dup
-    IL_0048:  stloc.0
-    IL_0049:  stfld      ""int Test.<F>d__0.<>1__state""
-   <IL_004e:  ldarg.0
-    IL_004f:  ldloc.2
-    IL_0050:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
-    IL_0055:  ldarg.0
-    IL_0056:  stloc.3
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_006b
+   -IL_000e:  nop
+   -IL_000f:  call       ""System.Threading.Tasks.TaskFactory System.Threading.Tasks.Task.Factory.get""
+    IL_0014:  ldsfld     ""System.Func<int> Test.<>c.<>9__0_0""
+    IL_0019:  dup
+    IL_001a:  brtrue.s   IL_0033
+    IL_001c:  pop
+    IL_001d:  ldsfld     ""Test.<>c Test.<>c.<>9""
+    IL_0022:  ldftn      ""int Test.<>c.<F>b__0_0()""
+    IL_0028:  newobj     ""System.Func<int>..ctor(object, System.IntPtr)""
+    IL_002d:  dup
+    IL_002e:  stsfld     ""System.Func<int> Test.<>c.<>9__0_0""
+    IL_0033:  callvirt   ""System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)""
+    IL_0038:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003d:  stloc.2
+   ~IL_003e:  ldloca.s   V_2
+    IL_0040:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0045:  brtrue.s   IL_0087
+    IL_0047:  ldarg.0
+    IL_0048:  ldc.i4.0
+    IL_0049:  dup
+    IL_004a:  stloc.0
+    IL_004b:  stfld      ""int Test.<F>d__0.<>1__state""
+   <IL_0050:  ldarg.0
+    IL_0051:  ldloc.2
+    IL_0052:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
     IL_0057:  ldarg.0
-    IL_0058:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-    IL_005d:  ldloca.s   V_2
-    IL_005f:  ldloca.s   V_3
-    IL_0061:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__0)""
-    IL_0066:  nop
-    IL_0067:  leave.s    IL_00ca
-   >IL_0069:  ldarg.0
-    IL_006a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
-    IL_006f:  stloc.2
-    IL_0070:  ldarg.0
-    IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
-    IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.m1
-    IL_007e:  dup
-    IL_007f:  stloc.0
-    IL_0080:  stfld      ""int Test.<F>d__0.<>1__state""
-    IL_0085:  ldarg.0
-    IL_0086:  ldloca.s   V_2
-    IL_0088:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008d:  stfld      ""int Test.<F>d__0.<>s__1""
-    IL_0092:  ldarg.0
-    IL_0093:  ldfld      ""int Test.<F>d__0.<>s__1""
-    IL_0098:  stloc.1
-    IL_0099:  leave.s    IL_00b5
+    IL_0058:  stloc.3
+    IL_0059:  ldarg.0
+    IL_005a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+    IL_005f:  ldloca.s   V_2
+    IL_0061:  ldloca.s   V_3
+    IL_0063:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__0)""
+    IL_0068:  nop
+    IL_0069:  leave.s    IL_00cc
+   >IL_006b:  ldarg.0
+    IL_006c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
+    IL_0071:  stloc.2
+    IL_0072:  ldarg.0
+    IL_0073:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
+    IL_0078:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007e:  ldarg.0
+    IL_007f:  ldc.i4.m1
+    IL_0080:  dup
+    IL_0081:  stloc.0
+    IL_0082:  stfld      ""int Test.<F>d__0.<>1__state""
+    IL_0087:  ldarg.0
+    IL_0088:  ldloca.s   V_2
+    IL_008a:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008f:  stfld      ""int Test.<F>d__0.<>s__1""
+    IL_0094:  ldarg.0
+    IL_0095:  ldfld      ""int Test.<F>d__0.<>s__1""
+    IL_009a:  stloc.1
+    IL_009b:  leave.s    IL_00b7
   }
   catch System.Exception
   {
-   ~IL_009b:  stloc.s    V_4
-    IL_009d:  ldarg.0
-    IL_009e:  ldc.i4.s   -2
-    IL_00a0:  stfld      ""int Test.<F>d__0.<>1__state""
-    IL_00a5:  ldarg.0
-    IL_00a6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-    IL_00ab:  ldloc.s    V_4
-    IL_00ad:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00b2:  nop
-    IL_00b3:  leave.s    IL_00ca
+   ~IL_009d:  stloc.s    V_4
+    IL_009f:  ldarg.0
+    IL_00a0:  ldc.i4.s   -2
+    IL_00a2:  stfld      ""int Test.<F>d__0.<>1__state""
+    IL_00a7:  ldarg.0
+    IL_00a8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+    IL_00ad:  ldloc.s    V_4
+    IL_00af:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00b4:  nop
+    IL_00b5:  leave.s    IL_00cc
   }
- -IL_00b5:  ldarg.0
-  IL_00b6:  ldc.i4.s   -2
-  IL_00b8:  stfld      ""int Test.<F>d__0.<>1__state""
- ~IL_00bd:  ldarg.0
-  IL_00be:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-  IL_00c3:  ldloc.1
-  IL_00c4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00c9:  nop
-  IL_00ca:  ret
+ -IL_00b7:  ldarg.0
+  IL_00b8:  ldc.i4.s   -2
+  IL_00ba:  stfld      ""int Test.<F>d__0.<>1__state""
+ ~IL_00bf:  ldarg.0
+  IL_00c0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+  IL_00c5:  ldloc.1
+  IL_00c6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00cb:  nop
+  IL_00cc:  ret
 }", sequencePoints: "Test+<F>d__0.MoveNext");
 
             c.VerifyIL("Test.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine", @"
@@ -3431,7 +3428,6 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
                 );
         }
 
-
         [Fact]
         public void AsyncTasklikeBadAttributeArgument2()
         {
@@ -3546,7 +3542,6 @@ class Program {
                 );
         }
 
-
         [Fact]
         public void AsyncTasklikeCreateMethod()
         {
@@ -3646,7 +3641,6 @@ namespace System.Runtime.CompilerServices {{ class AsyncMethodBuilderAttribute :
                 );
         }
 
-
         [Fact]
         public void AsyncTasklikeBuilderAccessibility()
         {
@@ -3685,7 +3679,6 @@ namespace System.Runtime.CompilerServices {{ class AsyncMethodBuilderAttribute :
                 Diagnostic(ErrorCode.ERR_BadAsyncReturn, "=> await Task.Delay(3)").WithLocation(67, 19)
                 );
         }
-
 
         [Fact]
         public void AsyncTasklikeLambdaOverloads()
@@ -4048,7 +4041,7 @@ class Test
 
             v.VerifyIL("Test.<F>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      222 (0xde)
+  // Code size      224 (0xe0)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -4061,92 +4054,93 @@ class Test
   .try
   {
    ~IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_006b
-    IL_000a:  br.s       IL_000c
-   -IL_000c:  nop
-   -IL_000d:  ldarg.0
-    IL_000e:  ldc.i4.s   10
-    IL_0010:  newarr     ""S""
-    IL_0015:  stfld      ""S[] Test.<F>d__2.<array>5__1""
-   -IL_001a:  ldarg.0
-    IL_001b:  ldarg.0
-    IL_001c:  ldfld      ""S[] Test.<F>d__2.<array>5__1""
-    IL_0021:  stfld      ""S[] Test.<F>d__2.<>s__3""
-    IL_0026:  ldarg.0
-    IL_0027:  ldfld      ""S[] Test.<F>d__2.<>s__3""
-    IL_002c:  ldc.i4.1
-    IL_002d:  ldelema    ""S""
-    IL_0032:  pop
-    IL_0033:  call       ""System.Threading.Tasks.Task<int> Test.G()""
-    IL_0038:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003d:  stloc.2
-   ~IL_003e:  ldloca.s   V_2
-    IL_0040:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0045:  brtrue.s   IL_0087
-    IL_0047:  ldarg.0
-    IL_0048:  ldc.i4.0
-    IL_0049:  dup
-    IL_004a:  stloc.0
-    IL_004b:  stfld      ""int Test.<F>d__2.<>1__state""
-   <IL_0050:  ldarg.0
-    IL_0051:  ldloc.2
-    IL_0052:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
-    IL_0057:  ldarg.0
-    IL_0058:  stloc.3
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_006d
+   -IL_000e:  nop
+   -IL_000f:  ldarg.0
+    IL_0010:  ldc.i4.s   10
+    IL_0012:  newarr     ""S""
+    IL_0017:  stfld      ""S[] Test.<F>d__2.<array>5__1""
+   -IL_001c:  ldarg.0
+    IL_001d:  ldarg.0
+    IL_001e:  ldfld      ""S[] Test.<F>d__2.<array>5__1""
+    IL_0023:  stfld      ""S[] Test.<F>d__2.<>s__3""
+    IL_0028:  ldarg.0
+    IL_0029:  ldfld      ""S[] Test.<F>d__2.<>s__3""
+    IL_002e:  ldc.i4.1
+    IL_002f:  ldelema    ""S""
+    IL_0034:  pop
+    IL_0035:  call       ""System.Threading.Tasks.Task<int> Test.G()""
+    IL_003a:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003f:  stloc.2
+   ~IL_0040:  ldloca.s   V_2
+    IL_0042:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0047:  brtrue.s   IL_0089
+    IL_0049:  ldarg.0
+    IL_004a:  ldc.i4.0
+    IL_004b:  dup
+    IL_004c:  stloc.0
+    IL_004d:  stfld      ""int Test.<F>d__2.<>1__state""
+   <IL_0052:  ldarg.0
+    IL_0053:  ldloc.2
+    IL_0054:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
     IL_0059:  ldarg.0
-    IL_005a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-    IL_005f:  ldloca.s   V_2
-    IL_0061:  ldloca.s   V_3
-    IL_0063:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__2>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__2)""
-    IL_0068:  nop
-    IL_0069:  leave.s    IL_00dd
-   >IL_006b:  ldarg.0
-    IL_006c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
-    IL_0071:  stloc.2
-    IL_0072:  ldarg.0
-    IL_0073:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
-    IL_0078:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007e:  ldarg.0
-    IL_007f:  ldc.i4.m1
-    IL_0080:  dup
-    IL_0081:  stloc.0
-    IL_0082:  stfld      ""int Test.<F>d__2.<>1__state""
-    IL_0087:  ldarg.0
-    IL_0088:  ldloca.s   V_2
-    IL_008a:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008f:  stfld      ""int Test.<F>d__2.<>s__2""
-    IL_0094:  ldarg.0
-    IL_0095:  ldfld      ""S[] Test.<F>d__2.<>s__3""
-    IL_009a:  ldc.i4.1
-    IL_009b:  ldelema    ""S""
-    IL_00a0:  ldarg.0
-    IL_00a1:  ldfld      ""int Test.<F>d__2.<>s__2""
-    IL_00a6:  call       ""int S.Mutate(int)""
-    IL_00ab:  stloc.1
-    IL_00ac:  leave.s    IL_00c8
+    IL_005a:  stloc.3
+    IL_005b:  ldarg.0
+    IL_005c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+    IL_0061:  ldloca.s   V_2
+    IL_0063:  ldloca.s   V_3
+    IL_0065:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__2>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__2)""
+    IL_006a:  nop
+    IL_006b:  leave.s    IL_00df
+   >IL_006d:  ldarg.0
+    IL_006e:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
+    IL_0073:  stloc.2
+    IL_0074:  ldarg.0
+    IL_0075:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
+    IL_007a:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0080:  ldarg.0
+    IL_0081:  ldc.i4.m1
+    IL_0082:  dup
+    IL_0083:  stloc.0
+    IL_0084:  stfld      ""int Test.<F>d__2.<>1__state""
+    IL_0089:  ldarg.0
+    IL_008a:  ldloca.s   V_2
+    IL_008c:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0091:  stfld      ""int Test.<F>d__2.<>s__2""
+    IL_0096:  ldarg.0
+    IL_0097:  ldfld      ""S[] Test.<F>d__2.<>s__3""
+    IL_009c:  ldc.i4.1
+    IL_009d:  ldelema    ""S""
+    IL_00a2:  ldarg.0
+    IL_00a3:  ldfld      ""int Test.<F>d__2.<>s__2""
+    IL_00a8:  call       ""int S.Mutate(int)""
+    IL_00ad:  stloc.1
+    IL_00ae:  leave.s    IL_00ca
   }
   catch System.Exception
   {
-   ~IL_00ae:  stloc.s    V_4
-    IL_00b0:  ldarg.0
-    IL_00b1:  ldc.i4.s   -2
-    IL_00b3:  stfld      ""int Test.<F>d__2.<>1__state""
-    IL_00b8:  ldarg.0
-    IL_00b9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-    IL_00be:  ldloc.s    V_4
-    IL_00c0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00c5:  nop
-    IL_00c6:  leave.s    IL_00dd
+   ~IL_00b0:  stloc.s    V_4
+    IL_00b2:  ldarg.0
+    IL_00b3:  ldc.i4.s   -2
+    IL_00b5:  stfld      ""int Test.<F>d__2.<>1__state""
+    IL_00ba:  ldarg.0
+    IL_00bb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+    IL_00c0:  ldloc.s    V_4
+    IL_00c2:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00c7:  nop
+    IL_00c8:  leave.s    IL_00df
   }
- -IL_00c8:  ldarg.0
-  IL_00c9:  ldc.i4.s   -2
-  IL_00cb:  stfld      ""int Test.<F>d__2.<>1__state""
- ~IL_00d0:  ldarg.0
-  IL_00d1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-  IL_00d6:  ldloc.1
-  IL_00d7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00dc:  nop
-  IL_00dd:  ret
+ -IL_00ca:  ldarg.0
+  IL_00cb:  ldc.i4.s   -2
+  IL_00cd:  stfld      ""int Test.<F>d__2.<>1__state""
+ ~IL_00d2:  ldarg.0
+  IL_00d3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+  IL_00d8:  ldloc.1
+  IL_00d9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00de:  nop
+  IL_00df:  ret
 }",
             sequencePoints: "Test+<F>d__2.MoveNext");
         }
@@ -4799,7 +4793,6 @@ class C
                 //     async Task GetNumber(Task task) { await task; }
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await task; }").WithArguments("System.Runtime.CompilerServices.IAsyncStateMachine", "SetStateMachine").WithLocation(62, 37));
         }
-
 
         [Fact, WorkItem(16531, "https://github.com/dotnet/roslyn/issues/16531")]
         public void ArityMismatch()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -2481,7 +2481,7 @@ public class C
 
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      260 (0x104)
+  // Code size      262 (0x106)
   .maxstack  3
   .locals init (int V_0,
                 System.Threading.CancellationToken V_1,
@@ -2496,116 +2496,117 @@ public class C
   {
     // sequence point: <hidden>
     IL_0007:  ldloc.0
-    IL_0008:  brfalse    IL_0098
-    IL_000d:  br.s       IL_000f
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_0011
+    IL_000c:  br         IL_009a
     // sequence point: {
-    IL_000f:  nop
+    IL_0011:  nop
     // sequence point: foreach
-    IL_0010:  nop
+    IL_0012:  nop
     // sequence point: new C()
-    IL_0011:  ldarg.0
-    IL_0012:  newobj     ""C..ctor()""
-    IL_0017:  ldloca.s   V_1
-    IL_0019:  initobj    ""System.Threading.CancellationToken""
-    IL_001f:  ldloc.1
-    IL_0020:  call       ""C.Enumerator C.GetAsyncEnumerator(System.Threading.CancellationToken)""
-    IL_0025:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_0013:  ldarg.0
+    IL_0014:  newobj     ""C..ctor()""
+    IL_0019:  ldloca.s   V_1
+    IL_001b:  initobj    ""System.Threading.CancellationToken""
+    IL_0021:  ldloc.1
+    IL_0022:  call       ""C.Enumerator C.GetAsyncEnumerator(System.Threading.CancellationToken)""
+    IL_0027:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
     // sequence point: <hidden>
-    IL_002a:  br.s       IL_005a
+    IL_002c:  br.s       IL_005c
     // sequence point: var i
-    IL_002c:  ldarg.0
-    IL_002d:  ldarg.0
-    IL_002e:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
-    IL_0033:  callvirt   ""int C.Enumerator.Current.get""
-    IL_0038:  stfld      ""int C.<Main>d__0.<i>5__2""
+    IL_002e:  ldarg.0
+    IL_002f:  ldarg.0
+    IL_0030:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_0035:  callvirt   ""int C.Enumerator.Current.get""
+    IL_003a:  stfld      ""int C.<Main>d__0.<i>5__2""
     // sequence point: {
-    IL_003d:  nop
+    IL_003f:  nop
     // sequence point: Write($""Got({i}) "");
-    IL_003e:  ldstr      ""Got({0}) ""
-    IL_0043:  ldarg.0
-    IL_0044:  ldfld      ""int C.<Main>d__0.<i>5__2""
-    IL_0049:  box        ""int""
-    IL_004e:  call       ""string string.Format(string, object)""
-    IL_0053:  call       ""void System.Console.Write(string)""
-    IL_0058:  nop
+    IL_0040:  ldstr      ""Got({0}) ""
+    IL_0045:  ldarg.0
+    IL_0046:  ldfld      ""int C.<Main>d__0.<i>5__2""
+    IL_004b:  box        ""int""
+    IL_0050:  call       ""string string.Format(string, object)""
+    IL_0055:  call       ""void System.Console.Write(string)""
+    IL_005a:  nop
     // sequence point: }
-    IL_0059:  nop
+    IL_005b:  nop
     // sequence point: in
-    IL_005a:  ldarg.0
-    IL_005b:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
-    IL_0060:  callvirt   ""System.Threading.Tasks.Task<bool> C.Enumerator.MoveNextAsync()""
-    IL_0065:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
-    IL_006a:  stloc.2
+    IL_005c:  ldarg.0
+    IL_005d:  ldfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_0062:  callvirt   ""System.Threading.Tasks.Task<bool> C.Enumerator.MoveNextAsync()""
+    IL_0067:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
+    IL_006c:  stloc.2
     // sequence point: <hidden>
-    IL_006b:  ldloca.s   V_2
-    IL_006d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
-    IL_0072:  brtrue.s   IL_00b4
-    IL_0074:  ldarg.0
-    IL_0075:  ldc.i4.0
-    IL_0076:  dup
-    IL_0077:  stloc.0
-    IL_0078:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_006d:  ldloca.s   V_2
+    IL_006f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
+    IL_0074:  brtrue.s   IL_00b6
+    IL_0076:  ldarg.0
+    IL_0077:  ldc.i4.0
+    IL_0078:  dup
+    IL_0079:  stloc.0
+    IL_007a:  stfld      ""int C.<Main>d__0.<>1__state""
     // async: yield
-    IL_007d:  ldarg.0
-    IL_007e:  ldloc.2
-    IL_007f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_0084:  ldarg.0
-    IL_0085:  stloc.3
+    IL_007f:  ldarg.0
+    IL_0080:  ldloc.2
+    IL_0081:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
     IL_0086:  ldarg.0
-    IL_0087:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_008c:  ldloca.s   V_2
-    IL_008e:  ldloca.s   V_3
-    IL_0090:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
-    IL_0095:  nop
-    IL_0096:  leave.s    IL_0103
+    IL_0087:  stloc.3
+    IL_0088:  ldarg.0
+    IL_0089:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_008e:  ldloca.s   V_2
+    IL_0090:  ldloca.s   V_3
+    IL_0092:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
+    IL_0097:  nop
+    IL_0098:  leave.s    IL_0105
     // async: resume
-    IL_0098:  ldarg.0
-    IL_0099:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_009e:  stloc.2
-    IL_009f:  ldarg.0
-    IL_00a0:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_00a5:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
-    IL_00ab:  ldarg.0
-    IL_00ac:  ldc.i4.m1
-    IL_00ad:  dup
-    IL_00ae:  stloc.0
-    IL_00af:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_00b4:  ldarg.0
-    IL_00b5:  ldloca.s   V_2
-    IL_00b7:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
-    IL_00bc:  stfld      ""bool C.<Main>d__0.<>s__3""
-    IL_00c1:  ldarg.0
-    IL_00c2:  ldfld      ""bool C.<Main>d__0.<>s__3""
-    IL_00c7:  brtrue     IL_002c
-    IL_00cc:  ldarg.0
-    IL_00cd:  ldnull
-    IL_00ce:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
-    IL_00d3:  leave.s    IL_00ef
+    IL_009a:  ldarg.0
+    IL_009b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_00a0:  stloc.2
+    IL_00a1:  ldarg.0
+    IL_00a2:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_00a7:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
+    IL_00ad:  ldarg.0
+    IL_00ae:  ldc.i4.m1
+    IL_00af:  dup
+    IL_00b0:  stloc.0
+    IL_00b1:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00b6:  ldarg.0
+    IL_00b7:  ldloca.s   V_2
+    IL_00b9:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
+    IL_00be:  stfld      ""bool C.<Main>d__0.<>s__3""
+    IL_00c3:  ldarg.0
+    IL_00c4:  ldfld      ""bool C.<Main>d__0.<>s__3""
+    IL_00c9:  brtrue     IL_002e
+    IL_00ce:  ldarg.0
+    IL_00cf:  ldnull
+    IL_00d0:  stfld      ""C.Enumerator C.<Main>d__0.<>s__1""
+    IL_00d5:  leave.s    IL_00f1
   }
   catch System.Exception
   {
     // sequence point: <hidden>
-    IL_00d5:  stloc.s    V_4
-    IL_00d7:  ldarg.0
-    IL_00d8:  ldc.i4.s   -2
-    IL_00da:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_00df:  ldarg.0
-    IL_00e0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_00e5:  ldloc.s    V_4
-    IL_00e7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00ec:  nop
-    IL_00ed:  leave.s    IL_0103
+    IL_00d7:  stloc.s    V_4
+    IL_00d9:  ldarg.0
+    IL_00da:  ldc.i4.s   -2
+    IL_00dc:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00e1:  ldarg.0
+    IL_00e2:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_00e7:  ldloc.s    V_4
+    IL_00e9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00ee:  nop
+    IL_00ef:  leave.s    IL_0105
   }
   // sequence point: }
-  IL_00ef:  ldarg.0
-  IL_00f0:  ldc.i4.s   -2
-  IL_00f2:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_00f1:  ldarg.0
+  IL_00f2:  ldc.i4.s   -2
+  IL_00f4:  stfld      ""int C.<Main>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_00f7:  ldarg.0
-  IL_00f8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_00fd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0102:  nop
-  IL_0103:  ret
+  IL_00f9:  ldarg.0
+  IL_00fa:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_00ff:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0104:  nop
+  IL_0105:  ret
 }", sequencePoints: "C+<Main>d__0.MoveNext", source: source + s_IAsyncEnumerable);
         }
 
@@ -2901,7 +2902,7 @@ struct C : IAsyncEnumerable<int>
             // The thing to notice here is that the call to GetAsyncEnumerator is a constrained call (we're not boxing to `IAsyncEnumerable<int>`)
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      490 (0x1ea)
+  // Code size      496 (0x1f0)
   .maxstack  3
   .locals init (int V_0,
                 C V_1,
@@ -2919,198 +2920,201 @@ struct C : IAsyncEnumerable<int>
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0048
+    IL_0008:  brfalse.s  IL_0012
     IL_000a:  br.s       IL_000c
     IL_000c:  ldloc.0
     IL_000d:  ldc.i4.1
-    IL_000e:  beq        IL_0156
-    IL_0013:  br.s       IL_0015
-    IL_0015:  nop
-    IL_0016:  nop
-    IL_0017:  ldarg.0
-    IL_0018:  ldloca.s   V_1
-    IL_001a:  dup
-    IL_001b:  initobj    ""C""
-    IL_0021:  ldloca.s   V_2
-    IL_0023:  initobj    ""System.Threading.CancellationToken""
-    IL_0029:  ldloc.2
-    IL_002a:  constrained. ""C""
-    IL_0030:  callvirt   ""System.Collections.Generic.IAsyncEnumerator<int> System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
-    IL_0035:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
-    IL_003a:  ldarg.0
-    IL_003b:  ldnull
-    IL_003c:  stfld      ""object C.<Main>d__0.<>s__2""
-    IL_0041:  ldarg.0
-    IL_0042:  ldc.i4.0
-    IL_0043:  stfld      ""int C.<Main>d__0.<>s__3""
-    IL_0048:  nop
+    IL_000e:  beq.s      IL_0014
+    IL_0010:  br.s       IL_0019
+    IL_0012:  br.s       IL_004c
+    IL_0014:  br         IL_015c
+    IL_0019:  nop
+    IL_001a:  nop
+    IL_001b:  ldarg.0
+    IL_001c:  ldloca.s   V_1
+    IL_001e:  dup
+    IL_001f:  initobj    ""C""
+    IL_0025:  ldloca.s   V_2
+    IL_0027:  initobj    ""System.Threading.CancellationToken""
+    IL_002d:  ldloc.2
+    IL_002e:  constrained. ""C""
+    IL_0034:  callvirt   ""System.Collections.Generic.IAsyncEnumerator<int> System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
+    IL_0039:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
+    IL_003e:  ldarg.0
+    IL_003f:  ldnull
+    IL_0040:  stfld      ""object C.<Main>d__0.<>s__2""
+    IL_0045:  ldarg.0
+    IL_0046:  ldc.i4.0
+    IL_0047:  stfld      ""int C.<Main>d__0.<>s__3""
+    IL_004c:  nop
     .try
     {
-      IL_0049:  ldloc.0
-      IL_004a:  brfalse.s  IL_00c4
-      IL_004c:  br.s       IL_004e
-      IL_004e:  br.s       IL_007e
-      IL_0050:  ldarg.0
-      IL_0051:  ldarg.0
-      IL_0052:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
-      IL_0057:  callvirt   ""int System.Collections.Generic.IAsyncEnumerator<int>.Current.get""
-      IL_005c:  stfld      ""int C.<Main>d__0.<i>5__4""
-      IL_0061:  nop
-      IL_0062:  ldstr      ""Got({0}) ""
-      IL_0067:  ldarg.0
-      IL_0068:  ldfld      ""int C.<Main>d__0.<i>5__4""
-      IL_006d:  box        ""int""
-      IL_0072:  call       ""string string.Format(string, object)""
-      IL_0077:  call       ""void System.Console.Write(string)""
-      IL_007c:  nop
-      IL_007d:  nop
-      IL_007e:  ldarg.0
-      IL_007f:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
-      IL_0084:  callvirt   ""System.Threading.Tasks.ValueTask<bool> System.Collections.Generic.IAsyncEnumerator<int>.MoveNextAsync()""
-      IL_0089:  stloc.s    V_4
-      IL_008b:  ldloca.s   V_4
-      IL_008d:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> System.Threading.Tasks.ValueTask<bool>.GetAwaiter()""
-      IL_0092:  stloc.3
-      IL_0093:  ldloca.s   V_3
-      IL_0095:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.IsCompleted.get""
-      IL_009a:  brtrue.s   IL_00e0
-      IL_009c:  ldarg.0
-      IL_009d:  ldc.i4.0
-      IL_009e:  dup
-      IL_009f:  stloc.0
-      IL_00a0:  stfld      ""int C.<Main>d__0.<>1__state""
-      IL_00a5:  ldarg.0
-      IL_00a6:  ldloc.3
-      IL_00a7:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<Main>d__0.<>u__1""
-      IL_00ac:  ldarg.0
-      IL_00ad:  stloc.s    V_5
-      IL_00af:  ldarg.0
-      IL_00b0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-      IL_00b5:  ldloca.s   V_3
-      IL_00b7:  ldloca.s   V_5
-      IL_00b9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, ref C.<Main>d__0)""
-      IL_00be:  nop
-      IL_00bf:  leave      IL_01e9
-      IL_00c4:  ldarg.0
-      IL_00c5:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<Main>d__0.<>u__1""
-      IL_00ca:  stloc.3
-      IL_00cb:  ldarg.0
-      IL_00cc:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<Main>d__0.<>u__1""
-      IL_00d1:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool>""
-      IL_00d7:  ldarg.0
-      IL_00d8:  ldc.i4.m1
-      IL_00d9:  dup
-      IL_00da:  stloc.0
-      IL_00db:  stfld      ""int C.<Main>d__0.<>1__state""
-      IL_00e0:  ldarg.0
-      IL_00e1:  ldloca.s   V_3
-      IL_00e3:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.GetResult()""
-      IL_00e8:  stfld      ""bool C.<Main>d__0.<>s__5""
-      IL_00ed:  ldarg.0
-      IL_00ee:  ldfld      ""bool C.<Main>d__0.<>s__5""
-      IL_00f3:  brtrue     IL_0050
-      IL_00f8:  leave.s    IL_0106
+      IL_004d:  ldloc.0
+      IL_004e:  brfalse.s  IL_0052
+      IL_0050:  br.s       IL_0054
+      IL_0052:  br.s       IL_00ca
+      IL_0054:  br.s       IL_0084
+      IL_0056:  ldarg.0
+      IL_0057:  ldarg.0
+      IL_0058:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
+      IL_005d:  callvirt   ""int System.Collections.Generic.IAsyncEnumerator<int>.Current.get""
+      IL_0062:  stfld      ""int C.<Main>d__0.<i>5__4""
+      IL_0067:  nop
+      IL_0068:  ldstr      ""Got({0}) ""
+      IL_006d:  ldarg.0
+      IL_006e:  ldfld      ""int C.<Main>d__0.<i>5__4""
+      IL_0073:  box        ""int""
+      IL_0078:  call       ""string string.Format(string, object)""
+      IL_007d:  call       ""void System.Console.Write(string)""
+      IL_0082:  nop
+      IL_0083:  nop
+      IL_0084:  ldarg.0
+      IL_0085:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
+      IL_008a:  callvirt   ""System.Threading.Tasks.ValueTask<bool> System.Collections.Generic.IAsyncEnumerator<int>.MoveNextAsync()""
+      IL_008f:  stloc.s    V_4
+      IL_0091:  ldloca.s   V_4
+      IL_0093:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> System.Threading.Tasks.ValueTask<bool>.GetAwaiter()""
+      IL_0098:  stloc.3
+      IL_0099:  ldloca.s   V_3
+      IL_009b:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.IsCompleted.get""
+      IL_00a0:  brtrue.s   IL_00e6
+      IL_00a2:  ldarg.0
+      IL_00a3:  ldc.i4.0
+      IL_00a4:  dup
+      IL_00a5:  stloc.0
+      IL_00a6:  stfld      ""int C.<Main>d__0.<>1__state""
+      IL_00ab:  ldarg.0
+      IL_00ac:  ldloc.3
+      IL_00ad:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<Main>d__0.<>u__1""
+      IL_00b2:  ldarg.0
+      IL_00b3:  stloc.s    V_5
+      IL_00b5:  ldarg.0
+      IL_00b6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+      IL_00bb:  ldloca.s   V_3
+      IL_00bd:  ldloca.s   V_5
+      IL_00bf:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter<bool>, ref C.<Main>d__0)""
+      IL_00c4:  nop
+      IL_00c5:  leave      IL_01ef
+      IL_00ca:  ldarg.0
+      IL_00cb:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<Main>d__0.<>u__1""
+      IL_00d0:  stloc.3
+      IL_00d1:  ldarg.0
+      IL_00d2:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool> C.<Main>d__0.<>u__1""
+      IL_00d7:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter<bool>""
+      IL_00dd:  ldarg.0
+      IL_00de:  ldc.i4.m1
+      IL_00df:  dup
+      IL_00e0:  stloc.0
+      IL_00e1:  stfld      ""int C.<Main>d__0.<>1__state""
+      IL_00e6:  ldarg.0
+      IL_00e7:  ldloca.s   V_3
+      IL_00e9:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter<bool>.GetResult()""
+      IL_00ee:  stfld      ""bool C.<Main>d__0.<>s__5""
+      IL_00f3:  ldarg.0
+      IL_00f4:  ldfld      ""bool C.<Main>d__0.<>s__5""
+      IL_00f9:  brtrue     IL_0056
+      IL_00fe:  leave.s    IL_010c
     }
     catch object
     {
-      IL_00fa:  stloc.s    V_6
-      IL_00fc:  ldarg.0
-      IL_00fd:  ldloc.s    V_6
-      IL_00ff:  stfld      ""object C.<Main>d__0.<>s__2""
-      IL_0104:  leave.s    IL_0106
+      IL_0100:  stloc.s    V_6
+      IL_0102:  ldarg.0
+      IL_0103:  ldloc.s    V_6
+      IL_0105:  stfld      ""object C.<Main>d__0.<>s__2""
+      IL_010a:  leave.s    IL_010c
     }
-    IL_0106:  ldarg.0
-    IL_0107:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
-    IL_010c:  brfalse.s  IL_017b
-    IL_010e:  ldarg.0
-    IL_010f:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
-    IL_0114:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
-    IL_0119:  stloc.s    V_8
-    IL_011b:  ldloca.s   V_8
-    IL_011d:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
-    IL_0122:  stloc.s    V_7
-    IL_0124:  ldloca.s   V_7
-    IL_0126:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
-    IL_012b:  brtrue.s   IL_0173
-    IL_012d:  ldarg.0
-    IL_012e:  ldc.i4.1
-    IL_012f:  dup
-    IL_0130:  stloc.0
-    IL_0131:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_0136:  ldarg.0
-    IL_0137:  ldloc.s    V_7
-    IL_0139:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
-    IL_013e:  ldarg.0
-    IL_013f:  stloc.s    V_5
-    IL_0141:  ldarg.0
-    IL_0142:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_0147:  ldloca.s   V_7
-    IL_0149:  ldloca.s   V_5
-    IL_014b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
-    IL_0150:  nop
-    IL_0151:  leave      IL_01e9
-    IL_0156:  ldarg.0
-    IL_0157:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
-    IL_015c:  stloc.s    V_7
-    IL_015e:  ldarg.0
-    IL_015f:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
-    IL_0164:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
-    IL_016a:  ldarg.0
-    IL_016b:  ldc.i4.m1
-    IL_016c:  dup
-    IL_016d:  stloc.0
-    IL_016e:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_0173:  ldloca.s   V_7
-    IL_0175:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
-    IL_017a:  nop
-    IL_017b:  ldarg.0
-    IL_017c:  ldfld      ""object C.<Main>d__0.<>s__2""
-    IL_0181:  stloc.s    V_6
-    IL_0183:  ldloc.s    V_6
-    IL_0185:  brfalse.s  IL_01a4
-    IL_0187:  ldloc.s    V_6
-    IL_0189:  isinst     ""System.Exception""
-    IL_018e:  stloc.s    V_9
-    IL_0190:  ldloc.s    V_9
-    IL_0192:  brtrue.s   IL_0197
-    IL_0194:  ldloc.s    V_6
-    IL_0196:  throw
-    IL_0197:  ldloc.s    V_9
-    IL_0199:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_019e:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_01a3:  nop
-    IL_01a4:  ldarg.0
-    IL_01a5:  ldfld      ""int C.<Main>d__0.<>s__3""
-    IL_01aa:  pop
-    IL_01ab:  ldarg.0
-    IL_01ac:  ldnull
-    IL_01ad:  stfld      ""object C.<Main>d__0.<>s__2""
-    IL_01b2:  ldarg.0
-    IL_01b3:  ldnull
-    IL_01b4:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
-    IL_01b9:  leave.s    IL_01d5
+    IL_010c:  ldarg.0
+    IL_010d:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
+    IL_0112:  brfalse.s  IL_0181
+    IL_0114:  ldarg.0
+    IL_0115:  ldfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
+    IL_011a:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
+    IL_011f:  stloc.s    V_8
+    IL_0121:  ldloca.s   V_8
+    IL_0123:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
+    IL_0128:  stloc.s    V_7
+    IL_012a:  ldloca.s   V_7
+    IL_012c:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
+    IL_0131:  brtrue.s   IL_0179
+    IL_0133:  ldarg.0
+    IL_0134:  ldc.i4.1
+    IL_0135:  dup
+    IL_0136:  stloc.0
+    IL_0137:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_013c:  ldarg.0
+    IL_013d:  ldloc.s    V_7
+    IL_013f:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
+    IL_0144:  ldarg.0
+    IL_0145:  stloc.s    V_5
+    IL_0147:  ldarg.0
+    IL_0148:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_014d:  ldloca.s   V_7
+    IL_014f:  ldloca.s   V_5
+    IL_0151:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
+    IL_0156:  nop
+    IL_0157:  leave      IL_01ef
+    IL_015c:  ldarg.0
+    IL_015d:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
+    IL_0162:  stloc.s    V_7
+    IL_0164:  ldarg.0
+    IL_0165:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__2""
+    IL_016a:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
+    IL_0170:  ldarg.0
+    IL_0171:  ldc.i4.m1
+    IL_0172:  dup
+    IL_0173:  stloc.0
+    IL_0174:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_0179:  ldloca.s   V_7
+    IL_017b:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
+    IL_0180:  nop
+    IL_0181:  ldarg.0
+    IL_0182:  ldfld      ""object C.<Main>d__0.<>s__2""
+    IL_0187:  stloc.s    V_6
+    IL_0189:  ldloc.s    V_6
+    IL_018b:  brfalse.s  IL_01aa
+    IL_018d:  ldloc.s    V_6
+    IL_018f:  isinst     ""System.Exception""
+    IL_0194:  stloc.s    V_9
+    IL_0196:  ldloc.s    V_9
+    IL_0198:  brtrue.s   IL_019d
+    IL_019a:  ldloc.s    V_6
+    IL_019c:  throw
+    IL_019d:  ldloc.s    V_9
+    IL_019f:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_01a4:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_01a9:  nop
+    IL_01aa:  ldarg.0
+    IL_01ab:  ldfld      ""int C.<Main>d__0.<>s__3""
+    IL_01b0:  pop
+    IL_01b1:  ldarg.0
+    IL_01b2:  ldnull
+    IL_01b3:  stfld      ""object C.<Main>d__0.<>s__2""
+    IL_01b8:  ldarg.0
+    IL_01b9:  ldnull
+    IL_01ba:  stfld      ""System.Collections.Generic.IAsyncEnumerator<int> C.<Main>d__0.<>s__1""
+    IL_01bf:  leave.s    IL_01db
   }
   catch System.Exception
   {
-    IL_01bb:  stloc.s    V_9
-    IL_01bd:  ldarg.0
-    IL_01be:  ldc.i4.s   -2
-    IL_01c0:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_01c5:  ldarg.0
-    IL_01c6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_01cb:  ldloc.s    V_9
-    IL_01cd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_01d2:  nop
-    IL_01d3:  leave.s    IL_01e9
+    IL_01c1:  stloc.s    V_9
+    IL_01c3:  ldarg.0
+    IL_01c4:  ldc.i4.s   -2
+    IL_01c6:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_01cb:  ldarg.0
+    IL_01cc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_01d1:  ldloc.s    V_9
+    IL_01d3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_01d8:  nop
+    IL_01d9:  leave.s    IL_01ef
   }
-  IL_01d5:  ldarg.0
-  IL_01d6:  ldc.i4.s   -2
-  IL_01d8:  stfld      ""int C.<Main>d__0.<>1__state""
-  IL_01dd:  ldarg.0
-  IL_01de:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_01e3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_01e8:  nop
-  IL_01e9:  ret
+  IL_01db:  ldarg.0
+  IL_01dc:  ldc.i4.s   -2
+  IL_01de:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_01e3:  ldarg.0
+  IL_01e4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_01e9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_01ee:  nop
+  IL_01ef:  ret
 }");
         }
 
@@ -4183,7 +4187,7 @@ class C
 
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      256 (0x100)
+  // Code size      258 (0x102)
   .maxstack  3
   .locals init (int V_0,
                 System.Threading.CancellationToken V_1,
@@ -4198,117 +4202,118 @@ class C
   {
     // sequence point: <hidden>
     IL_0007:  ldloc.0
-    IL_0008:  brfalse    IL_0094
-    IL_000d:  br.s       IL_000f
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_0011
+    IL_000c:  br         IL_0096
     // sequence point: {
-    IL_000f:  nop
+    IL_0011:  nop
     // sequence point: ICollection<int> c = new Collection<int>();
-    IL_0010:  ldarg.0
-    IL_0011:  newobj     ""Collection<int>..ctor()""
-    IL_0016:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
+    IL_0012:  ldarg.0
+    IL_0013:  newobj     ""Collection<int>..ctor()""
+    IL_0018:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
     // sequence point: foreach
-    IL_001b:  nop
+    IL_001d:  nop
     // sequence point: c
-    IL_001c:  ldarg.0
-    IL_001d:  ldarg.0
-    IL_001e:  ldfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
-    IL_0023:  ldloca.s   V_1
-    IL_0025:  initobj    ""System.Threading.CancellationToken""
-    IL_002b:  ldloc.1
-    IL_002c:  callvirt   ""IMyAsyncEnumerator<int> ICollection<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
-    IL_0031:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_001e:  ldarg.0
+    IL_001f:  ldarg.0
+    IL_0020:  ldfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
+    IL_0025:  ldloca.s   V_1
+    IL_0027:  initobj    ""System.Threading.CancellationToken""
+    IL_002d:  ldloc.1
+    IL_002e:  callvirt   ""IMyAsyncEnumerator<int> ICollection<int>.GetAsyncEnumerator(System.Threading.CancellationToken)""
+    IL_0033:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
     // sequence point: <hidden>
-    IL_0036:  br.s       IL_0056
+    IL_0038:  br.s       IL_0058
     // sequence point: var i
-    IL_0038:  ldarg.0
-    IL_0039:  ldarg.0
-    IL_003a:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-    IL_003f:  callvirt   ""int IMyAsyncEnumerator<int>.Current.get""
-    IL_0044:  stfld      ""int C.<Main>d__0.<i>5__3""
+    IL_003a:  ldarg.0
+    IL_003b:  ldarg.0
+    IL_003c:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_0041:  callvirt   ""int IMyAsyncEnumerator<int>.Current.get""
+    IL_0046:  stfld      ""int C.<Main>d__0.<i>5__3""
     // sequence point: {
-    IL_0049:  nop
+    IL_004b:  nop
     // sequence point: Write($""Got "");
-    IL_004a:  ldstr      ""Got ""
-    IL_004f:  call       ""void System.Console.Write(string)""
-    IL_0054:  nop
+    IL_004c:  ldstr      ""Got ""
+    IL_0051:  call       ""void System.Console.Write(string)""
+    IL_0056:  nop
     // sequence point: }
-    IL_0055:  nop
+    IL_0057:  nop
     // sequence point: in
-    IL_0056:  ldarg.0
-    IL_0057:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-    IL_005c:  callvirt   ""System.Threading.Tasks.Task<bool> IMyAsyncEnumerator<int>.MoveNextAsync()""
-    IL_0061:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
-    IL_0066:  stloc.2
+    IL_0058:  ldarg.0
+    IL_0059:  ldfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_005e:  callvirt   ""System.Threading.Tasks.Task<bool> IMyAsyncEnumerator<int>.MoveNextAsync()""
+    IL_0063:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
+    IL_0068:  stloc.2
     // sequence point: <hidden>
-    IL_0067:  ldloca.s   V_2
-    IL_0069:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
-    IL_006e:  brtrue.s   IL_00b0
-    IL_0070:  ldarg.0
-    IL_0071:  ldc.i4.0
-    IL_0072:  dup
-    IL_0073:  stloc.0
-    IL_0074:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_0069:  ldloca.s   V_2
+    IL_006b:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
+    IL_0070:  brtrue.s   IL_00b2
+    IL_0072:  ldarg.0
+    IL_0073:  ldc.i4.0
+    IL_0074:  dup
+    IL_0075:  stloc.0
+    IL_0076:  stfld      ""int C.<Main>d__0.<>1__state""
     // async: yield
-    IL_0079:  ldarg.0
-    IL_007a:  ldloc.2
-    IL_007b:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_0080:  ldarg.0
-    IL_0081:  stloc.3
+    IL_007b:  ldarg.0
+    IL_007c:  ldloc.2
+    IL_007d:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
     IL_0082:  ldarg.0
-    IL_0083:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_0088:  ldloca.s   V_2
-    IL_008a:  ldloca.s   V_3
-    IL_008c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
-    IL_0091:  nop
-    IL_0092:  leave.s    IL_00ff
+    IL_0083:  stloc.3
+    IL_0084:  ldarg.0
+    IL_0085:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_008a:  ldloca.s   V_2
+    IL_008c:  ldloca.s   V_3
+    IL_008e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
+    IL_0093:  nop
+    IL_0094:  leave.s    IL_0101
     // async: resume
-    IL_0094:  ldarg.0
-    IL_0095:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_009a:  stloc.2
-    IL_009b:  ldarg.0
-    IL_009c:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
-    IL_00a1:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
-    IL_00a7:  ldarg.0
-    IL_00a8:  ldc.i4.m1
-    IL_00a9:  dup
-    IL_00aa:  stloc.0
-    IL_00ab:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_00b0:  ldarg.0
-    IL_00b1:  ldloca.s   V_2
-    IL_00b3:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
-    IL_00b8:  stfld      ""bool C.<Main>d__0.<>s__4""
-    IL_00bd:  ldarg.0
-    IL_00be:  ldfld      ""bool C.<Main>d__0.<>s__4""
-    IL_00c3:  brtrue     IL_0038
-    IL_00c8:  ldarg.0
-    IL_00c9:  ldnull
-    IL_00ca:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-    IL_00cf:  leave.s    IL_00eb
+    IL_0096:  ldarg.0
+    IL_0097:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_009c:  stloc.2
+    IL_009d:  ldarg.0
+    IL_009e:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
+    IL_00a3:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
+    IL_00a9:  ldarg.0
+    IL_00aa:  ldc.i4.m1
+    IL_00ab:  dup
+    IL_00ac:  stloc.0
+    IL_00ad:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00b2:  ldarg.0
+    IL_00b3:  ldloca.s   V_2
+    IL_00b5:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
+    IL_00ba:  stfld      ""bool C.<Main>d__0.<>s__4""
+    IL_00bf:  ldarg.0
+    IL_00c0:  ldfld      ""bool C.<Main>d__0.<>s__4""
+    IL_00c5:  brtrue     IL_003a
+    IL_00ca:  ldarg.0
+    IL_00cb:  ldnull
+    IL_00cc:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
+    IL_00d1:  leave.s    IL_00ed
   }
   catch System.Exception
   {
     // sequence point: <hidden>
-    IL_00d1:  stloc.s    V_4
-    IL_00d3:  ldarg.0
-    IL_00d4:  ldc.i4.s   -2
-    IL_00d6:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_00db:  ldarg.0
-    IL_00dc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_00e1:  ldloc.s    V_4
-    IL_00e3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00e8:  nop
-    IL_00e9:  leave.s    IL_00ff
+    IL_00d3:  stloc.s    V_4
+    IL_00d5:  ldarg.0
+    IL_00d6:  ldc.i4.s   -2
+    IL_00d8:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00dd:  ldarg.0
+    IL_00de:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_00e3:  ldloc.s    V_4
+    IL_00e5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00ea:  nop
+    IL_00eb:  leave.s    IL_0101
   }
   // sequence point: }
-  IL_00eb:  ldarg.0
-  IL_00ec:  ldc.i4.s   -2
-  IL_00ee:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_00ed:  ldarg.0
+  IL_00ee:  ldc.i4.s   -2
+  IL_00f0:  stfld      ""int C.<Main>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_00f3:  ldarg.0
-  IL_00f4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_00f9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_00fe:  nop
-  IL_00ff:  ret
+  IL_00f5:  ldarg.0
+  IL_00f6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_00fb:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0100:  nop
+  IL_0101:  ret
 }", sequencePoints: "C+<Main>d__0.MoveNext", source: source);
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
@@ -1001,7 +1001,7 @@ class C : System.IAsyncDisposable
             var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      304 (0x130)
+  // Code size      306 (0x132)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
@@ -1016,137 +1016,137 @@ class C : System.IAsyncDisposable
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse    IL_0097
-    IL_000d:  br.s       IL_000f
-    IL_000f:  nop
-    IL_0010:  ldarg.0
-    IL_0011:  newobj     ""C..ctor()""
-    IL_0016:  stfld      ""C C.<Main>d__0.<>s__1""
-    IL_001b:  ldarg.0
-    IL_001c:  ldnull
-    IL_001d:  stfld      ""object C.<Main>d__0.<>s__2""
-    IL_0022:  ldarg.0
-    IL_0023:  ldc.i4.0
-    IL_0024:  stfld      ""int C.<Main>d__0.<>s__3""
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_0011
+    IL_000c:  br         IL_0099
+    IL_0011:  nop
+    IL_0012:  ldarg.0
+    IL_0013:  newobj     ""C..ctor()""
+    IL_0018:  stfld      ""C C.<Main>d__0.<>s__1""
+    IL_001d:  ldarg.0
+    IL_001e:  ldnull
+    IL_001f:  stfld      ""object C.<Main>d__0.<>s__2""
+    IL_0024:  ldarg.0
+    IL_0025:  ldc.i4.0
+    IL_0026:  stfld      ""int C.<Main>d__0.<>s__3""
     .try
     {
-      IL_0029:  nop
-      IL_002a:  ldstr      ""body ""
-      IL_002f:  call       ""void System.Console.Write(string)""
-      IL_0034:  nop
-      IL_0035:  br.s       IL_0037
-      IL_0037:  ldarg.0
-      IL_0038:  ldc.i4.1
-      IL_0039:  stfld      ""int C.<Main>d__0.<>s__3""
-      IL_003e:  leave.s    IL_004a
+      IL_002b:  nop
+      IL_002c:  ldstr      ""body ""
+      IL_0031:  call       ""void System.Console.Write(string)""
+      IL_0036:  nop
+      IL_0037:  br.s       IL_0039
+      IL_0039:  ldarg.0
+      IL_003a:  ldc.i4.1
+      IL_003b:  stfld      ""int C.<Main>d__0.<>s__3""
+      IL_0040:  leave.s    IL_004c
     }
     catch object
     {
-      IL_0040:  stloc.1
-      IL_0041:  ldarg.0
-      IL_0042:  ldloc.1
-      IL_0043:  stfld      ""object C.<Main>d__0.<>s__2""
-      IL_0048:  leave.s    IL_004a
+      IL_0042:  stloc.1
+      IL_0043:  ldarg.0
+      IL_0044:  ldloc.1
+      IL_0045:  stfld      ""object C.<Main>d__0.<>s__2""
+      IL_004a:  leave.s    IL_004c
     }
-    IL_004a:  ldarg.0
-    IL_004b:  ldfld      ""C C.<Main>d__0.<>s__1""
-    IL_0050:  brfalse.s  IL_00bb
-    IL_0052:  ldarg.0
-    IL_0053:  ldfld      ""C C.<Main>d__0.<>s__1""
-    IL_0058:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
-    IL_005d:  stloc.3
-    IL_005e:  ldloca.s   V_3
-    IL_0060:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
-    IL_0065:  stloc.2
-    IL_0066:  ldloca.s   V_2
-    IL_0068:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
-    IL_006d:  brtrue.s   IL_00b3
-    IL_006f:  ldarg.0
-    IL_0070:  ldc.i4.0
-    IL_0071:  dup
-    IL_0072:  stloc.0
-    IL_0073:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_0078:  ldarg.0
-    IL_0079:  ldloc.2
-    IL_007a:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
-    IL_007f:  ldarg.0
-    IL_0080:  stloc.s    V_4
-    IL_0082:  ldarg.0
-    IL_0083:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_0088:  ldloca.s   V_2
-    IL_008a:  ldloca.s   V_4
-    IL_008c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
-    IL_0091:  nop
-    IL_0092:  leave      IL_012f
-    IL_0097:  ldarg.0
-    IL_0098:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
-    IL_009d:  stloc.2
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
-    IL_00a4:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
-    IL_00aa:  ldarg.0
-    IL_00ab:  ldc.i4.m1
-    IL_00ac:  dup
-    IL_00ad:  stloc.0
-    IL_00ae:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_00b3:  ldloca.s   V_2
-    IL_00b5:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
-    IL_00ba:  nop
-    IL_00bb:  ldarg.0
-    IL_00bc:  ldfld      ""object C.<Main>d__0.<>s__2""
-    IL_00c1:  stloc.1
-    IL_00c2:  ldloc.1
-    IL_00c3:  brfalse.s  IL_00e0
-    IL_00c5:  ldloc.1
-    IL_00c6:  isinst     ""System.Exception""
-    IL_00cb:  stloc.s    V_5
-    IL_00cd:  ldloc.s    V_5
-    IL_00cf:  brtrue.s   IL_00d3
-    IL_00d1:  ldloc.1
-    IL_00d2:  throw
-    IL_00d3:  ldloc.s    V_5
-    IL_00d5:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_00da:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_00df:  nop
-    IL_00e0:  ldarg.0
-    IL_00e1:  ldfld      ""int C.<Main>d__0.<>s__3""
-    IL_00e6:  stloc.s    V_6
-    IL_00e8:  ldloc.s    V_6
-    IL_00ea:  ldc.i4.1
-    IL_00eb:  beq.s      IL_00ef
-    IL_00ed:  br.s       IL_00f1
-    IL_00ef:  leave.s    IL_011b
-    IL_00f1:  ldarg.0
-    IL_00f2:  ldnull
-    IL_00f3:  stfld      ""object C.<Main>d__0.<>s__2""
-    IL_00f8:  ldarg.0
-    IL_00f9:  ldnull
-    IL_00fa:  stfld      ""C C.<Main>d__0.<>s__1""
-    IL_00ff:  leave.s    IL_011b
+    IL_004c:  ldarg.0
+    IL_004d:  ldfld      ""C C.<Main>d__0.<>s__1""
+    IL_0052:  brfalse.s  IL_00bd
+    IL_0054:  ldarg.0
+    IL_0055:  ldfld      ""C C.<Main>d__0.<>s__1""
+    IL_005a:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
+    IL_005f:  stloc.3
+    IL_0060:  ldloca.s   V_3
+    IL_0062:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
+    IL_0067:  stloc.2
+    IL_0068:  ldloca.s   V_2
+    IL_006a:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
+    IL_006f:  brtrue.s   IL_00b5
+    IL_0071:  ldarg.0
+    IL_0072:  ldc.i4.0
+    IL_0073:  dup
+    IL_0074:  stloc.0
+    IL_0075:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_007a:  ldarg.0
+    IL_007b:  ldloc.2
+    IL_007c:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
+    IL_0081:  ldarg.0
+    IL_0082:  stloc.s    V_4
+    IL_0084:  ldarg.0
+    IL_0085:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_008a:  ldloca.s   V_2
+    IL_008c:  ldloca.s   V_4
+    IL_008e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
+    IL_0093:  nop
+    IL_0094:  leave      IL_0131
+    IL_0099:  ldarg.0
+    IL_009a:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
+    IL_009f:  stloc.2
+    IL_00a0:  ldarg.0
+    IL_00a1:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
+    IL_00a6:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
+    IL_00ac:  ldarg.0
+    IL_00ad:  ldc.i4.m1
+    IL_00ae:  dup
+    IL_00af:  stloc.0
+    IL_00b0:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00b5:  ldloca.s   V_2
+    IL_00b7:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
+    IL_00bc:  nop
+    IL_00bd:  ldarg.0
+    IL_00be:  ldfld      ""object C.<Main>d__0.<>s__2""
+    IL_00c3:  stloc.1
+    IL_00c4:  ldloc.1
+    IL_00c5:  brfalse.s  IL_00e2
+    IL_00c7:  ldloc.1
+    IL_00c8:  isinst     ""System.Exception""
+    IL_00cd:  stloc.s    V_5
+    IL_00cf:  ldloc.s    V_5
+    IL_00d1:  brtrue.s   IL_00d5
+    IL_00d3:  ldloc.1
+    IL_00d4:  throw
+    IL_00d5:  ldloc.s    V_5
+    IL_00d7:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_00dc:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_00e1:  nop
+    IL_00e2:  ldarg.0
+    IL_00e3:  ldfld      ""int C.<Main>d__0.<>s__3""
+    IL_00e8:  stloc.s    V_6
+    IL_00ea:  ldloc.s    V_6
+    IL_00ec:  ldc.i4.1
+    IL_00ed:  beq.s      IL_00f1
+    IL_00ef:  br.s       IL_00f3
+    IL_00f1:  leave.s    IL_011d
+    IL_00f3:  ldarg.0
+    IL_00f4:  ldnull
+    IL_00f5:  stfld      ""object C.<Main>d__0.<>s__2""
+    IL_00fa:  ldarg.0
+    IL_00fb:  ldnull
+    IL_00fc:  stfld      ""C C.<Main>d__0.<>s__1""
+    IL_0101:  leave.s    IL_011d
   }
   catch System.Exception
   {
-    IL_0101:  stloc.s    V_5
-    IL_0103:  ldarg.0
-    IL_0104:  ldc.i4.s   -2
-    IL_0106:  stfld      ""int C.<Main>d__0.<>1__state""
-    IL_010b:  ldarg.0
-    IL_010c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_0111:  ldloc.s    V_5
-    IL_0113:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0118:  nop
-    IL_0119:  leave.s    IL_012f
+    IL_0103:  stloc.s    V_5
+    IL_0105:  ldarg.0
+    IL_0106:  ldc.i4.s   -2
+    IL_0108:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_010d:  ldarg.0
+    IL_010e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_0113:  ldloc.s    V_5
+    IL_0115:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_011a:  nop
+    IL_011b:  leave.s    IL_0131
   }
-  IL_011b:  ldarg.0
-  IL_011c:  ldc.i4.s   -2
-  IL_011e:  stfld      ""int C.<Main>d__0.<>1__state""
-  IL_0123:  ldarg.0
-  IL_0124:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_0129:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_012e:  nop
-  IL_012f:  ret
-}
-");
+  IL_011d:  ldarg.0
+  IL_011e:  ldc.i4.s   -2
+  IL_0120:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_0125:  ldarg.0
+  IL_0126:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_012b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0130:  nop
+  IL_0131:  ret
+}");
         }
 
         [Fact]
@@ -1245,7 +1245,7 @@ struct S : System.IAsyncDisposable
             var verifier = CompileAndVerify(comp, expectedOutput: "body DisposeAsync");
             verifier.VerifyIL("S.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      296 (0x128)
+  // Code size      298 (0x12a)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
@@ -1260,132 +1260,132 @@ struct S : System.IAsyncDisposable
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse    IL_0096
-    IL_000d:  br.s       IL_000f
-    IL_000f:  nop
-    IL_0010:  ldarg.0
-    IL_0011:  ldflda     ""S S.<Main>d__0.<>s__1""
-    IL_0016:  initobj    ""S""
-    IL_001c:  ldarg.0
-    IL_001d:  ldnull
-    IL_001e:  stfld      ""object S.<Main>d__0.<>s__2""
-    IL_0023:  ldarg.0
-    IL_0024:  ldc.i4.0
-    IL_0025:  stfld      ""int S.<Main>d__0.<>s__3""
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_0011
+    IL_000c:  br         IL_0098
+    IL_0011:  nop
+    IL_0012:  ldarg.0
+    IL_0013:  ldflda     ""S S.<Main>d__0.<>s__1""
+    IL_0018:  initobj    ""S""
+    IL_001e:  ldarg.0
+    IL_001f:  ldnull
+    IL_0020:  stfld      ""object S.<Main>d__0.<>s__2""
+    IL_0025:  ldarg.0
+    IL_0026:  ldc.i4.0
+    IL_0027:  stfld      ""int S.<Main>d__0.<>s__3""
     .try
     {
-      IL_002a:  nop
-      IL_002b:  ldstr      ""body ""
-      IL_0030:  call       ""void System.Console.Write(string)""
-      IL_0035:  nop
-      IL_0036:  br.s       IL_0038
-      IL_0038:  ldarg.0
-      IL_0039:  ldc.i4.1
-      IL_003a:  stfld      ""int S.<Main>d__0.<>s__3""
-      IL_003f:  leave.s    IL_004b
+      IL_002c:  nop
+      IL_002d:  ldstr      ""body ""
+      IL_0032:  call       ""void System.Console.Write(string)""
+      IL_0037:  nop
+      IL_0038:  br.s       IL_003a
+      IL_003a:  ldarg.0
+      IL_003b:  ldc.i4.1
+      IL_003c:  stfld      ""int S.<Main>d__0.<>s__3""
+      IL_0041:  leave.s    IL_004d
     }
     catch object
     {
-      IL_0041:  stloc.1
-      IL_0042:  ldarg.0
-      IL_0043:  ldloc.1
-      IL_0044:  stfld      ""object S.<Main>d__0.<>s__2""
-      IL_0049:  leave.s    IL_004b
+      IL_0043:  stloc.1
+      IL_0044:  ldarg.0
+      IL_0045:  ldloc.1
+      IL_0046:  stfld      ""object S.<Main>d__0.<>s__2""
+      IL_004b:  leave.s    IL_004d
     }
-    IL_004b:  ldarg.0
-    IL_004c:  ldflda     ""S S.<Main>d__0.<>s__1""
-    IL_0051:  constrained. ""S""
-    IL_0057:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
-    IL_005c:  stloc.3
-    IL_005d:  ldloca.s   V_3
-    IL_005f:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
-    IL_0064:  stloc.2
-    IL_0065:  ldloca.s   V_2
-    IL_0067:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
-    IL_006c:  brtrue.s   IL_00b2
-    IL_006e:  ldarg.0
-    IL_006f:  ldc.i4.0
-    IL_0070:  dup
-    IL_0071:  stloc.0
-    IL_0072:  stfld      ""int S.<Main>d__0.<>1__state""
-    IL_0077:  ldarg.0
-    IL_0078:  ldloc.2
-    IL_0079:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter S.<Main>d__0.<>u__1""
-    IL_007e:  ldarg.0
-    IL_007f:  stloc.s    V_4
-    IL_0081:  ldarg.0
-    IL_0082:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
-    IL_0087:  ldloca.s   V_2
-    IL_0089:  ldloca.s   V_4
-    IL_008b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, S.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref S.<Main>d__0)""
-    IL_0090:  nop
-    IL_0091:  leave      IL_0127
-    IL_0096:  ldarg.0
-    IL_0097:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter S.<Main>d__0.<>u__1""
-    IL_009c:  stloc.2
-    IL_009d:  ldarg.0
-    IL_009e:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter S.<Main>d__0.<>u__1""
-    IL_00a3:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
-    IL_00a9:  ldarg.0
-    IL_00aa:  ldc.i4.m1
-    IL_00ab:  dup
-    IL_00ac:  stloc.0
-    IL_00ad:  stfld      ""int S.<Main>d__0.<>1__state""
-    IL_00b2:  ldloca.s   V_2
-    IL_00b4:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
-    IL_00b9:  nop
-    IL_00ba:  ldarg.0
-    IL_00bb:  ldfld      ""object S.<Main>d__0.<>s__2""
-    IL_00c0:  stloc.1
-    IL_00c1:  ldloc.1
-    IL_00c2:  brfalse.s  IL_00df
-    IL_00c4:  ldloc.1
-    IL_00c5:  isinst     ""System.Exception""
-    IL_00ca:  stloc.s    V_5
-    IL_00cc:  ldloc.s    V_5
-    IL_00ce:  brtrue.s   IL_00d2
-    IL_00d0:  ldloc.1
-    IL_00d1:  throw
-    IL_00d2:  ldloc.s    V_5
-    IL_00d4:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_00d9:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_00de:  nop
-    IL_00df:  ldarg.0
-    IL_00e0:  ldfld      ""int S.<Main>d__0.<>s__3""
-    IL_00e5:  stloc.s    V_6
-    IL_00e7:  ldloc.s    V_6
-    IL_00e9:  ldc.i4.1
-    IL_00ea:  beq.s      IL_00ee
-    IL_00ec:  br.s       IL_00f0
-    IL_00ee:  leave.s    IL_0113
-    IL_00f0:  ldarg.0
-    IL_00f1:  ldnull
-    IL_00f2:  stfld      ""object S.<Main>d__0.<>s__2""
-    IL_00f7:  leave.s    IL_0113
+    IL_004d:  ldarg.0
+    IL_004e:  ldflda     ""S S.<Main>d__0.<>s__1""
+    IL_0053:  constrained. ""S""
+    IL_0059:  callvirt   ""System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync()""
+    IL_005e:  stloc.3
+    IL_005f:  ldloca.s   V_3
+    IL_0061:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
+    IL_0066:  stloc.2
+    IL_0067:  ldloca.s   V_2
+    IL_0069:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
+    IL_006e:  brtrue.s   IL_00b4
+    IL_0070:  ldarg.0
+    IL_0071:  ldc.i4.0
+    IL_0072:  dup
+    IL_0073:  stloc.0
+    IL_0074:  stfld      ""int S.<Main>d__0.<>1__state""
+    IL_0079:  ldarg.0
+    IL_007a:  ldloc.2
+    IL_007b:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter S.<Main>d__0.<>u__1""
+    IL_0080:  ldarg.0
+    IL_0081:  stloc.s    V_4
+    IL_0083:  ldarg.0
+    IL_0084:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
+    IL_0089:  ldloca.s   V_2
+    IL_008b:  ldloca.s   V_4
+    IL_008d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, S.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref S.<Main>d__0)""
+    IL_0092:  nop
+    IL_0093:  leave      IL_0129
+    IL_0098:  ldarg.0
+    IL_0099:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter S.<Main>d__0.<>u__1""
+    IL_009e:  stloc.2
+    IL_009f:  ldarg.0
+    IL_00a0:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter S.<Main>d__0.<>u__1""
+    IL_00a5:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
+    IL_00ab:  ldarg.0
+    IL_00ac:  ldc.i4.m1
+    IL_00ad:  dup
+    IL_00ae:  stloc.0
+    IL_00af:  stfld      ""int S.<Main>d__0.<>1__state""
+    IL_00b4:  ldloca.s   V_2
+    IL_00b6:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
+    IL_00bb:  nop
+    IL_00bc:  ldarg.0
+    IL_00bd:  ldfld      ""object S.<Main>d__0.<>s__2""
+    IL_00c2:  stloc.1
+    IL_00c3:  ldloc.1
+    IL_00c4:  brfalse.s  IL_00e1
+    IL_00c6:  ldloc.1
+    IL_00c7:  isinst     ""System.Exception""
+    IL_00cc:  stloc.s    V_5
+    IL_00ce:  ldloc.s    V_5
+    IL_00d0:  brtrue.s   IL_00d4
+    IL_00d2:  ldloc.1
+    IL_00d3:  throw
+    IL_00d4:  ldloc.s    V_5
+    IL_00d6:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_00db:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_00e0:  nop
+    IL_00e1:  ldarg.0
+    IL_00e2:  ldfld      ""int S.<Main>d__0.<>s__3""
+    IL_00e7:  stloc.s    V_6
+    IL_00e9:  ldloc.s    V_6
+    IL_00eb:  ldc.i4.1
+    IL_00ec:  beq.s      IL_00f0
+    IL_00ee:  br.s       IL_00f2
+    IL_00f0:  leave.s    IL_0115
+    IL_00f2:  ldarg.0
+    IL_00f3:  ldnull
+    IL_00f4:  stfld      ""object S.<Main>d__0.<>s__2""
+    IL_00f9:  leave.s    IL_0115
   }
   catch System.Exception
   {
-    IL_00f9:  stloc.s    V_5
-    IL_00fb:  ldarg.0
-    IL_00fc:  ldc.i4.s   -2
-    IL_00fe:  stfld      ""int S.<Main>d__0.<>1__state""
-    IL_0103:  ldarg.0
-    IL_0104:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
-    IL_0109:  ldloc.s    V_5
-    IL_010b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0110:  nop
-    IL_0111:  leave.s    IL_0127
+    IL_00fb:  stloc.s    V_5
+    IL_00fd:  ldarg.0
+    IL_00fe:  ldc.i4.s   -2
+    IL_0100:  stfld      ""int S.<Main>d__0.<>1__state""
+    IL_0105:  ldarg.0
+    IL_0106:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
+    IL_010b:  ldloc.s    V_5
+    IL_010d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0112:  nop
+    IL_0113:  leave.s    IL_0129
   }
-  IL_0113:  ldarg.0
-  IL_0114:  ldc.i4.s   -2
-  IL_0116:  stfld      ""int S.<Main>d__0.<>1__state""
-  IL_011b:  ldarg.0
-  IL_011c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
-  IL_0121:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0126:  nop
-  IL_0127:  ret
-}
-");
+  IL_0115:  ldarg.0
+  IL_0116:  ldc.i4.s   -2
+  IL_0118:  stfld      ""int S.<Main>d__0.<>1__state""
+  IL_011d:  ldarg.0
+  IL_011e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder S.<Main>d__0.<>t__builder""
+  IL_0123:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0128:  nop
+  IL_0129:  ret
+}");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -231,12 +231,12 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x1b"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1c"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x2c"" hidden=""true"" document=""1"" />
-        <entry offset=""0x33"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x20"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x30"" hidden=""true"" document=""1"" />
+        <entry offset=""0x37"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x35"">
+      <scope startOffset=""0x0"" endOffset=""0x39"">
         <namespace name=""System.Collections.Generic"" />
       </scope>
     </method>
@@ -738,73 +738,77 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       53 (0x35)
+  // Code size       57 (0x39)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_002c
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldc.i4.2
-  IL_001e:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0023:  ldarg.0
-  IL_0024:  ldc.i4.1
-  IL_0025:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_002a:  ldc.i4.1
-  IL_002b:  ret
-  IL_002c:  ldarg.0
-  IL_002d:  ldc.i4.m1
-  IL_002e:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0033:  ldc.i4.0
-  IL_0034:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_0030
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.2
+  IL_0022:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0027:  ldarg.0
+  IL_0028:  ldc.i4.1
+  IL_0029:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_002e:  ldc.i4.1
+  IL_002f:  ret
+  IL_0030:  ldarg.0
+  IL_0031:  ldc.i4.m1
+  IL_0032:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0037:  ldc.i4.0
+  IL_0038:  ret
 }");
                     v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       53 (0x35)
+  // Code size       57 (0x39)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_002c
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldc.i4.1
-  IL_001e:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0023:  ldarg.0
-  IL_0024:  ldc.i4.1
-  IL_0025:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_002a:  ldc.i4.1
-  IL_002b:  ret
-  IL_002c:  ldarg.0
-  IL_002d:  ldc.i4.m1
-  IL_002e:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0033:  ldc.i4.0
-  IL_0034:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_0030
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0027:  ldarg.0
+  IL_0028:  ldc.i4.1
+  IL_0029:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_002e:  ldc.i4.1
+  IL_002f:  ret
+  IL_0030:  ldarg.0
+  IL_0031:  ldc.i4.m1
+  IL_0032:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0037:  ldc.i4.0
+  IL_0038:  ret
 }");
                 }
             }
@@ -869,7 +873,7 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      160 (0xa0)
+  // Code size      162 (0xa2)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -882,77 +886,78 @@ class C
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0047
-    IL_000a:  br.s       IL_000c
-    IL_000c:  nop
-    IL_000d:  ldc.i4.s   10
-    IL_000f:  call       ""System.Threading.Tasks.Task<int> System.Threading.Tasks.Task.FromResult<int>(int)""
-    IL_0014:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0019:  stloc.2
-    IL_001a:  ldloca.s   V_2
-    IL_001c:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0021:  brtrue.s   IL_0063
-    IL_0023:  ldarg.0
-    IL_0024:  ldc.i4.0
-    IL_0025:  dup
-    IL_0026:  stloc.0
-    IL_0027:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_002c:  ldarg.0
-    IL_002d:  ldloc.2
-    IL_002e:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
-    IL_0033:  ldarg.0
-    IL_0034:  stloc.3
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_0049
+    IL_000e:  nop
+    IL_000f:  ldc.i4.s   10
+    IL_0011:  call       ""System.Threading.Tasks.Task<int> System.Threading.Tasks.Task.FromResult<int>(int)""
+    IL_0016:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_001b:  stloc.2
+    IL_001c:  ldloca.s   V_2
+    IL_001e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0023:  brtrue.s   IL_0065
+    IL_0025:  ldarg.0
+    IL_0026:  ldc.i4.0
+    IL_0027:  dup
+    IL_0028:  stloc.0
+    IL_0029:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_002e:  ldarg.0
+    IL_002f:  ldloc.2
+    IL_0030:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
     IL_0035:  ldarg.0
-    IL_0036:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_003b:  ldloca.s   V_2
-    IL_003d:  ldloca.s   V_3
-    IL_003f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__0)""
-    IL_0044:  nop
-    IL_0045:  leave.s    IL_009f
-    IL_0047:  ldarg.0
-    IL_0048:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
-    IL_004d:  stloc.2
-    IL_004e:  ldarg.0
-    IL_004f:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
-    IL_0054:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_005a:  ldarg.0
-    IL_005b:  ldc.i4.m1
-    IL_005c:  dup
-    IL_005d:  stloc.0
-    IL_005e:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0063:  ldloca.s   V_2
-    IL_0065:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_006a:  pop
-    IL_006b:  ldc.i4.s   20
-    IL_006d:  stloc.1
-    IL_006e:  leave.s    IL_008a
+    IL_0036:  stloc.3
+    IL_0037:  ldarg.0
+    IL_0038:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_003d:  ldloca.s   V_2
+    IL_003f:  ldloca.s   V_3
+    IL_0041:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__0)""
+    IL_0046:  nop
+    IL_0047:  leave.s    IL_00a1
+    IL_0049:  ldarg.0
+    IL_004a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
+    IL_004f:  stloc.2
+    IL_0050:  ldarg.0
+    IL_0051:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
+    IL_0056:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_005c:  ldarg.0
+    IL_005d:  ldc.i4.m1
+    IL_005e:  dup
+    IL_005f:  stloc.0
+    IL_0060:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0065:  ldloca.s   V_2
+    IL_0067:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_006c:  pop
+    IL_006d:  ldc.i4.s   20
+    IL_006f:  stloc.1
+    IL_0070:  leave.s    IL_008c
   }
   catch System.Exception
   {
-    IL_0070:  stloc.s    V_4
-    IL_0072:  ldarg.0
-    IL_0073:  ldc.i4.s   -2
-    IL_0075:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_007a:  ldarg.0
-    IL_007b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_0080:  ldloc.s    V_4
-    IL_0082:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0087:  nop
-    IL_0088:  leave.s    IL_009f
+    IL_0072:  stloc.s    V_4
+    IL_0074:  ldarg.0
+    IL_0075:  ldc.i4.s   -2
+    IL_0077:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_007c:  ldarg.0
+    IL_007d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0082:  ldloc.s    V_4
+    IL_0084:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0089:  nop
+    IL_008a:  leave.s    IL_00a1
   }
-  IL_008a:  ldarg.0
-  IL_008b:  ldc.i4.s   -2
-  IL_008d:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0092:  ldarg.0
-  IL_0093:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_0098:  ldloc.1
-  IL_0099:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_009e:  nop
-  IL_009f:  ret
+  IL_008c:  ldarg.0
+  IL_008d:  ldc.i4.s   -2
+  IL_008f:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0094:  ldarg.0
+  IL_0095:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_009a:  ldloc.1
+  IL_009b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00a0:  nop
+  IL_00a1:  ret
 }");
                     v0.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      158 (0x9e)
+  // Code size      160 (0xa0)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -965,73 +970,74 @@ class C
   .try
   {
    ~IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0046
-    IL_000a:  br.s       IL_000c
-   -IL_000c:  nop
-   -IL_000d:  ldc.i4.1
-    IL_000e:  call       ""System.Threading.Tasks.Task<int> System.Threading.Tasks.Task.FromResult<int>(int)""
-    IL_0013:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0018:  stloc.2
-   ~IL_0019:  ldloca.s   V_2
-    IL_001b:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0020:  brtrue.s   IL_0062
-    IL_0022:  ldarg.0
-    IL_0023:  ldc.i4.0
-    IL_0024:  dup
-    IL_0025:  stloc.0
-    IL_0026:  stfld      ""int C.<F>d__0.<>1__state""
-   <IL_002b:  ldarg.0
-    IL_002c:  ldloc.2
-    IL_002d:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
-    IL_0032:  ldarg.0
-    IL_0033:  stloc.3
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_0048
+   -IL_000e:  nop
+   -IL_000f:  ldc.i4.1
+    IL_0010:  call       ""System.Threading.Tasks.Task<int> System.Threading.Tasks.Task.FromResult<int>(int)""
+    IL_0015:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_001a:  stloc.2
+   ~IL_001b:  ldloca.s   V_2
+    IL_001d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0022:  brtrue.s   IL_0064
+    IL_0024:  ldarg.0
+    IL_0025:  ldc.i4.0
+    IL_0026:  dup
+    IL_0027:  stloc.0
+    IL_0028:  stfld      ""int C.<F>d__0.<>1__state""
+   <IL_002d:  ldarg.0
+    IL_002e:  ldloc.2
+    IL_002f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
     IL_0034:  ldarg.0
-    IL_0035:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_003a:  ldloca.s   V_2
-    IL_003c:  ldloca.s   V_3
-    IL_003e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__0)""
-    IL_0043:  nop
-    IL_0044:  leave.s    IL_009d
-   >IL_0046:  ldarg.0
-    IL_0047:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
-    IL_004c:  stloc.2
-    IL_004d:  ldarg.0
-    IL_004e:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
-    IL_0053:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0059:  ldarg.0
-    IL_005a:  ldc.i4.m1
-    IL_005b:  dup
-    IL_005c:  stloc.0
-    IL_005d:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0062:  ldloca.s   V_2
-    IL_0064:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0069:  pop
-   -IL_006a:  ldc.i4.2
-    IL_006b:  stloc.1
-    IL_006c:  leave.s    IL_0088
+    IL_0035:  stloc.3
+    IL_0036:  ldarg.0
+    IL_0037:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_003c:  ldloca.s   V_2
+    IL_003e:  ldloca.s   V_3
+    IL_0040:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__0)""
+    IL_0045:  nop
+    IL_0046:  leave.s    IL_009f
+   >IL_0048:  ldarg.0
+    IL_0049:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
+    IL_004e:  stloc.2
+    IL_004f:  ldarg.0
+    IL_0050:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
+    IL_0055:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_005b:  ldarg.0
+    IL_005c:  ldc.i4.m1
+    IL_005d:  dup
+    IL_005e:  stloc.0
+    IL_005f:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0064:  ldloca.s   V_2
+    IL_0066:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_006b:  pop
+   -IL_006c:  ldc.i4.2
+    IL_006d:  stloc.1
+    IL_006e:  leave.s    IL_008a
   }
   catch System.Exception
   {
-   ~IL_006e:  stloc.s    V_4
-    IL_0070:  ldarg.0
-    IL_0071:  ldc.i4.s   -2
-    IL_0073:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0078:  ldarg.0
-    IL_0079:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_007e:  ldloc.s    V_4
-    IL_0080:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0085:  nop
-    IL_0086:  leave.s    IL_009d
+   ~IL_0070:  stloc.s    V_4
+    IL_0072:  ldarg.0
+    IL_0073:  ldc.i4.s   -2
+    IL_0075:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_007a:  ldarg.0
+    IL_007b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0080:  ldloc.s    V_4
+    IL_0082:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0087:  nop
+    IL_0088:  leave.s    IL_009f
   }
- -IL_0088:  ldarg.0
-  IL_0089:  ldc.i4.s   -2
-  IL_008b:  stfld      ""int C.<F>d__0.<>1__state""
- ~IL_0090:  ldarg.0
-  IL_0091:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_0096:  ldloc.1
-  IL_0097:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_009c:  nop
-  IL_009d:  ret
+ -IL_008a:  ldarg.0
+  IL_008b:  ldc.i4.s   -2
+  IL_008d:  stfld      ""int C.<F>d__0.<>1__state""
+ ~IL_0092:  ldarg.0
+  IL_0093:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_0098:  ldloc.1
+  IL_0099:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_009e:  nop
+  IL_009f:  ret
 }", sequencePoints: "C+<F>d__0.MoveNext");
 
                     v0.VerifyPdb("C+<F>d__0.MoveNext", @"
@@ -1056,20 +1062,20 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xd"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""34"" document=""1"" />
-        <entry offset=""0x19"" hidden=""true"" document=""1"" />
-        <entry offset=""0x6a"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
-        <entry offset=""0x6e"" hidden=""true"" document=""1"" />
-        <entry offset=""0x88"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x90"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x1b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x70"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8a"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x92"" hidden=""true"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x9e"">
+      <scope startOffset=""0x0"" endOffset=""0xa0"">
         <namespace name=""System.Threading.Tasks"" />
       </scope>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""F"" />
-        <await yield=""0x2b"" resume=""0x46"" declaringType=""C+&lt;F&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x2d"" resume=""0x48"" declaringType=""C+&lt;F&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -1138,42 +1144,44 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       65 (0x41)
+  // Code size       69 (0x45)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0038
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldarg.0
-  IL_001e:  ldfld      ""int C.<F>d__0.p""
-  IL_0023:  stfld      ""int C.<F>d__0.<x>5__1""
-  IL_0028:  ldarg.0
-  IL_0029:  ldc.i4.2
-  IL_002a:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_002f:  ldarg.0
-  IL_0030:  ldc.i4.1
-  IL_0031:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0036:  ldc.i4.1
-  IL_0037:  ret
-  IL_0038:  ldarg.0
-  IL_0039:  ldc.i4.m1
-  IL_003a:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_003f:  ldc.i4.0
-  IL_0040:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003c
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldarg.0
+  IL_0022:  ldfld      ""int C.<F>d__0.p""
+  IL_0027:  stfld      ""int C.<F>d__0.<x>5__1""
+  IL_002c:  ldarg.0
+  IL_002d:  ldc.i4.2
+  IL_002e:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0033:  ldarg.0
+  IL_0034:  ldc.i4.1
+  IL_0035:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003a:  ldc.i4.1
+  IL_003b:  ret
+  IL_003c:  ldarg.0
+  IL_003d:  ldc.i4.m1
+  IL_003e:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0043:  ldc.i4.0
+  IL_0044:  ret
 }");
                 }
             }
@@ -1240,50 +1248,52 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       93 (0x5d)
+  // Code size       97 (0x61)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0048
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldc.i4     0x4d2
-  IL_0022:  stfld      ""int C.<F>d__0.<y>5__2""
-  IL_0027:  ldarg.0
-  IL_0028:  ldarg.0
-  IL_0029:  ldfld      ""int C.<F>d__0.p""
-  IL_002e:  stfld      ""int C.<F>d__0.<x>5__1""
-  IL_0033:  ldarg.0
-  IL_0034:  ldarg.0
-  IL_0035:  ldfld      ""int C.<F>d__0.<y>5__2""
-  IL_003a:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_003f:  ldarg.0
-  IL_0040:  ldc.i4.1
-  IL_0041:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0046:  ldc.i4.1
-  IL_0047:  ret
-  IL_0048:  ldarg.0
-  IL_0049:  ldc.i4.m1
-  IL_004a:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_004f:  ldarg.0
-  IL_0050:  ldfld      ""int C.<F>d__0.<x>5__1""
-  IL_0055:  call       ""void System.Console.WriteLine(int)""
-  IL_005a:  nop
-  IL_005b:  ldc.i4.0
-  IL_005c:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_004c
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4     0x4d2
+  IL_0026:  stfld      ""int C.<F>d__0.<y>5__2""
+  IL_002b:  ldarg.0
+  IL_002c:  ldarg.0
+  IL_002d:  ldfld      ""int C.<F>d__0.p""
+  IL_0032:  stfld      ""int C.<F>d__0.<x>5__1""
+  IL_0037:  ldarg.0
+  IL_0038:  ldarg.0
+  IL_0039:  ldfld      ""int C.<F>d__0.<y>5__2""
+  IL_003e:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0043:  ldarg.0
+  IL_0044:  ldc.i4.1
+  IL_0045:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_004a:  ldc.i4.1
+  IL_004b:  ret
+  IL_004c:  ldarg.0
+  IL_004d:  ldc.i4.m1
+  IL_004e:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0053:  ldarg.0
+  IL_0054:  ldfld      ""int C.<F>d__0.<x>5__1""
+  IL_0059:  call       ""void System.Console.WriteLine(int)""
+  IL_005e:  nop
+  IL_005f:  ldc.i4.0
+  IL_0060:  ret
 }");
                 }
             }
@@ -1349,46 +1359,48 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       81 (0x51)
+  // Code size       85 (0x55)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_003c
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldc.i4     0x4d2
-  IL_0022:  stfld      ""int C.<F>d__0.<y>5__2""
-  IL_0027:  ldarg.0
-  IL_0028:  ldarg.0
-  IL_0029:  ldfld      ""int C.<F>d__0.<y>5__2""
-  IL_002e:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0033:  ldarg.0
-  IL_0034:  ldc.i4.1
-  IL_0035:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_003a:  ldc.i4.1
-  IL_003b:  ret
-  IL_003c:  ldarg.0
-  IL_003d:  ldc.i4.m1
-  IL_003e:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0043:  ldarg.0
-  IL_0044:  ldfld      ""int C.<F>d__0.p""
-  IL_0049:  call       ""void System.Console.WriteLine(int)""
-  IL_004e:  nop
-  IL_004f:  ldc.i4.0
-  IL_0050:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_0040
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4     0x4d2
+  IL_0026:  stfld      ""int C.<F>d__0.<y>5__2""
+  IL_002b:  ldarg.0
+  IL_002c:  ldarg.0
+  IL_002d:  ldfld      ""int C.<F>d__0.<y>5__2""
+  IL_0032:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0037:  ldarg.0
+  IL_0038:  ldc.i4.1
+  IL_0039:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003e:  ldc.i4.1
+  IL_003f:  ret
+  IL_0040:  ldarg.0
+  IL_0041:  ldc.i4.m1
+  IL_0042:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0047:  ldarg.0
+  IL_0048:  ldfld      ""int C.<F>d__0.p""
+  IL_004d:  call       ""void System.Console.WriteLine(int)""
+  IL_0052:  nop
+  IL_0053:  ldc.i4.0
+  IL_0054:  ret
 }");
                 }
             }
@@ -1455,45 +1467,47 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       80 (0x50)
+  // Code size       84 (0x54)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_003b
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldc.r8     1
-  IL_0026:  stfld      ""double C.<F>d__0.<x>5__2""
-  IL_002b:  ldarg.0
-  IL_002c:  ldc.i4.2
-  IL_002d:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0032:  ldarg.0
-  IL_0033:  ldc.i4.1
-  IL_0034:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0039:  ldc.i4.1
-  IL_003a:  ret
-  IL_003b:  ldarg.0
-  IL_003c:  ldc.i4.m1
-  IL_003d:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0042:  ldarg.0
-  IL_0043:  ldfld      ""double C.<F>d__0.<x>5__2""
-  IL_0048:  call       ""void System.Console.WriteLine(double)""
-  IL_004d:  nop
-  IL_004e:  ldc.i4.0
-  IL_004f:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003f
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.r8     1
+  IL_002a:  stfld      ""double C.<F>d__0.<x>5__2""
+  IL_002f:  ldarg.0
+  IL_0030:  ldc.i4.2
+  IL_0031:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0036:  ldarg.0
+  IL_0037:  ldc.i4.1
+  IL_0038:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003d:  ldc.i4.1
+  IL_003e:  ret
+  IL_003f:  ldarg.0
+  IL_0040:  ldc.i4.m1
+  IL_0041:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0046:  ldarg.0
+  IL_0047:  ldfld      ""double C.<F>d__0.<x>5__2""
+  IL_004c:  call       ""void System.Console.WriteLine(double)""
+  IL_0051:  nop
+  IL_0052:  ldc.i4.0
+  IL_0053:  ret
 }");
                 }
             }
@@ -1570,80 +1584,82 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size      157 (0x9d)
+  // Code size      161 (0xa1)
   .maxstack  5
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0067
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  nop
-  IL_001d:  ldarg.0
-  IL_001e:  ldc.i4.1
-  IL_001f:  newarr     ""double""
-  IL_0024:  dup
-  IL_0025:  ldc.i4.0
-  IL_0026:  ldc.r8     1
-  IL_002f:  stelem.r8
-  IL_0030:  stfld      ""double[] C.<F>d__0.<>s__4""
-  IL_0035:  ldarg.0
-  IL_0036:  ldc.i4.0
-  IL_0037:  stfld      ""int C.<F>d__0.<>s__2""
-  IL_003c:  br.s       IL_0084
-  IL_003e:  ldarg.0
-  IL_003f:  ldarg.0
-  IL_0040:  ldfld      ""double[] C.<F>d__0.<>s__4""
-  IL_0045:  ldarg.0
-  IL_0046:  ldfld      ""int C.<F>d__0.<>s__2""
-  IL_004b:  ldelem.r8
-  IL_004c:  box        ""double""
-  IL_0051:  stfld      ""object C.<F>d__0.<item>5__3""
-  IL_0056:  nop
-  IL_0057:  ldarg.0
-  IL_0058:  ldc.i4.1
-  IL_0059:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_005e:  ldarg.0
-  IL_005f:  ldc.i4.1
-  IL_0060:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0065:  ldc.i4.1
-  IL_0066:  ret
-  IL_0067:  ldarg.0
-  IL_0068:  ldc.i4.m1
-  IL_0069:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_006e:  nop
-  IL_006f:  ldarg.0
-  IL_0070:  ldnull
-  IL_0071:  stfld      ""object C.<F>d__0.<item>5__3""
-  IL_0076:  ldarg.0
-  IL_0077:  ldarg.0
-  IL_0078:  ldfld      ""int C.<F>d__0.<>s__2""
-  IL_007d:  ldc.i4.1
-  IL_007e:  add
-  IL_007f:  stfld      ""int C.<F>d__0.<>s__2""
-  IL_0084:  ldarg.0
-  IL_0085:  ldfld      ""int C.<F>d__0.<>s__2""
-  IL_008a:  ldarg.0
-  IL_008b:  ldfld      ""double[] C.<F>d__0.<>s__4""
-  IL_0090:  ldlen
-  IL_0091:  conv.i4
-  IL_0092:  blt.s      IL_003e
-  IL_0094:  ldarg.0
-  IL_0095:  ldnull
-  IL_0096:  stfld      ""double[] C.<F>d__0.<>s__4""
-  IL_009b:  ldc.i4.0
-  IL_009c:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_006b
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  nop
+  IL_0021:  ldarg.0
+  IL_0022:  ldc.i4.1
+  IL_0023:  newarr     ""double""
+  IL_0028:  dup
+  IL_0029:  ldc.i4.0
+  IL_002a:  ldc.r8     1
+  IL_0033:  stelem.r8
+  IL_0034:  stfld      ""double[] C.<F>d__0.<>s__4""
+  IL_0039:  ldarg.0
+  IL_003a:  ldc.i4.0
+  IL_003b:  stfld      ""int C.<F>d__0.<>s__2""
+  IL_0040:  br.s       IL_0088
+  IL_0042:  ldarg.0
+  IL_0043:  ldarg.0
+  IL_0044:  ldfld      ""double[] C.<F>d__0.<>s__4""
+  IL_0049:  ldarg.0
+  IL_004a:  ldfld      ""int C.<F>d__0.<>s__2""
+  IL_004f:  ldelem.r8
+  IL_0050:  box        ""double""
+  IL_0055:  stfld      ""object C.<F>d__0.<item>5__3""
+  IL_005a:  nop
+  IL_005b:  ldarg.0
+  IL_005c:  ldc.i4.1
+  IL_005d:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0062:  ldarg.0
+  IL_0063:  ldc.i4.1
+  IL_0064:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0069:  ldc.i4.1
+  IL_006a:  ret
+  IL_006b:  ldarg.0
+  IL_006c:  ldc.i4.m1
+  IL_006d:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0072:  nop
+  IL_0073:  ldarg.0
+  IL_0074:  ldnull
+  IL_0075:  stfld      ""object C.<F>d__0.<item>5__3""
+  IL_007a:  ldarg.0
+  IL_007b:  ldarg.0
+  IL_007c:  ldfld      ""int C.<F>d__0.<>s__2""
+  IL_0081:  ldc.i4.1
+  IL_0082:  add
+  IL_0083:  stfld      ""int C.<F>d__0.<>s__2""
+  IL_0088:  ldarg.0
+  IL_0089:  ldfld      ""int C.<F>d__0.<>s__2""
+  IL_008e:  ldarg.0
+  IL_008f:  ldfld      ""double[] C.<F>d__0.<>s__4""
+  IL_0094:  ldlen
+  IL_0095:  conv.i4
+  IL_0096:  blt.s      IL_0042
+  IL_0098:  ldarg.0
+  IL_0099:  ldnull
+  IL_009a:  stfld      ""double[] C.<F>d__0.<>s__4""
+  IL_009f:  ldc.i4.0
+  IL_00a0:  ret
 }");
                 }
             }
@@ -1863,7 +1879,7 @@ class C
 
             diff1.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      176 (0xb0)
+  // Code size      178 (0xb2)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -1876,79 +1892,80 @@ class C
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0058
-    IL_000a:  br.s       IL_000c
-    IL_000c:  nop
-    IL_000d:  ldarg.0
-    IL_000e:  newobj     ""C..ctor()""
-    IL_0013:  stfld      ""C C.<F>d__0.<a1>5__3""
-    IL_0018:  ldarg.0
-    IL_0019:  ldc.i4.3
-    IL_001a:  stfld      ""int C.<F>d__0.<a2>5__2""
-    IL_001f:  ldc.i4.0
-    IL_0020:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.Delay(int)""
-    IL_0025:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
-    IL_002a:  stloc.2
-    IL_002b:  ldloca.s   V_2
-    IL_002d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
-    IL_0032:  brtrue.s   IL_0074
-    IL_0034:  ldarg.0
-    IL_0035:  ldc.i4.0
-    IL_0036:  dup
-    IL_0037:  stloc.0
-    IL_0038:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_003d:  ldarg.0
-    IL_003e:  ldloc.2
-    IL_003f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
-    IL_0044:  ldarg.0
-    IL_0045:  stloc.3
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_005a
+    IL_000e:  nop
+    IL_000f:  ldarg.0
+    IL_0010:  newobj     ""C..ctor()""
+    IL_0015:  stfld      ""C C.<F>d__0.<a1>5__3""
+    IL_001a:  ldarg.0
+    IL_001b:  ldc.i4.3
+    IL_001c:  stfld      ""int C.<F>d__0.<a2>5__2""
+    IL_0021:  ldc.i4.0
+    IL_0022:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.Delay(int)""
+    IL_0027:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
+    IL_002c:  stloc.2
+    IL_002d:  ldloca.s   V_2
+    IL_002f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
+    IL_0034:  brtrue.s   IL_0076
+    IL_0036:  ldarg.0
+    IL_0037:  ldc.i4.0
+    IL_0038:  dup
+    IL_0039:  stloc.0
+    IL_003a:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_003f:  ldarg.0
+    IL_0040:  ldloc.2
+    IL_0041:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
     IL_0046:  ldarg.0
-    IL_0047:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_004c:  ldloca.s   V_2
-    IL_004e:  ldloca.s   V_3
-    IL_0050:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
-    IL_0055:  nop
-    IL_0056:  leave.s    IL_00af
-    IL_0058:  ldarg.0
-    IL_0059:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
-    IL_005e:  stloc.2
-    IL_005f:  ldarg.0
-    IL_0060:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
-    IL_0065:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_006b:  ldarg.0
-    IL_006c:  ldc.i4.m1
-    IL_006d:  dup
-    IL_006e:  stloc.0
-    IL_006f:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0074:  ldloca.s   V_2
-    IL_0076:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_007b:  nop
-    IL_007c:  ldc.i4.1
-    IL_007d:  stloc.1
-    IL_007e:  leave.s    IL_009a
+    IL_0047:  stloc.3
+    IL_0048:  ldarg.0
+    IL_0049:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_004e:  ldloca.s   V_2
+    IL_0050:  ldloca.s   V_3
+    IL_0052:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
+    IL_0057:  nop
+    IL_0058:  leave.s    IL_00b1
+    IL_005a:  ldarg.0
+    IL_005b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
+    IL_0060:  stloc.2
+    IL_0061:  ldarg.0
+    IL_0062:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
+    IL_0067:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_006d:  ldarg.0
+    IL_006e:  ldc.i4.m1
+    IL_006f:  dup
+    IL_0070:  stloc.0
+    IL_0071:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0076:  ldloca.s   V_2
+    IL_0078:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+    IL_007d:  nop
+    IL_007e:  ldc.i4.1
+    IL_007f:  stloc.1
+    IL_0080:  leave.s    IL_009c
   }
   catch System.Exception
   {
-    IL_0080:  stloc.s    V_4
-    IL_0082:  ldarg.0
-    IL_0083:  ldc.i4.s   -2
-    IL_0085:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_008a:  ldarg.0
-    IL_008b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_0090:  ldloc.s    V_4
-    IL_0092:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0097:  nop
-    IL_0098:  leave.s    IL_00af
+    IL_0082:  stloc.s    V_4
+    IL_0084:  ldarg.0
+    IL_0085:  ldc.i4.s   -2
+    IL_0087:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_008c:  ldarg.0
+    IL_008d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0092:  ldloc.s    V_4
+    IL_0094:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0099:  nop
+    IL_009a:  leave.s    IL_00b1
   }
-  IL_009a:  ldarg.0
-  IL_009b:  ldc.i4.s   -2
-  IL_009d:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_00a2:  ldarg.0
-  IL_00a3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00a8:  ldloc.1
-  IL_00a9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00ae:  nop
-  IL_00af:  ret
+  IL_009c:  ldarg.0
+  IL_009d:  ldc.i4.s   -2
+  IL_009f:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_00a4:  ldarg.0
+  IL_00a5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00aa:  ldloc.1
+  IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00b0:  nop
+  IL_00b1:  ret
 }");
             // 2 field defs added (both variables a1 and a2 of F changed their types) & 2 methods updated
             CheckEncLogDefinitions(md2.Reader,
@@ -1965,7 +1982,7 @@ class C
 
             diff2.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      176 (0xb0)
+  // Code size      178 (0xb2)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -1978,79 +1995,80 @@ class C
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0058
-    IL_000a:  br.s       IL_000c
-    IL_000c:  nop
-    IL_000d:  ldarg.0
-    IL_000e:  ldc.i4.1
-    IL_000f:  stfld      ""bool C.<F>d__0.<a1>5__4""
-    IL_0014:  ldarg.0
-    IL_0015:  newobj     ""C..ctor()""
-    IL_001a:  stfld      ""C C.<F>d__0.<a2>5__5""
-    IL_001f:  ldc.i4.0
-    IL_0020:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.Delay(int)""
-    IL_0025:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
-    IL_002a:  stloc.2
-    IL_002b:  ldloca.s   V_2
-    IL_002d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
-    IL_0032:  brtrue.s   IL_0074
-    IL_0034:  ldarg.0
-    IL_0035:  ldc.i4.0
-    IL_0036:  dup
-    IL_0037:  stloc.0
-    IL_0038:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_003d:  ldarg.0
-    IL_003e:  ldloc.2
-    IL_003f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
-    IL_0044:  ldarg.0
-    IL_0045:  stloc.3
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_005a
+    IL_000e:  nop
+    IL_000f:  ldarg.0
+    IL_0010:  ldc.i4.1
+    IL_0011:  stfld      ""bool C.<F>d__0.<a1>5__4""
+    IL_0016:  ldarg.0
+    IL_0017:  newobj     ""C..ctor()""
+    IL_001c:  stfld      ""C C.<F>d__0.<a2>5__5""
+    IL_0021:  ldc.i4.0
+    IL_0022:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.Delay(int)""
+    IL_0027:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
+    IL_002c:  stloc.2
+    IL_002d:  ldloca.s   V_2
+    IL_002f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
+    IL_0034:  brtrue.s   IL_0076
+    IL_0036:  ldarg.0
+    IL_0037:  ldc.i4.0
+    IL_0038:  dup
+    IL_0039:  stloc.0
+    IL_003a:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_003f:  ldarg.0
+    IL_0040:  ldloc.2
+    IL_0041:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
     IL_0046:  ldarg.0
-    IL_0047:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_004c:  ldloca.s   V_2
-    IL_004e:  ldloca.s   V_3
-    IL_0050:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
-    IL_0055:  nop
-    IL_0056:  leave.s    IL_00af
-    IL_0058:  ldarg.0
-    IL_0059:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
-    IL_005e:  stloc.2
-    IL_005f:  ldarg.0
-    IL_0060:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
-    IL_0065:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_006b:  ldarg.0
-    IL_006c:  ldc.i4.m1
-    IL_006d:  dup
-    IL_006e:  stloc.0
-    IL_006f:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0074:  ldloca.s   V_2
-    IL_0076:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_007b:  nop
-    IL_007c:  ldc.i4.1
-    IL_007d:  stloc.1
-    IL_007e:  leave.s    IL_009a
+    IL_0047:  stloc.3
+    IL_0048:  ldarg.0
+    IL_0049:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_004e:  ldloca.s   V_2
+    IL_0050:  ldloca.s   V_3
+    IL_0052:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
+    IL_0057:  nop
+    IL_0058:  leave.s    IL_00b1
+    IL_005a:  ldarg.0
+    IL_005b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
+    IL_0060:  stloc.2
+    IL_0061:  ldarg.0
+    IL_0062:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
+    IL_0067:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_006d:  ldarg.0
+    IL_006e:  ldc.i4.m1
+    IL_006f:  dup
+    IL_0070:  stloc.0
+    IL_0071:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0076:  ldloca.s   V_2
+    IL_0078:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+    IL_007d:  nop
+    IL_007e:  ldc.i4.1
+    IL_007f:  stloc.1
+    IL_0080:  leave.s    IL_009c
   }
   catch System.Exception
   {
-    IL_0080:  stloc.s    V_4
-    IL_0082:  ldarg.0
-    IL_0083:  ldc.i4.s   -2
-    IL_0085:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_008a:  ldarg.0
-    IL_008b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_0090:  ldloc.s    V_4
-    IL_0092:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0097:  nop
-    IL_0098:  leave.s    IL_00af
+    IL_0082:  stloc.s    V_4
+    IL_0084:  ldarg.0
+    IL_0085:  ldc.i4.s   -2
+    IL_0087:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_008c:  ldarg.0
+    IL_008d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0092:  ldloc.s    V_4
+    IL_0094:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0099:  nop
+    IL_009a:  leave.s    IL_00b1
   }
-  IL_009a:  ldarg.0
-  IL_009b:  ldc.i4.s   -2
-  IL_009d:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_00a2:  ldarg.0
-  IL_00a3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00a8:  ldloc.1
-  IL_00a9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00ae:  nop
-  IL_00af:  ret
+  IL_009c:  ldarg.0
+  IL_009d:  ldc.i4.s   -2
+  IL_009f:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_00a4:  ldarg.0
+  IL_00a5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00aa:  ldloc.1
+  IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00b0:  nop
+  IL_00b1:  ret
 }");
             // 2 field defs added - variables of G and H changed their types; 4 methods updated: G, H kickoff and MoveNext
             CheckEncLogDefinitions(md3.Reader,
@@ -2109,61 +2127,63 @@ class C
 
             var baselineIL0 = @"
 {
-  // Code size      143 (0x8f)
+  // Code size      147 (0x93)
   .maxstack  3
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0038
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldc.i4.1
-  IL_001e:  box        ""int""
-  IL_0023:  stfld      ""dynamic C.<F>d__0.<x>5__1""
-  IL_0028:  ldarg.0
-  IL_0029:  ldc.i4.1
-  IL_002a:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_002f:  ldarg.0
-  IL_0030:  ldc.i4.1
-  IL_0031:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0036:  ldc.i4.1
-  IL_0037:  ret
-  IL_0038:  ldarg.0
-  IL_0039:  ldc.i4.m1
-  IL_003a:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_003f:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
-  IL_0044:  brfalse.s  IL_0048
-  IL_0046:  br.s       IL_006d
-  IL_0048:  ldc.i4.s   16
-  IL_004a:  ldtoken    ""int""
-  IL_004f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_0054:  ldtoken    ""C""
-  IL_0059:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_005e:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
-  IL_0063:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_0068:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
-  IL_006d:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
-  IL_0072:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Target""
-  IL_0077:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
-  IL_007c:  ldarg.0
-  IL_007d:  ldfld      ""dynamic C.<F>d__0.<x>5__1""
-  IL_0082:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-  IL_0087:  call       ""void System.Console.WriteLine(int)""
-  IL_008c:  nop
-  IL_008d:  ldc.i4.0
-  IL_008e:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003c
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  box        ""int""
+  IL_0027:  stfld      ""dynamic C.<F>d__0.<x>5__1""
+  IL_002c:  ldarg.0
+  IL_002d:  ldc.i4.1
+  IL_002e:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0033:  ldarg.0
+  IL_0034:  ldc.i4.1
+  IL_0035:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003a:  ldc.i4.1
+  IL_003b:  ret
+  IL_003c:  ldarg.0
+  IL_003d:  ldc.i4.m1
+  IL_003e:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0043:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
+  IL_0048:  brfalse.s  IL_004c
+  IL_004a:  br.s       IL_0071
+  IL_004c:  ldc.i4.s   16
+  IL_004e:  ldtoken    ""int""
+  IL_0053:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0058:  ldtoken    ""C""
+  IL_005d:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0062:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_0067:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_006c:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
+  IL_0071:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
+  IL_0076:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Target""
+  IL_007b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<>o__0.<>p__0""
+  IL_0080:  ldarg.0
+  IL_0081:  ldfld      ""dynamic C.<F>d__0.<x>5__1""
+  IL_0086:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_008b:  call       ""void System.Console.WriteLine(int)""
+  IL_0090:  nop
+  IL_0091:  ldc.i4.0
+  IL_0092:  ret
 }";
             v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL0);
 
@@ -2174,65 +2194,66 @@ class C
 
             var baselineIL = @"
 {
-  // Code size      145 (0x91)
+  // Code size      149 (0x95)
   .maxstack  3
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0038
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldc.i4.1
-  IL_001e:  box        ""int""
-  IL_0023:  stfld      ""dynamic C.<F>d__0.<x>5__1""
-  IL_0028:  ldarg.0
-  IL_0029:  ldc.i4.1
-  IL_002a:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_002f:  ldarg.0
-  IL_0030:  ldc.i4.1
-  IL_0031:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0036:  ldc.i4.1
-  IL_0037:  ret
-  IL_0038:  ldarg.0
-  IL_0039:  ldc.i4.m1
-  IL_003a:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_003f:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
-  IL_0044:  brfalse.s  IL_0048
-  IL_0046:  br.s       IL_006d
-  IL_0048:  ldc.i4.s   16
-  IL_004a:  ldtoken    ""int""
-  IL_004f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_0054:  ldtoken    ""C""
-  IL_0059:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_005e:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
-  IL_0063:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_0068:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
-  IL_006d:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
-  IL_0072:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Target""
-  IL_0077:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
-  IL_007c:  ldarg.0
-  IL_007d:  ldfld      ""dynamic C.<F>d__0.<x>5__1""
-  IL_0082:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-  IL_0087:  ldc.i4.<<VALUE>>
-  IL_0088:  add
-  IL_0089:  call       ""void System.Console.WriteLine(int)""
-  IL_008e:  nop
-  IL_008f:  ldc.i4.0
-  IL_0090:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003c
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  box        ""int""
+  IL_0027:  stfld      ""dynamic C.<F>d__0.<x>5__1""
+  IL_002c:  ldarg.0
+  IL_002d:  ldc.i4.1
+  IL_002e:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0033:  ldarg.0
+  IL_0034:  ldc.i4.1
+  IL_0035:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003a:  ldc.i4.1
+  IL_003b:  ret
+  IL_003c:  ldarg.0
+  IL_003d:  ldc.i4.m1
+  IL_003e:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0043:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
+  IL_0048:  brfalse.s  IL_004c
+  IL_004a:  br.s       IL_0071
+  IL_004c:  ldc.i4.s   16
+  IL_004e:  ldtoken    ""int""
+  IL_0053:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0058:  ldtoken    ""C""
+  IL_005d:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0062:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_0067:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_006c:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
+  IL_0071:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
+  IL_0076:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>>.Target""
+  IL_007b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>> C.<<DYNAMIC_CONTAINER_NAME>>.<>p__0""
+  IL_0080:  ldarg.0
+  IL_0081:  ldfld      ""dynamic C.<F>d__0.<x>5__1""
+  IL_0086:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, dynamic, int>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_008b:  ldc.i4.<<VALUE>>
+  IL_008c:  add
+  IL_008d:  call       ""void System.Console.WriteLine(int)""
+  IL_0092:  nop
+  IL_0093:  ldc.i4.0
+  IL_0094:  ret
 }";
-
 
             diff1.VerifySynthesizedMembers(
                 "C: {<>o__0#1, <F>d__0}",
@@ -2594,7 +2615,7 @@ class C
             // Note that the new awaiter is allocated slot <>u__3 since <>u__1 and <>u__2 are taken.
             diff1.VerifyIL("C.<F>d__3.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      264 (0x108)
+  // Code size      268 (0x10c)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -2608,113 +2629,115 @@ class C
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0051
+    IL_0008:  brfalse.s  IL_0012
     IL_000a:  br.s       IL_000c
     IL_000c:  ldloc.0
     IL_000d:  ldc.i4.1
-    IL_000e:  beq        IL_00af
-    IL_0013:  br.s       IL_0015
-    IL_0015:  nop
-    IL_0016:  call       ""System.Threading.Tasks.Task<C> C.A3()""
-    IL_001b:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<C> System.Threading.Tasks.Task<C>.GetAwaiter()""
-    IL_0020:  stloc.2
-    IL_0021:  ldloca.s   V_2
-    IL_0023:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<C>.IsCompleted.get""
-    IL_0028:  brtrue.s   IL_006d
-    IL_002a:  ldarg.0
-    IL_002b:  ldc.i4.0
-    IL_002c:  dup
-    IL_002d:  stloc.0
-    IL_002e:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_0033:  ldarg.0
-    IL_0034:  ldloc.2
-    IL_0035:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
-    IL_003a:  ldarg.0
-    IL_003b:  stloc.3
-    IL_003c:  ldarg.0
-    IL_003d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-    IL_0042:  ldloca.s   V_2
-    IL_0044:  ldloca.s   V_3
-    IL_0046:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<C>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<C>, ref C.<F>d__3)""
-    IL_004b:  nop
-    IL_004c:  leave      IL_0107
-    IL_0051:  ldarg.0
-    IL_0052:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
-    IL_0057:  stloc.2
-    IL_0058:  ldarg.0
-    IL_0059:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
-    IL_005e:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<C>""
-    IL_0064:  ldarg.0
-    IL_0065:  ldc.i4.m1
-    IL_0066:  dup
-    IL_0067:  stloc.0
-    IL_0068:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_006d:  ldloca.s   V_2
-    IL_006f:  call       ""C System.Runtime.CompilerServices.TaskAwaiter<C>.GetResult()""
-    IL_0074:  pop
-    IL_0075:  call       ""System.Threading.Tasks.Task<int> C.A2()""
-    IL_007a:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_007f:  stloc.s    V_4
-    IL_0081:  ldloca.s   V_4
-    IL_0083:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0088:  brtrue.s   IL_00cc
-    IL_008a:  ldarg.0
-    IL_008b:  ldc.i4.1
-    IL_008c:  dup
-    IL_008d:  stloc.0
-    IL_008e:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_0093:  ldarg.0
-    IL_0094:  ldloc.s    V_4
-    IL_0096:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
-    IL_009b:  ldarg.0
-    IL_009c:  stloc.3
-    IL_009d:  ldarg.0
-    IL_009e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-    IL_00a3:  ldloca.s   V_4
-    IL_00a5:  ldloca.s   V_3
-    IL_00a7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__3)""
-    IL_00ac:  nop
-    IL_00ad:  leave.s    IL_0107
-    IL_00af:  ldarg.0
-    IL_00b0:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
-    IL_00b5:  stloc.s    V_4
-    IL_00b7:  ldarg.0
-    IL_00b8:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
-    IL_00bd:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_00c3:  ldarg.0
-    IL_00c4:  ldc.i4.m1
-    IL_00c5:  dup
-    IL_00c6:  stloc.0
-    IL_00c7:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_00cc:  ldloca.s   V_4
-    IL_00ce:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00d3:  pop
-    IL_00d4:  ldc.i4.1
-    IL_00d5:  stloc.1
-    IL_00d6:  leave.s    IL_00f2
+    IL_000e:  beq.s      IL_0014
+    IL_0010:  br.s       IL_0019
+    IL_0012:  br.s       IL_0055
+    IL_0014:  br         IL_00b3
+    IL_0019:  nop
+    IL_001a:  call       ""System.Threading.Tasks.Task<C> C.A3()""
+    IL_001f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<C> System.Threading.Tasks.Task<C>.GetAwaiter()""
+    IL_0024:  stloc.2
+    IL_0025:  ldloca.s   V_2
+    IL_0027:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<C>.IsCompleted.get""
+    IL_002c:  brtrue.s   IL_0071
+    IL_002e:  ldarg.0
+    IL_002f:  ldc.i4.0
+    IL_0030:  dup
+    IL_0031:  stloc.0
+    IL_0032:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_0037:  ldarg.0
+    IL_0038:  ldloc.2
+    IL_0039:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
+    IL_003e:  ldarg.0
+    IL_003f:  stloc.3
+    IL_0040:  ldarg.0
+    IL_0041:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+    IL_0046:  ldloca.s   V_2
+    IL_0048:  ldloca.s   V_3
+    IL_004a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<C>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<C>, ref C.<F>d__3)""
+    IL_004f:  nop
+    IL_0050:  leave      IL_010b
+    IL_0055:  ldarg.0
+    IL_0056:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
+    IL_005b:  stloc.2
+    IL_005c:  ldarg.0
+    IL_005d:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
+    IL_0062:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<C>""
+    IL_0068:  ldarg.0
+    IL_0069:  ldc.i4.m1
+    IL_006a:  dup
+    IL_006b:  stloc.0
+    IL_006c:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_0071:  ldloca.s   V_2
+    IL_0073:  call       ""C System.Runtime.CompilerServices.TaskAwaiter<C>.GetResult()""
+    IL_0078:  pop
+    IL_0079:  call       ""System.Threading.Tasks.Task<int> C.A2()""
+    IL_007e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0083:  stloc.s    V_4
+    IL_0085:  ldloca.s   V_4
+    IL_0087:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_008c:  brtrue.s   IL_00d0
+    IL_008e:  ldarg.0
+    IL_008f:  ldc.i4.1
+    IL_0090:  dup
+    IL_0091:  stloc.0
+    IL_0092:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_0097:  ldarg.0
+    IL_0098:  ldloc.s    V_4
+    IL_009a:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
+    IL_009f:  ldarg.0
+    IL_00a0:  stloc.3
+    IL_00a1:  ldarg.0
+    IL_00a2:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+    IL_00a7:  ldloca.s   V_4
+    IL_00a9:  ldloca.s   V_3
+    IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__3)""
+    IL_00b0:  nop
+    IL_00b1:  leave.s    IL_010b
+    IL_00b3:  ldarg.0
+    IL_00b4:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
+    IL_00b9:  stloc.s    V_4
+    IL_00bb:  ldarg.0
+    IL_00bc:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
+    IL_00c1:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_00c7:  ldarg.0
+    IL_00c8:  ldc.i4.m1
+    IL_00c9:  dup
+    IL_00ca:  stloc.0
+    IL_00cb:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_00d0:  ldloca.s   V_4
+    IL_00d2:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00d7:  pop
+    IL_00d8:  ldc.i4.1
+    IL_00d9:  stloc.1
+    IL_00da:  leave.s    IL_00f6
   }
   catch System.Exception
   {
-    IL_00d8:  stloc.s    V_5
-    IL_00da:  ldarg.0
-    IL_00db:  ldc.i4.s   -2
-    IL_00dd:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_00e2:  ldarg.0
-    IL_00e3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-    IL_00e8:  ldloc.s    V_5
-    IL_00ea:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00ef:  nop
-    IL_00f0:  leave.s    IL_0107
+    IL_00dc:  stloc.s    V_5
+    IL_00de:  ldarg.0
+    IL_00df:  ldc.i4.s   -2
+    IL_00e1:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_00e6:  ldarg.0
+    IL_00e7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+    IL_00ec:  ldloc.s    V_5
+    IL_00ee:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00f3:  nop
+    IL_00f4:  leave.s    IL_010b
   }
-  IL_00f2:  ldarg.0
-  IL_00f3:  ldc.i4.s   -2
-  IL_00f5:  stfld      ""int C.<F>d__3.<>1__state""
-  IL_00fa:  ldarg.0
-  IL_00fb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-  IL_0100:  ldloc.1
-  IL_0101:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_0106:  nop
-  IL_0107:  ret
+  IL_00f6:  ldarg.0
+  IL_00f7:  ldc.i4.s   -2
+  IL_00f9:  stfld      ""int C.<F>d__3.<>1__state""
+  IL_00fe:  ldarg.0
+  IL_00ff:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+  IL_0104:  ldloc.1
+  IL_0105:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_010a:  nop
+  IL_010b:  ret
 }");
             // 1 field def added & 2 methods updated
             CheckEncLogDefinitions(md2.Reader,
@@ -2730,7 +2753,7 @@ class C
             // Note that the new awaiters are allocated slots <>u__4, <>u__5.
             diff2.VerifyIL("C.<F>d__3.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      264 (0x108)
+  // Code size      268 (0x10c)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -2744,113 +2767,115 @@ class C
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0051
+    IL_0008:  brfalse.s  IL_0012
     IL_000a:  br.s       IL_000c
     IL_000c:  ldloc.0
     IL_000d:  ldc.i4.1
-    IL_000e:  beq        IL_00af
-    IL_0013:  br.s       IL_0015
-    IL_0015:  nop
-    IL_0016:  call       ""System.Threading.Tasks.Task<bool> C.A1()""
-    IL_001b:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
-    IL_0020:  stloc.2
-    IL_0021:  ldloca.s   V_2
-    IL_0023:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
-    IL_0028:  brtrue.s   IL_006d
-    IL_002a:  ldarg.0
-    IL_002b:  ldc.i4.0
-    IL_002c:  dup
-    IL_002d:  stloc.0
-    IL_002e:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_0033:  ldarg.0
-    IL_0034:  ldloc.2
-    IL_0035:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<F>d__3.<>u__4""
-    IL_003a:  ldarg.0
-    IL_003b:  stloc.3
-    IL_003c:  ldarg.0
-    IL_003d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-    IL_0042:  ldloca.s   V_2
-    IL_0044:  ldloca.s   V_3
-    IL_0046:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<F>d__3)""
-    IL_004b:  nop
-    IL_004c:  leave      IL_0107
-    IL_0051:  ldarg.0
-    IL_0052:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<F>d__3.<>u__4""
-    IL_0057:  stloc.2
-    IL_0058:  ldarg.0
-    IL_0059:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<F>d__3.<>u__4""
-    IL_005e:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
-    IL_0064:  ldarg.0
-    IL_0065:  ldc.i4.m1
-    IL_0066:  dup
-    IL_0067:  stloc.0
-    IL_0068:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_006d:  ldloca.s   V_2
-    IL_006f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
-    IL_0074:  pop
-    IL_0075:  call       ""System.Threading.Tasks.Task<C> C.A3()""
-    IL_007a:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<C> System.Threading.Tasks.Task<C>.GetAwaiter()""
-    IL_007f:  stloc.s    V_4
-    IL_0081:  ldloca.s   V_4
-    IL_0083:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<C>.IsCompleted.get""
-    IL_0088:  brtrue.s   IL_00cc
-    IL_008a:  ldarg.0
-    IL_008b:  ldc.i4.1
-    IL_008c:  dup
-    IL_008d:  stloc.0
-    IL_008e:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_0093:  ldarg.0
-    IL_0094:  ldloc.s    V_4
-    IL_0096:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
-    IL_009b:  ldarg.0
-    IL_009c:  stloc.3
-    IL_009d:  ldarg.0
-    IL_009e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-    IL_00a3:  ldloca.s   V_4
-    IL_00a5:  ldloca.s   V_3
-    IL_00a7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<C>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<C>, ref C.<F>d__3)""
-    IL_00ac:  nop
-    IL_00ad:  leave.s    IL_0107
-    IL_00af:  ldarg.0
-    IL_00b0:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
-    IL_00b5:  stloc.s    V_4
-    IL_00b7:  ldarg.0
-    IL_00b8:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
-    IL_00bd:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<C>""
-    IL_00c3:  ldarg.0
-    IL_00c4:  ldc.i4.m1
-    IL_00c5:  dup
-    IL_00c6:  stloc.0
-    IL_00c7:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_00cc:  ldloca.s   V_4
-    IL_00ce:  call       ""C System.Runtime.CompilerServices.TaskAwaiter<C>.GetResult()""
-    IL_00d3:  pop
-    IL_00d4:  ldc.i4.1
-    IL_00d5:  stloc.1
-    IL_00d6:  leave.s    IL_00f2
+    IL_000e:  beq.s      IL_0014
+    IL_0010:  br.s       IL_0019
+    IL_0012:  br.s       IL_0055
+    IL_0014:  br         IL_00b3
+    IL_0019:  nop
+    IL_001a:  call       ""System.Threading.Tasks.Task<bool> C.A1()""
+    IL_001f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
+    IL_0024:  stloc.2
+    IL_0025:  ldloca.s   V_2
+    IL_0027:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.IsCompleted.get""
+    IL_002c:  brtrue.s   IL_0071
+    IL_002e:  ldarg.0
+    IL_002f:  ldc.i4.0
+    IL_0030:  dup
+    IL_0031:  stloc.0
+    IL_0032:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_0037:  ldarg.0
+    IL_0038:  ldloc.2
+    IL_0039:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<F>d__3.<>u__4""
+    IL_003e:  ldarg.0
+    IL_003f:  stloc.3
+    IL_0040:  ldarg.0
+    IL_0041:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+    IL_0046:  ldloca.s   V_2
+    IL_0048:  ldloca.s   V_3
+    IL_004a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<F>d__3)""
+    IL_004f:  nop
+    IL_0050:  leave      IL_010b
+    IL_0055:  ldarg.0
+    IL_0056:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<F>d__3.<>u__4""
+    IL_005b:  stloc.2
+    IL_005c:  ldarg.0
+    IL_005d:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<F>d__3.<>u__4""
+    IL_0062:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
+    IL_0068:  ldarg.0
+    IL_0069:  ldc.i4.m1
+    IL_006a:  dup
+    IL_006b:  stloc.0
+    IL_006c:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_0071:  ldloca.s   V_2
+    IL_0073:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
+    IL_0078:  pop
+    IL_0079:  call       ""System.Threading.Tasks.Task<C> C.A3()""
+    IL_007e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<C> System.Threading.Tasks.Task<C>.GetAwaiter()""
+    IL_0083:  stloc.s    V_4
+    IL_0085:  ldloca.s   V_4
+    IL_0087:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<C>.IsCompleted.get""
+    IL_008c:  brtrue.s   IL_00d0
+    IL_008e:  ldarg.0
+    IL_008f:  ldc.i4.1
+    IL_0090:  dup
+    IL_0091:  stloc.0
+    IL_0092:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_0097:  ldarg.0
+    IL_0098:  ldloc.s    V_4
+    IL_009a:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
+    IL_009f:  ldarg.0
+    IL_00a0:  stloc.3
+    IL_00a1:  ldarg.0
+    IL_00a2:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+    IL_00a7:  ldloca.s   V_4
+    IL_00a9:  ldloca.s   V_3
+    IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<C>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<C>, ref C.<F>d__3)""
+    IL_00b0:  nop
+    IL_00b1:  leave.s    IL_010b
+    IL_00b3:  ldarg.0
+    IL_00b4:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
+    IL_00b9:  stloc.s    V_4
+    IL_00bb:  ldarg.0
+    IL_00bc:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
+    IL_00c1:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<C>""
+    IL_00c7:  ldarg.0
+    IL_00c8:  ldc.i4.m1
+    IL_00c9:  dup
+    IL_00ca:  stloc.0
+    IL_00cb:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_00d0:  ldloca.s   V_4
+    IL_00d2:  call       ""C System.Runtime.CompilerServices.TaskAwaiter<C>.GetResult()""
+    IL_00d7:  pop
+    IL_00d8:  ldc.i4.1
+    IL_00d9:  stloc.1
+    IL_00da:  leave.s    IL_00f6
   }
   catch System.Exception
   {
-    IL_00d8:  stloc.s    V_5
-    IL_00da:  ldarg.0
-    IL_00db:  ldc.i4.s   -2
-    IL_00dd:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_00e2:  ldarg.0
-    IL_00e3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-    IL_00e8:  ldloc.s    V_5
-    IL_00ea:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00ef:  nop
-    IL_00f0:  leave.s    IL_0107
+    IL_00dc:  stloc.s    V_5
+    IL_00de:  ldarg.0
+    IL_00df:  ldc.i4.s   -2
+    IL_00e1:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_00e6:  ldarg.0
+    IL_00e7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+    IL_00ec:  ldloc.s    V_5
+    IL_00ee:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00f3:  nop
+    IL_00f4:  leave.s    IL_010b
   }
-  IL_00f2:  ldarg.0
-  IL_00f3:  ldc.i4.s   -2
-  IL_00f5:  stfld      ""int C.<F>d__3.<>1__state""
-  IL_00fa:  ldarg.0
-  IL_00fb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-  IL_0100:  ldloc.1
-  IL_0101:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_0106:  nop
-  IL_0107:  ret
+  IL_00f6:  ldarg.0
+  IL_00f7:  ldc.i4.s   -2
+  IL_00f9:  stfld      ""int C.<F>d__3.<>1__state""
+  IL_00fe:  ldarg.0
+  IL_00ff:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+  IL_0104:  ldloc.1
+  IL_0105:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_010a:  nop
+  IL_010b:  ret
 }");
             // 2 field defs added - G and H awaiters & 4 methods updated: G, H kickoff and MoveNext
             CheckEncLogDefinitions(md3.Reader,
@@ -3228,49 +3253,51 @@ class C
 
             var baselineIL = @"
 {
-  // Code size       84 (0x54)
+  // Code size       88 (0x58)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0038
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldc.i4.1
-  IL_001e:  newobj     ""<>f__AnonymousType0<int>..ctor(int)""
-  IL_0023:  stfld      ""<anonymous type: int A> C.<F>d__0.<x>5__1""
-  IL_0028:  ldarg.0
-  IL_0029:  ldc.i4.1
-  IL_002a:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_002f:  ldarg.0
-  IL_0030:  ldc.i4.1
-  IL_0031:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0036:  ldc.i4.1
-  IL_0037:  ret
-  IL_0038:  ldarg.0
-  IL_0039:  ldc.i4.m1
-  IL_003a:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_003f:  ldarg.0
-  IL_0040:  ldfld      ""<anonymous type: int A> C.<F>d__0.<x>5__1""
-  IL_0045:  callvirt   ""int <>f__AnonymousType0<int>.A.get""
-  IL_004a:  ldc.i4.<<VALUE>>
-  IL_004b:  add
-  IL_004c:  call       ""void System.Console.WriteLine(int)""
-  IL_0051:  nop
-  IL_0052:  ldc.i4.0
-  IL_0053:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003c
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  newobj     ""<>f__AnonymousType0<int>..ctor(int)""
+  IL_0027:  stfld      ""<anonymous type: int A> C.<F>d__0.<x>5__1""
+  IL_002c:  ldarg.0
+  IL_002d:  ldc.i4.1
+  IL_002e:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0033:  ldarg.0
+  IL_0034:  ldc.i4.1
+  IL_0035:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003a:  ldc.i4.1
+  IL_003b:  ret
+  IL_003c:  ldarg.0
+  IL_003d:  ldc.i4.m1
+  IL_003e:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0043:  ldarg.0
+  IL_0044:  ldfld      ""<anonymous type: int A> C.<F>d__0.<x>5__1""
+  IL_0049:  callvirt   ""int <>f__AnonymousType0<int>.A.get""
+  IL_004e:  ldc.i4.<<VALUE>>
+  IL_004f:  add
+  IL_0050:  call       ""void System.Console.WriteLine(int)""
+  IL_0055:  nop
+  IL_0056:  ldc.i4.0
+  IL_0057:  ret
 }";
             v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "1"));
 
@@ -3360,58 +3387,60 @@ class C
 
             var baselineIL = @"
 {
-  // Code size      105 (0x69)
+  // Code size      109 (0x6d)
   .maxstack  5
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0046
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldc.i4.1
-  IL_001e:  newarr     ""<>f__AnonymousType0<<anonymous type: int B>>""
-  IL_0023:  dup
-  IL_0024:  ldc.i4.0
-  IL_0025:  ldc.i4.1
-  IL_0026:  newobj     ""<>f__AnonymousType1<int>..ctor(int)""
-  IL_002b:  newobj     ""<>f__AnonymousType0<<anonymous type: int B>>..ctor(<anonymous type: int B>)""
-  IL_0030:  stelem.ref
-  IL_0031:  stfld      ""<anonymous type: <anonymous type: int B> A>[] C.<F>d__0.<x>5__1""
-  IL_0036:  ldarg.0
-  IL_0037:  ldc.i4.1
-  IL_0038:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_003d:  ldarg.0
-  IL_003e:  ldc.i4.1
-  IL_003f:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0044:  ldc.i4.1
-  IL_0045:  ret
-  IL_0046:  ldarg.0
-  IL_0047:  ldc.i4.m1
-  IL_0048:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_004d:  ldarg.0
-  IL_004e:  ldfld      ""<anonymous type: <anonymous type: int B> A>[] C.<F>d__0.<x>5__1""
-  IL_0053:  ldc.i4.0
-  IL_0054:  ldelem.ref
-  IL_0055:  callvirt   ""<anonymous type: int B> <>f__AnonymousType0<<anonymous type: int B>>.A.get""
-  IL_005a:  callvirt   ""int <>f__AnonymousType1<int>.B.get""
-  IL_005f:  ldc.i4.<<VALUE>>
-  IL_0060:  add
-  IL_0061:  call       ""void System.Console.WriteLine(int)""
-  IL_0066:  nop
-  IL_0067:  ldc.i4.0
-  IL_0068:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_004a
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.1
+  IL_0022:  newarr     ""<>f__AnonymousType0<<anonymous type: int B>>""
+  IL_0027:  dup
+  IL_0028:  ldc.i4.0
+  IL_0029:  ldc.i4.1
+  IL_002a:  newobj     ""<>f__AnonymousType1<int>..ctor(int)""
+  IL_002f:  newobj     ""<>f__AnonymousType0<<anonymous type: int B>>..ctor(<anonymous type: int B>)""
+  IL_0034:  stelem.ref
+  IL_0035:  stfld      ""<anonymous type: <anonymous type: int B> A>[] C.<F>d__0.<x>5__1""
+  IL_003a:  ldarg.0
+  IL_003b:  ldc.i4.1
+  IL_003c:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0041:  ldarg.0
+  IL_0042:  ldc.i4.1
+  IL_0043:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0048:  ldc.i4.1
+  IL_0049:  ret
+  IL_004a:  ldarg.0
+  IL_004b:  ldc.i4.m1
+  IL_004c:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0051:  ldarg.0
+  IL_0052:  ldfld      ""<anonymous type: <anonymous type: int B> A>[] C.<F>d__0.<x>5__1""
+  IL_0057:  ldc.i4.0
+  IL_0058:  ldelem.ref
+  IL_0059:  callvirt   ""<anonymous type: int B> <>f__AnonymousType0<<anonymous type: int B>>.A.get""
+  IL_005e:  callvirt   ""int <>f__AnonymousType1<int>.B.get""
+  IL_0063:  ldc.i4.<<VALUE>>
+  IL_0064:  add
+  IL_0065:  call       ""void System.Console.WriteLine(int)""
+  IL_006a:  nop
+  IL_006b:  ldc.i4.0
+  IL_006c:  ret
 }";
             v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "1"));
 
@@ -3518,53 +3547,55 @@ class C
 
             var baselineIL = @"
 {
-  // Code size      104 (0x68)
+  // Code size      108 (0x6c)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0037
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  newobj     ""Z<double>.S<int>..ctor()""
-  IL_0022:  stfld      ""Z<double>.S<int> C.<F>d__0.<x>5__1""
-  IL_0027:  ldarg.0
-  IL_0028:  ldc.i4.1
-  IL_0029:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_002e:  ldarg.0
-  IL_002f:  ldc.i4.1
-  IL_0030:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0035:  ldc.i4.1
-  IL_0036:  ret
-  IL_0037:  ldarg.0
-  IL_0038:  ldc.i4.m1
-  IL_0039:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_003e:  ldarg.0
-  IL_003f:  ldfld      ""Z<double>.S<int> C.<F>d__0.<x>5__1""
-  IL_0044:  ldfld      ""double Z<double>.S<int>.a""
-  IL_0049:  ldarg.0
-  IL_004a:  ldfld      ""Z<double>.S<int> C.<F>d__0.<x>5__1""
-  IL_004f:  ldfld      ""int Z<double>.S<int>.b""
-  IL_0054:  conv.r8
-  IL_0055:  add
-  IL_0056:  ldc.r8     <<VALUE>>
-  IL_005f:  add
-  IL_0060:  call       ""void System.Console.WriteLine(double)""
-  IL_0065:  nop
-  IL_0066:  ldc.i4.0
-  IL_0067:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003b
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  newobj     ""Z<double>.S<int>..ctor()""
+  IL_0026:  stfld      ""Z<double>.S<int> C.<F>d__0.<x>5__1""
+  IL_002b:  ldarg.0
+  IL_002c:  ldc.i4.1
+  IL_002d:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0032:  ldarg.0
+  IL_0033:  ldc.i4.1
+  IL_0034:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0039:  ldc.i4.1
+  IL_003a:  ret
+  IL_003b:  ldarg.0
+  IL_003c:  ldc.i4.m1
+  IL_003d:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0042:  ldarg.0
+  IL_0043:  ldfld      ""Z<double>.S<int> C.<F>d__0.<x>5__1""
+  IL_0048:  ldfld      ""double Z<double>.S<int>.a""
+  IL_004d:  ldarg.0
+  IL_004e:  ldfld      ""Z<double>.S<int> C.<F>d__0.<x>5__1""
+  IL_0053:  ldfld      ""int Z<double>.S<int>.b""
+  IL_0058:  conv.r8
+  IL_0059:  add
+  IL_005a:  ldc.r8     <<VALUE>>
+  IL_0063:  add
+  IL_0064:  call       ""void System.Console.WriteLine(double)""
+  IL_0069:  nop
+  IL_006a:  ldc.i4.0
+  IL_006b:  ret
 }";
             v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL.Replace("<<VALUE>>", "1"));
 
@@ -3628,48 +3659,50 @@ class C
 
             var baselineIL0 = @"
 {
-  // Code size       83 (0x53)
+  // Code size       87 (0x57)
   .maxstack  3
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0039
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldnull
-  IL_001e:  ldc.i4.1
-  IL_001f:  newobj     ""<>f__AnonymousType0<dynamic, int>..ctor(dynamic, int)""
-  IL_0024:  stfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
-  IL_0029:  ldarg.0
-  IL_002a:  ldc.i4.1
-  IL_002b:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0030:  ldarg.0
-  IL_0031:  ldc.i4.1
-  IL_0032:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0037:  ldc.i4.1
-  IL_0038:  ret
-  IL_0039:  ldarg.0
-  IL_003a:  ldc.i4.m1
-  IL_003b:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0040:  ldarg.0
-  IL_0041:  ldfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
-  IL_0046:  callvirt   ""int <>f__AnonymousType0<dynamic, int>.B.get""
-  IL_004b:  call       ""void System.Console.WriteLine(int)""
-  IL_0050:  nop
-  IL_0051:  ldc.i4.0
-  IL_0052:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003d
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldnull
+  IL_0022:  ldc.i4.1
+  IL_0023:  newobj     ""<>f__AnonymousType0<dynamic, int>..ctor(dynamic, int)""
+  IL_0028:  stfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
+  IL_002d:  ldarg.0
+  IL_002e:  ldc.i4.1
+  IL_002f:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0034:  ldarg.0
+  IL_0035:  ldc.i4.1
+  IL_0036:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003b:  ldc.i4.1
+  IL_003c:  ret
+  IL_003d:  ldarg.0
+  IL_003e:  ldc.i4.m1
+  IL_003f:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0044:  ldarg.0
+  IL_0045:  ldfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
+  IL_004a:  callvirt   ""int <>f__AnonymousType0<dynamic, int>.B.get""
+  IL_004f:  call       ""void System.Console.WriteLine(int)""
+  IL_0054:  nop
+  IL_0055:  ldc.i4.0
+  IL_0056:  ret
 }";
             v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext()", baselineIL0);
 
@@ -3680,50 +3713,52 @@ class C
 
             var baselineIL = @"
 {
-  // Code size       85 (0x55)
+  // Code size       89 (0x59)
   .maxstack  3
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0039
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldnull
-  IL_001e:  ldc.i4.1
-  IL_001f:  newobj     ""<>f__AnonymousType0<dynamic, int>..ctor(dynamic, int)""
-  IL_0024:  stfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
-  IL_0029:  ldarg.0
-  IL_002a:  ldc.i4.1
-  IL_002b:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_0030:  ldarg.0
-  IL_0031:  ldc.i4.1
-  IL_0032:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0037:  ldc.i4.1
-  IL_0038:  ret
-  IL_0039:  ldarg.0
-  IL_003a:  ldc.i4.m1
-  IL_003b:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0040:  ldarg.0
-  IL_0041:  ldfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
-  IL_0046:  callvirt   ""int <>f__AnonymousType0<dynamic, int>.B.get""
-  IL_004b:  ldc.i4.<<VALUE>>
-  IL_004c:  add
-  IL_004d:  call       ""void System.Console.WriteLine(int)""
-  IL_0052:  nop
-  IL_0053:  ldc.i4.0
-  IL_0054:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003d
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldnull
+  IL_0022:  ldc.i4.1
+  IL_0023:  newobj     ""<>f__AnonymousType0<dynamic, int>..ctor(dynamic, int)""
+  IL_0028:  stfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
+  IL_002d:  ldarg.0
+  IL_002e:  ldc.i4.1
+  IL_002f:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0034:  ldarg.0
+  IL_0035:  ldc.i4.1
+  IL_0036:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_003b:  ldc.i4.1
+  IL_003c:  ret
+  IL_003d:  ldarg.0
+  IL_003e:  ldc.i4.m1
+  IL_003f:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0044:  ldarg.0
+  IL_0045:  ldfld      ""<anonymous type: dynamic A, int B> C.<F>d__0.<x>5__1""
+  IL_004a:  callvirt   ""int <>f__AnonymousType0<dynamic, int>.B.get""
+  IL_004f:  ldc.i4.<<VALUE>>
+  IL_0050:  add
+  IL_0051:  call       ""void System.Console.WriteLine(int)""
+  IL_0056:  nop
+  IL_0057:  ldc.i4.0
+  IL_0058:  ret
 }";
 
             diff1.VerifySynthesizedMembers(
@@ -4034,7 +4069,7 @@ class Program
 
             v0.VerifyIL("Program.<Iterator>d__1.System.Collections.IEnumerator.MoveNext()", @"
 {
-  // Code size      794 (0x31a)
+  // Code size      798 (0x31e)
   .maxstack  5
   .locals init (int V_0,
                 bool V_1,
@@ -4044,261 +4079,263 @@ class Program
   IL_0001:  ldfld      ""int Program.<Iterator>d__1.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0017
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq        IL_0197
-  IL_0013:  br.s       IL_0015
-  IL_0015:  ldc.i4.0
-  IL_0016:  ret
-  IL_0017:  ldarg.0
-  IL_0018:  ldc.i4.m1
-  IL_0019:  stfld      ""int Program.<Iterator>d__1.<>1__state""
-  IL_001e:  nop
-  IL_001f:  ldarg.0
-  IL_0020:  ldc.i4.4
-  IL_0021:  newarr     ""string""
-  IL_0026:  dup
-  IL_0027:  ldc.i4.0
-  IL_0028:  ldstr      ""a""
-  IL_002d:  stelem.ref
-  IL_002e:  dup
-  IL_002f:  ldc.i4.1
-  IL_0030:  ldstr      ""bB""
-  IL_0035:  stelem.ref
-  IL_0036:  dup
-  IL_0037:  ldc.i4.2
-  IL_0038:  ldstr      ""Cc""
-  IL_003d:  stelem.ref
-  IL_003e:  dup
-  IL_003f:  ldc.i4.3
-  IL_0040:  ldstr      ""DD""
-  IL_0045:  stelem.ref
-  IL_0046:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
-  IL_004b:  ldarg.0
-  IL_004c:  ldnull
-  IL_004d:  ldnull
-  IL_004e:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
-  IL_0053:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
-  IL_0058:  ldarg.0
-  IL_0059:  ldc.i4.0
-  IL_005a:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
-  IL_005f:  br         IL_0301
-  IL_0064:  nop
-  IL_0065:  ldarg.0
-  IL_0066:  ldarg.0
-  IL_0067:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
-  IL_006c:  ldsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
-  IL_0071:  dup
-  IL_0072:  brtrue.s   IL_008b
-  IL_0074:  pop
-  IL_0075:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_007a:  ldftn      ""<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> Program.<>c.<Iterator>b__1_0(string)""
-  IL_0080:  newobj     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>..ctor(object, System.IntPtr)""
-  IL_0085:  dup
-  IL_0086:  stsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
-  IL_008b:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> System.Linq.Enumerable.Select<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>(System.Collections.Generic.IEnumerable<string>, System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>)""
-  IL_0090:  ldsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
-  IL_0095:  dup
-  IL_0096:  brtrue.s   IL_00af
-  IL_0098:  pop
-  IL_0099:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_009e:  ldftn      ""<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y> Program.<>c.<Iterator>b__1_1(<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>)""
-  IL_00a4:  newobj     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>..ctor(object, System.IntPtr)""
-  IL_00a9:  dup
-  IL_00aa:  stsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
-  IL_00af:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Select<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>, System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>)""
-  IL_00b4:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
-  IL_00b9:  dup
-  IL_00ba:  brtrue.s   IL_00d3
-  IL_00bc:  pop
-  IL_00bd:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_00c2:  ldftn      ""bool Program.<>c.<Iterator>b__1_2(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
-  IL_00c8:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>..ctor(object, System.IntPtr)""
-  IL_00cd:  dup
-  IL_00ce:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
-  IL_00d3:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>)""
-  IL_00d8:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
-  IL_00dd:  dup
-  IL_00de:  brtrue.s   IL_00f7
-  IL_00e0:  pop
-  IL_00e1:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_00e6:  ldftn      ""int Program.<>c.<Iterator>b__1_3(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
-  IL_00ec:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>..ctor(object, System.IntPtr)""
-  IL_00f1:  dup
-  IL_00f2:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
-  IL_00f7:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.OrderBy<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>)""
-  IL_00fc:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
-  IL_0101:  dup
-  IL_0102:  brtrue.s   IL_011b
-  IL_0104:  pop
-  IL_0105:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_010a:  ldftn      ""string Program.<>c.<Iterator>b__1_4(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
-  IL_0110:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>..ctor(object, System.IntPtr)""
-  IL_0115:  dup
-  IL_0116:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
-  IL_011b:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.ThenByDescending<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>(System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>)""
-  IL_0120:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
-  IL_0125:  dup
-  IL_0126:  brtrue.s   IL_013f
-  IL_0128:  pop
-  IL_0129:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_012e:  ldftn      ""<anonymous type: string Value, int Length> Program.<>c.<Iterator>b__1_5(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
-  IL_0134:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>..ctor(object, System.IntPtr)""
-  IL_0139:  dup
-  IL_013a:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
-  IL_013f:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>)""
-  IL_0144:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
-  IL_0149:  ldarg.0
-  IL_014a:  ldarg.0
-  IL_014b:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
-  IL_0150:  ldnull
-  IL_0151:  ldsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
-  IL_0156:  dup
-  IL_0157:  brtrue.s   IL_0170
-  IL_0159:  pop
-  IL_015a:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_015f:  ldftn      ""<anonymous type: string Head, dynamic Tail> Program.<>c.<Iterator>b__1_6(<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>)""
-  IL_0165:  newobj     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>..ctor(object, System.IntPtr)""
-  IL_016a:  dup
-  IL_016b:  stsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
-  IL_0170:  call       ""<anonymous type: string Head, dynamic Tail> System.Linq.Enumerable.Aggregate<<anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, <anonymous type: string Head, dynamic Tail>, System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>)""
-  IL_0175:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
-  IL_017a:  br.s       IL_01f1
-  IL_017c:  nop
-  IL_017d:  ldarg.0
-  IL_017e:  ldarg.0
-  IL_017f:  ldfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
-  IL_0184:  callvirt   ""string <>f__AnonymousType0<string, dynamic>.Head.get""
-  IL_0189:  stfld      ""string Program.<Iterator>d__1.<>2__current""
-  IL_018e:  ldarg.0
-  IL_018f:  ldc.i4.1
-  IL_0190:  stfld      ""int Program.<Iterator>d__1.<>1__state""
-  IL_0195:  ldc.i4.1
-  IL_0196:  ret
-  IL_0197:  ldarg.0
-  IL_0198:  ldc.i4.m1
-  IL_0199:  stfld      ""int Program.<Iterator>d__1.<>1__state""
-  IL_019e:  ldarg.0
-  IL_019f:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
-  IL_01a4:  brfalse.s  IL_01a8
-  IL_01a6:  br.s       IL_01cc
-  IL_01a8:  ldc.i4.0
-  IL_01a9:  ldtoken    ""<>f__AnonymousType0<string, dynamic>""
-  IL_01ae:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_01b3:  ldtoken    ""Program""
-  IL_01b8:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_01bd:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
-  IL_01c2:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_01c7:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
-  IL_01cc:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
-  IL_01d1:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>>.Target""
-  IL_01d6:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
-  IL_01db:  ldarg.0
-  IL_01dc:  ldfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
-  IL_01e1:  callvirt   ""dynamic <>f__AnonymousType0<string, dynamic>.Tail.get""
-  IL_01e6:  callvirt   ""<anonymous type: string Head, dynamic Tail> System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-  IL_01eb:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
-  IL_01f0:  nop
-  IL_01f1:  ldarg.0
-  IL_01f2:  ldfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
-  IL_01f7:  ldnull
-  IL_01f8:  cgt.un
-  IL_01fa:  stloc.1
-  IL_01fb:  ldloc.1
-  IL_01fc:  brtrue     IL_017c
-  IL_0201:  ldarg.0
-  IL_0202:  ldarg.0
-  IL_0203:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
-  IL_0208:  ldsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
-  IL_020d:  dup
-  IL_020e:  brtrue.s   IL_0227
-  IL_0210:  pop
-  IL_0211:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_0216:  ldftn      ""<anonymous type: <anonymous type: string Value, int Length> a, string value> Program.<>c.<Iterator>b__1_7(<anonymous type: string Value, int Length>)""
-  IL_021c:  newobj     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>..ctor(object, System.IntPtr)""
-  IL_0221:  dup
-  IL_0222:  stsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
-  IL_0227:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>> System.Linq.Enumerable.Select<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>)""
-  IL_022c:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
-  IL_0231:  dup
-  IL_0232:  brtrue.s   IL_024b
-  IL_0234:  pop
-  IL_0235:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_023a:  ldftn      ""<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length> Program.<>c.<Iterator>b__1_8(<anonymous type: <anonymous type: string Value, int Length> a, string value>)""
-  IL_0240:  newobj     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>..ctor(object, System.IntPtr)""
-  IL_0245:  dup
-  IL_0246:  stsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
-  IL_024b:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>>, System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>)""
-  IL_0250:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
-  IL_0255:  dup
-  IL_0256:  brtrue.s   IL_026f
-  IL_0258:  pop
-  IL_0259:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_025e:  ldftn      ""bool Program.<>c.<Iterator>b__1_9(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
-  IL_0264:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>..ctor(object, System.IntPtr)""
-  IL_0269:  dup
-  IL_026a:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
-  IL_026f:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>)""
-  IL_0274:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
-  IL_0279:  dup
-  IL_027a:  brtrue.s   IL_0293
-  IL_027c:  pop
-  IL_027d:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_0282:  ldftn      ""string Program.<>c.<Iterator>b__1_10(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
-  IL_0288:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>..ctor(object, System.IntPtr)""
-  IL_028d:  dup
-  IL_028e:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
-  IL_0293:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>)""
-  IL_0298:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
-  IL_029d:  ldarg.0
-  IL_029e:  ldarg.0
-  IL_029f:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
-  IL_02a4:  ldarg.0
-  IL_02a5:  ldfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
-  IL_02aa:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Concat<string>(System.Collections.Generic.IEnumerable<string>, System.Collections.Generic.IEnumerable<string>)""
-  IL_02af:  call       ""string[] System.Linq.Enumerable.ToArray<string>(System.Collections.Generic.IEnumerable<string>)""
-  IL_02b4:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
-  IL_02b9:  ldarg.0
-  IL_02ba:  ldarg.0
-  IL_02bb:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
-  IL_02c0:  box        ""int""
-  IL_02c5:  ldarg.0
-  IL_02c6:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
-  IL_02cb:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
-  IL_02d0:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
-  IL_02d5:  call       ""void System.Diagnostics.Debugger.Break()""
-  IL_02da:  nop
-  IL_02db:  nop
-  IL_02dc:  ldarg.0
-  IL_02dd:  ldnull
-  IL_02de:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
-  IL_02e3:  ldarg.0
-  IL_02e4:  ldnull
-  IL_02e5:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
-  IL_02ea:  ldarg.0
-  IL_02eb:  ldnull
-  IL_02ec:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
-  IL_02f1:  ldarg.0
-  IL_02f2:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
-  IL_02f7:  stloc.2
-  IL_02f8:  ldarg.0
-  IL_02f9:  ldloc.2
-  IL_02fa:  ldc.i4.1
-  IL_02fb:  add
-  IL_02fc:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
-  IL_0301:  ldarg.0
-  IL_0302:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
-  IL_0307:  ldc.i4.s   10
-  IL_0309:  clt
-  IL_030b:  stloc.3
-  IL_030c:  ldloc.3
-  IL_030d:  brtrue     IL_0064
-  IL_0312:  call       ""void System.Diagnostics.Debugger.Break()""
-  IL_0317:  nop
-  IL_0318:  ldc.i4.0
-  IL_0319:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0019
+  IL_0012:  br.s       IL_001b
+  IL_0014:  br         IL_019b
+  IL_0019:  ldc.i4.0
+  IL_001a:  ret
+  IL_001b:  ldarg.0
+  IL_001c:  ldc.i4.m1
+  IL_001d:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_0022:  nop
+  IL_0023:  ldarg.0
+  IL_0024:  ldc.i4.4
+  IL_0025:  newarr     ""string""
+  IL_002a:  dup
+  IL_002b:  ldc.i4.0
+  IL_002c:  ldstr      ""a""
+  IL_0031:  stelem.ref
+  IL_0032:  dup
+  IL_0033:  ldc.i4.1
+  IL_0034:  ldstr      ""bB""
+  IL_0039:  stelem.ref
+  IL_003a:  dup
+  IL_003b:  ldc.i4.2
+  IL_003c:  ldstr      ""Cc""
+  IL_0041:  stelem.ref
+  IL_0042:  dup
+  IL_0043:  ldc.i4.3
+  IL_0044:  ldstr      ""DD""
+  IL_0049:  stelem.ref
+  IL_004a:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_004f:  ldarg.0
+  IL_0050:  ldnull
+  IL_0051:  ldnull
+  IL_0052:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
+  IL_0057:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_005c:  ldarg.0
+  IL_005d:  ldc.i4.0
+  IL_005e:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0063:  br         IL_0305
+  IL_0068:  nop
+  IL_0069:  ldarg.0
+  IL_006a:  ldarg.0
+  IL_006b:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_0070:  ldsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
+  IL_0075:  dup
+  IL_0076:  brtrue.s   IL_008f
+  IL_0078:  pop
+  IL_0079:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_007e:  ldftn      ""<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> Program.<>c.<Iterator>b__1_0(string)""
+  IL_0084:  newobj     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>..ctor(object, System.IntPtr)""
+  IL_0089:  dup
+  IL_008a:  stsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
+  IL_008f:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> System.Linq.Enumerable.Select<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>(System.Collections.Generic.IEnumerable<string>, System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>)""
+  IL_0094:  ldsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
+  IL_0099:  dup
+  IL_009a:  brtrue.s   IL_00b3
+  IL_009c:  pop
+  IL_009d:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00a2:  ldftn      ""<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y> Program.<>c.<Iterator>b__1_1(<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>)""
+  IL_00a8:  newobj     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>..ctor(object, System.IntPtr)""
+  IL_00ad:  dup
+  IL_00ae:  stsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
+  IL_00b3:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Select<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>, System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>)""
+  IL_00b8:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
+  IL_00bd:  dup
+  IL_00be:  brtrue.s   IL_00d7
+  IL_00c0:  pop
+  IL_00c1:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00c6:  ldftn      ""bool Program.<>c.<Iterator>b__1_2(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_00cc:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>..ctor(object, System.IntPtr)""
+  IL_00d1:  dup
+  IL_00d2:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
+  IL_00d7:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>)""
+  IL_00dc:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
+  IL_00e1:  dup
+  IL_00e2:  brtrue.s   IL_00fb
+  IL_00e4:  pop
+  IL_00e5:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00ea:  ldftn      ""int Program.<>c.<Iterator>b__1_3(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_00f0:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>..ctor(object, System.IntPtr)""
+  IL_00f5:  dup
+  IL_00f6:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
+  IL_00fb:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.OrderBy<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>)""
+  IL_0100:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
+  IL_0105:  dup
+  IL_0106:  brtrue.s   IL_011f
+  IL_0108:  pop
+  IL_0109:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_010e:  ldftn      ""string Program.<>c.<Iterator>b__1_4(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_0114:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>..ctor(object, System.IntPtr)""
+  IL_0119:  dup
+  IL_011a:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
+  IL_011f:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.ThenByDescending<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>(System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>)""
+  IL_0124:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
+  IL_0129:  dup
+  IL_012a:  brtrue.s   IL_0143
+  IL_012c:  pop
+  IL_012d:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0132:  ldftn      ""<anonymous type: string Value, int Length> Program.<>c.<Iterator>b__1_5(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_0138:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>..ctor(object, System.IntPtr)""
+  IL_013d:  dup
+  IL_013e:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
+  IL_0143:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>)""
+  IL_0148:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_014d:  ldarg.0
+  IL_014e:  ldarg.0
+  IL_014f:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_0154:  ldnull
+  IL_0155:  ldsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
+  IL_015a:  dup
+  IL_015b:  brtrue.s   IL_0174
+  IL_015d:  pop
+  IL_015e:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0163:  ldftn      ""<anonymous type: string Head, dynamic Tail> Program.<>c.<Iterator>b__1_6(<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>)""
+  IL_0169:  newobj     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>..ctor(object, System.IntPtr)""
+  IL_016e:  dup
+  IL_016f:  stsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
+  IL_0174:  call       ""<anonymous type: string Head, dynamic Tail> System.Linq.Enumerable.Aggregate<<anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, <anonymous type: string Head, dynamic Tail>, System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>)""
+  IL_0179:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_017e:  br.s       IL_01f5
+  IL_0180:  nop
+  IL_0181:  ldarg.0
+  IL_0182:  ldarg.0
+  IL_0183:  ldfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_0188:  callvirt   ""string <>f__AnonymousType0<string, dynamic>.Head.get""
+  IL_018d:  stfld      ""string Program.<Iterator>d__1.<>2__current""
+  IL_0192:  ldarg.0
+  IL_0193:  ldc.i4.1
+  IL_0194:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_0199:  ldc.i4.1
+  IL_019a:  ret
+  IL_019b:  ldarg.0
+  IL_019c:  ldc.i4.m1
+  IL_019d:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_01a2:  ldarg.0
+  IL_01a3:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
+  IL_01a8:  brfalse.s  IL_01ac
+  IL_01aa:  br.s       IL_01d0
+  IL_01ac:  ldc.i4.0
+  IL_01ad:  ldtoken    ""<>f__AnonymousType0<string, dynamic>""
+  IL_01b2:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_01b7:  ldtoken    ""Program""
+  IL_01bc:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_01c1:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_01c6:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_01cb:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
+  IL_01d0:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
+  IL_01d5:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>>.Target""
+  IL_01da:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>> Program.<>o__1.<>p__0""
+  IL_01df:  ldarg.0
+  IL_01e0:  ldfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_01e5:  callvirt   ""dynamic <>f__AnonymousType0<string, dynamic>.Tail.get""
+  IL_01ea:  callvirt   ""<anonymous type: string Head, dynamic Tail> System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: string Head, dynamic Tail>>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_01ef:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_01f4:  nop
+  IL_01f5:  ldarg.0
+  IL_01f6:  ldfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_01fb:  ldnull
+  IL_01fc:  cgt.un
+  IL_01fe:  stloc.1
+  IL_01ff:  ldloc.1
+  IL_0200:  brtrue     IL_0180
+  IL_0205:  ldarg.0
+  IL_0206:  ldarg.0
+  IL_0207:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_020c:  ldsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
+  IL_0211:  dup
+  IL_0212:  brtrue.s   IL_022b
+  IL_0214:  pop
+  IL_0215:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_021a:  ldftn      ""<anonymous type: <anonymous type: string Value, int Length> a, string value> Program.<>c.<Iterator>b__1_7(<anonymous type: string Value, int Length>)""
+  IL_0220:  newobj     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>..ctor(object, System.IntPtr)""
+  IL_0225:  dup
+  IL_0226:  stsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
+  IL_022b:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>> System.Linq.Enumerable.Select<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>)""
+  IL_0230:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
+  IL_0235:  dup
+  IL_0236:  brtrue.s   IL_024f
+  IL_0238:  pop
+  IL_0239:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_023e:  ldftn      ""<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length> Program.<>c.<Iterator>b__1_8(<anonymous type: <anonymous type: string Value, int Length> a, string value>)""
+  IL_0244:  newobj     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>..ctor(object, System.IntPtr)""
+  IL_0249:  dup
+  IL_024a:  stsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
+  IL_024f:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>>, System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>)""
+  IL_0254:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
+  IL_0259:  dup
+  IL_025a:  brtrue.s   IL_0273
+  IL_025c:  pop
+  IL_025d:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0262:  ldftn      ""bool Program.<>c.<Iterator>b__1_9(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
+  IL_0268:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>..ctor(object, System.IntPtr)""
+  IL_026d:  dup
+  IL_026e:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
+  IL_0273:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>)""
+  IL_0278:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
+  IL_027d:  dup
+  IL_027e:  brtrue.s   IL_0297
+  IL_0280:  pop
+  IL_0281:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0286:  ldftn      ""string Program.<>c.<Iterator>b__1_10(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
+  IL_028c:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>..ctor(object, System.IntPtr)""
+  IL_0291:  dup
+  IL_0292:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
+  IL_0297:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>)""
+  IL_029c:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_02a1:  ldarg.0
+  IL_02a2:  ldarg.0
+  IL_02a3:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_02a8:  ldarg.0
+  IL_02a9:  ldfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_02ae:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Concat<string>(System.Collections.Generic.IEnumerable<string>, System.Collections.Generic.IEnumerable<string>)""
+  IL_02b3:  call       ""string[] System.Linq.Enumerable.ToArray<string>(System.Collections.Generic.IEnumerable<string>)""
+  IL_02b8:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_02bd:  ldarg.0
+  IL_02be:  ldarg.0
+  IL_02bf:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_02c4:  box        ""int""
+  IL_02c9:  ldarg.0
+  IL_02ca:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_02cf:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
+  IL_02d4:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_02d9:  call       ""void System.Diagnostics.Debugger.Break()""
+  IL_02de:  nop
+  IL_02df:  nop
+  IL_02e0:  ldarg.0
+  IL_02e1:  ldnull
+  IL_02e2:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_02e7:  ldarg.0
+  IL_02e8:  ldnull
+  IL_02e9:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_02ee:  ldarg.0
+  IL_02ef:  ldnull
+  IL_02f0:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_02f5:  ldarg.0
+  IL_02f6:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_02fb:  stloc.2
+  IL_02fc:  ldarg.0
+  IL_02fd:  ldloc.2
+  IL_02fe:  ldc.i4.1
+  IL_02ff:  add
+  IL_0300:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0305:  ldarg.0
+  IL_0306:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_030b:  ldc.i4.s   10
+  IL_030d:  clt
+  IL_030f:  stloc.3
+  IL_0310:  ldloc.3
+  IL_0311:  brtrue     IL_0068
+  IL_0316:  call       ""void System.Diagnostics.Debugger.Break()""
+  IL_031b:  nop
+  IL_031c:  ldc.i4.0
+  IL_031d:  ret
 }");
 
             var diff1 = compilation1.EmitDifference(
@@ -4320,7 +4357,7 @@ class Program
 
             diff1.VerifyIL("Program.<Iterator>d__1.System.Collections.IEnumerator.MoveNext()", @"
 {
-  // Code size      881 (0x371)
+  // Code size      885 (0x375)
   .maxstack  5
   .locals init (int V_0,
                 bool V_1,
@@ -4330,283 +4367,285 @@ class Program
   IL_0001:  ldfld      ""int Program.<Iterator>d__1.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0017
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq        IL_01e7
-  IL_0013:  br.s       IL_0015
-  IL_0015:  ldc.i4.0
-  IL_0016:  ret
-  IL_0017:  ldarg.0
-  IL_0018:  ldc.i4.m1
-  IL_0019:  stfld      ""int Program.<Iterator>d__1.<>1__state""
-  IL_001e:  nop
-  IL_001f:  ldarg.0
-  IL_0020:  ldc.i4.4
-  IL_0021:  newarr     ""string""
-  IL_0026:  dup
-  IL_0027:  ldc.i4.0
-  IL_0028:  ldstr      ""a""
-  IL_002d:  stelem.ref
-  IL_002e:  dup
-  IL_002f:  ldc.i4.1
-  IL_0030:  ldstr      ""bB""
-  IL_0035:  stelem.ref
-  IL_0036:  dup
-  IL_0037:  ldc.i4.2
-  IL_0038:  ldstr      ""Cc""
-  IL_003d:  stelem.ref
-  IL_003e:  dup
-  IL_003f:  ldc.i4.3
-  IL_0040:  ldstr      ""DD""
-  IL_0045:  stelem.ref
-  IL_0046:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
-  IL_004b:  ldarg.0
-  IL_004c:  ldnull
-  IL_004d:  ldnull
-  IL_004e:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
-  IL_0053:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
-  IL_0058:  ldarg.0
-  IL_0059:  ldc.i4.0
-  IL_005a:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
-  IL_005f:  br         IL_0358
-  IL_0064:  nop
-  IL_0065:  ldarg.0
-  IL_0066:  ldarg.0
-  IL_0067:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
-  IL_006c:  ldsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
-  IL_0071:  dup
-  IL_0072:  brtrue.s   IL_008b
-  IL_0074:  pop
-  IL_0075:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_007a:  ldftn      ""<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> Program.<>c.<Iterator>b__1_0(string)""
-  IL_0080:  newobj     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>..ctor(object, System.IntPtr)""
-  IL_0085:  dup
-  IL_0086:  stsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
-  IL_008b:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> System.Linq.Enumerable.Select<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>(System.Collections.Generic.IEnumerable<string>, System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>)""
-  IL_0090:  ldsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
-  IL_0095:  dup
-  IL_0096:  brtrue.s   IL_00af
-  IL_0098:  pop
-  IL_0099:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_009e:  ldftn      ""<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y> Program.<>c.<Iterator>b__1_1(<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>)""
-  IL_00a4:  newobj     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>..ctor(object, System.IntPtr)""
-  IL_00a9:  dup
-  IL_00aa:  stsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
-  IL_00af:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Select<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>, System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>)""
-  IL_00b4:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
-  IL_00b9:  dup
-  IL_00ba:  brtrue.s   IL_00d3
-  IL_00bc:  pop
-  IL_00bd:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_00c2:  ldftn      ""bool Program.<>c.<Iterator>b__1_2(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
-  IL_00c8:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>..ctor(object, System.IntPtr)""
-  IL_00cd:  dup
-  IL_00ce:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
-  IL_00d3:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>)""
-  IL_00d8:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
-  IL_00dd:  dup
-  IL_00de:  brtrue.s   IL_00f7
-  IL_00e0:  pop
-  IL_00e1:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_00e6:  ldftn      ""int Program.<>c.<Iterator>b__1_3(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
-  IL_00ec:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>..ctor(object, System.IntPtr)""
-  IL_00f1:  dup
-  IL_00f2:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
-  IL_00f7:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.OrderBy<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>)""
-  IL_00fc:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
-  IL_0101:  dup
-  IL_0102:  brtrue.s   IL_011b
-  IL_0104:  pop
-  IL_0105:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_010a:  ldftn      ""string Program.<>c.<Iterator>b__1_4(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
-  IL_0110:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>..ctor(object, System.IntPtr)""
-  IL_0115:  dup
-  IL_0116:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
-  IL_011b:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.ThenByDescending<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>(System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>)""
-  IL_0120:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
-  IL_0125:  dup
-  IL_0126:  brtrue.s   IL_013f
-  IL_0128:  pop
-  IL_0129:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_012e:  ldftn      ""<anonymous type: string Value, int Length> Program.<>c.<Iterator>b__1_5(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
-  IL_0134:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>..ctor(object, System.IntPtr)""
-  IL_0139:  dup
-  IL_013a:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
-  IL_013f:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>)""
-  IL_0144:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
-  IL_0149:  ldarg.0
-  IL_014a:  ldarg.0
-  IL_014b:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
-  IL_0150:  ldnull
-  IL_0151:  ldsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
-  IL_0156:  dup
-  IL_0157:  brtrue.s   IL_0170
-  IL_0159:  pop
-  IL_015a:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_015f:  ldftn      ""<anonymous type: string Head, dynamic Tail> Program.<>c.<Iterator>b__1_6(<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>)""
-  IL_0165:  newobj     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>..ctor(object, System.IntPtr)""
-  IL_016a:  dup
-  IL_016b:  stsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
-  IL_0170:  call       ""<anonymous type: string Head, dynamic Tail> System.Linq.Enumerable.Aggregate<<anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, <anonymous type: string Head, dynamic Tail>, System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>)""
-  IL_0175:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
-  IL_017a:  ldarg.0
-  IL_017b:  ldarg.0
-  IL_017c:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
-  IL_0181:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
-  IL_0186:  br         IL_0241
-  IL_018b:  nop
-  IL_018c:  ldarg.0
-  IL_018d:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
-  IL_0192:  brfalse.s  IL_0196
-  IL_0194:  br.s       IL_01ba
-  IL_0196:  ldc.i4.0
-  IL_0197:  ldtoken    ""string""
-  IL_019c:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_01a1:  ldtoken    ""Program""
-  IL_01a6:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_01ab:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
-  IL_01b0:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_01b5:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
-  IL_01ba:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
-  IL_01bf:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>>.Target""
-  IL_01c4:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
-  IL_01c9:  ldarg.0
-  IL_01ca:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
-  IL_01cf:  callvirt   ""dynamic <>f__AnonymousType0<dynamic, dynamic>.Head.get""
-  IL_01d4:  callvirt   ""string System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-  IL_01d9:  stfld      ""string Program.<Iterator>d__1.<>2__current""
-  IL_01de:  ldarg.0
-  IL_01df:  ldc.i4.1
-  IL_01e0:  stfld      ""int Program.<Iterator>d__1.<>1__state""
-  IL_01e5:  ldc.i4.1
-  IL_01e6:  ret
-  IL_01e7:  ldarg.0
-  IL_01e8:  ldc.i4.m1
-  IL_01e9:  stfld      ""int Program.<Iterator>d__1.<>1__state""
-  IL_01ee:  ldarg.0
-  IL_01ef:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
-  IL_01f4:  brfalse.s  IL_01f8
-  IL_01f6:  br.s       IL_021c
-  IL_01f8:  ldc.i4.0
-  IL_01f9:  ldtoken    ""<>f__AnonymousType0<dynamic, dynamic>""
-  IL_01fe:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_0203:  ldtoken    ""Program""
-  IL_0208:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_020d:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
-  IL_0212:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_0217:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
-  IL_021c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
-  IL_0221:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>>.Target""
-  IL_0226:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
-  IL_022b:  ldarg.0
-  IL_022c:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
-  IL_0231:  callvirt   ""dynamic <>f__AnonymousType0<dynamic, dynamic>.Tail.get""
-  IL_0236:  callvirt   ""<anonymous type: dynamic Head, dynamic Tail> System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-  IL_023b:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
-  IL_0240:  nop
-  IL_0241:  ldarg.0
-  IL_0242:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
-  IL_0247:  ldnull
-  IL_0248:  cgt.un
-  IL_024a:  stloc.1
-  IL_024b:  ldloc.1
-  IL_024c:  brtrue     IL_018b
-  IL_0251:  ldarg.0
-  IL_0252:  ldarg.0
-  IL_0253:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
-  IL_0258:  ldsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
-  IL_025d:  dup
-  IL_025e:  brtrue.s   IL_0277
-  IL_0260:  pop
-  IL_0261:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_0266:  ldftn      ""<anonymous type: <anonymous type: string Value, int Length> a, string value> Program.<>c.<Iterator>b__1_7(<anonymous type: string Value, int Length>)""
-  IL_026c:  newobj     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>..ctor(object, System.IntPtr)""
-  IL_0271:  dup
-  IL_0272:  stsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
-  IL_0277:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>> System.Linq.Enumerable.Select<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>)""
-  IL_027c:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
-  IL_0281:  dup
-  IL_0282:  brtrue.s   IL_029b
-  IL_0284:  pop
-  IL_0285:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_028a:  ldftn      ""<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length> Program.<>c.<Iterator>b__1_8(<anonymous type: <anonymous type: string Value, int Length> a, string value>)""
-  IL_0290:  newobj     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>..ctor(object, System.IntPtr)""
-  IL_0295:  dup
-  IL_0296:  stsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
-  IL_029b:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>>, System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>)""
-  IL_02a0:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
-  IL_02a5:  dup
-  IL_02a6:  brtrue.s   IL_02bf
-  IL_02a8:  pop
-  IL_02a9:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_02ae:  ldftn      ""bool Program.<>c.<Iterator>b__1_9(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
-  IL_02b4:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>..ctor(object, System.IntPtr)""
-  IL_02b9:  dup
-  IL_02ba:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
-  IL_02bf:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>)""
-  IL_02c4:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
-  IL_02c9:  dup
-  IL_02ca:  brtrue.s   IL_02e3
-  IL_02cc:  pop
-  IL_02cd:  ldsfld     ""Program.<>c Program.<>c.<>9""
-  IL_02d2:  ldftn      ""string Program.<>c.<Iterator>b__1_10(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
-  IL_02d8:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>..ctor(object, System.IntPtr)""
-  IL_02dd:  dup
-  IL_02de:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
-  IL_02e3:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>)""
-  IL_02e8:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
-  IL_02ed:  ldarg.0
-  IL_02ee:  ldarg.0
-  IL_02ef:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
-  IL_02f4:  ldarg.0
-  IL_02f5:  ldfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
-  IL_02fa:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Concat<string>(System.Collections.Generic.IEnumerable<string>, System.Collections.Generic.IEnumerable<string>)""
-  IL_02ff:  call       ""string[] System.Linq.Enumerable.ToArray<string>(System.Collections.Generic.IEnumerable<string>)""
-  IL_0304:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
-  IL_0309:  ldarg.0
-  IL_030a:  ldarg.0
-  IL_030b:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
-  IL_0310:  box        ""int""
-  IL_0315:  ldarg.0
-  IL_0316:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
-  IL_031b:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
-  IL_0320:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
-  IL_0325:  call       ""void System.Diagnostics.Debugger.Break()""
-  IL_032a:  nop
-  IL_032b:  nop
-  IL_032c:  ldarg.0
-  IL_032d:  ldnull
-  IL_032e:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
-  IL_0333:  ldarg.0
-  IL_0334:  ldnull
-  IL_0335:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
-  IL_033a:  ldarg.0
-  IL_033b:  ldnull
-  IL_033c:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
-  IL_0341:  ldarg.0
-  IL_0342:  ldnull
-  IL_0343:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
-  IL_0348:  ldarg.0
-  IL_0349:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
-  IL_034e:  stloc.2
-  IL_034f:  ldarg.0
-  IL_0350:  ldloc.2
-  IL_0351:  ldc.i4.1
-  IL_0352:  add
-  IL_0353:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
-  IL_0358:  ldarg.0
-  IL_0359:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
-  IL_035e:  ldc.i4.s   10
-  IL_0360:  clt
-  IL_0362:  stloc.3
-  IL_0363:  ldloc.3
-  IL_0364:  brtrue     IL_0064
-  IL_0369:  call       ""void System.Diagnostics.Debugger.Break()""
-  IL_036e:  nop
-  IL_036f:  ldc.i4.0
-  IL_0370:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0019
+  IL_0012:  br.s       IL_001b
+  IL_0014:  br         IL_01eb
+  IL_0019:  ldc.i4.0
+  IL_001a:  ret
+  IL_001b:  ldarg.0
+  IL_001c:  ldc.i4.m1
+  IL_001d:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_0022:  nop
+  IL_0023:  ldarg.0
+  IL_0024:  ldc.i4.4
+  IL_0025:  newarr     ""string""
+  IL_002a:  dup
+  IL_002b:  ldc.i4.0
+  IL_002c:  ldstr      ""a""
+  IL_0031:  stelem.ref
+  IL_0032:  dup
+  IL_0033:  ldc.i4.1
+  IL_0034:  ldstr      ""bB""
+  IL_0039:  stelem.ref
+  IL_003a:  dup
+  IL_003b:  ldc.i4.2
+  IL_003c:  ldstr      ""Cc""
+  IL_0041:  stelem.ref
+  IL_0042:  dup
+  IL_0043:  ldc.i4.3
+  IL_0044:  ldstr      ""DD""
+  IL_0049:  stelem.ref
+  IL_004a:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_004f:  ldarg.0
+  IL_0050:  ldnull
+  IL_0051:  ldnull
+  IL_0052:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
+  IL_0057:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_005c:  ldarg.0
+  IL_005d:  ldc.i4.0
+  IL_005e:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0063:  br         IL_035c
+  IL_0068:  nop
+  IL_0069:  ldarg.0
+  IL_006a:  ldarg.0
+  IL_006b:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_0070:  ldsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
+  IL_0075:  dup
+  IL_0076:  brtrue.s   IL_008f
+  IL_0078:  pop
+  IL_0079:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_007e:  ldftn      ""<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> Program.<>c.<Iterator>b__1_0(string)""
+  IL_0084:  newobj     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>..ctor(object, System.IntPtr)""
+  IL_0089:  dup
+  IL_008a:  stsfld     ""System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> Program.<>c.<>9__1_0""
+  IL_008f:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>> System.Linq.Enumerable.Select<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>(System.Collections.Generic.IEnumerable<string>, System.Func<string, <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>)""
+  IL_0094:  ldsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
+  IL_0099:  dup
+  IL_009a:  brtrue.s   IL_00b3
+  IL_009c:  pop
+  IL_009d:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00a2:  ldftn      ""<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y> Program.<>c.<Iterator>b__1_1(<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>)""
+  IL_00a8:  newobj     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>..ctor(object, System.IntPtr)""
+  IL_00ad:  dup
+  IL_00ae:  stsfld     ""System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> Program.<>c.<>9__1_1""
+  IL_00b3:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Select<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>>, System.Func<<anonymous type: string a, System.Collections.Generic.IEnumerable<char> x>, <anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>)""
+  IL_00b8:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
+  IL_00bd:  dup
+  IL_00be:  brtrue.s   IL_00d7
+  IL_00c0:  pop
+  IL_00c1:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00c6:  ldftn      ""bool Program.<>c.<Iterator>b__1_2(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_00cc:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>..ctor(object, System.IntPtr)""
+  IL_00d1:  dup
+  IL_00d2:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool> Program.<>c.<>9__1_2""
+  IL_00d7:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, bool>)""
+  IL_00dc:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
+  IL_00e1:  dup
+  IL_00e2:  brtrue.s   IL_00fb
+  IL_00e4:  pop
+  IL_00e5:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_00ea:  ldftn      ""int Program.<>c.<Iterator>b__1_3(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_00f0:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>..ctor(object, System.IntPtr)""
+  IL_00f5:  dup
+  IL_00f6:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int> Program.<>c.<>9__1_3""
+  IL_00fb:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.OrderBy<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, int>)""
+  IL_0100:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
+  IL_0105:  dup
+  IL_0106:  brtrue.s   IL_011f
+  IL_0108:  pop
+  IL_0109:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_010e:  ldftn      ""string Program.<>c.<Iterator>b__1_4(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_0114:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>..ctor(object, System.IntPtr)""
+  IL_0119:  dup
+  IL_011a:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string> Program.<>c.<>9__1_4""
+  IL_011f:  call       ""System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>> System.Linq.Enumerable.ThenByDescending<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>(System.Linq.IOrderedEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, string>)""
+  IL_0124:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
+  IL_0129:  dup
+  IL_012a:  brtrue.s   IL_0143
+  IL_012c:  pop
+  IL_012d:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0132:  ldftn      ""<anonymous type: string Value, int Length> Program.<>c.<Iterator>b__1_5(<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>)""
+  IL_0138:  newobj     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>..ctor(object, System.IntPtr)""
+  IL_013d:  dup
+  IL_013e:  stsfld     ""System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>> Program.<>c.<>9__1_5""
+  IL_0143:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>>, System.Func<<anonymous type: <anonymous type: string a, System.Collections.Generic.IEnumerable<char> x> <>h__TransparentIdentifier0, System.Collections.Generic.IEnumerable<char> y>, <anonymous type: string Value, int Length>>)""
+  IL_0148:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_014d:  ldarg.0
+  IL_014e:  ldarg.0
+  IL_014f:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_0154:  ldnull
+  IL_0155:  ldsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
+  IL_015a:  dup
+  IL_015b:  brtrue.s   IL_0174
+  IL_015d:  pop
+  IL_015e:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_0163:  ldftn      ""<anonymous type: string Head, dynamic Tail> Program.<>c.<Iterator>b__1_6(<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>)""
+  IL_0169:  newobj     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>..ctor(object, System.IntPtr)""
+  IL_016e:  dup
+  IL_016f:  stsfld     ""System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>> Program.<>c.<>9__1_6""
+  IL_0174:  call       ""<anonymous type: string Head, dynamic Tail> System.Linq.Enumerable.Aggregate<<anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, <anonymous type: string Head, dynamic Tail>, System.Func<<anonymous type: string Head, dynamic Tail>, <anonymous type: string Value, int Length>, <anonymous type: string Head, dynamic Tail>>)""
+  IL_0179:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_017e:  ldarg.0
+  IL_017f:  ldarg.0
+  IL_0180:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_0185:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_018a:  br         IL_0245
+  IL_018f:  nop
+  IL_0190:  ldarg.0
+  IL_0191:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
+  IL_0196:  brfalse.s  IL_019a
+  IL_0198:  br.s       IL_01be
+  IL_019a:  ldc.i4.0
+  IL_019b:  ldtoken    ""string""
+  IL_01a0:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_01a5:  ldtoken    ""Program""
+  IL_01aa:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_01af:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_01b4:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_01b9:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
+  IL_01be:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
+  IL_01c3:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>>.Target""
+  IL_01c8:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>> Program.<>o__1#1.<>p__0""
+  IL_01cd:  ldarg.0
+  IL_01ce:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_01d3:  callvirt   ""dynamic <>f__AnonymousType0<dynamic, dynamic>.Head.get""
+  IL_01d8:  callvirt   ""string System.Func<System.Runtime.CompilerServices.CallSite, dynamic, string>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_01dd:  stfld      ""string Program.<Iterator>d__1.<>2__current""
+  IL_01e2:  ldarg.0
+  IL_01e3:  ldc.i4.1
+  IL_01e4:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_01e9:  ldc.i4.1
+  IL_01ea:  ret
+  IL_01eb:  ldarg.0
+  IL_01ec:  ldc.i4.m1
+  IL_01ed:  stfld      ""int Program.<Iterator>d__1.<>1__state""
+  IL_01f2:  ldarg.0
+  IL_01f3:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
+  IL_01f8:  brfalse.s  IL_01fc
+  IL_01fa:  br.s       IL_0220
+  IL_01fc:  ldc.i4.0
+  IL_01fd:  ldtoken    ""<>f__AnonymousType0<dynamic, dynamic>""
+  IL_0202:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0207:  ldtoken    ""Program""
+  IL_020c:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0211:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_0216:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_021b:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
+  IL_0220:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
+  IL_0225:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>>.Target""
+  IL_022a:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>> Program.<>o__1#1.<>p__1""
+  IL_022f:  ldarg.0
+  IL_0230:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_0235:  callvirt   ""dynamic <>f__AnonymousType0<dynamic, dynamic>.Tail.get""
+  IL_023a:  callvirt   ""<anonymous type: dynamic Head, dynamic Tail> System.Func<System.Runtime.CompilerServices.CallSite, dynamic, <anonymous type: dynamic Head, dynamic Tail>>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+  IL_023f:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_0244:  nop
+  IL_0245:  ldarg.0
+  IL_0246:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_024b:  ldnull
+  IL_024c:  cgt.un
+  IL_024e:  stloc.1
+  IL_024f:  ldloc.1
+  IL_0250:  brtrue     IL_018f
+  IL_0255:  ldarg.0
+  IL_0256:  ldarg.0
+  IL_0257:  ldfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_025c:  ldsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
+  IL_0261:  dup
+  IL_0262:  brtrue.s   IL_027b
+  IL_0264:  pop
+  IL_0265:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_026a:  ldftn      ""<anonymous type: <anonymous type: string Value, int Length> a, string value> Program.<>c.<Iterator>b__1_7(<anonymous type: string Value, int Length>)""
+  IL_0270:  newobj     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>..ctor(object, System.IntPtr)""
+  IL_0275:  dup
+  IL_0276:  stsfld     ""System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>> Program.<>c.<>9__1_7""
+  IL_027b:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>> System.Linq.Enumerable.Select<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>(System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>>, System.Func<<anonymous type: string Value, int Length>, <anonymous type: <anonymous type: string Value, int Length> a, string value>>)""
+  IL_0280:  ldsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
+  IL_0285:  dup
+  IL_0286:  brtrue.s   IL_029f
+  IL_0288:  pop
+  IL_0289:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_028e:  ldftn      ""<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length> Program.<>c.<Iterator>b__1_8(<anonymous type: <anonymous type: string Value, int Length> a, string value>)""
+  IL_0294:  newobj     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>..ctor(object, System.IntPtr)""
+  IL_0299:  dup
+  IL_029a:  stsfld     ""System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> Program.<>c.<>9__1_8""
+  IL_029f:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: string Value, int Length> a, string value>>, System.Func<<anonymous type: <anonymous type: string Value, int Length> a, string value>, <anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>)""
+  IL_02a4:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
+  IL_02a9:  dup
+  IL_02aa:  brtrue.s   IL_02c3
+  IL_02ac:  pop
+  IL_02ad:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_02b2:  ldftn      ""bool Program.<>c.<Iterator>b__1_9(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
+  IL_02b8:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>..ctor(object, System.IntPtr)""
+  IL_02bd:  dup
+  IL_02be:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool> Program.<>c.<>9__1_9""
+  IL_02c3:  call       ""System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>> System.Linq.Enumerable.Where<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, bool>)""
+  IL_02c8:  ldsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
+  IL_02cd:  dup
+  IL_02ce:  brtrue.s   IL_02e7
+  IL_02d0:  pop
+  IL_02d1:  ldsfld     ""Program.<>c Program.<>c.<>9""
+  IL_02d6:  ldftn      ""string Program.<>c.<Iterator>b__1_10(<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>)""
+  IL_02dc:  newobj     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>..ctor(object, System.IntPtr)""
+  IL_02e1:  dup
+  IL_02e2:  stsfld     ""System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string> Program.<>c.<>9__1_10""
+  IL_02e7:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Select<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>(System.Collections.Generic.IEnumerable<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>>, System.Func<<anonymous type: <anonymous type: <anonymous type: string Value, int Length> a, string value> <>h__TransparentIdentifier0, int length>, string>)""
+  IL_02ec:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_02f1:  ldarg.0
+  IL_02f2:  ldarg.0
+  IL_02f3:  ldfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_02f8:  ldarg.0
+  IL_02f9:  ldfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_02fe:  call       ""System.Collections.Generic.IEnumerable<string> System.Linq.Enumerable.Concat<string>(System.Collections.Generic.IEnumerable<string>, System.Collections.Generic.IEnumerable<string>)""
+  IL_0303:  call       ""string[] System.Linq.Enumerable.ToArray<string>(System.Collections.Generic.IEnumerable<string>)""
+  IL_0308:  stfld      ""string[] Program.<Iterator>d__1.<args>5__1""
+  IL_030d:  ldarg.0
+  IL_030e:  ldarg.0
+  IL_030f:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0314:  box        ""int""
+  IL_0319:  ldarg.0
+  IL_031a:  ldfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_031f:  newobj     ""<>f__AnonymousType0<dynamic, dynamic>..ctor(dynamic, dynamic)""
+  IL_0324:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<list>5__2""
+  IL_0329:  call       ""void System.Diagnostics.Debugger.Break()""
+  IL_032e:  nop
+  IL_032f:  nop
+  IL_0330:  ldarg.0
+  IL_0331:  ldnull
+  IL_0332:  stfld      ""System.Collections.Generic.IEnumerable<<anonymous type: string Value, int Length>> Program.<Iterator>d__1.<result>5__4""
+  IL_0337:  ldarg.0
+  IL_0338:  ldnull
+  IL_0339:  stfld      ""<anonymous type: string Head, dynamic Tail> Program.<Iterator>d__1.<linked>5__5""
+  IL_033e:  ldarg.0
+  IL_033f:  ldnull
+  IL_0340:  stfld      ""<anonymous type: dynamic Head, dynamic Tail> Program.<Iterator>d__1.<temp>5__7""
+  IL_0345:  ldarg.0
+  IL_0346:  ldnull
+  IL_0347:  stfld      ""System.Collections.Generic.IEnumerable<string> Program.<Iterator>d__1.<newArgs>5__6""
+  IL_034c:  ldarg.0
+  IL_034d:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0352:  stloc.2
+  IL_0353:  ldarg.0
+  IL_0354:  ldloc.2
+  IL_0355:  ldc.i4.1
+  IL_0356:  add
+  IL_0357:  stfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_035c:  ldarg.0
+  IL_035d:  ldfld      ""int Program.<Iterator>d__1.<i>5__3""
+  IL_0362:  ldc.i4.s   10
+  IL_0364:  clt
+  IL_0366:  stloc.3
+  IL_0367:  ldloc.3
+  IL_0368:  brtrue     IL_0068
+  IL_036d:  call       ""void System.Diagnostics.Debugger.Break()""
+  IL_0372:  nop
+  IL_0373:  ldc.i4.0
+  IL_0374:  ret
 }");
 
             var diff2 = compilation2.EmitDifference(

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -3263,72 +3263,74 @@ class C
 
             v0.VerifyIL("C.<F>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size      127 (0x7f)
+  // Code size      131 (0x83)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0076
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_001b:  nop
-  IL_001c:  ldarg.0
-  IL_001d:  ldarg.0
-  IL_001e:  ldfld      ""C C.<F>d__0.<>4__this""
-  IL_0023:  call       ""System.Collections.Generic.IEnumerable<int> C.F()""
-  IL_0028:  stfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
-  IL_002d:  ldarg.0
-  IL_002e:  ldc.i4.0
-  IL_002f:  stfld      ""bool C.<F>d__0.<>s__2""
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_007a
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_001f:  nop
+  IL_0020:  ldarg.0
+  IL_0021:  ldarg.0
+  IL_0022:  ldfld      ""C C.<F>d__0.<>4__this""
+  IL_0027:  call       ""System.Collections.Generic.IEnumerable<int> C.F()""
+  IL_002c:  stfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
+  IL_0031:  ldarg.0
+  IL_0032:  ldc.i4.0
+  IL_0033:  stfld      ""bool C.<F>d__0.<>s__2""
   .try
   {
-    IL_0034:  ldarg.0
-    IL_0035:  ldfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
-    IL_003a:  ldarg.0
-    IL_003b:  ldflda     ""bool C.<F>d__0.<>s__2""
-    IL_0040:  call       ""void System.Threading.Monitor.Enter(object, ref bool)""
-    IL_0045:  nop
-    IL_0046:  nop
-    IL_0047:  nop
-    IL_0048:  leave.s    IL_005f
+    IL_0038:  ldarg.0
+    IL_0039:  ldfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
+    IL_003e:  ldarg.0
+    IL_003f:  ldflda     ""bool C.<F>d__0.<>s__2""
+    IL_0044:  call       ""void System.Threading.Monitor.Enter(object, ref bool)""
+    IL_0049:  nop
+    IL_004a:  nop
+    IL_004b:  nop
+    IL_004c:  leave.s    IL_0063
   }
   finally
   {
-    IL_004a:  ldarg.0
-    IL_004b:  ldfld      ""bool C.<F>d__0.<>s__2""
-    IL_0050:  brfalse.s  IL_005e
-    IL_0052:  ldarg.0
-    IL_0053:  ldfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
-    IL_0058:  call       ""void System.Threading.Monitor.Exit(object)""
-    IL_005d:  nop
-    IL_005e:  endfinally
+    IL_004e:  ldarg.0
+    IL_004f:  ldfld      ""bool C.<F>d__0.<>s__2""
+    IL_0054:  brfalse.s  IL_0062
+    IL_0056:  ldarg.0
+    IL_0057:  ldfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
+    IL_005c:  call       ""void System.Threading.Monitor.Exit(object)""
+    IL_0061:  nop
+    IL_0062:  endfinally
   }
-  IL_005f:  ldarg.0
-  IL_0060:  ldnull
-  IL_0061:  stfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
-  IL_0066:  ldarg.0
-  IL_0067:  ldc.i4.1
-  IL_0068:  stfld      ""int C.<F>d__0.<>2__current""
-  IL_006d:  ldarg.0
-  IL_006e:  ldc.i4.1
-  IL_006f:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_0074:  ldc.i4.1
-  IL_0075:  ret
-  IL_0076:  ldarg.0
-  IL_0077:  ldc.i4.m1
-  IL_0078:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_007d:  ldc.i4.0
-  IL_007e:  ret
+  IL_0063:  ldarg.0
+  IL_0064:  ldnull
+  IL_0065:  stfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
+  IL_006a:  ldarg.0
+  IL_006b:  ldc.i4.1
+  IL_006c:  stfld      ""int C.<F>d__0.<>2__current""
+  IL_0071:  ldarg.0
+  IL_0072:  ldc.i4.1
+  IL_0073:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0078:  ldc.i4.1
+  IL_0079:  ret
+  IL_007a:  ldarg.0
+  IL_007b:  ldc.i4.m1
+  IL_007c:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0081:  ldc.i4.0
+  IL_0082:  ret
 }");
 
 #if TODO 
@@ -3370,7 +3372,7 @@ class C
 
             v0.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      244 (0xf4)
+  // Code size      246 (0xf6)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -3383,111 +3385,112 @@ class C
   .try
   {
    ~IL_0007:  ldloc.0
-    IL_0008:  brfalse    IL_009c
-    IL_000d:  br.s       IL_000f
-   -IL_000f:  nop
-   -IL_0010:  ldarg.0
-    IL_0011:  ldarg.0
-    IL_0012:  ldfld      ""C C.<F>d__0.<>4__this""
-    IL_0017:  call       ""System.Threading.Tasks.Task<int> C.F()""
-    IL_001c:  stfld      ""System.Threading.Tasks.Task<int> C.<F>d__0.<>s__1""
-    IL_0021:  ldarg.0
-    IL_0022:  ldc.i4.0
-    IL_0023:  stfld      ""bool C.<F>d__0.<>s__2""
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_0011
+    IL_000c:  br         IL_009e
+   -IL_0011:  nop
+   -IL_0012:  ldarg.0
+    IL_0013:  ldarg.0
+    IL_0014:  ldfld      ""C C.<F>d__0.<>4__this""
+    IL_0019:  call       ""System.Threading.Tasks.Task<int> C.F()""
+    IL_001e:  stfld      ""System.Threading.Tasks.Task<int> C.<F>d__0.<>s__1""
+    IL_0023:  ldarg.0
+    IL_0024:  ldc.i4.0
+    IL_0025:  stfld      ""bool C.<F>d__0.<>s__2""
     .try
     {
-      IL_0028:  ldarg.0
-      IL_0029:  ldfld      ""System.Threading.Tasks.Task<int> C.<F>d__0.<>s__1""
-      IL_002e:  ldarg.0
-      IL_002f:  ldflda     ""bool C.<F>d__0.<>s__2""
-      IL_0034:  call       ""void System.Threading.Monitor.Enter(object, ref bool)""
-      IL_0039:  nop
-     -IL_003a:  nop
-     -IL_003b:  nop
-      IL_003c:  leave.s    IL_0057
+      IL_002a:  ldarg.0
+      IL_002b:  ldfld      ""System.Threading.Tasks.Task<int> C.<F>d__0.<>s__1""
+      IL_0030:  ldarg.0
+      IL_0031:  ldflda     ""bool C.<F>d__0.<>s__2""
+      IL_0036:  call       ""void System.Threading.Monitor.Enter(object, ref bool)""
+      IL_003b:  nop
+     -IL_003c:  nop
+     -IL_003d:  nop
+      IL_003e:  leave.s    IL_0059
     }
     finally
     {
-     ~IL_003e:  ldloc.0
-      IL_003f:  ldc.i4.0
-      IL_0040:  bge.s      IL_0056
-      IL_0042:  ldarg.0
-      IL_0043:  ldfld      ""bool C.<F>d__0.<>s__2""
-      IL_0048:  brfalse.s  IL_0056
-      IL_004a:  ldarg.0
-      IL_004b:  ldfld      ""System.Threading.Tasks.Task<int> C.<F>d__0.<>s__1""
-      IL_0050:  call       ""void System.Threading.Monitor.Exit(object)""
-      IL_0055:  nop
-     ~IL_0056:  endfinally
+     ~IL_0040:  ldloc.0
+      IL_0041:  ldc.i4.0
+      IL_0042:  bge.s      IL_0058
+      IL_0044:  ldarg.0
+      IL_0045:  ldfld      ""bool C.<F>d__0.<>s__2""
+      IL_004a:  brfalse.s  IL_0058
+      IL_004c:  ldarg.0
+      IL_004d:  ldfld      ""System.Threading.Tasks.Task<int> C.<F>d__0.<>s__1""
+      IL_0052:  call       ""void System.Threading.Monitor.Exit(object)""
+      IL_0057:  nop
+     ~IL_0058:  endfinally
     }
-   ~IL_0057:  ldarg.0
-    IL_0058:  ldnull
-    IL_0059:  stfld      ""System.Threading.Tasks.Task<int> C.<F>d__0.<>s__1""
-   -IL_005e:  ldarg.0
-    IL_005f:  ldfld      ""C C.<F>d__0.<>4__this""
-    IL_0064:  call       ""System.Threading.Tasks.Task<int> C.F()""
-    IL_0069:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_006e:  stloc.2
-   ~IL_006f:  ldloca.s   V_2
-    IL_0071:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0076:  brtrue.s   IL_00b8
-    IL_0078:  ldarg.0
-    IL_0079:  ldc.i4.0
-    IL_007a:  dup
-    IL_007b:  stloc.0
-    IL_007c:  stfld      ""int C.<F>d__0.<>1__state""
-   <IL_0081:  ldarg.0
-    IL_0082:  ldloc.2
-    IL_0083:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
-    IL_0088:  ldarg.0
-    IL_0089:  stloc.3
+   ~IL_0059:  ldarg.0
+    IL_005a:  ldnull
+    IL_005b:  stfld      ""System.Threading.Tasks.Task<int> C.<F>d__0.<>s__1""
+   -IL_0060:  ldarg.0
+    IL_0061:  ldfld      ""C C.<F>d__0.<>4__this""
+    IL_0066:  call       ""System.Threading.Tasks.Task<int> C.F()""
+    IL_006b:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0070:  stloc.2
+   ~IL_0071:  ldloca.s   V_2
+    IL_0073:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0078:  brtrue.s   IL_00ba
+    IL_007a:  ldarg.0
+    IL_007b:  ldc.i4.0
+    IL_007c:  dup
+    IL_007d:  stloc.0
+    IL_007e:  stfld      ""int C.<F>d__0.<>1__state""
+   <IL_0083:  ldarg.0
+    IL_0084:  ldloc.2
+    IL_0085:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
     IL_008a:  ldarg.0
-    IL_008b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_0090:  ldloca.s   V_2
-    IL_0092:  ldloca.s   V_3
-    IL_0094:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__0)""
-    IL_0099:  nop
-    IL_009a:  leave.s    IL_00f3
-   >IL_009c:  ldarg.0
-    IL_009d:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
-    IL_00a2:  stloc.2
-    IL_00a3:  ldarg.0
-    IL_00a4:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
-    IL_00a9:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_00af:  ldarg.0
-    IL_00b0:  ldc.i4.m1
-    IL_00b1:  dup
-    IL_00b2:  stloc.0
-    IL_00b3:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_00b8:  ldloca.s   V_2
-    IL_00ba:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00bf:  pop
-   -IL_00c0:  ldc.i4.1
-    IL_00c1:  stloc.1
-    IL_00c2:  leave.s    IL_00de
+    IL_008b:  stloc.3
+    IL_008c:  ldarg.0
+    IL_008d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0092:  ldloca.s   V_2
+    IL_0094:  ldloca.s   V_3
+    IL_0096:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__0)""
+    IL_009b:  nop
+    IL_009c:  leave.s    IL_00f5
+   >IL_009e:  ldarg.0
+    IL_009f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
+    IL_00a4:  stloc.2
+    IL_00a5:  ldarg.0
+    IL_00a6:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
+    IL_00ab:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_00b1:  ldarg.0
+    IL_00b2:  ldc.i4.m1
+    IL_00b3:  dup
+    IL_00b4:  stloc.0
+    IL_00b5:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_00ba:  ldloca.s   V_2
+    IL_00bc:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00c1:  pop
+   -IL_00c2:  ldc.i4.1
+    IL_00c3:  stloc.1
+    IL_00c4:  leave.s    IL_00e0
   }
   catch System.Exception
   {
-   ~IL_00c4:  stloc.s    V_4
-    IL_00c6:  ldarg.0
-    IL_00c7:  ldc.i4.s   -2
-    IL_00c9:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_00ce:  ldarg.0
-    IL_00cf:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_00d4:  ldloc.s    V_4
-    IL_00d6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00db:  nop
-    IL_00dc:  leave.s    IL_00f3
+   ~IL_00c6:  stloc.s    V_4
+    IL_00c8:  ldarg.0
+    IL_00c9:  ldc.i4.s   -2
+    IL_00cb:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_00d0:  ldarg.0
+    IL_00d1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_00d6:  ldloc.s    V_4
+    IL_00d8:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00dd:  nop
+    IL_00de:  leave.s    IL_00f5
   }
- -IL_00de:  ldarg.0
-  IL_00df:  ldc.i4.s   -2
-  IL_00e1:  stfld      ""int C.<F>d__0.<>1__state""
- ~IL_00e6:  ldarg.0
-  IL_00e7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00ec:  ldloc.1
-  IL_00ed:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00f2:  nop
-  IL_00f3:  ret
+ -IL_00e0:  ldarg.0
+  IL_00e1:  ldc.i4.s   -2
+  IL_00e3:  stfld      ""int C.<F>d__0.<>1__state""
+ ~IL_00e8:  ldarg.0
+  IL_00e9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00ee:  ldloc.1
+  IL_00ef:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00f4:  nop
+  IL_00f5:  ret
 }", sequencePoints: "C+<F>d__0.MoveNext");
 
 #if TODO

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -63,7 +63,7 @@ class Driver
 
             v.VerifyIL("TestCase.<Run>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      287 (0x11f)
+  // Code size      289 (0x121)
   .maxstack  3
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_1,
@@ -76,111 +76,112 @@ class Driver
   .try
   {
    ~IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0089
-    IL_000a:  br.s       IL_000c
-   -IL_000c:  nop
-   -IL_000d:  ldarg.0
-    IL_000e:  newobj     ""DynamicMembers..ctor()""
-    IL_0013:  stfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
-   -IL_0018:  ldarg.0
-    IL_0019:  ldfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
-    IL_001e:  ldsfld     ""System.Func<System.Threading.Tasks.Task<int>> TestCase.<>c.<>9__1_0""
-    IL_0023:  dup
-    IL_0024:  brtrue.s   IL_003d
-    IL_0026:  pop
-    IL_0027:  ldsfld     ""TestCase.<>c TestCase.<>c.<>9""
-    IL_002c:  ldftn      ""System.Threading.Tasks.Task<int> TestCase.<>c.<Run>b__1_0()""
-    IL_0032:  newobj     ""System.Func<System.Threading.Tasks.Task<int>>..ctor(object, System.IntPtr)""
-    IL_0037:  dup
-    IL_0038:  stsfld     ""System.Func<System.Threading.Tasks.Task<int>> TestCase.<>c.<>9__1_0""
-    IL_003d:  callvirt   ""void DynamicMembers.Prop.set""
-    IL_0042:  nop
-   -IL_0043:  ldarg.0
-    IL_0044:  ldfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
-    IL_0049:  callvirt   ""System.Func<System.Threading.Tasks.Task<int>> DynamicMembers.Prop.get""
-    IL_004e:  callvirt   ""System.Threading.Tasks.Task<int> System.Func<System.Threading.Tasks.Task<int>>.Invoke()""
-    IL_0053:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0058:  stloc.1
-   ~IL_0059:  ldloca.s   V_1
-    IL_005b:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0060:  brtrue.s   IL_00a5
-    IL_0062:  ldarg.0
-    IL_0063:  ldc.i4.0
-    IL_0064:  dup
-    IL_0065:  stloc.0
-    IL_0066:  stfld      ""int TestCase.<Run>d__1.<>1__state""
-   <IL_006b:  ldarg.0
-    IL_006c:  ldloc.1
-    IL_006d:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
-    IL_0072:  ldarg.0
-    IL_0073:  stloc.2
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_008b
+   -IL_000e:  nop
+   -IL_000f:  ldarg.0
+    IL_0010:  newobj     ""DynamicMembers..ctor()""
+    IL_0015:  stfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
+   -IL_001a:  ldarg.0
+    IL_001b:  ldfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
+    IL_0020:  ldsfld     ""System.Func<System.Threading.Tasks.Task<int>> TestCase.<>c.<>9__1_0""
+    IL_0025:  dup
+    IL_0026:  brtrue.s   IL_003f
+    IL_0028:  pop
+    IL_0029:  ldsfld     ""TestCase.<>c TestCase.<>c.<>9""
+    IL_002e:  ldftn      ""System.Threading.Tasks.Task<int> TestCase.<>c.<Run>b__1_0()""
+    IL_0034:  newobj     ""System.Func<System.Threading.Tasks.Task<int>>..ctor(object, System.IntPtr)""
+    IL_0039:  dup
+    IL_003a:  stsfld     ""System.Func<System.Threading.Tasks.Task<int>> TestCase.<>c.<>9__1_0""
+    IL_003f:  callvirt   ""void DynamicMembers.Prop.set""
+    IL_0044:  nop
+   -IL_0045:  ldarg.0
+    IL_0046:  ldfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
+    IL_004b:  callvirt   ""System.Func<System.Threading.Tasks.Task<int>> DynamicMembers.Prop.get""
+    IL_0050:  callvirt   ""System.Threading.Tasks.Task<int> System.Func<System.Threading.Tasks.Task<int>>.Invoke()""
+    IL_0055:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_005a:  stloc.1
+   ~IL_005b:  ldloca.s   V_1
+    IL_005d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0062:  brtrue.s   IL_00a7
+    IL_0064:  ldarg.0
+    IL_0065:  ldc.i4.0
+    IL_0066:  dup
+    IL_0067:  stloc.0
+    IL_0068:  stfld      ""int TestCase.<Run>d__1.<>1__state""
+   <IL_006d:  ldarg.0
+    IL_006e:  ldloc.1
+    IL_006f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
     IL_0074:  ldarg.0
-    IL_0075:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
-    IL_007a:  ldloca.s   V_1
-    IL_007c:  ldloca.s   V_2
-    IL_007e:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, TestCase.<Run>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref TestCase.<Run>d__1)""
-    IL_0083:  nop
-    IL_0084:  leave      IL_011e
-   >IL_0089:  ldarg.0
-    IL_008a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
-    IL_008f:  stloc.1
-    IL_0090:  ldarg.0
-    IL_0091:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
-    IL_0096:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_009c:  ldarg.0
-    IL_009d:  ldc.i4.m1
-    IL_009e:  dup
-    IL_009f:  stloc.0
-    IL_00a0:  stfld      ""int TestCase.<Run>d__1.<>1__state""
-    IL_00a5:  ldarg.0
-    IL_00a6:  ldloca.s   V_1
-    IL_00a8:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00ad:  stfld      ""int TestCase.<Run>d__1.<>s__3""
-    IL_00b2:  ldarg.0
-    IL_00b3:  ldarg.0
-    IL_00b4:  ldfld      ""int TestCase.<Run>d__1.<>s__3""
-    IL_00b9:  stfld      ""int TestCase.<Run>d__1.<rez2>5__2""
-   -IL_00be:  ldarg.0
-    IL_00bf:  ldfld      ""int TestCase.<Run>d__1.<rez2>5__2""
-    IL_00c4:  ldc.i4.3
-    IL_00c5:  ceq
-    IL_00c7:  stloc.3
-   ~IL_00c8:  ldloc.3
-    IL_00c9:  brfalse.s  IL_00d7
-   -IL_00cb:  ldsfld     ""int TestCase.Count""
-    IL_00d0:  ldc.i4.1
-    IL_00d1:  add
-    IL_00d2:  stsfld     ""int TestCase.Count""
-   -IL_00d7:  ldsfld     ""int TestCase.Count""
-    IL_00dc:  ldc.i4.1
-    IL_00dd:  sub
-    IL_00de:  stsfld     ""int Driver.Result""
-   -IL_00e3:  ldsfld     ""System.Threading.AutoResetEvent Driver.CompletedSignal""
-    IL_00e8:  callvirt   ""bool System.Threading.EventWaitHandle.Set()""
-    IL_00ed:  pop
-    IL_00ee:  leave.s    IL_010a
+    IL_0075:  stloc.2
+    IL_0076:  ldarg.0
+    IL_0077:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
+    IL_007c:  ldloca.s   V_1
+    IL_007e:  ldloca.s   V_2
+    IL_0080:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, TestCase.<Run>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref TestCase.<Run>d__1)""
+    IL_0085:  nop
+    IL_0086:  leave      IL_0120
+   >IL_008b:  ldarg.0
+    IL_008c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
+    IL_0091:  stloc.1
+    IL_0092:  ldarg.0
+    IL_0093:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
+    IL_0098:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_009e:  ldarg.0
+    IL_009f:  ldc.i4.m1
+    IL_00a0:  dup
+    IL_00a1:  stloc.0
+    IL_00a2:  stfld      ""int TestCase.<Run>d__1.<>1__state""
+    IL_00a7:  ldarg.0
+    IL_00a8:  ldloca.s   V_1
+    IL_00aa:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00af:  stfld      ""int TestCase.<Run>d__1.<>s__3""
+    IL_00b4:  ldarg.0
+    IL_00b5:  ldarg.0
+    IL_00b6:  ldfld      ""int TestCase.<Run>d__1.<>s__3""
+    IL_00bb:  stfld      ""int TestCase.<Run>d__1.<rez2>5__2""
+   -IL_00c0:  ldarg.0
+    IL_00c1:  ldfld      ""int TestCase.<Run>d__1.<rez2>5__2""
+    IL_00c6:  ldc.i4.3
+    IL_00c7:  ceq
+    IL_00c9:  stloc.3
+   ~IL_00ca:  ldloc.3
+    IL_00cb:  brfalse.s  IL_00d9
+   -IL_00cd:  ldsfld     ""int TestCase.Count""
+    IL_00d2:  ldc.i4.1
+    IL_00d3:  add
+    IL_00d4:  stsfld     ""int TestCase.Count""
+   -IL_00d9:  ldsfld     ""int TestCase.Count""
+    IL_00de:  ldc.i4.1
+    IL_00df:  sub
+    IL_00e0:  stsfld     ""int Driver.Result""
+   -IL_00e5:  ldsfld     ""System.Threading.AutoResetEvent Driver.CompletedSignal""
+    IL_00ea:  callvirt   ""bool System.Threading.EventWaitHandle.Set()""
+    IL_00ef:  pop
+    IL_00f0:  leave.s    IL_010c
   }
   catch System.Exception
   {
-  ~$IL_00f0:  stloc.s    V_4
-    IL_00f2:  ldarg.0
-    IL_00f3:  ldc.i4.s   -2
-    IL_00f5:  stfld      ""int TestCase.<Run>d__1.<>1__state""
-    IL_00fa:  ldarg.0
-    IL_00fb:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
-    IL_0100:  ldloc.s    V_4
-    IL_0102:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
-    IL_0107:  nop
-    IL_0108:  leave.s    IL_011e
+  ~$IL_00f2:  stloc.s    V_4
+    IL_00f4:  ldarg.0
+    IL_00f5:  ldc.i4.s   -2
+    IL_00f7:  stfld      ""int TestCase.<Run>d__1.<>1__state""
+    IL_00fc:  ldarg.0
+    IL_00fd:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
+    IL_0102:  ldloc.s    V_4
+    IL_0104:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
+    IL_0109:  nop
+    IL_010a:  leave.s    IL_0120
   }
- -IL_010a:  ldarg.0
-  IL_010b:  ldc.i4.s   -2
-  IL_010d:  stfld      ""int TestCase.<Run>d__1.<>1__state""
- ~IL_0112:  ldarg.0
-  IL_0113:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
-  IL_0118:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
-  IL_011d:  nop
-  IL_011e:  ret
+ -IL_010c:  ldarg.0
+  IL_010d:  ldc.i4.s   -2
+  IL_010f:  stfld      ""int TestCase.<Run>d__1.<>1__state""
+ ~IL_0114:  ldarg.0
+  IL_0115:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
+  IL_011a:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
+  IL_011f:  nop
+  IL_0120:  ret
 }",
 sequencePoints: "TestCase+<Run>d__1.MoveNext");
 
@@ -267,8 +268,8 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
       <customDebugInfo>
         <forward declaringType=""TestCase"" methodName="".cctor"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x11f"" />
-          <slot startOffset=""0x0"" endOffset=""0x11f"" />
+          <slot startOffset=""0x0"" endOffset=""0x121"" />
+          <slot startOffset=""0x0"" endOffset=""0x121"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -281,24 +282,24 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xd"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""51"" document=""1"" />
-        <entry offset=""0x18"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""71"" document=""1"" />
-        <entry offset=""0x43"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""37"" document=""1"" />
-        <entry offset=""0x59"" hidden=""true"" document=""1"" />
-        <entry offset=""0xbe"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""23"" document=""1"" />
-        <entry offset=""0xc8"" hidden=""true"" document=""1"" />
-        <entry offset=""0xcb"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""32"" document=""1"" />
-        <entry offset=""0xd7"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""44"" document=""1"" />
-        <entry offset=""0xe3"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xf0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x10a"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x112"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""51"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""71"" document=""1"" />
+        <entry offset=""0x45"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""37"" document=""1"" />
+        <entry offset=""0x5b"" hidden=""true"" document=""1"" />
+        <entry offset=""0xc0"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xca"" hidden=""true"" document=""1"" />
+        <entry offset=""0xcd"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""32"" document=""1"" />
+        <entry offset=""0xd9"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""44"" document=""1"" />
+        <entry offset=""0xe5"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xf2"" hidden=""true"" document=""1"" />
+        <entry offset=""0x10c"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x114"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
-        <catchHandler offset=""0xf0"" />
+        <catchHandler offset=""0xf2"" />
         <kickoffMethod declaringType=""TestCase"" methodName=""Run"" />
-        <await yield=""0x6b"" resume=""0x89"" declaringType=""TestCase+&lt;Run&gt;d__1"" methodName=""MoveNext"" />
+        <await yield=""0x6d"" resume=""0x8b"" declaringType=""TestCase+&lt;Run&gt;d__1"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
     <method containingType=""TestCase+&lt;&gt;c+&lt;&lt;Run&gt;b__1_0&gt;d"" name=""MoveNext"">
@@ -315,17 +316,17 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""33"" document=""1"" />
-        <entry offset=""0xd"" startLine=""16"" startColumn=""34"" endLine=""16"" endColumn=""58"" document=""1"" />
-        <entry offset=""0x1d"" hidden=""true"" document=""1"" />
-        <entry offset=""0x6e"" startLine=""16"" startColumn=""59"" endLine=""16"" endColumn=""68"" document=""1"" />
-        <entry offset=""0x72"" hidden=""true"" document=""1"" />
-        <entry offset=""0x8c"" startLine=""16"" startColumn=""69"" endLine=""16"" endColumn=""70"" document=""1"" />
-        <entry offset=""0x94"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""33"" document=""1"" />
+        <entry offset=""0xf"" startLine=""16"" startColumn=""34"" endLine=""16"" endColumn=""58"" document=""1"" />
+        <entry offset=""0x1f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x70"" startLine=""16"" startColumn=""59"" endLine=""16"" endColumn=""68"" document=""1"" />
+        <entry offset=""0x74"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8e"" startLine=""16"" startColumn=""69"" endLine=""16"" endColumn=""70"" document=""1"" />
+        <entry offset=""0x96"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""TestCase+&lt;&gt;c"" methodName=""&lt;Run&gt;b__1_0"" />
-        <await yield=""0x2f"" resume=""0x4a"" declaringType=""TestCase+&lt;&gt;c+&lt;&lt;Run&gt;b__1_0&gt;d"" methodName=""MoveNext"" />
+        <await yield=""0x31"" resume=""0x4c"" declaringType=""TestCase+&lt;&gt;c+&lt;&lt;Run&gt;b__1_0&gt;d"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -447,28 +448,28 @@ namespace ConsoleApplication1
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
-        <entry offset=""0xd"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""26"" document=""1"" />
-        <entry offset=""0x1e"" hidden=""true"" document=""1"" />
-        <entry offset=""0x71"" hidden=""true"" document=""1"" />
-        <entry offset=""0x89"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x91"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xf"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x20"" hidden=""true"" document=""1"" />
+        <entry offset=""0x73"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8b"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x93"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
-        <catchHandler offset=""0x71"" />
+        <catchHandler offset=""0x73"" />
         <kickoffMethod declaringType=""ConsoleApplication1.Program"" methodName=""QBar"" />
-        <await yield=""0x30"" resume=""0x4b"" declaringType=""ConsoleApplication1.Program+&lt;QBar&gt;d__2"" methodName=""MoveNext"" />
+        <await yield=""0x32"" resume=""0x4d"" declaringType=""ConsoleApplication1.Program+&lt;QBar&gt;d__2"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
     <method containingType=""ConsoleApplication1.Program+&lt;ZBar&gt;d__3"" name=""MoveNext"">
       <customDebugInfo>
         <forward declaringType=""ConsoleApplication1.Program"" methodName=""Main"" parameterNames=""args"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x142"" />
+          <slot startOffset=""0x0"" endOffset=""0x144"" />
           <slot />
           <slot />
-          <slot startOffset=""0x3f"" endOffset=""0xe1"" />
-          <slot startOffset=""0x52"" endOffset=""0xe1"" />
+          <slot startOffset=""0x41"" endOffset=""0xe3"" />
+          <slot startOffset=""0x54"" endOffset=""0xe3"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -481,27 +482,27 @@ namespace ConsoleApplication1
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xf"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x10"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""45"" document=""1"" />
-        <entry offset=""0x1b"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""20"" document=""1"" />
-        <entry offset=""0x1c"" startLine=""22"" startColumn=""31"" endLine=""22"" endColumn=""46"" document=""1"" />
-        <entry offset=""0x3a"" hidden=""true"" document=""1"" />
-        <entry offset=""0x3f"" startLine=""22"" startColumn=""22"" endLine=""22"" endColumn=""27"" document=""1"" />
-        <entry offset=""0x52"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""14"" document=""1"" />
-        <entry offset=""0x53"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""55"" document=""1"" />
-        <entry offset=""0x69"" hidden=""true"" document=""1"" />
-        <entry offset=""0xce"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""39"" document=""1"" />
-        <entry offset=""0xe0"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""14"" document=""1"" />
-        <entry offset=""0xe1"" hidden=""true"" document=""1"" />
-        <entry offset=""0xef"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""30"" document=""1"" />
-        <entry offset=""0x109"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""30"" document=""1"" />
-        <entry offset=""0x112"" hidden=""true"" document=""1"" />
-        <entry offset=""0x12c"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x134"" hidden=""true"" document=""1"" />
+        <entry offset=""0x11"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x12"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""45"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""22"" startColumn=""31"" endLine=""22"" endColumn=""46"" document=""1"" />
+        <entry offset=""0x3c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x41"" startLine=""22"" startColumn=""22"" endLine=""22"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x54"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x55"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""55"" document=""1"" />
+        <entry offset=""0x6b"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd0"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""39"" document=""1"" />
+        <entry offset=""0xe2"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""14"" document=""1"" />
+        <entry offset=""0xe3"" hidden=""true"" document=""1"" />
+        <entry offset=""0xf1"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x10b"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x114"" hidden=""true"" document=""1"" />
+        <entry offset=""0x12e"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x136"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""ConsoleApplication1.Program"" methodName=""ZBar"" />
-        <await yield=""0x7b"" resume=""0x99"" declaringType=""ConsoleApplication1.Program+&lt;ZBar&gt;d__3"" methodName=""MoveNext"" />
+        <await yield=""0x7d"" resume=""0x9b"" declaringType=""ConsoleApplication1.Program+&lt;ZBar&gt;d__3"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -550,7 +551,7 @@ class TestCase
           <namespace usingCount=""0"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x25b"" />
+          <slot startOffset=""0x0"" endOffset=""0x25d"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -564,17 +565,17 @@ class TestCase
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xf"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x10"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""27"" document=""1"" />
-        <entry offset=""0xac"" hidden=""true"" document=""1"" />
-        <entry offset=""0x22c"" hidden=""true"" document=""1"" />
-        <entry offset=""0x246"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x24e"" hidden=""true"" document=""1"" />
+        <entry offset=""0x11"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x12"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""27"" document=""1"" />
+        <entry offset=""0xae"" hidden=""true"" document=""1"" />
+        <entry offset=""0x22e"" hidden=""true"" document=""1"" />
+        <entry offset=""0x248"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x250"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
-        <catchHandler offset=""0x22c"" />
+        <catchHandler offset=""0x22e"" />
         <kickoffMethod declaringType=""TestCase"" methodName=""Await"" parameterNames=""d"" />
-        <await yield=""0x146"" resume=""0x18d"" declaringType=""TestCase+&lt;Await&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x148"" resume=""0x18f"" declaringType=""TestCase+&lt;Await&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -627,7 +628,7 @@ sequencePoints: "C.F");
 
             v.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      158 (0x9e)
+  // Code size      160 (0xa0)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -640,73 +641,74 @@ sequencePoints: "C.F");
   .try
   {
    ~IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0046
-    IL_000a:  br.s       IL_000c
-   -IL_000c:  nop
-   -IL_000d:  ldc.i4.1
-    IL_000e:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.Delay(int)""
-    IL_0013:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
-    IL_0018:  stloc.2
-   ~IL_0019:  ldloca.s   V_2
-    IL_001b:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
-    IL_0020:  brtrue.s   IL_0062
-    IL_0022:  ldarg.0
-    IL_0023:  ldc.i4.0
-    IL_0024:  dup
-    IL_0025:  stloc.0
-    IL_0026:  stfld      ""int C.<F>d__0.<>1__state""
-   <IL_002b:  ldarg.0
-    IL_002c:  ldloc.2
-    IL_002d:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
-    IL_0032:  ldarg.0
-    IL_0033:  stloc.3
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_0048
+   -IL_000e:  nop
+   -IL_000f:  ldc.i4.1
+    IL_0010:  call       ""System.Threading.Tasks.Task System.Threading.Tasks.Task.Delay(int)""
+    IL_0015:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
+    IL_001a:  stloc.2
+   ~IL_001b:  ldloca.s   V_2
+    IL_001d:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
+    IL_0022:  brtrue.s   IL_0064
+    IL_0024:  ldarg.0
+    IL_0025:  ldc.i4.0
+    IL_0026:  dup
+    IL_0027:  stloc.0
+    IL_0028:  stfld      ""int C.<F>d__0.<>1__state""
+   <IL_002d:  ldarg.0
+    IL_002e:  ldloc.2
+    IL_002f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
     IL_0034:  ldarg.0
-    IL_0035:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_003a:  ldloca.s   V_2
-    IL_003c:  ldloca.s   V_3
-    IL_003e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
-    IL_0043:  nop
-    IL_0044:  leave.s    IL_009d
-   >IL_0046:  ldarg.0
-    IL_0047:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
-    IL_004c:  stloc.2
-    IL_004d:  ldarg.0
-    IL_004e:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
-    IL_0053:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0059:  ldarg.0
-    IL_005a:  ldc.i4.m1
-    IL_005b:  dup
-    IL_005c:  stloc.0
-    IL_005d:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0062:  ldloca.s   V_2
-    IL_0064:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_0069:  nop
-   -IL_006a:  ldc.i4.1
-    IL_006b:  stloc.1
-    IL_006c:  leave.s    IL_0088
+    IL_0035:  stloc.3
+    IL_0036:  ldarg.0
+    IL_0037:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_003c:  ldloca.s   V_2
+    IL_003e:  ldloca.s   V_3
+    IL_0040:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
+    IL_0045:  nop
+    IL_0046:  leave.s    IL_009f
+   >IL_0048:  ldarg.0
+    IL_0049:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
+    IL_004e:  stloc.2
+    IL_004f:  ldarg.0
+    IL_0050:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
+    IL_0055:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_005b:  ldarg.0
+    IL_005c:  ldc.i4.m1
+    IL_005d:  dup
+    IL_005e:  stloc.0
+    IL_005f:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0064:  ldloca.s   V_2
+    IL_0066:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+    IL_006b:  nop
+   -IL_006c:  ldc.i4.1
+    IL_006d:  stloc.1
+    IL_006e:  leave.s    IL_008a
   }
   catch System.Exception
   {
-   ~IL_006e:  stloc.s    V_4
-    IL_0070:  ldarg.0
-    IL_0071:  ldc.i4.s   -2
-    IL_0073:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0078:  ldarg.0
-    IL_0079:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_007e:  ldloc.s    V_4
-    IL_0080:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0085:  nop
-    IL_0086:  leave.s    IL_009d
+   ~IL_0070:  stloc.s    V_4
+    IL_0072:  ldarg.0
+    IL_0073:  ldc.i4.s   -2
+    IL_0075:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_007a:  ldarg.0
+    IL_007b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0080:  ldloc.s    V_4
+    IL_0082:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0087:  nop
+    IL_0088:  leave.s    IL_009f
   }
- -IL_0088:  ldarg.0
-  IL_0089:  ldc.i4.s   -2
-  IL_008b:  stfld      ""int C.<F>d__0.<>1__state""
- ~IL_0090:  ldarg.0
-  IL_0091:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_0096:  ldloc.1
-  IL_0097:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_009c:  nop
-  IL_009d:  ret
+ -IL_008a:  ldarg.0
+  IL_008b:  ldc.i4.s   -2
+  IL_008d:  stfld      ""int C.<F>d__0.<>1__state""
+ ~IL_0092:  ldarg.0
+  IL_0093:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_0098:  ldloc.1
+  IL_0099:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_009e:  nop
+  IL_009f:  ret
 }", sequencePoints: "C+<F>d__0.MoveNext");
         }
 
@@ -846,7 +848,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x104"" />
+          <slot startOffset=""0x0"" endOffset=""0x106"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -858,21 +860,21 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xf"" hidden=""true"" document=""1"" />
-        <entry offset=""0x1a"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x27"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x33"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x3f"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
-        <entry offset=""0x56"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" document=""1"" />
-        <entry offset=""0x84"" hidden=""true"" document=""1"" />
-        <entry offset=""0xd7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xef"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xf7"" hidden=""true"" document=""1"" />
+        <entry offset=""0x11"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x35"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x86"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd9"" hidden=""true"" document=""1"" />
+        <entry offset=""0xf1"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf9"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
-        <await yield=""0x96"" resume=""0xb1"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x98"" resume=""0xb3"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -1035,7 +1037,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0xf3"" />
+          <slot startOffset=""0x0"" endOffset=""0xf5"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1047,22 +1049,22 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xf"" hidden=""true"" document=""1"" />
-        <entry offset=""0x1a"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x27"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x33"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x3f"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
-        <entry offset=""0x56"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" document=""1"" />
-        <entry offset=""0x62"" hidden=""true"" document=""1"" />
-        <entry offset=""0xb3"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" document=""1"" />
-        <entry offset=""0xc6"" hidden=""true"" document=""1"" />
-        <entry offset=""0xde"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xe6"" hidden=""true"" document=""1"" />
+        <entry offset=""0x11"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x35"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x64"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb5"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" document=""1"" />
+        <entry offset=""0xc8"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe0"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xe8"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
-        <await yield=""0x74"" resume=""0x8f"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x76"" resume=""0x91"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -1258,11 +1260,11 @@ class C
           <namespace usingCount=""2"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x26"" endOffset=""0xb0"" />
-          <slot startOffset=""0x26"" endOffset=""0xb0"" />
-          <slot startOffset=""0xc2"" endOffset=""0x160"" />
-          <slot startOffset=""0xc2"" endOffset=""0x160"" />
-          <slot startOffset=""0xc2"" endOffset=""0x160"" />
+          <slot startOffset=""0x2a"" endOffset=""0xb4"" />
+          <slot startOffset=""0x2a"" endOffset=""0xb4"" />
+          <slot startOffset=""0xc6"" endOffset=""0x164"" />
+          <slot startOffset=""0xc6"" endOffset=""0x164"" />
+          <slot startOffset=""0xc6"" endOffset=""0x164"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1277,42 +1279,42 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0x15"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x16"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""19"" document=""1"" />
-        <entry offset=""0x20"" hidden=""true"" document=""1"" />
-        <entry offset=""0x26"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x27"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x2f"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x37"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""33"" document=""1"" />
-        <entry offset=""0x43"" hidden=""true"" document=""1"" />
-        <entry offset=""0x97"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""34"" document=""1"" />
-        <entry offset=""0xa3"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""34"" document=""1"" />
-        <entry offset=""0xaf"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
-        <entry offset=""0xb0"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""19"" document=""1"" />
-        <entry offset=""0xbb"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc2"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" document=""1"" />
-        <entry offset=""0xc3"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""24"" document=""1"" />
-        <entry offset=""0xcb"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""25"" document=""1"" />
-        <entry offset=""0xd3"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""24"" document=""1"" />
-        <entry offset=""0xdb"" startLine=""24"" startColumn=""13"" endLine=""24"" endColumn=""33"" document=""1"" />
-        <entry offset=""0xe8"" hidden=""true"" document=""1"" />
-        <entry offset=""0x13b"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""34"" document=""1"" />
-        <entry offset=""0x147"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""35"" document=""1"" />
-        <entry offset=""0x153"" startLine=""28"" startColumn=""13"" endLine=""28"" endColumn=""34"" document=""1"" />
-        <entry offset=""0x15f"" startLine=""29"" startColumn=""9"" endLine=""29"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x160"" hidden=""true"" document=""1"" />
-        <entry offset=""0x162"" hidden=""true"" document=""1"" />
-        <entry offset=""0x17c"" startLine=""30"" startColumn=""5"" endLine=""30"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x184"" hidden=""true"" document=""1"" />
+        <entry offset=""0x19"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x24"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x33"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x3b"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x47"" hidden=""true"" document=""1"" />
+        <entry offset=""0x9b"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""34"" document=""1"" />
+        <entry offset=""0xa7"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""34"" document=""1"" />
+        <entry offset=""0xb3"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xb4"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""19"" document=""1"" />
+        <entry offset=""0xbf"" hidden=""true"" document=""1"" />
+        <entry offset=""0xc6"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xc7"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""24"" document=""1"" />
+        <entry offset=""0xcf"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""25"" document=""1"" />
+        <entry offset=""0xd7"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""24"" document=""1"" />
+        <entry offset=""0xdf"" startLine=""24"" startColumn=""13"" endLine=""24"" endColumn=""33"" document=""1"" />
+        <entry offset=""0xec"" hidden=""true"" document=""1"" />
+        <entry offset=""0x13f"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x14b"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x157"" startLine=""28"" startColumn=""13"" endLine=""28"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x163"" startLine=""29"" startColumn=""9"" endLine=""29"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x164"" hidden=""true"" document=""1"" />
+        <entry offset=""0x166"" hidden=""true"" document=""1"" />
+        <entry offset=""0x180"" startLine=""30"" startColumn=""5"" endLine=""30"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x188"" hidden=""true"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x191"">
+      <scope startOffset=""0x0"" endOffset=""0x195"">
         <namespace name=""System"" />
         <namespace name=""System.Threading.Tasks"" />
       </scope>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
-        <await yield=""0x55"" resume=""0x73"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
-        <await yield=""0xfa"" resume=""0x116"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x59"" resume=""0x77"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0xfe"" resume=""0x11a"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -1362,7 +1364,7 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x100"" />
+          <slot startOffset=""0x0"" endOffset=""0x102"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1374,21 +1376,21 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xd"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x19"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""29"" document=""1"" />
-        <entry offset=""0x25"" hidden=""true"" document=""1"" />
-        <entry offset=""0x79"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" document=""1"" />
-        <entry offset=""0xd3"" hidden=""true"" document=""1"" />
-        <entry offset=""0xeb"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xf3"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x27"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7b"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" document=""1"" />
+        <entry offset=""0xd5"" hidden=""true"" document=""1"" />
+        <entry offset=""0xed"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf5"" hidden=""true"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x100"">
+      <scope startOffset=""0x0"" endOffset=""0x102"">
         <namespace name=""System.Threading.Tasks"" />
       </scope>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" />
-        <await yield=""0x37"" resume=""0x55"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x39"" resume=""0x57"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -1541,7 +1543,7 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x100"" />
+          <slot startOffset=""0x0"" endOffset=""0x102"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1553,21 +1555,21 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xf"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x10"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x1c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" document=""1"" />
-        <entry offset=""0x74"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""29"" document=""1"" />
-        <entry offset=""0x80"" hidden=""true"" document=""1"" />
-        <entry offset=""0xd3"" hidden=""true"" document=""1"" />
-        <entry offset=""0xeb"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xf3"" hidden=""true"" document=""1"" />
+        <entry offset=""0x11"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x12"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x76"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x82"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd5"" hidden=""true"" document=""1"" />
+        <entry offset=""0xed"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf5"" hidden=""true"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x100"">
+      <scope startOffset=""0x0"" endOffset=""0x102"">
         <namespace name=""System.Threading.Tasks"" />
       </scope>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" />
-        <await yield=""0x92"" resume=""0xad"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x94"" resume=""0xaf"" declaringType=""C+&lt;M&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -1695,7 +1697,7 @@ class C
 
             v.VerifyIL("C.<G>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      272 (0x110)
+  // Code size      274 (0x112)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -1709,125 +1711,126 @@ class C
   .try
   {
    ~IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_006e
-    IL_000a:  br.s       IL_000c
-   -IL_000c:  nop
-   -IL_000d:  ldarg.0
-    IL_000e:  ldc.i4.s   42
-    IL_0010:  stfld      ""int C.<G>d__0.<x>5__1""
-   ~IL_0015:  ldarg.0
-    IL_0016:  ldnull
-    IL_0017:  stfld      ""object C.<G>d__0.<>s__2""
-    IL_001c:  ldarg.0
-    IL_001d:  ldc.i4.0
-    IL_001e:  stfld      ""int C.<G>d__0.<>s__3""
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_000e
+    IL_000c:  br.s       IL_0070
+   -IL_000e:  nop
+   -IL_000f:  ldarg.0
+    IL_0010:  ldc.i4.s   42
+    IL_0012:  stfld      ""int C.<G>d__0.<x>5__1""
+   ~IL_0017:  ldarg.0
+    IL_0018:  ldnull
+    IL_0019:  stfld      ""object C.<G>d__0.<>s__2""
+    IL_001e:  ldarg.0
+    IL_001f:  ldc.i4.0
+    IL_0020:  stfld      ""int C.<G>d__0.<>s__3""
     .try
     {
-     -IL_0023:  nop
-     -IL_0024:  nop
-     ~IL_0025:  leave.s    IL_0031
+     -IL_0025:  nop
+     -IL_0026:  nop
+     ~IL_0027:  leave.s    IL_0033
     }
     catch object
     {
-     ~IL_0027:  stloc.2
-      IL_0028:  ldarg.0
-      IL_0029:  ldloc.2
-      IL_002a:  stfld      ""object C.<G>d__0.<>s__2""
-      IL_002f:  leave.s    IL_0031
+     ~IL_0029:  stloc.2
+      IL_002a:  ldarg.0
+      IL_002b:  ldloc.2
+      IL_002c:  stfld      ""object C.<G>d__0.<>s__2""
+      IL_0031:  leave.s    IL_0033
     }
-   -IL_0031:  nop
-   -IL_0032:  call       ""System.Threading.Tasks.Task<int> C.G()""
-    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.3
-   ~IL_003d:  ldloca.s   V_3
-    IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0044:  brtrue.s   IL_008a
-    IL_0046:  ldarg.0
-    IL_0047:  ldc.i4.0
-    IL_0048:  dup
-    IL_0049:  stloc.0
-    IL_004a:  stfld      ""int C.<G>d__0.<>1__state""
-   <IL_004f:  ldarg.0
-    IL_0050:  ldloc.3
-    IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<G>d__0.<>u__1""
-    IL_0056:  ldarg.0
-    IL_0057:  stloc.s    V_4
-    IL_0059:  ldarg.0
-    IL_005a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<G>d__0.<>t__builder""
-    IL_005f:  ldloca.s   V_3
-    IL_0061:  ldloca.s   V_4
-    IL_0063:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<G>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<G>d__0)""
-    IL_0068:  nop
-    IL_0069:  leave      IL_010f
-   >IL_006e:  ldarg.0
-    IL_006f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<G>d__0.<>u__1""
-    IL_0074:  stloc.3
-    IL_0075:  ldarg.0
-    IL_0076:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<G>d__0.<>u__1""
-    IL_007b:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0081:  ldarg.0
-    IL_0082:  ldc.i4.m1
-    IL_0083:  dup
-    IL_0084:  stloc.0
-    IL_0085:  stfld      ""int C.<G>d__0.<>1__state""
-    IL_008a:  ldarg.0
-    IL_008b:  ldloca.s   V_3
-    IL_008d:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0092:  stfld      ""int C.<G>d__0.<>s__4""
-    IL_0097:  ldarg.0
-    IL_0098:  ldarg.0
-    IL_0099:  ldfld      ""int C.<G>d__0.<>s__4""
-    IL_009e:  stfld      ""int C.<G>d__0.<x>5__1""
-   -IL_00a3:  nop
-   ~IL_00a4:  ldarg.0
-    IL_00a5:  ldfld      ""object C.<G>d__0.<>s__2""
-    IL_00aa:  stloc.2
-    IL_00ab:  ldloc.2
-    IL_00ac:  brfalse.s  IL_00c9
-    IL_00ae:  ldloc.2
-    IL_00af:  isinst     ""System.Exception""
-    IL_00b4:  stloc.s    V_5
-    IL_00b6:  ldloc.s    V_5
-    IL_00b8:  brtrue.s   IL_00bc
-    IL_00ba:  ldloc.2
-    IL_00bb:  throw
-    IL_00bc:  ldloc.s    V_5
-    IL_00be:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_00c3:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_00c8:  nop
-    IL_00c9:  ldarg.0
-    IL_00ca:  ldfld      ""int C.<G>d__0.<>s__3""
-    IL_00cf:  pop
-    IL_00d0:  ldarg.0
-    IL_00d1:  ldnull
-    IL_00d2:  stfld      ""object C.<G>d__0.<>s__2""
-   -IL_00d7:  ldarg.0
-    IL_00d8:  ldfld      ""int C.<G>d__0.<x>5__1""
-    IL_00dd:  stloc.1
-    IL_00de:  leave.s    IL_00fa
+   -IL_0033:  nop
+   -IL_0034:  call       ""System.Threading.Tasks.Task<int> C.G()""
+    IL_0039:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003e:  stloc.3
+   ~IL_003f:  ldloca.s   V_3
+    IL_0041:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0046:  brtrue.s   IL_008c
+    IL_0048:  ldarg.0
+    IL_0049:  ldc.i4.0
+    IL_004a:  dup
+    IL_004b:  stloc.0
+    IL_004c:  stfld      ""int C.<G>d__0.<>1__state""
+   <IL_0051:  ldarg.0
+    IL_0052:  ldloc.3
+    IL_0053:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<G>d__0.<>u__1""
+    IL_0058:  ldarg.0
+    IL_0059:  stloc.s    V_4
+    IL_005b:  ldarg.0
+    IL_005c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<G>d__0.<>t__builder""
+    IL_0061:  ldloca.s   V_3
+    IL_0063:  ldloca.s   V_4
+    IL_0065:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<G>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<G>d__0)""
+    IL_006a:  nop
+    IL_006b:  leave      IL_0111
+   >IL_0070:  ldarg.0
+    IL_0071:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<G>d__0.<>u__1""
+    IL_0076:  stloc.3
+    IL_0077:  ldarg.0
+    IL_0078:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<G>d__0.<>u__1""
+    IL_007d:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0083:  ldarg.0
+    IL_0084:  ldc.i4.m1
+    IL_0085:  dup
+    IL_0086:  stloc.0
+    IL_0087:  stfld      ""int C.<G>d__0.<>1__state""
+    IL_008c:  ldarg.0
+    IL_008d:  ldloca.s   V_3
+    IL_008f:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0094:  stfld      ""int C.<G>d__0.<>s__4""
+    IL_0099:  ldarg.0
+    IL_009a:  ldarg.0
+    IL_009b:  ldfld      ""int C.<G>d__0.<>s__4""
+    IL_00a0:  stfld      ""int C.<G>d__0.<x>5__1""
+   -IL_00a5:  nop
+   ~IL_00a6:  ldarg.0
+    IL_00a7:  ldfld      ""object C.<G>d__0.<>s__2""
+    IL_00ac:  stloc.2
+    IL_00ad:  ldloc.2
+    IL_00ae:  brfalse.s  IL_00cb
+    IL_00b0:  ldloc.2
+    IL_00b1:  isinst     ""System.Exception""
+    IL_00b6:  stloc.s    V_5
+    IL_00b8:  ldloc.s    V_5
+    IL_00ba:  brtrue.s   IL_00be
+    IL_00bc:  ldloc.2
+    IL_00bd:  throw
+    IL_00be:  ldloc.s    V_5
+    IL_00c0:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_00c5:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_00ca:  nop
+    IL_00cb:  ldarg.0
+    IL_00cc:  ldfld      ""int C.<G>d__0.<>s__3""
+    IL_00d1:  pop
+    IL_00d2:  ldarg.0
+    IL_00d3:  ldnull
+    IL_00d4:  stfld      ""object C.<G>d__0.<>s__2""
+   -IL_00d9:  ldarg.0
+    IL_00da:  ldfld      ""int C.<G>d__0.<x>5__1""
+    IL_00df:  stloc.1
+    IL_00e0:  leave.s    IL_00fc
   }
   catch System.Exception
   {
-   ~IL_00e0:  stloc.s    V_5
-    IL_00e2:  ldarg.0
-    IL_00e3:  ldc.i4.s   -2
-    IL_00e5:  stfld      ""int C.<G>d__0.<>1__state""
-    IL_00ea:  ldarg.0
-    IL_00eb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<G>d__0.<>t__builder""
-    IL_00f0:  ldloc.s    V_5
-    IL_00f2:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00f7:  nop
-    IL_00f8:  leave.s    IL_010f
+   ~IL_00e2:  stloc.s    V_5
+    IL_00e4:  ldarg.0
+    IL_00e5:  ldc.i4.s   -2
+    IL_00e7:  stfld      ""int C.<G>d__0.<>1__state""
+    IL_00ec:  ldarg.0
+    IL_00ed:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<G>d__0.<>t__builder""
+    IL_00f2:  ldloc.s    V_5
+    IL_00f4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00f9:  nop
+    IL_00fa:  leave.s    IL_0111
   }
- -IL_00fa:  ldarg.0
-  IL_00fb:  ldc.i4.s   -2
-  IL_00fd:  stfld      ""int C.<G>d__0.<>1__state""
- ~IL_0102:  ldarg.0
-  IL_0103:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<G>d__0.<>t__builder""
-  IL_0108:  ldloc.1
-  IL_0109:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_010e:  nop
-  IL_010f:  ret
+ -IL_00fc:  ldarg.0
+  IL_00fd:  ldc.i4.s   -2
+  IL_00ff:  stfld      ""int C.<G>d__0.<>1__state""
+ ~IL_0104:  ldarg.0
+  IL_0105:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<G>d__0.<>t__builder""
+  IL_010a:  ldloc.1
+  IL_010b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_0110:  nop
+  IL_0111:  ret
 }", sequencePoints: "C+<G>d__0.MoveNext");
 
             v.VerifyPdb("C+<G>d__0.MoveNext", @"
@@ -1842,8 +1845,8 @@ class C
           <namespace usingCount=""2"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x110"" />
-          <slot startOffset=""0x27"" endOffset=""0x31"" />
+          <slot startOffset=""0x0"" endOffset=""0x112"" />
+          <slot startOffset=""0x29"" endOffset=""0x33"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1857,30 +1860,30 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xd"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" document=""1"" />
-        <entry offset=""0x15"" hidden=""true"" document=""1"" />
-        <entry offset=""0x23"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x24"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x25"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x17"" hidden=""true"" document=""1"" />
+        <entry offset=""0x25"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x26"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
         <entry offset=""0x27"" hidden=""true"" document=""1"" />
-        <entry offset=""0x31"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x32"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""27"" document=""1"" />
-        <entry offset=""0x3d"" hidden=""true"" document=""1"" />
-        <entry offset=""0xa3"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
-        <entry offset=""0xa4"" hidden=""true"" document=""1"" />
-        <entry offset=""0xd7"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""18"" document=""1"" />
-        <entry offset=""0xe0"" hidden=""true"" document=""1"" />
-        <entry offset=""0xfa"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x102"" hidden=""true"" document=""1"" />
+        <entry offset=""0x29"" hidden=""true"" document=""1"" />
+        <entry offset=""0x33"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x34"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x3f"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa5"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xa6"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd9"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""18"" document=""1"" />
+        <entry offset=""0xe2"" hidden=""true"" document=""1"" />
+        <entry offset=""0xfc"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x104"" hidden=""true"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x110"">
+      <scope startOffset=""0x0"" endOffset=""0x112"">
         <namespace name=""System"" />
         <namespace name=""System.Threading.Tasks"" />
       </scope>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""G"" />
-        <await yield=""0x4f"" resume=""0x6e"" declaringType=""C+&lt;G&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x51"" resume=""0x70"" declaringType=""C+&lt;G&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
@@ -426,7 +426,7 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x1c"" endOffset=""0x63"" />
+          <slot startOffset=""0x20"" endOffset=""0x67"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -436,23 +436,23 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x1b"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1c"" startLine=""9"" startColumn=""14"" endLine=""9"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x23"" hidden=""true"" document=""1"" />
-        <entry offset=""0x25"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x26"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""36"" document=""1"" />
-        <entry offset=""0x3d"" hidden=""true"" document=""1"" />
-        <entry offset=""0x44"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x45"" startLine=""9"" startColumn=""33"" endLine=""9"" endColumn=""36"" document=""1"" />
-        <entry offset=""0x55"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""31"" document=""1"" />
-        <entry offset=""0x60"" hidden=""true"" document=""1"" />
-        <entry offset=""0x63"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x20"" startLine=""9"" startColumn=""14"" endLine=""9"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x27"" hidden=""true"" document=""1"" />
+        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x41"" hidden=""true"" document=""1"" />
+        <entry offset=""0x48"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x49"" startLine=""9"" startColumn=""33"" endLine=""9"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x59"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x64"" hidden=""true"" document=""1"" />
+        <entry offset=""0x67"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x65"">
+      <scope startOffset=""0x0"" endOffset=""0x69"">
         <namespace name=""System.Collections.Generic"" />
-        <scope startOffset=""0x1b"" endOffset=""0x65"">
+        <scope startOffset=""0x1f"" endOffset=""0x69"">
           <constant name=""x"" value=""1"" type=""Int32"" />
-          <scope startOffset=""0x25"" endOffset=""0x45"">
+          <scope startOffset=""0x29"" endOffset=""0x49"">
             <constant name=""y"" value=""2"" type=""Int32"" />
           </scope>
         </scope>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
@@ -2,9 +2,7 @@
 
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Reflection.Metadata;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -52,8 +50,8 @@ class Program
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x15"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x16"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x17"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x18"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -97,8 +95,8 @@ class Program
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x15"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x16"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x17"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x18"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -142,10 +140,10 @@ class Program
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x1b"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1c"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x2c"" hidden=""true"" document=""1"" />
-        <entry offset=""0x33"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x20"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x30"" hidden=""true"" document=""1"" />
+        <entry offset=""0x37"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -273,8 +271,8 @@ class Program
           <namespace usingCount=""0"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x2c"" endOffset=""0xb9"" />
-          <slot startOffset=""0x71"" endOffset=""0xb7"" />
+          <slot startOffset=""0x39"" endOffset=""0xc6"" />
+          <slot startOffset=""0x7e"" endOffset=""0xc4"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -282,20 +280,20 @@ class Program
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x2c"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x2d"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""20"" document=""1"" />
-        <entry offset=""0x39"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x4e"" hidden=""true"" document=""1"" />
-        <entry offset=""0x55"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x6a"" hidden=""true"" document=""1"" />
-        <entry offset=""0x71"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x72"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x7e"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" document=""1"" />
-        <entry offset=""0x93"" hidden=""true"" document=""1"" />
-        <entry offset=""0x9a"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""28"" document=""1"" />
-        <entry offset=""0xaf"" hidden=""true"" document=""1"" />
-        <entry offset=""0xb6"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
-        <entry offset=""0xb7"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x39"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x3a"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x46"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x5b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x62"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x77"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x7f"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x8b"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" document=""1"" />
+        <entry offset=""0xa0"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa7"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""28"" document=""1"" />
+        <entry offset=""0xbc"" hidden=""true"" document=""1"" />
+        <entry offset=""0xc3"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xc4"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -347,9 +345,9 @@ class Test<T>
           <namespace usingCount=""2"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x29"" endOffset=""0xd9"" />
+          <slot startOffset=""0x32"" endOffset=""0xe2"" />
           <slot />
-          <slot startOffset=""0x52"" endOffset=""0x9c"" />
+          <slot startOffset=""0x5b"" endOffset=""0xa5"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""temp"" />
@@ -358,24 +356,24 @@ class Test<T>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x29"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x2a"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""28"" document=""1"" />
-        <entry offset=""0x36"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""16"" document=""1"" />
-        <entry offset=""0x37"" startLine=""11"" startColumn=""28"" endLine=""11"" endColumn=""33"" document=""1"" />
-        <entry offset=""0x50"" hidden=""true"" document=""1"" />
-        <entry offset=""0x52"" startLine=""11"" startColumn=""18"" endLine=""11"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x63"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x64"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x70"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""30"" document=""1"" />
-        <entry offset=""0x87"" hidden=""true"" document=""1"" />
-        <entry offset=""0x8f"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x9c"" startLine=""11"" startColumn=""25"" endLine=""11"" endColumn=""27"" document=""1"" />
-        <entry offset=""0xb7"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""26"" document=""1"" />
-        <entry offset=""0xce"" hidden=""true"" document=""1"" />
-        <entry offset=""0xd5"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xd9"" hidden=""true"" document=""1"" />
+        <entry offset=""0x32"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x33"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x3f"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x40"" startLine=""11"" startColumn=""28"" endLine=""11"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x59"" hidden=""true"" document=""1"" />
+        <entry offset=""0x5b"" startLine=""11"" startColumn=""18"" endLine=""11"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x6c"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x6d"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x79"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x90"" hidden=""true"" document=""1"" />
+        <entry offset=""0x98"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xa5"" startLine=""11"" startColumn=""25"" endLine=""11"" endColumn=""27"" document=""1"" />
+        <entry offset=""0xc0"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""26"" document=""1"" />
+        <entry offset=""0xd7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xde"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xe2"" hidden=""true"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xe3"">
+      <scope startOffset=""0x0"" endOffset=""0xec"">
         <namespace name=""System"" />
         <namespace name=""System.Collections.Generic"" />
       </scope>
@@ -613,9 +611,9 @@ public class Test
         <forward declaringType=""Test`1"" methodName=""System.Collections.IEnumerable.GetEnumerator"" />
         <hoistedLocalScopes>
           <slot />
-          <slot startOffset=""0x4b"" endOffset=""0x8c"" />
+          <slot startOffset=""0x54"" endOffset=""0x95"" />
           <slot />
-          <slot startOffset=""0xc8"" endOffset=""0x106"" />
+          <slot startOffset=""0xd1"" endOffset=""0x10f"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""temp"" />
@@ -624,27 +622,27 @@ public class Test
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x29"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x2a"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""16"" document=""1"" />
-        <entry offset=""0x2b"" startLine=""15"" startColumn=""27"" endLine=""15"" endColumn=""40"" document=""1"" />
-        <entry offset=""0x49"" hidden=""true"" document=""1"" />
-        <entry offset=""0x4b"" startLine=""15"" startColumn=""18"" endLine=""15"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x5c"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x5d"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""28"" document=""1"" />
-        <entry offset=""0x77"" hidden=""true"" document=""1"" />
-        <entry offset=""0x7f"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x8c"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""26"" document=""1"" />
-        <entry offset=""0xa7"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""16"" document=""1"" />
-        <entry offset=""0xa8"" startLine=""19"" startColumn=""27"" endLine=""19"" endColumn=""39"" document=""1"" />
-        <entry offset=""0xc6"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc8"" startLine=""19"" startColumn=""18"" endLine=""19"" endColumn=""23"" document=""1"" />
-        <entry offset=""0xd9"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" document=""1"" />
-        <entry offset=""0xda"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""28"" document=""1"" />
-        <entry offset=""0xf1"" hidden=""true"" document=""1"" />
-        <entry offset=""0xf9"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x106"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""26"" document=""1"" />
-        <entry offset=""0x121"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x125"" hidden=""true"" document=""1"" />
+        <entry offset=""0x32"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x33"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x34"" startLine=""15"" startColumn=""27"" endLine=""15"" endColumn=""40"" document=""1"" />
+        <entry offset=""0x52"" hidden=""true"" document=""1"" />
+        <entry offset=""0x54"" startLine=""15"" startColumn=""18"" endLine=""15"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x65"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x66"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x80"" hidden=""true"" document=""1"" />
+        <entry offset=""0x88"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x95"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""26"" document=""1"" />
+        <entry offset=""0xb0"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""16"" document=""1"" />
+        <entry offset=""0xb1"" startLine=""19"" startColumn=""27"" endLine=""19"" endColumn=""39"" document=""1"" />
+        <entry offset=""0xcf"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd1"" startLine=""19"" startColumn=""18"" endLine=""19"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xe2"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xe3"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""28"" document=""1"" />
+        <entry offset=""0xfa"" hidden=""true"" document=""1"" />
+        <entry offset=""0x102"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x10f"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x12a"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x12e"" hidden=""true"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Test`1+&lt;get_IterProp&gt;d__3"" name=""MoveNext"">
@@ -656,12 +654,12 @@ public class Test
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x24"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x25"" startLine=""29"" startColumn=""13"" endLine=""29"" endColumn=""31"" document=""1"" />
-        <entry offset=""0x3a"" hidden=""true"" document=""1"" />
-        <entry offset=""0x41"" startLine=""30"" startColumn=""13"" endLine=""30"" endColumn=""31"" document=""1"" />
-        <entry offset=""0x56"" hidden=""true"" document=""1"" />
-        <entry offset=""0x5d"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""29"" startColumn=""13"" endLine=""29"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x40"" hidden=""true"" document=""1"" />
+        <entry offset=""0x47"" startLine=""30"" startColumn=""13"" endLine=""30"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x5c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x63"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""10"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Test`1+&lt;IterMethod&gt;d__4"" name=""MoveNext"">
@@ -673,12 +671,12 @@ public class Test
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x24"" startLine=""35"" startColumn=""5"" endLine=""35"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x25"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""33"" document=""1"" />
-        <entry offset=""0x3a"" hidden=""true"" document=""1"" />
-        <entry offset=""0x41"" startLine=""37"" startColumn=""9"" endLine=""37"" endColumn=""27"" document=""1"" />
-        <entry offset=""0x56"" hidden=""true"" document=""1"" />
-        <entry offset=""0x5d"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""35"" startColumn=""5"" endLine=""35"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x40"" hidden=""true"" document=""1"" />
+        <entry offset=""0x47"" startLine=""37"" startColumn=""9"" endLine=""37"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x5c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x63"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -727,8 +725,8 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x24"" endOffset=""0x7d"" />
-          <slot startOffset=""0x24"" endOffset=""0x7d"" />
+          <slot startOffset=""0x2a"" endOffset=""0x83"" />
+          <slot startOffset=""0x2a"" endOffset=""0x83"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -736,16 +734,16 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x24"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x25"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""19"" document=""1"" />
-        <entry offset=""0x2c"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""26"" document=""1"" />
-        <entry offset=""0x38"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x4d"" hidden=""true"" document=""1"" />
-        <entry offset=""0x54"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""27"" document=""1"" />
-        <entry offset=""0x74"" hidden=""true"" document=""1"" />
-        <entry offset=""0x7b"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x32"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x3e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x53"" hidden=""true"" document=""1"" />
+        <entry offset=""0x5a"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x7a"" hidden=""true"" document=""1"" />
+        <entry offset=""0x81"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x7d"">
+      <scope startOffset=""0x0"" endOffset=""0x83"">
         <namespace name=""System.Collections.Generic"" />
       </scope>
     </method>
@@ -785,7 +783,7 @@ class C
 
             v.VerifyIL("C.<F>d__1.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size       64 (0x40)
+  // Code size       68 (0x44)
   .maxstack  2
   .locals init (int V_0,
                 bool V_1)
@@ -793,37 +791,39 @@ class C
   IL_0001:  ldfld      ""int C.<F>d__1.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0036
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<F>d__1.<>1__state""
-  IL_001b:  nop
-  IL_001c:  call       ""bool C.B()""
-  IL_0021:  stloc.1
-  IL_0022:  ldloc.1
-  IL_0023:  brfalse.s  IL_003e
-  IL_0025:  nop
-  IL_0026:  ldarg.0
-  IL_0027:  ldc.i4.1
-  IL_0028:  stfld      ""int C.<F>d__1.<>2__current""
-  IL_002d:  ldarg.0
-  IL_002e:  ldc.i4.1
-  IL_002f:  stfld      ""int C.<F>d__1.<>1__state""
-  IL_0034:  ldc.i4.1
-  IL_0035:  ret
-  IL_0036:  ldarg.0
-  IL_0037:  ldc.i4.m1
-  IL_0038:  stfld      ""int C.<F>d__1.<>1__state""
-  IL_003d:  nop
-  IL_003e:  ldc.i4.0
-  IL_003f:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_003a
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<F>d__1.<>1__state""
+  IL_001f:  nop
+  IL_0020:  call       ""bool C.B()""
+  IL_0025:  stloc.1
+  IL_0026:  ldloc.1
+  IL_0027:  brfalse.s  IL_0042
+  IL_0029:  nop
+  IL_002a:  ldarg.0
+  IL_002b:  ldc.i4.1
+  IL_002c:  stfld      ""int C.<F>d__1.<>2__current""
+  IL_0031:  ldarg.0
+  IL_0032:  ldc.i4.1
+  IL_0033:  stfld      ""int C.<F>d__1.<>1__state""
+  IL_0038:  ldc.i4.1
+  IL_0039:  ret
+  IL_003a:  ldarg.0
+  IL_003b:  ldc.i4.m1
+  IL_003c:  stfld      ""int C.<F>d__1.<>1__state""
+  IL_0041:  nop
+  IL_0042:  ldc.i4.0
+  IL_0043:  ret
 }");
 
             v.VerifyPdb("C+<F>d__1.MoveNext", @"
@@ -842,14 +842,14 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x1b"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""17"" document=""1"" />
-        <entry offset=""0x22"" hidden=""true"" document=""1"" />
-        <entry offset=""0x25"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x26"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" document=""1"" />
-        <entry offset=""0x36"" hidden=""true"" document=""1"" />
-        <entry offset=""0x3d"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x3e"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x20"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""17"" document=""1"" />
+        <entry offset=""0x26"" hidden=""true"" document=""1"" />
+        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x3a"" hidden=""true"" document=""1"" />
+        <entry offset=""0x41"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x42"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1003,7 +1003,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x24"" endOffset=""0xdf"" />
+          <slot startOffset=""0x30"" endOffset=""0xeb"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1011,17 +1011,17 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x24"" hidden=""true"" document=""1"" />
-        <entry offset=""0x2f"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x30"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x3c"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x48"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x54"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
-        <entry offset=""0x6b"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""35"" document=""1"" />
-        <entry offset=""0x9d"" hidden=""true"" document=""1"" />
-        <entry offset=""0xa4"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""35"" document=""1"" />
-        <entry offset=""0xd6"" hidden=""true"" document=""1"" />
-        <entry offset=""0xdd"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x30"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3b"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x3c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x48"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x54"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x60"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x77"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""35"" document=""1"" />
+        <entry offset=""0xa9"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb0"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""35"" document=""1"" />
+        <entry offset=""0xe2"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe9"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1192,59 +1192,61 @@ class C
 
             v.VerifyIL("C.<M>d__0.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size      123 (0x7b)
+  // Code size      127 (0x7f)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<M>d__0.<>1__state""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0014
+  IL_0008:  brfalse.s  IL_0012
   IL_000a:  br.s       IL_000c
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  beq.s      IL_0072
-  IL_0010:  br.s       IL_0012
-  IL_0012:  ldc.i4.0
-  IL_0013:  ret
-  IL_0014:  ldarg.0
-  IL_0015:  ldc.i4.m1
-  IL_0016:  stfld      ""int C.<M>d__0.<>1__state""
-  IL_001b:  ldarg.0
-  IL_001c:  newobj     ""C.<>c__DisplayClass0_0..ctor()""
-  IL_0021:  stfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_0026:  nop
-  IL_0027:  ldarg.0
-  IL_0028:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_002d:  ldc.i4.1
-  IL_002e:  stfld      ""byte C.<>c__DisplayClass0_0.x1""
-  IL_0033:  ldarg.0
-  IL_0034:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_0039:  ldc.i4.1
-  IL_003a:  stfld      ""byte C.<>c__DisplayClass0_0.x2""
-  IL_003f:  ldarg.0
-  IL_0040:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_0045:  ldc.i4.1
-  IL_0046:  stfld      ""byte C.<>c__DisplayClass0_0.x3""
-  IL_004b:  ldarg.0
-  IL_004c:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
-  IL_0051:  ldftn      ""void C.<>c__DisplayClass0_0.<M>b__0()""
-  IL_0057:  newobj     ""System.Action..ctor(object, System.IntPtr)""
-  IL_005c:  callvirt   ""void System.Action.Invoke()""
-  IL_0061:  nop
-  IL_0062:  ldarg.0
-  IL_0063:  ldc.i4.1
-  IL_0064:  stfld      ""int C.<M>d__0.<>2__current""
-  IL_0069:  ldarg.0
-  IL_006a:  ldc.i4.1
-  IL_006b:  stfld      ""int C.<M>d__0.<>1__state""
-  IL_0070:  ldc.i4.1
-  IL_0071:  ret
-  IL_0072:  ldarg.0
-  IL_0073:  ldc.i4.m1
-  IL_0074:  stfld      ""int C.<M>d__0.<>1__state""
-  IL_0079:  ldc.i4.0
-  IL_007a:  ret
+  IL_000e:  beq.s      IL_0014
+  IL_0010:  br.s       IL_0016
+  IL_0012:  br.s       IL_0018
+  IL_0014:  br.s       IL_0076
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+  IL_0018:  ldarg.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_001f:  ldarg.0
+  IL_0020:  newobj     ""C.<>c__DisplayClass0_0..ctor()""
+  IL_0025:  stfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_002a:  nop
+  IL_002b:  ldarg.0
+  IL_002c:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_0031:  ldc.i4.1
+  IL_0032:  stfld      ""byte C.<>c__DisplayClass0_0.x1""
+  IL_0037:  ldarg.0
+  IL_0038:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_003d:  ldc.i4.1
+  IL_003e:  stfld      ""byte C.<>c__DisplayClass0_0.x2""
+  IL_0043:  ldarg.0
+  IL_0044:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_0049:  ldc.i4.1
+  IL_004a:  stfld      ""byte C.<>c__DisplayClass0_0.x3""
+  IL_004f:  ldarg.0
+  IL_0050:  ldfld      ""C.<>c__DisplayClass0_0 C.<M>d__0.<>8__1""
+  IL_0055:  ldftn      ""void C.<>c__DisplayClass0_0.<M>b__0()""
+  IL_005b:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_0060:  callvirt   ""void System.Action.Invoke()""
+  IL_0065:  nop
+  IL_0066:  ldarg.0
+  IL_0067:  ldc.i4.1
+  IL_0068:  stfld      ""int C.<M>d__0.<>2__current""
+  IL_006d:  ldarg.0
+  IL_006e:  ldc.i4.1
+  IL_006f:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_0074:  ldc.i4.1
+  IL_0075:  ret
+  IL_0076:  ldarg.0
+  IL_0077:  ldc.i4.m1
+  IL_0078:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_007d:  ldc.i4.0
+  IL_007e:  ret
 }");
 
             v.VerifyPdb("C+<M>d__0.MoveNext", @"
@@ -1257,7 +1259,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x1b"" endOffset=""0x7b"" />
+          <slot startOffset=""0x1f"" endOffset=""0x7f"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1265,15 +1267,15 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x1b"" hidden=""true"" document=""1"" />
-        <entry offset=""0x26"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x27"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x33"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x3f"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
-        <entry offset=""0x4b"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
-        <entry offset=""0x62"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x72"" hidden=""true"" document=""1"" />
-        <entry offset=""0x79"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x37"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x43"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x4f"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x66"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x76"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7d"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1345,7 +1347,7 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x1b"" endOffset=""0xdf"" />
+          <slot startOffset=""0x1f"" endOffset=""0xe3"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1353,14 +1355,14 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x1b"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1c"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x28"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x7e"" hidden=""true"" document=""1"" />
-        <entry offset=""0x85"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" document=""1"" />
-        <entry offset=""0xdd"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x20"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x2c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x82"" hidden=""true"" document=""1"" />
+        <entry offset=""0x89"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" document=""1"" />
+        <entry offset=""0xe1"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xdf"">
+      <scope startOffset=""0x0"" endOffset=""0xe3"">
         <namespace name=""System.Collections.Generic"" />
       </scope>
     </method>
@@ -1488,7 +1490,7 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x1b"" endOffset=""0x87"" />
+          <slot startOffset=""0x1f"" endOffset=""0x8b"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1496,13 +1498,13 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x1b"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1c"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x28"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""1"" />
-        <entry offset=""0x7e"" hidden=""true"" document=""1"" />
-        <entry offset=""0x85"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x20"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x2c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x82"" hidden=""true"" document=""1"" />
+        <entry offset=""0x89"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x87"">
+      <scope startOffset=""0x0"" endOffset=""0x8b"">
         <namespace name=""System.Collections.Generic"" />
       </scope>
     </method>
@@ -1549,8 +1551,8 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x15"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x16"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x17"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x18"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1598,10 +1600,10 @@ MethodDebugInformation (index: 0x31, size: 40):
   Locals: 0x11000001 (StandAloneSig)
   Document: #1
   IL_0000: <hidden>
-  IL_001B: (5, 26) - (5, 27)
-  IL_001C: (5, 28) - (5, 43)
-  IL_002C: <hidden>
-  IL_0033: (5, 44) - (5, 45)
+  IL_001F: (5, 26) - (5, 27)
+  IL_0020: (5, 28) - (5, 43)
+  IL_0030: <hidden>
+  IL_0037: (5, 44) - (5, 45)
 }
 6: nil
 7: nil

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -7135,9 +7135,9 @@ class C
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c"" methodName=""&lt;F&gt;b__0_0"" parameterNames=""i"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x23"" endOffset=""0xd1"" />
+          <slot startOffset=""0x27"" endOffset=""0xd5"" />
           <slot />
-          <slot startOffset=""0x7b"" endOffset=""0xb2"" />
+          <slot startOffset=""0x7f"" endOffset=""0xb6"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""temp"" />
@@ -7146,19 +7146,19 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x23"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x24"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""35"" document=""1"" />
-        <entry offset=""0x3b"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""16"" document=""1"" />
-        <entry offset=""0x3c"" startLine=""8"" startColumn=""27"" endLine=""8"" endColumn=""43"" document=""1"" />
-        <entry offset=""0x79"" hidden=""true"" document=""1"" />
-        <entry offset=""0x7b"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x8c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x8d"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""28"" document=""1"" />
-        <entry offset=""0xa9"" hidden=""true"" document=""1"" />
-        <entry offset=""0xb1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
-        <entry offset=""0xb2"" startLine=""8"" startColumn=""24"" endLine=""8"" endColumn=""26"" document=""1"" />
-        <entry offset=""0xcd"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xd1"" hidden=""true"" document=""1"" />
+        <entry offset=""0x27"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x28"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x3f"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x40"" startLine=""8"" startColumn=""27"" endLine=""8"" endColumn=""43"" document=""1"" />
+        <entry offset=""0x7d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7f"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x90"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x91"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""28"" document=""1"" />
+        <entry offset=""0xad"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb5"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xb6"" startLine=""8"" startColumn=""24"" endLine=""8"" endColumn=""26"" document=""1"" />
+        <entry offset=""0xd1"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xd5"" hidden=""true"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>


### PR DESCRIPTION
`SyntheticBoundNodeFactory.Switch()` is used to generate synthesized switch statements for async rewriters, and the `goto` maybe a branch outside of the current `try` block, so merging a `Beq` + `Br` might result in a conditional branch outside of the block which is not supported in the code generator.

Fixes #33542 
Fixes #34720