### PR TITLE
Remove redundant line.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -949,7 +949,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 TryEatNewLine(ScannerState.VB)
             Else
                 operatorToken = DirectCast(HandleUnexpectedToken(SyntaxKind.IsKeyword), KeywordSyntax)
-                ReportSyntaxError(operatorToken, ERRID.ERR_MissingIsInTypeOf)
             End If
 
             Dim typeName = ParseGeneralType()


### PR DESCRIPTION
Discovered through contributor's fork of Roslyn tinkering.

Due to the immutable nature of Roslyn syntax tree, the result of the `ReportSyntaxError` function call isn't used. The same diagnostic is produced though, via the `HandleUnexpectedToken` method. So no change in behavior is observable. _(as for I can tell)_