### PR TITLE
Remove unnecessary code: was When generating constructor, trim known prefixes from argument name to get parameter name 

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
@@ -3680,7 +3680,9 @@ class D
         [WorkItem(33673, "https://github.com/dotnet/roslyn/issues/33673")]
         [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         [InlineData("_s", "s")]
+        [InlineData("_S", "s")]
         [InlineData("m_s", "s")]
+        [InlineData("m_S", "s")]
         [InlineData("s_s", "s")]
         [InlineData("t_s", "s")]
         public async Task GenerateConstructor_ArgumentHasCommonPrefix(string argumentName, string fieldName)

--- a/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
@@ -3676,5 +3676,41 @@ class D
 {
 }", options: options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscore, options.ParameterNamesAreCamelCaseWithPUnderscorePrefix, LanguageNames.CSharp));
         }
+
+        [WorkItem(33673, "https://github.com/dotnet/roslyn/issues/33673")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [InlineData("_s", "s")]
+        [InlineData("m_s", "s")]
+        [InlineData("s_s", "s")]
+        [InlineData("t_s", "s")]
+        public async Task GenerateConstructor_ArgumentHasCommonPrefix(string argumentName, string fieldName)
+        {
+            await TestInRegularAndScriptAsync(
+$@"
+class Program
+{{
+    static void Main(string[] args)
+    {{
+        string {argumentName} = "";
+        new Prog[||]ram({argumentName});
+    }}
+}}",
+$@"
+class Program
+{{
+    private string {fieldName};
+
+    public Program(string {fieldName})
+    {{
+        this.{fieldName} = {fieldName};
+    }}
+
+    static void Main(string[] args)
+    {{
+        string {argumentName} = "";
+        new Program({argumentName});
+    }}
+}}");
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/NamingStyles/NamingStyle.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/NamingStyle.cs
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis.NamingStyles
             return FinishFixingName(name);
         }
 
-        private static string StripCommonPrefixes(string name, out string prefix)
+        internal static string StripCommonPrefixes(string name, out string prefix)
         {
             var index = 0;
             while (index + 1 < name.Length)

--- a/src/Workspaces/Core/Portable/NamingStyles/NamingStyle.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/NamingStyle.cs
@@ -346,12 +346,6 @@ namespace Microsoft.CodeAnalysis.NamingStyles
             return FinishFixingName(name);
         }
 
-        public static string StripCommonPrefixes(string name)
-        {
-            StripCommonPrefixes(name, out _);
-            return name;
-        }
-
         public static string StripCommonPrefixes(string name, out string prefix)
         {
             var index = 0;

--- a/src/Workspaces/Core/Portable/NamingStyles/NamingStyle.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/NamingStyle.cs
@@ -346,7 +346,13 @@ namespace Microsoft.CodeAnalysis.NamingStyles
             return FinishFixingName(name);
         }
 
-        internal static string StripCommonPrefixes(string name, out string prefix)
+        public static string StripCommonPrefixes(string name)
+        {
+            StripCommonPrefixes(name, out _);
+            return name;
+        }
+
+        public static string StripCommonPrefixes(string name, out string prefix)
         {
             var index = 0;
             while (index + 1 < name.Length)

--- a/src/Workspaces/Core/Portable/NamingStyles/NamingStyle.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/NamingStyle.cs
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis.NamingStyles
             return FinishFixingName(name);
         }
 
-        public static string StripCommonPrefixes(string name, out string prefix)
+        private static string StripCommonPrefixes(string name, out string prefix)
         {
             var index = 0;
             while (index + 1 < name.Length)

--- a/src/Workspaces/Core/Portable/Utilities/ParameterName.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ParameterName.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
-using Microsoft.CodeAnalysis.NamingStyles;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Utilities
@@ -52,9 +51,7 @@ namespace Microsoft.CodeAnalysis.Utilities
             {
                 // Otherwise, massage it a bit to be a more suitable match for
                 // how people actually writing parameters.
-                var trimmed = NamingStyle.StripCommonPrefixes(nameBasedOnArgument);
-                BestNameForParameter = trimmed.Length > 0 ? trimmed.ToCamelCase() : nameBasedOnArgument;
-                BestNameForParameter = parameterNamingRule.NamingStyle.MakeCompliant(BestNameForParameter).First();
+                BestNameForParameter = parameterNamingRule.NamingStyle.MakeCompliant(nameBasedOnArgument).First();
             }
         }
 

--- a/src/Workspaces/Core/Portable/Utilities/ParameterName.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ParameterName.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.NamingStyles;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Utilities
 {
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Utilities
             {
                 // Otherwise, massage it a bit to be a more suitable match for
                 // how people actually writing parameters.
-                var trimmed = NamingStyle.StripCommonPrefixes(nameBasedOnArgument, out var _);
+                var trimmed = NamingStyle.StripCommonPrefixes(nameBasedOnArgument);
                 BestNameForParameter = trimmed.Length > 0 ? trimmed.ToCamelCase() : nameBasedOnArgument;
                 BestNameForParameter = parameterNamingRule.NamingStyle.MakeCompliant(BestNameForParameter).First();
             }

--- a/src/Workspaces/Core/Portable/Utilities/ParameterName.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ParameterName.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.NamingStyles;
 
 namespace Microsoft.CodeAnalysis.Utilities
 {
@@ -51,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Utilities
             {
                 // Otherwise, massage it a bit to be a more suitable match for
                 // how people actually writing parameters.
-                var trimmed = nameBasedOnArgument.TrimStart('_');
+                var trimmed = NamingStyle.StripCommonPrefixes(nameBasedOnArgument, out var _);
                 BestNameForParameter = trimmed.Length > 0 ? trimmed.ToCamelCase() : nameBasedOnArgument;
                 BestNameForParameter = parameterNamingRule.NamingStyle.MakeCompliant(BestNameForParameter).First();
             }


### PR DESCRIPTION
Fixes #33673 

When generating a constructor, the name of the constructor's parameter is based on the name of the argument that was passed to the constructor.  This PR removes any common prefixes  ("_", "m_", "s_", "t_") before creating the parameter name.