### PR TITLE
Roslyn Installer: Stop processes that block VSIX installation.

### DIFF
--- a/src/Setup/Installer/tools/install.ps1
+++ b/src/Setup/Installer/tools/install.ps1
@@ -9,11 +9,6 @@ $ErrorActionPreference="Stop"
 try {
   . (Join-Path $PSScriptRoot "utils.ps1")
 
-  if (Test-Process "devenv") {
-      Write-Host "Please shut down all instances of Visual Studio before running" -ForegroundColor Red
-      exit 1
-  }
-
   # Welcome Message
   Write-Host "Installing Roslyn Preview Build" -ForegroundColor Green
 
@@ -48,6 +43,9 @@ try {
   $vsDir = $vsInstance.installationPath.Trim("\")
   $vsId = $vsInstance.instanceId
   $vsMajorVersion = $vsInstance.installationVersion.Split(".")[0]
+  $mefCacheFolder = Get-MefCacheDir -vsMajorVersion $vsMajorVersion -vsId $vsId -rootSuffix $rootSuffix
+
+  Stop-Processes $vsDir (Split-Path $mefCacheFolder)
 
   # Install VSIX
   $vsExe = Join-Path $vsDir "Common7\IDE\devenv.exe"
@@ -58,7 +56,6 @@ try {
 
   # Clear MEF Cache
   Write-Host "Refreshing MEF Cache" -ForegroundColor Gray
-  $mefCacheFolder = Get-MefCacheDir -vsMajorVersion $vsMajorVersion -vsId $vsId -rootSuffix $rootSuffix
   if (Test-Path $mefCacheFolder) {
     Get-ChildItem -Path $mefCacheFolder -Include *.* -File -Recurse | foreach { Remove-Item $_ }
   }

--- a/src/Setup/Installer/tools/install.ps1
+++ b/src/Setup/Installer/tools/install.ps1
@@ -43,9 +43,9 @@ try {
   $vsDir = $vsInstance.installationPath.Trim("\")
   $vsId = $vsInstance.instanceId
   $vsMajorVersion = $vsInstance.installationVersion.Split(".")[0]
-  $mefCacheFolder = Get-MefCacheDir -vsMajorVersion $vsMajorVersion -vsId $vsId -rootSuffix $rootSuffix
+  $vsLocalDir = Get-VisualStudioLocalDir -vsMajorVersion $vsMajorVersion -vsId $vsId -rootSuffix $rootSuffix
 
-  Stop-Processes $vsDir (Split-Path $mefCacheFolder)
+  Stop-Processes $vsDir $vsLocalDir
 
   # Install VSIX
   $vsExe = Join-Path $vsDir "Common7\IDE\devenv.exe"
@@ -56,6 +56,7 @@ try {
 
   # Clear MEF Cache
   Write-Host "Refreshing MEF Cache" -ForegroundColor Gray
+  $mefCacheFolder = Get-MefCacheDir $vsLocalDir
   if (Test-Path $mefCacheFolder) {
     Get-ChildItem -Path $mefCacheFolder -Include *.* -File -Recurse | foreach { Remove-Item $_ }
   }

--- a/src/Setup/Installer/tools/uninstall.ps1
+++ b/src/Setup/Installer/tools/uninstall.ps1
@@ -19,14 +19,15 @@ try {
     $vsDir = $vsInstance.installationPath.Trim("\")
     $vsId = $vsInstance.instanceId
     $vsMajorVersion = $vsInstance.installationVersion.Split(".")[0]
-    $mefCacheFolder = Get-MefCacheDir -vsMajorVersion $vsMajorVersion -vsId $vsId -rootSuffix $rootSuffix
+    $vsLocalDir = Get-VisualStudioLocalDir -vsMajorVersion $vsMajorVersion -vsId $vsId -rootSuffix $rootSuffix
     
-    Stop-Processes $vsDir (Split-Path $mefCacheFolder)
+    Stop-Processes $vsDir $vsLocalDir
 
     Uninstall-VsixViaTool -vsDir $vsDir -vsId $vsId -rootSuffix $rootSuffix
 
     # Clear MEF Cache
     Write-Host "Refreshing MEF Cache" -ForegroundColor Gray
+    $mefCacheFolder = Get-MefCacheDir $vsLocalDir
     if (Test-Path $mefCacheFolder) {
       Get-ChildItem -Path $mefCacheFolder -Include *.* -File -Recurse | foreach { Remove-Item $_ }
     }

--- a/src/Setup/Installer/tools/uninstall.ps1
+++ b/src/Setup/Installer/tools/uninstall.ps1
@@ -9,11 +9,6 @@ $ErrorActionPreference="Stop"
 try {
   . (Join-Path $PSScriptRoot "utils.ps1")
 
-  if (Test-Process "devenv") {
-    Write-Host "Please shut down all instances of Visual Studio before running" -ForegroundColor Red
-    exit 1
-  }
-
   # Find VS Instance
   $vsInstances = Get-VisualStudioInstances
 
@@ -24,13 +19,14 @@ try {
     $vsDir = $vsInstance.installationPath.Trim("\")
     $vsId = $vsInstance.instanceId
     $vsMajorVersion = $vsInstance.installationVersion.Split(".")[0]
+    $mefCacheFolder = Get-MefCacheDir -vsMajorVersion $vsMajorVersion -vsId $vsId -rootSuffix $rootSuffix
+    
+    Stop-Processes $vsDir (Split-Path $mefCacheFolder)
 
     Uninstall-VsixViaTool -vsDir $vsDir -vsId $vsId -rootSuffix $rootSuffix
 
     # Clear MEF Cache
     Write-Host "Refreshing MEF Cache" -ForegroundColor Gray
-    
-    $mefCacheFolder = Get-MefCacheDir -vsMajorVersion $vsMajorVersion -vsId $vsId -rootSuffix $rootSuffix
     if (Test-Path $mefCacheFolder) {
       Get-ChildItem -Path $mefCacheFolder -Include *.* -File -Recurse | foreach { Remove-Item $_ }
     }

--- a/src/Setup/Installer/tools/utils.ps1
+++ b/src/Setup/Installer/tools/utils.ps1
@@ -93,8 +93,12 @@ function Test-Process([string]$processName) {
   return $all -ne $null
 }
 
-function Get-MefCacheDir([string]$vsMajorVersion, [string]$vsId, [string]$rootSuffix) {
-  return Join-Path $env:LOCALAPPDATA "Microsoft\VisualStudio\$vsMajorVersion.0_$vsId$rootSuffix\ComponentModelCache"
+function Get-VisualStudioLocalDir([string]$vsMajorVersion, [string]$vsId, [string]$rootSuffix) {
+  return Join-Path $env:LOCALAPPDATA "Microsoft\VisualStudio\$vsMajorVersion.0_$vsId$rootSuffix"
+}
+
+function Get-MefCacheDir([string]$vsLocalDir) {
+  return Join-Path $vsLocalDir "ComponentModelCache"
 }
 
 function Install-VsixViaTool([string]$vsDir, [string]$vsId, [string]$rootSuffix) {
@@ -163,7 +167,6 @@ function Stop-Processes([string]$vsDir, [string]$extensionDir) {
   }
 
   foreach ($process in $stopProcesses) {
-    Write-Host "Stopping $($process.Path)"
-    $_ = $process.Kill
+    Stop-Process $process.Id -Force -ErrorAction SilentlyContinue
   }
 }

--- a/src/Setup/Installer/tools/utils.ps1
+++ b/src/Setup/Installer/tools/utils.ps1
@@ -135,3 +135,35 @@ function Use-VsixTool([string]$vsDir, [string]$vsId, [string]$rootSuffix, [strin
     Exec-Console "`"$installerExe`"" "`"$vsixPath`" /vsInstallDir:`"$vsDir`" $rootSuffixArg $additionalArgs"
   }
 }
+
+function Stop-Processes([string]$vsDir, [string]$extensionDir) {
+  $stopProcesses = @()
+  foreach ($process in Get-Process) {
+    if ($process.Path) {
+      $dir = Split-Path $process.Path
+      if ($dir.StartsWith($vsDir) -or $dir.StartsWith($extensionDir)) {
+        $stopProcesses += $process
+      }
+    }
+  }
+
+  if ($stopProcesses.Length -eq 0) {
+    return
+  }
+
+  Write-Host "The following processes need to be stopped before installation can continue. Proceed? [Y/N]"
+  foreach ($process in $stopProcesses) {
+    Write-Host "> $($process.Path)"
+  }
+
+  $input = Read-Host
+  if ($input -ne "y" -and $input -ne "yes") {
+    Write-Host "Installation cancelled" -ForegroundColor Yellow
+    exit 1
+  }
+
+  foreach ($process in $stopProcesses) {
+    Write-Host "Stopping $($process.Path)"
+    $_ = $process.Kill
+  }
+}


### PR DESCRIPTION
Rather than requiring no devenv processes to be running when installing the VSIX, detect what processes might block the installation (those whose module is under the target VS install and extension dirs) and kill them if the user confirms.