### PR TITLE
Revert "Regex Completion + Async Completion = Failure to trigger on `[` in VB"

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -258,6 +258,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             // If we don't have a best completion item yet, then pick the first item from the list.
             var bestOrFirstCompletionItem = bestItem ?? itemsInList.First().FilterResult.CompletionItem;
 
+            // Check that it is a filter symbol. We can be called for a non-filter symbol.
+            if (filterReason == CompletionFilterReason.Insertion &&
+                !IsPotentialFilterCharacter(typeChar) &&
+                !string.IsNullOrEmpty(filterText) &&
+                !Helpers.IsFilterCharacter(bestOrFirstCompletionItem, typeChar, filterText))
+            {
+                return null;
+            }
+
             bool isHardSelection = IsHardSelection(
                 filterText, initialRoslynTriggerKind, bestOrFirstCompletionItem,
                 completionHelper, filterReason, recentItems, hasSuggestedItemOptions);

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_Regex.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_Regex.vb
@@ -57,7 +57,7 @@ class c
             End Using
         End Function
 
-        <MemberData(NameOf(AllCompletionImplementations))>
+        <MemberData(NameOf(AllCompletionImplementations), Skip:="https://github.com/dotnet/roslyn/issues/33852")>
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestCaretPlacement(completionImplementation As CompletionImplementation) As Task
             Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
@@ -74,11 +74,8 @@ class c
 
                 state.SendTypeChars("[")
 
-                ' WaitForAsynchronousOperationsAsync is not enough for waiting in the async completion.
-                ' To be sure that calculations are done, need to check session.GetComputedItems, 
-                ' E.g. via AssertSelectedCompletionItem.
                 Await state.WaitForAsynchronousOperationsAsync()
-                Await state.AssertSelectedCompletionItem("[  character-group  ]")
+                Await state.AssertCompletionSession()
                 state.SendDownKey()
                 state.SendDownKey()
                 state.SendDownKey()

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests_Regex.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests_Regex.vb
@@ -33,7 +33,7 @@ end class
             End Using
         End Function
 
-        <MemberData(NameOf(AllCompletionImplementations))>
+        <MemberData(NameOf(AllCompletionImplementations), Skip:="https://github.com/dotnet/roslyn/issues/33852")>
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestCaretPlacement(completionImplementation As CompletionImplementation) As Task
             Using state = TestStateFactory.CreateVisualBasicTestState(completionImplementation,
@@ -48,11 +48,8 @@ end class
 
                 state.SendTypeChars("[")
 
-                ' WaitForAsynchronousOperationsAsync is not enough for waiting in the async completion.
-                ' To be sure that calculations are done, need to check session.GetComputedItems, 
-                ' E.g. via AssertSelectedCompletionItem.
                 Await state.WaitForAsynchronousOperationsAsync()
-                Await state.AssertSelectedCompletionItem("[  character-group  ]")
+                Await state.AssertCompletionSession()
                 state.SendDownKey()
                 state.SendDownKey()
                 state.SendDownKey()
@@ -61,7 +58,7 @@ end class
                 state.SendTab()
                 Await state.AssertNoCompletionSession()
                 Assert.Contains("New Regex(""[^-]"")", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
-                Await state.AssertLineTextAroundCaret("        dim r = New Regex(""[^", "-]"")")
+                Await state.AssertLineTextAroundCaret("        Dim r = New Regex(""[^", "-]"")")
             End Using
         End Function
 
@@ -91,7 +88,7 @@ end class
             End Using
         End Function
 
-        <MemberData(NameOf(AllCompletionImplementations))>
+        <MemberData(NameOf(AllCompletionImplementations), Skip:="https://github.com/dotnet/roslyn/issues/33852")>
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function OnlyClasses(completionImplementation As CompletionImplementation) As Task
             Using state = TestStateFactory.CreateVisualBasicTestState(completionImplementation,


### PR DESCRIPTION
This reverts commit 094dd50db9c07b7c01b12ad5470dfda0b8aad844 from PR https://github.com/dotnet/roslyn/pull/33921

This will reopen https://github.com/dotnet/roslyn/issues/33852

This broke a major TypeScript scenario, so we're rolling it back for Preview 2 and will then continue looking at a more satisfactory solution for all scenarios. With the "Only use Tab or Enter to commit" setting enabled, typing non-commit characters would not dismiss, so you could get things like this (with or without Suggestion Mode):

![image](https://user-images.githubusercontent.com/235241/55838767-65467f00-5ada-11e9-8fba-95ddf9561f85.png)

Only escaping/tab/enter/`.` would make the list commit or go away.

I have confirmed that this breaks `[` Regex triggering in VB only (C# still works fine), and the TypeScript team is verifying the change on their end.