### PR TITLE
Don't complete statement when multiple characters are selected

### DIFF
--- a/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
 
         private void BeforeExecuteCommand(TypeCharCommandArgs args, CommandExecutionContext executionContext)
         {
-            if (args.TypedChar != ';')
+            if (args.TypedChar != ';' || !args.TextView.Selection.IsEmpty)
             {
                 return;
             }

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -3344,9 +3344,19 @@ class C
 }";
             VerifyNoSpecialSemicolonHandling(code);
         }
+
         internal override VSCommanding.ICommandHandler GetCommandHandler(TestWorkspace workspace)
         {
             return workspace.ExportProvider.GetExportedValues<VSCommanding.ICommandHandler>().OfType<CompleteStatementCommandHandler>().Single();
+        }
+
+        [WorkItem(32337, "https://github.com/dotnet/roslyn/issues/32337")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CompleteStatement)]
+        public void ArgumentList_MultipleCharsSelected()
+        {
+            var code = CreateTestWithMethodCall(@"var test = ClassC.MethodM([|x[0]|], x[1])");
+
+            VerifyNoSpecialSemicolonHandling(code);
         }
 
         protected override TestWorkspace CreateTestWorkspace(string code)

--- a/src/EditorFeatures/TestUtilities/CompleteStatement/AbstractCompleteStatementTests.cs
+++ b/src/EditorFeatures/TestUtilities/CompleteStatement/AbstractCompleteStatementTests.cs
@@ -12,6 +12,9 @@ using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Roslyn.Test.Utilities;
 using Xunit;
 using VSCommanding = Microsoft.VisualStudio.Commanding;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.CompleteStatement
 {
@@ -25,14 +28,20 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CompleteStatement
         protected abstract TestWorkspace CreateTestWorkspace(string code);
 
         /// <summary>
-        /// Verify that typing a semicolon at the location in <paramref name="initialMarkup"/> marked with <c>$$</c>
-        /// does not perform any special "complete statement" operations, e.g. inserting missing delimiters or moving
-        /// the caret prior to the semicolon character insertion. In other words, statement completion does not impact
-        /// typing behavior for the case.
+        /// Verify that typing a semicolon at the location in <paramref name="initialMarkup"/> 
+        /// marked with 
+        ///     - <c>$$</c> for caret position
+        ///     - or, <c>[|</c> and <c>|]</c> for selected span
+        /// does not perform any special "complete statement" operations, e.g. inserting missing 
+        /// delimiters or moving the caret prior to the semicolon character insertion. In other words, 
+        /// statement completion does not impact typing behavior for the case.
         /// </summary>
         protected void VerifyNoSpecialSemicolonHandling(string initialMarkup, string newLine = "\r\n")
         {
-            var expected = initialMarkup.Replace("$$", ";$$");
+            var expected = initialMarkup.Contains("$$") ?
+                initialMarkup.Replace("$$", ";$$") :
+                initialMarkup.Replace("|]", ";$$|]");
+
             VerifyTypingSemicolon(initialMarkup, expected, newLine);
         }
 
@@ -73,8 +82,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CompleteStatement
             {
                 var testDocument = workspace.Documents.Single();
 
-                Assert.True(testDocument.CursorPosition.HasValue, "No caret position set!");
-                var startCaretPosition = testDocument.CursorPosition.Value;
+                Assert.True(testDocument.CursorPosition.HasValue || testDocument.SelectedSpans.Any(), "No caret position or selected spans are set!");
+                var startCaretPosition = testDocument.CursorPosition ?? testDocument.SelectedSpans.Last().End;
 
                 var view = testDocument.GetTextView();
 
@@ -82,14 +91,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CompleteStatement
                 {
                     var selectedSpan = testDocument.SelectedSpans[0];
 
-                    var isReversed = selectedSpan.Start == startCaretPosition
-                        ? true
-                        : false;
+                    var isReversed = selectedSpan.Start == startCaretPosition;
 
                     view.Selection.Select(new SnapshotSpan(view.TextSnapshot, selectedSpan.Start, selectedSpan.Length), isReversed);
                 }
 
-                view.Caret.MoveTo(new SnapshotPoint(view.TextSnapshot, testDocument.CursorPosition.Value));
+                view.Caret.MoveTo(new SnapshotPoint(view.TextSnapshot, startCaretPosition));
 
                 setOptionsOpt?.Invoke(workspace);
 

--- a/src/Test/Utilities/Portable/MarkedSource/MarkupTestFile.cs
+++ b/src/Test/Utilities/Portable/MarkedSource/MarkupTestFile.cs
@@ -228,7 +228,7 @@ namespace Roslyn.Test.Utilities
         public static void GetPositionAndSpans(string input, out string output, out int cursorPosition, out ImmutableArray<TextSpan> spans)
         {
             GetPositionAndSpans(input, out output, out int? pos, out spans);
-            cursorPosition = pos ?? default;
+            cursorPosition = pos.Value;
         }
 
         public static void GetPosition(string input, out string output, out int? cursorPosition)

--- a/src/Test/Utilities/Portable/MarkedSource/MarkupTestFile.cs
+++ b/src/Test/Utilities/Portable/MarkedSource/MarkupTestFile.cs
@@ -228,7 +228,7 @@ namespace Roslyn.Test.Utilities
         public static void GetPositionAndSpans(string input, out string output, out int cursorPosition, out ImmutableArray<TextSpan> spans)
         {
             GetPositionAndSpans(input, out output, out int? pos, out spans);
-            cursorPosition = pos.Value;
+            cursorPosition = pos ?? default;
         }
 
         public static void GetPosition(string input, out string output, out int? cursorPosition)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/32337

https://github.com/dotnet/roslyn/issues/32125 is also fixed as a result of this change.  Verified via manual testing.