### PR TITLE
Cleanups to callers of GetSemanticInfo

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -1251,6 +1251,12 @@ class D
                 MainDescription("class System.String"));
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestNullLiteralWithVar()
+        {
+            await TestInMethodAsync(@"var f = null$$");
+        }
+
         [WorkItem(26027, "https://github.com/dotnet/roslyn/issues/26027")]
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task TestDefaultLiteral()

--- a/src/EditorFeatures/Test2/Extensions/ISymbolExtensionsTests.vb
+++ b/src/EditorFeatures/Test2/Extensions/ISymbolExtensionsTests.vb
@@ -3,6 +3,7 @@
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.FindSymbols
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
     <[UseExportProvider]>
@@ -15,12 +16,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 Dim cursorPosition = cursorDocument.CursorPosition.Value
                 Dim document = workspace.CurrentSolution.GetDocument(cursorDocument.Id)
 
-                Dim tree = Await document.GetSyntaxTreeAsync()
-                Dim commonSyntaxToken = Await tree.GetTouchingTokenAsync(cursorPosition, Nothing)
-
                 Dim semanticModel = Await document.GetSemanticModelAsync()
-                Dim symbol = semanticModel.GetSemanticInfo(commonSyntaxToken, document.Project.Solution.Workspace, Nothing).
-                                           GetAnySymbol(includeType:=False)
+                Dim symbol = Await SymbolFinder.FindSymbolAtPositionAsync(document, cursorPosition)
                 Dim namedTypeSymbol = semanticModel.GetEnclosingNamedType(cursorPosition, CancellationToken.None)
 
                 Dim actualVisible = symbol.IsAccessibleWithin(namedTypeSymbol)

--- a/src/EditorFeatures/Test2/Workspaces/SymbolDescriptionServiceTests.vb
+++ b/src/EditorFeatures/Test2/Workspaces/SymbolDescriptionServiceTests.vb
@@ -3,6 +3,7 @@
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.FindSymbols
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.LanguageServices
 
@@ -19,21 +20,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             Dim cursorBuffer = cursorDocument.TextBuffer
 
             Dim document = workspace.CurrentSolution.GetDocument(cursorDocument.Id)
-
-            ' using GetTouchingWord instead of FindToken allows us to test scenarios where cursor is at the end of token (E.g: Goo$$)
-            Dim tree = Await document.GetSyntaxTreeAsync()
-            Dim commonSyntaxToken = Await tree.GetTouchingWordAsync(cursorPosition, languageServiceProvider.GetService(Of ISyntaxFactsService), Nothing)
-
-            ' For String Literals GetTouchingWord returns Nothing, we still need this for Quick Info. Quick Info code does exactly the following.
-            ' caveat: The comment above the previous line of code. Do not put the cursor at the end of the token.
-            If commonSyntaxToken = Nothing Then
-                commonSyntaxToken = (Await document.GetSyntaxRootAsync()).FindToken(cursorPosition)
-            End If
-
             Dim semanticModel = Await document.GetSemanticModelAsync()
-            Dim symbol = semanticModel.GetSemanticInfo(commonSyntaxToken, document.Project.Solution.Workspace, CancellationToken.None).
-                                       GetSymbols(includeType:=True).
-                                       AsImmutable()
+            Dim symbol = Await SymbolFinder.FindSymbolAtPositionAsync(document, cursorPosition)
 
             Dim symbolDescriptionService = languageServiceProvider.GetService(Of ISymbolDisplayService)()
 
@@ -106,44 +94,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
     </Project>
 </Workspace>
             Await TestCSharpAsync(workspace, $"({FeaturesResources.local_constant}) int x = 2")
