### PR TITLE
🔼 Compute indices when OOP is disabled

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -139,6 +139,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 client?.Shutdown();
             }
 
+            bool IRemoteHostClientService.IsEnabled()
+            {
+                // We enable the remote host if either RemoteHostTest or RemoteHost are on.
+                if (!_workspace.Options.GetOption(RemoteHostOptions.RemoteHostTest)
+                    && !_workspace.Options.GetOption(RemoteHostOptions.RemoteHost))
+                {
+                    // not turned on
+                    return false;
+                }
+
+                var remoteHostClientFactory = _workspace.Services.GetService<IRemoteHostClientFactory>();
+                if (remoteHostClientFactory is null)
+                {
+                    // not available
+                    return false;
+                }
+
+                return true;
+            }
+
             public Task<RemoteHostClient> TryGetRemoteHostClientAsync(CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/Workspaces/Core/Portable/Remote/DefaultRemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/Workspaces/Core/Portable/Remote/DefaultRemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Roslyn.Utilities;
@@ -29,6 +28,11 @@ namespace Microsoft.CodeAnalysis.Remote
                 _remoteHostClientFactory = remoteHostClientFactory;
 
                 _lazyInstance = CreateNewLazyRemoteHostClient();
+            }
+
+            public bool IsEnabled()
+            {
+                return !(_lazyInstance is null);
             }
 
             public Task<RemoteHostClient> TryGetRemoteHostClientAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Remote/IRemoteHostClientService.cs
+++ b/src/Workspaces/Core/Portable/Remote/IRemoteHostClientService.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -12,6 +11,8 @@ namespace Microsoft.CodeAnalysis.Remote
     /// </summary>
     internal interface IRemoteHostClientService : IWorkspaceService
     {
+        bool IsEnabled();
+
         /// <summary>
         /// Request new remote host. 
         /// 

--- a/src/Workspaces/Core/Portable/Remote/RemoteFeatureOptions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteFeatureOptions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     return true;
 
                 case WorkspaceKind.Host:
+                case WorkspaceKind.MSBuild:
                     // Compute indices in the host workspace when OOP is disabled.
                     var remoteHostClientService = workspace.Services.GetService<IRemoteHostClientService>();
                     if (remoteHostClientService is null)

--- a/src/Workspaces/Core/Portable/Remote/RemoteFeatureOptions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteFeatureOptions.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Remote
@@ -25,6 +23,16 @@ namespace Microsoft.CodeAnalysis.Remote
                 case WorkspaceKind.RemoteWorkspace:
                     // Always compute indices in the remote workspace.
                     return true;
+
+                case WorkspaceKind.Host:
+                    // Compute indices in the host workspace when OOP is disabled.
+                    var remoteHostClientService = workspace.Services.GetService<IRemoteHostClientService>();
+                    if (remoteHostClientService is null)
+                    {
+                        return true;
+                    }
+
+                    return !remoteHostClientService.IsEnabled();
             }
 
             // Otherwise, don't compute the index for any other workspaces.


### PR DESCRIPTION
Fixes #34631

### Customer scenario

Solution crawler indexing is disabled in host environments that do not support OOP (e.g. Visual Studio for Mac), or where OOP has been manually disabled (e.g. some customer scenarios for Visual Studio).

### Bugs this fixes

#34631

### Workarounds, if any

None.

### Risk

Low. This does not change behavior for primary host environments where OOP is used.

### Performance impact

No significant impact.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

#31644 (specifically commit 6f5be2ef2849b22dc185081ed9e389f02b80e473) assumed that OOP is supported by the host. This is not always the case, and Visual Studio for Mac scenarios failed as a result.

### How was the bug found?

Reported by developers on Visual Studio for Mac.

### Test documentation updated?

No.
