### PR TITLE
IsConflictMarker implementation refactored.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -2344,7 +2344,7 @@ LoopExit:
                     case '<':
                         if (!isTrailing)
                         {
-                            if (IsConflictMarkerTrivia())
+                            if (this.IsConflictMarkerTrivia())
                             {
                                 this.LexConflictMarkerTrivia(ref triviaList);
                                 break;
@@ -2365,35 +2365,21 @@ LoopExit:
 
         private bool IsConflictMarkerTrivia()
         {
-            var position = TextWindow.Position;
-            var text = TextWindow.Text;
-            if (position == 0 || SyntaxFacts.IsNewLine(text[position - 1]))
+            // Is directly after a newline?
+            if (!IsAtNewLine())
             {
-                var firstCh = text[position];
-                Debug.Assert(firstCh == '<' || firstCh == '=' || firstCh == '>');
-
-                if ((position + s_conflictMarkerLength) <= text.Length)
-                {
-                    for (int i = 0, n = s_conflictMarkerLength; i < n; i++)
-                    {
-                        if (text[position + i] != firstCh)
-                        {
-                            return false;
-                        }
-                    }
-
-                    if (firstCh == '=')
-                    {
-                        return true;
-                    }
-
-                    return (position + s_conflictMarkerLength) < text.Length &&
-                        text[position + s_conflictMarkerLength] == ' ';
-                }
+                return false;
             }
-
-            return false;
+            // Is the branch seperator marker?
+            if (TextWindow.NextAre("======="))
+            {
+                return true;
+            }
+            // Is branch conflict marker, and followed by a space.
+            return TextWindow.NextIs(' ', s_conflictMarkerLength) && (TextWindow.NextAre("<<<<<<<") || TextWindow.NextAre(">>>>>>>"));
         }
+
+        private bool IsAtNewLine() => (TextWindow.Offset == 0) || SyntaxFacts.IsNewLine(TextWindow.PeekChar(-1));
 
         private void LexConflictMarkerTrivia(ref SyntaxListBuilder triviaList)
         {

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -2365,18 +2365,8 @@ LoopExit:
 
         private bool IsConflictMarkerTrivia()
         {
-            // Is directly after a newline?
-            if (!IsAtNewLine())
-            {
-                return false;
-            }
-            // Is the branch seperator marker?
-            if (TextWindow.NextAre("======="))
-            {
-                return true;
-            }
-            // Is branch conflict marker, and followed by a space.
-            return TextWindow.NextIs(' ', s_conflictMarkerLength) && (TextWindow.NextAre("<<<<<<<") || TextWindow.NextAre(">>>>>>>"));
+            // Is directly after a newlinem andalso a Conflict Branch Seperator or a branch conflict marker that is followed by a space.
+            return IsAtNewLine() && (TextWindow.NextAre("=======") || TextWindow.NextAre("<<<<<<< ") || TextWindow.NextAre(">>>>>>> "));
         }
 
         private bool IsAtNewLine() => (TextWindow.Offset == 0) || SyntaxFacts.IsNewLine(TextWindow.PeekChar(-1));

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -2359,10 +2359,6 @@ LoopExit:
             }
         }
 
-        // All conflict markers consist of the same character repeated seven times.  If it is
-        // a <<<<<<< or >>>>>>> marker then it is also followed by a space.
-        private static readonly int s_conflictMarkerLength = "<<<<<<<".Length;
-
         private bool IsConflictMarkerTrivia()
         {
             // Is directly after a newlinem andalso a Conflict Branch Seperator or a branch conflict marker that is followed by a space.
@@ -2375,7 +2371,8 @@ LoopExit:
         {
             this.Start();
 
-            this.AddError(TextWindow.Position, s_conflictMarkerLength,
+            // Conflict markers are 7 character long.
+            this.AddError(TextWindow.Position, 7,
                 ErrorCode.ERR_Merge_conflict_marker_encountered);
 
             var startCh = this.TextWindow.PeekChar();

--- a/src/Compilers/CSharp/Portable/Parser/SlidingTextWindow.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SlidingTextWindow.cs
@@ -340,7 +340,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (!CanGet(offset + n - 1)) return false;
             for (var i = 0; i < n; i++)
             {
-                if (chars[i] != PeekChar(offset + i)) return false;
+                if (chars[i] != PeekChar(offset + i))
+                {
+                    return false;
+                }
             }
             return true;
         }

--- a/src/Compilers/CSharp/Portable/Parser/SlidingTextWindow.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SlidingTextWindow.cs
@@ -333,6 +333,34 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return ch;
         }
 
+        public bool NextAre(string chars, int offset = 0)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(chars));
+            var n = chars.Length;
+            if (!CanGet(offset + n - 1)) return false;
+            for (var i = 0; i < n; i++)
+            {
+                if (chars[i] != PeekChar(offset + i)) return false;
+            }
+            return true;
+        }
+
+        public bool NextIs(char c, int offset = 0) => TryGet(out var ch, offset) && (ch == c);
+
+        public bool CanGet(int num = 0)
+        {
+            Debug.Assert(_offset + num >= 0);
+            //  Debug.Assert(num >= -MaxCharsLookBehind);
+            return _offset + num < _characterWindowCount;
+        }
+
+        public bool TryGet(out char ch, int num = 0)
+        {
+            var ok = CanGet(num);
+            ch = ok ? PeekChar(num) : default;
+            return ok;
+        }
+
         public bool IsUnicodeEscape()
         {
             if (this.PeekChar() == '\\')

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -696,10 +696,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Return False
         End Function
 
-        ' All conflict markers consist of the same character repeated seven times.  If it Is
-        ' a <<<<<<< Or >>>>>>> marker then it Is also followed by a space.
-        Private Shared ReadOnly s_conflictMarkerLength As Integer = "<<<<<<<".Length
-
         Private Function IsConflictMarkerTrivia() As Boolean
             ' Is directly after a newlinem andalso a Conflict Branch Seperator or a branch conflict marker that is followed by a space.
             Return IsAtNewLine() AndAlso (NextAre("=======") OrElse NextAre("<<<<<<< ") OrElse NextAre(">>>>>>> "))

--- a/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/Scanner.vb
@@ -701,16 +701,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Shared ReadOnly s_conflictMarkerLength As Integer = "<<<<<<<".Length
 
         Private Function IsConflictMarkerTrivia() As Boolean
-            ' Is directly after a newline?
-            If Not IsAtNewLine Then
-                Return False
-            End If
-            ' Is branch seperator?
-            If NextAre("=======") Then
-                Return True
-            End If
-            ' Is branch conflict marker, and followed by a space.
-            Return NextIs(" "c, s_conflictMarkerLength) AndAlso (NextAre("<<<<<<<") OrElse NextAre(">>>>>>>"))
+            ' Is directly after a newlinem andalso a Conflict Branch Seperator or a branch conflict marker that is followed by a space.
+            Return IsAtNewLine() AndAlso (NextAre("=======") OrElse NextAre("<<<<<<< ") OrElse NextAre(">>>>>>> "))
         End Function
 
         Private Sub ScanConflictMarker(tList As SyntaxListBuilder)

--- a/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/ScannerXml.vb
@@ -119,22 +119,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                                     If CanGet(2) Then
                                         Select Case (Peek(2))
                                             Case "-"c
-                                                If NextIs(3, "-"c) Then
+                                                If NextIs("-"c, 3) Then
                                                     Return XmlMakeBeginCommentToken(leadingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If NextAre(3, "CDATA[") Then
+                                                If NextAre("CDATA[", 3) Then
                                                     Return XmlMakeBeginCDataToken(leadingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If NextAre(3, "OCTYPE") Then
+                                                If NextAre("OCTYPE", 3) Then
                                                     Return XmlMakeBeginDTDToken(leadingTrivia)
                                                 End If
                                         End Select
                                     End If
                                     Return XmlLessThanExclamationToken(state, leadingTrivia)
                                 Case "%"c
-                                    If NextIs(2, "="c) Then
+                                    If NextIs("="c, 2) Then
                                         Return XmlMakeBeginEmbeddedToken(leadingTrivia)
                                     End If
                                 Case "?"c
@@ -148,7 +148,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                     Case "?"c
 
-                        If NextIs(1, ">"c) Then
+                        If NextIs(">"c, 1) Then
                             ' // Create token for the '?>' termination sequence
                             Return XmlMakeEndProcessingInstructionToken(leadingTrivia)
                         End If
@@ -348,21 +348,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                                     If CanGet(2) Then
                                         Select Case (Peek(2))
                                             Case "-"c
-                                                If NextIs(3, "-"c) Then
+                                                If NextIs("-"c, 3) Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If NextAre(3, "CDATA[") Then
+                                                If NextAre("CDATA[", 3) Then
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If NextAre(3, "OCTYPE") Then
+                                                If NextAre("OCTYPE", 3) Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
                                     End If
                                 Case "%"c
-                                    If NextIs(2, "="c) Then
+                                    If NextIs("="c, 2) Then
                                         Return XmlMakeBeginEmbeddedToken(precedingTrivia)
                                     End If
                                 Case "?"c
@@ -375,7 +375,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Return XmlMakeLessToken(precedingTrivia)
 
                     Case "]"c
-                        If NextAre(Here + 1, "]>") Then
+                        If NextAre("]>", Here + 1) Then
 
                             ' // If valid characters found then return them.
                             If Here <> 0 Then
@@ -499,7 +499,7 @@ ScanChars:
                         Return XmlMakeCommentToken(precedingTrivia, Here + LengthOfLineBreak(c, Here))
 
                     Case "-"c
-                        If NextIs(Here + 1, "-"c) Then
+                        If NextIs("-"c, Here + 1) Then
 
                             ' // --> terminates an Xml comment but otherwise -- is an illegal character sequence.
                             ' // The scanner will always returns "--" as a separate comment data string and the
@@ -593,7 +593,7 @@ ScanChars:
                         Return XmlMakeCDataToken(precedingTrivia, Here, scratch)
 
                     Case "]"c
-                        If NextAre(Here + 1, "]>") Then
+                        If NextAre("]>", Here + 1) Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -668,7 +668,7 @@ ScanChars:
                         GoTo CleanUp
 
                     Case "?"c
-                        If NextIs(Here + 1, ">"c) Then
+                        If NextIs(">"c, Here + 1) Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -735,13 +735,13 @@ CleanUp:
                             Dim ch As Char = Peek(1)
                             Select Case ch
                                 Case "!"c
-                                    If NextAre(2, "--") Then
+                                    If NextAre("--", 2) Then
                                         Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
-                                    ElseIf NextAre(2, "DOCTYPE") Then
+                                    ElseIf NextAre("DOCTYPE", 2) Then
                                         Return XmlMakeBeginDTDToken(precedingTrivia)
                                     End If
                                 Case "%"c
-                                    If NextIs(2, "="c) Then
+                                    If NextIs("="c, 2) Then
                                         Return XmlMakeBeginEmbeddedToken(precedingTrivia)
                                     End If
                                 Case "?"c
@@ -823,7 +823,7 @@ CleanUp:
                         End If
 
                     Case "/"c
-                        If NextIs(Here + 1, ">"c) Then
+                        If NextIs(">"c, Here + 1) Then
                             If Here <> 0 Then
                                 Return XmlMakeAttributeDataToken(Nothing, Here, scratch)
                             Else
@@ -922,7 +922,7 @@ ScanChars:
                             GoTo CleanUp
                         Else
                             ' report unexpected <%= in a special way.
-                            If NextAre(1, "%=") Then
+                            If NextAre("%=", 1) Then
                                 Dim errEmbedStart = XmlMakeAttributeDataToken(precedingTrivia, 3, "<%=")
                                 Dim errEmbedInfo = ErrorFactory.ErrorInfo(ERRID.ERR_QuotedEmbeddedExpression)
                                 result = DirectCast(errEmbedStart.SetDiagnostics({errEmbedInfo}), SyntaxToken)
@@ -1162,7 +1162,7 @@ CreateNCNameToken:
                         ' // &amp;
                         ' // &apos;
 
-                        If CanGet(4) AndAlso NextAre(2, "mp") Then
+                        If CanGet(4) AndAlso NextAre("mp", 2) Then
                             If Peek(4) = ";"c Then
                                 Return XmlMakeAmpLiteralToken(precedingTrivia)
                             Else
@@ -1171,7 +1171,7 @@ CreateNCNameToken:
                                 Return DirectCast(noSemicolon.SetDiagnostics({noSemicolonError}), XmlTextTokenSyntax)
                             End If
 
-                        ElseIf CanGet(5) AndAlso NextAre(2, "pos") Then
+                        ElseIf CanGet(5) AndAlso NextAre("pos", 2) Then
 
                             If Peek(5) = ";"c Then
                                 Return XmlMakeAposLiteralToken(precedingTrivia)
@@ -1185,7 +1185,7 @@ CreateNCNameToken:
                     Case "l"c
                         ' // &lt;
 
-                        If CanGet(3) AndAlso NextIs(2, "t"c) Then
+                        If CanGet(3) AndAlso NextIs("t"c, 2) Then
 
                             If Peek(3) = ";"c Then
                                 Return XmlMakeLtLiteralToken(precedingTrivia)
@@ -1199,7 +1199,7 @@ CreateNCNameToken:
                     Case "g"c
                         ' // &gt;
 
-                        If CanGet(3) AndAlso NextIs(2, "t"c) Then
+                        If CanGet(3) AndAlso NextIs("t"c, 2) Then
 
                             If Peek(3) = ";"c Then
                                 Return XmlMakeGtLiteralToken(precedingTrivia)
@@ -1213,7 +1213,7 @@ CreateNCNameToken:
                     Case "q"c
                         ' // &quot;
 
-                        If CanGet(5) AndAlso NextAre(2, "uot") Then
+                        If CanGet(5) AndAlso NextAre("uot", 2) Then
 
                             If Peek(5) = ";"c Then
                                 Return XmlMakeQuotLiteralToken(precedingTrivia)

--- a/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/XmlDocComments.vb
@@ -288,15 +288,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                                     If CanGet(2) Then
                                         Select Case (Peek(2))
                                             Case "-"c
-                                                If NextIs(3, "-"c) Then
+                                                If NextIs("-"c, 3) Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If NextAre(3, "CDATA[") Then
+                                                If NextAre("CDATA[", 3) Then
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If NextAre(3, "OCTYPE") Then
+                                                If NextAre("OCTYPE", 3) Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
@@ -311,7 +311,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                         Return XmlMakeLessToken(precedingTrivia)
 
                     Case "]"c
-                        If NextAre(Here + 1, "]>") Then
+                        If NextAre("]>", Here + 1) Then
 
                             ' // If valid characters found then return them.
                             If Here <> 0 Then
@@ -395,7 +395,7 @@ ScanChars:
                         GoTo CleanUp
 
                     Case "?"c
-                        If NextIs(Here + 1, ">"c) Then
+                        If NextIs(">"c, Here + 1) Then
 
                             '// If valid characters found then return them.
                             If Here <> 0 Then
@@ -487,7 +487,7 @@ CleanUp:
                         End If
 
                     Case "/"c
-                        If NextIs(1, ">"c) Then
+                        If NextIs(">"c, 1) Then
                             Return XmlMakeEndEmptyElementToken(precedingTrivia)
                         End If
                         Return XmlMakeDivToken(precedingTrivia)
@@ -512,15 +512,15 @@ CleanUp:
                                     If CanGet(2) Then
                                         Select Case (Peek(2))
                                             Case "-"c
-                                                If NextIs(3, "-"c) Then
+                                                If NextIs("-"c, 3) Then
                                                     Return XmlMakeBeginCommentToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "["c
-                                                If NextAre(3, "CDATA[") Then
+                                                If NextAre("CDATA[", 3) Then
                                                     Return XmlMakeBeginCDataToken(precedingTrivia, s_scanNoTriviaFunc)
                                                 End If
                                             Case "D"c
-                                                If NextAre(3, "OCTYPE") Then
+                                                If NextAre("OCTYPE", 3) Then
                                                     Return XmlMakeBeginDTDToken(precedingTrivia)
                                                 End If
                                         End Select
@@ -536,7 +536,7 @@ CleanUp:
                         Return XmlMakeLessToken(precedingTrivia)
 
                     Case "?"c
-                        If NextIs(1, ">"c) Then
+                        If NextIs(">"c, 1) Then
                             ' // Create token for the '?>' termination sequence
                             Return XmlMakeEndProcessingInstructionToken(precedingTrivia)
                         End If


### PR DESCRIPTION
To make use of existing helper functions and remove the direct usage of `_buffer` and `_lineBufferOffset`