-        End Function
-
-        <Fact>
-        Public Async Function TestCSharpNullLiteralVar() As Task
-            Dim workspace =
-<Workspace>
-    <Project Language="C#" CommonReferences="true">
-        <Document>
-            class Goo
-            {    
-                void Method()
-                {
-                    var x = nu$$ll
-                }
-            }
-        </Document>
-    </Project>
-</Workspace>
-            Await TestCSharpAsync(workspace, "")
-        End Function
-
-        <Fact>
-        Public Async Function TestCSharpNullLiteralString() As Task
-            Dim workspace =
-<Workspace>
-    <Project Language="C#" CommonReferences="true">
-        <Document>
-            class Goo
-            {    
-                void Method()
-                {
-                    string x = nu$$ll
-                }
-            }
-        </Document>
-    </Project>
-</Workspace>
-            Await TestCSharpAsync(workspace, "class System.String")
         End Function
 
         <Fact>
@@ -647,125 +597,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
     </Project>
 </Workspace>
             Await TestBasicAsync(workspace, $"({FeaturesResources.local_variable}) x As String")
-        End Function
-
-        <Fact>
-        Public Async Function TestStringLiteral() As Task
-            Dim workspace =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-            Class Goo
-                Sub Method()
-                    Dim x As String = "Hel$$lo"
-                End Sub
-            End Class
-        </Document>
-    </Project>
-</Workspace>
-            Await TestBasicAsync(workspace, "Class System.String")
-        End Function
-
-        <Fact>
-        Public Async Function TestIntegerLiteral() As Task
-            Dim workspace =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-            Class Goo
-                Sub Method()
-                    Dim x = 4$$2
-                End Sub
-            End Class
-        </Document>
-    </Project>
-</Workspace>
-            Await TestBasicAsync(workspace, "Structure System.Int32")
-        End Function
-
-        <Fact>
-        Public Async Function TestDateLiteral() As Task
-            Dim workspace =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-            Class Goo
-                Sub Method()
-                       Dim d As Date
-                       d = #8/23/1970 $$3:45:39 AM#
-                End Sub
-            End Class
-        </Document>
-    </Project>
-</Workspace>
-            Await TestBasicAsync(workspace, "Structure System.DateTime")
-        End Function
-
-        <Fact>
-        Public Async Function TestNothingLiteralDim() As Task
-            Dim workspace =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-            Class Goo
-                Sub Method()
-                    Dim x = Nothin$$g
-                End Sub
-            End Class
-        </Document>
-    </Project>
-</Workspace>
-            Await TestBasicAsync(workspace, "Class System.Object")
-        End Function
-
-        <Fact>
-        Public Async Function TestNothingLiteralDimAsString() As Task
-            Dim workspace =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-            Class Goo
-                Sub Method()
-                    Dim x As String = Nothin$$g
-                End Sub
-            End Class
-        </Document>
-    </Project>
-</Workspace>
-            Await TestBasicAsync(workspace, "Class System.String")
-        End Function
-
-        <Fact>
-        Public Async Function TestNothingLiteralFieldDimOptionStrict() As Task
-            Dim workspace =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-            Option Strict On
-            Class Goo
-                Dim x = Nothin$$g
-            End Class
-        </Document>
-    </Project>
-</Workspace>
-            Await TestBasicAsync(workspace, "Class System.Object")
-        End Function
-
-        <Fact>
-        Public Async Function TestTrueKeyword() As Task
-            Dim workspace =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-            Class Goo
-                Sub Method()
-                    Dim x = Tr$$ue
-                End Sub
-            End Class
-        </Document>
-    </Project>
-</Workspace>
-            Await TestBasicAsync(workspace, "Structure System.Boolean")
         End Function
 
         <WorkItem(538732, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538732")>

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -1752,6 +1752,12 @@ End Class]]></text>.NormalizedValue(),
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        Public Async Function TestDateLiteral() As Task
+            Await TestInMethodAsync("Dim f = #8/23/1970 $$3:45:39 AM#",
+                                    MainDescription("Structure System.DateTime"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
         Public Async Function TestTrueKeyword() As Task
             Await TestInMethodAsync("Dim f = True$$",
                                     MainDescription("Structure System.Boolean"))
@@ -1768,6 +1774,22 @@ End Class]]></text>.NormalizedValue(),
         Public Async Function TestNothingLiteral() As Task
             Await TestInMethodAsync("Dim f As String = Nothing$$",
                                     MainDescription("Class System.String"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        Public Async Function TestNothingLiteralWithNoType() As Task
+            Await TestInMethodAsync("Dim f = Nothing$$",
+                                    MainDescription("Class System.Object"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        Public Async Function TestNothingLiteralFieldDimOptionStrict() As Task
+            Await TestAsync("
+Option Strict On
+Class C
+    Dim f = Nothing$$
+End Class",
+                            MainDescription("Class System.Object"))
         End Function
 
         ''' <Remarks>

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
@@ -73,26 +73,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return typeInfo.Type ?? symbolInfo.GetAnySymbol().ConvertToType(semanticModel.Compilation);
         }
 
-        public static TokenSemanticInfo GetSemanticInfo(
-            this SemanticModel semanticModel,
-            SyntaxToken token,
-            Workspace workspace,
-            CancellationToken cancellationToken)
-        {
-            var languageServices = workspace.Services.GetLanguageServices(token.Language);
-            var syntaxFacts = languageServices.GetService<ISyntaxFactsService>();
-            if (!syntaxFacts.IsBindableToken(token))
-            {
-                return TokenSemanticInfo.Empty;
-            }
-
-            var semanticFacts = languageServices.GetService<ISemanticFactsService>();
-
-            return GetSemanticInfo(
-                semanticModel, semanticFacts, syntaxFacts,
-                token, cancellationToken);
-        }
-
         private static ISymbol MapSymbol(ISymbol symbol, ITypeSymbol type)
         {
             if (symbol.IsConstructor() && symbol.ContainingType.IsAnonymousType)
@@ -141,13 +121,21 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return symbol;
         }
 
-        private static TokenSemanticInfo GetSemanticInfo(
-            SemanticModel semanticModel,
-            ISemanticFactsService semanticFacts,
-            ISyntaxFactsService syntaxFacts,
+        public static TokenSemanticInfo GetSemanticInfo(
+            this SemanticModel semanticModel,
             SyntaxToken token,
+            Workspace workspace,
             CancellationToken cancellationToken)
         {
+            var languageServices = workspace.Services.GetLanguageServices(token.Language);
+            var syntaxFacts = languageServices.GetService<ISyntaxFactsService>();
+            if (!syntaxFacts.IsBindableToken(token))
+            {
+                return TokenSemanticInfo.Empty;
+            }
+
+            var semanticFacts = languageServices.GetService<ISemanticFactsService>();
+
             IAliasSymbol aliasSymbol;
             ITypeSymbol type;
             ITypeSymbol convertedType;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
@@ -6,62 +6,11 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Operations;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
-    internal struct TokenSemanticInfo
-    {
-        public static readonly TokenSemanticInfo Empty = new TokenSemanticInfo(
-            null, null, ImmutableArray<ISymbol>.Empty, null, null, default(TextSpan));
-
-        public readonly ISymbol DeclaredSymbol;
-        public readonly IAliasSymbol AliasSymbol;
-        public readonly ImmutableArray<ISymbol> ReferencedSymbols;
-        public readonly ITypeSymbol Type;
-        public readonly ITypeSymbol ConvertedType;
-        public readonly TextSpan Span;
-
-        public TokenSemanticInfo(
-            ISymbol declaredSymbol,
-            IAliasSymbol aliasSymbol,
-            ImmutableArray<ISymbol> referencedSymbols,
-            ITypeSymbol type,
-            ITypeSymbol convertedType,
-            TextSpan span)
-        {
-            DeclaredSymbol = declaredSymbol;
-            AliasSymbol = aliasSymbol;
-            ReferencedSymbols = referencedSymbols;
-            Type = type;
-            ConvertedType = convertedType;
-            Span = span;
-        }
-
-        public ImmutableArray<ISymbol> GetSymbols(bool includeType)
-        {
-            var result = ArrayBuilder<ISymbol>.GetInstance();
-            result.AddIfNotNull(DeclaredSymbol);
-            result.AddIfNotNull(AliasSymbol);
-            result.AddRange(ReferencedSymbols);
-
-            if (includeType)
-            {
-                result.AddIfNotNull(Type ?? ConvertedType);
-            }
-
-            return result.ToImmutableAndFree();
-        }
-
-        public ISymbol GetAnySymbol(bool includeType)
-        {
-            return GetSymbols(includeType).FirstOrDefault();
-        }
-    }
-
     internal static class SemanticModelExtensions
     {
         public static SemanticMap GetSemanticMap(this SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/TokenSemanticInfo.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/TokenSemanticInfo.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Shared.Extensions
+{
+    internal struct TokenSemanticInfo
+    {
+        public static readonly TokenSemanticInfo Empty = new TokenSemanticInfo(
+            null, null, ImmutableArray<ISymbol>.Empty, null, null, default(TextSpan));
+
+        public readonly ISymbol DeclaredSymbol;
+        public readonly IAliasSymbol AliasSymbol;
+        public readonly ImmutableArray<ISymbol> ReferencedSymbols;
+        public readonly ITypeSymbol Type;
+        public readonly ITypeSymbol ConvertedType;
+        public readonly TextSpan Span;
+
+        public TokenSemanticInfo(
+            ISymbol declaredSymbol,
+            IAliasSymbol aliasSymbol,
+            ImmutableArray<ISymbol> referencedSymbols,
+            ITypeSymbol type,
+            ITypeSymbol convertedType,
+            TextSpan span)
+        {
+            DeclaredSymbol = declaredSymbol;
+            AliasSymbol = aliasSymbol;
+            ReferencedSymbols = referencedSymbols;
+            Type = type;
+            ConvertedType = convertedType;
+            Span = span;
+        }
+
+        public ImmutableArray<ISymbol> GetSymbols(bool includeType)
+        {
+            var result = ArrayBuilder<ISymbol>.GetInstance();
+            result.AddIfNotNull(DeclaredSymbol);
+            result.AddIfNotNull(AliasSymbol);
+            result.AddRange(ReferencedSymbols);
+
+            if (includeType)
+            {
+                result.AddIfNotNull(Type ?? ConvertedType);
+            }
+
+            return result.ToImmutableAndFree();
+        }
+
+        public ISymbol GetAnySymbol(bool includeType)
+        {
+            return GetSymbols(includeType).FirstOrDefault();
+        }
+    }
+}


### PR DESCRIPTION
The IDE codebase has a "GetSemanticInfo" helper that returns a struct that's sort of a spiritual merge between GetDeclaredSymbol, GetTypeInfo, GetSymbolInfo and GetAliasInfo, and used for features like Quick Info where we might be operating on either a declaration or reference. Trying to add additional smarts to Quick Info for nullable means having to figure out how this strange merged type should represent nullability, which is somewhat tricky since there's a few different consumers with radically different needs.

One way to simplify satisfying everybody's need is to remove some of the needs entirely -- two of the callers were tests. One of them could just use a public API, and the other one I suspect was tests that got forked out of Quick Info and so were reimplementing _in the test_ some Quick Info logic.

After this it looks like the only remaining callers are:

1. The public SymbolFinder.SymbolAtPositionAsync which just wants a symbol and nothing more.
2. Quick Info itself (which makes sense) which just wants the symbol but also has special-case handling
for literals.
3. Some tricky bits inside of rename.
4. F1 help, which is the same as quick info and also wants the literal special case handling.

Once I can understand the tricky stuff rename is doing, I might be able to simplify this to not have a complicated struct and just return symbol (with literal special case handling) and any stuff Quick Info specifically needs.