### PR TITLE
publish feature branch bits (nuget/vsix) so that partner team can try…

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -65,7 +65,17 @@
             "vsBranch": "lab/d16.1stg",
             "vsMajorVersion": 16,
             "ibcSourceBranch": "master-vs-deps"
-        }
+        },
+        "features/lspSupport": {
+            "nugetKind": [ "Shipping", "NonShipping" ],
+            "version": "3.1.*",
+            "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+            "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
+            "channels": [ "lspSupport" ],
+            "vsBranch": "lab/d16.1stg",
+            "vsMajorVersion": 16,
+            "ibcSourceBranch": "master-vs-deps"
+      }
     },
     "releases": {
         "dev15.5": {


### PR DESCRIPTION
… those.

...

package versions will show up here
https://github.com/dotnet/versions/blob/master/build-info/dotnet/roslyn/lspSupport/Latest_Packages.txt

once the very first package is published.