### PR TITLE
Improve assertion message on quick info test failure

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/IntellisenseQuickInfoBuilderTests.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Text
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Classification
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
@@ -611,33 +612,42 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Function
 
         Private Shared Sub AssertEqualAdornments(expected As Object, actual As Object)
-            Assert.IsType(expected.GetType, actual)
+            Try
+                Assert.IsType(expected.GetType, actual)
 
-            Dim containerElement = TryCast(expected, ContainerElement)
-            If containerElement IsNot Nothing Then
-                AssertEqualContainerElement(containerElement, DirectCast(actual, ContainerElement))
-                Return
-            End If
+                Dim containerElement = TryCast(expected, ContainerElement)
+                If containerElement IsNot Nothing Then
+                    AssertEqualContainerElement(containerElement, DirectCast(actual, ContainerElement))
+                    Return
+                End If
 
-            Dim imageElement = TryCast(expected, ImageElement)
-            If imageElement IsNot Nothing Then
-                AssertEqualImageElement(imageElement, DirectCast(actual, ImageElement))
-                Return
-            End If
+                Dim imageElement = TryCast(expected, ImageElement)
+                If imageElement IsNot Nothing Then
+                    AssertEqualImageElement(imageElement, DirectCast(actual, ImageElement))
+                    Return
+                End If
 
-            Dim classifiedTextElement = TryCast(expected, ClassifiedTextElement)
-            If classifiedTextElement IsNot Nothing Then
-                AssertEqualClassifiedTextElement(classifiedTextElement, DirectCast(actual, ClassifiedTextElement))
-                Return
-            End If
+                Dim classifiedTextElement = TryCast(expected, ClassifiedTextElement)
+                If classifiedTextElement IsNot Nothing Then
+                    AssertEqualClassifiedTextElement(classifiedTextElement, DirectCast(actual, ClassifiedTextElement))
+                    Return
+                End If
 
-            Dim classifiedTextRun = TryCast(expected, ClassifiedTextRun)
-            If classifiedTextRun IsNot Nothing Then
-                AssertEqualClassifiedTextRun(classifiedTextRun, DirectCast(actual, ClassifiedTextRun))
-                Return
-            End If
+                Dim classifiedTextRun = TryCast(expected, ClassifiedTextRun)
+                If classifiedTextRun IsNot Nothing Then
+                    AssertEqualClassifiedTextRun(classifiedTextRun, DirectCast(actual, ClassifiedTextRun))
+                    Return
+                End If
 
-            Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
+                Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
+            Catch ex As Exception
+                Dim renderedExpected = ContainerToString(expected)
+                Dim renderedActual = ContainerToString(actual)
+                AssertEx.EqualOrDiff(renderedExpected, renderedActual)
+
+                ' This is not expected to be hit, but it will be hit if the difference cannot be detected within the diff
+                Throw
+            End Try
         End Sub
 
         Private Shared Sub AssertEqualContainerElement(expected As ContainerElement, actual As ContainerElement)
@@ -665,5 +675,122 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Assert.Equal(expected.ClassificationTypeName, actual.ClassificationTypeName)
             Assert.Equal(expected.Text, actual.Text)
         End Sub
+
+        Private Shared Function ContainerToString(element As Object) As String
+            Dim result = New StringBuilder
+            ContainerToString(element, "", result)
+            Return result.ToString()
+        End Function
+
+        Private Shared Sub ContainerToString(element As Object, indent As String, result As StringBuilder)
+            result.Append($"{indent}New {element.GetType().Name}(")
+
+            Dim container = TryCast(element, ContainerElement)
+            If container IsNot Nothing Then
+                result.AppendLine()
+                indent += "    "
+                result.AppendLine($"{indent}{ContainerStyleToString(container.Style)},")
+                Dim elements = container.Elements.ToArray()
+                For i = 0 To elements.Length - 1
+                    ContainerToString(elements(i), indent, result)
+
+                    If i < elements.Length - 1 Then
+                        result.AppendLine(",")
+                    Else
+                        result.Append(")")
+                    End If
+                Next
+
+                Return
+            End If
+
+            Dim image = TryCast(element, ImageElement)
+            If image IsNot Nothing Then
+                Dim guid = GetKnownImageGuid(image.ImageId.Guid)
+                Dim id = GetKnownImageId(image.ImageId.Id)
+                result.Append($"New {NameOf(ImageId)}({guid}, {id}))")
+                Return
+            End If
+
+            Dim classifiedTextElement = TryCast(element, ClassifiedTextElement)
+            If classifiedTextElement IsNot Nothing Then
+                result.AppendLine()
+                indent += "    "
+                Dim runs = classifiedTextElement.Runs.ToArray()
+                For i = 0 To runs.Length - 1
+                    ContainerToString(runs(i), indent, result)
+
+                    If i < runs.Length - 1 Then
+                        result.AppendLine(",")
+                    Else
+                        result.Append(")")
+                    End If
+                Next
+
+                Return
+            End If
+
+            Dim classifiedTextRun = TryCast(element, ClassifiedTextRun)
+            If classifiedTextRun IsNot Nothing Then
+                Dim classification = GetKnownClassification(classifiedTextRun.ClassificationTypeName)
+                result.Append($"{classification}, ""{classifiedTextRun.Text.Replace("""", """""")}"")")
+                Return
+            End If
+
+            Throw Roslyn.Utilities.ExceptionUtilities.Unreachable
+        End Sub
+
+        Private Shared Function ContainerStyleToString(style As ContainerElementStyle) As String
+            Dim stringValue = style.ToString()
+            Return String.Join(" Or ", stringValue.Split({","c, " "c}, StringSplitOptions.RemoveEmptyEntries).Select(Function(value) $"{NameOf(ContainerElementStyle)}.{value}"))
+        End Function
+
+        Private Shared Function GetKnownClassification(classification As String) As String
+            For Each field In GetType(ClassificationTypeNames).GetFields()
+                If Not field.IsStatic Then
+                    Continue For
+                End If
+
+                Dim rawValue = field.GetValue(Nothing)
+                Dim value = TryCast(rawValue, String)
+                If value = classification Then
+                    Return $"{NameOf(ClassificationTypeNames)}.{field.Name}"
+                End If
+            Next
+
+            Return $"""{classification}"""
+        End Function
+
+        Private Shared Function GetKnownImageGuid(guid As Guid) As String
+            For Each field In GetType(KnownImageIds).GetFields()
+                If Not field.IsStatic Then
+                    Continue For
+                End If
+
+                Dim rawValue = field.GetValue(Nothing)
+                Dim value As Guid? = If(TypeOf rawValue Is Guid, DirectCast(rawValue, Guid), Nothing)
+                If value = guid Then
+                    Return $"{NameOf(KnownImageIds)}.{field.Name}"
+                End If
+            Next
+
+            Return guid.ToString()
+        End Function
+
+        Private Shared Function GetKnownImageId(id As Integer) As String
+            For Each field In GetType(KnownImageIds).GetFields()
+                If Not field.IsStatic Then
+                    Continue For
+                End If
+
+                Dim rawValue = field.GetValue(Nothing)
+                Dim value As Integer? = If(TypeOf rawValue Is Integer, CInt(rawValue), Nothing)
+                If value = id Then
+                    Return $"{NameOf(KnownImageIds)}.{field.Name}"
+                End If
+            Next
+
+            Return id.ToString()
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Here is the new output for a manufactured test failure:

```
Test Name:	Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.IntellisenseQuickInfoBuilderTests.QuickInfoForTypeParameterReference
Test FullName:	Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.IntellisenseQuickInfoBuilderTests.QuickInfoForTypeParameterReference
Test Source:	C:\dev\roslyn\src\EditorFeatures\Test2\IntelliSense\IntellisenseQuickInfoBuilderTests.vb : line 542
Test Outcome:	Failed
Test Duration:	0:00:03.053

Result StackTrace:	
at Roslyn.Test.Utilities.AssertEx.EqualOrDiff(String expected, String actual, String message) in C:\dev\roslyn\src\Test\Utilities\Portable\Assert\AssertEx.cs:line 255
   at Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.IntellisenseQuickInfoBuilderTests.AssertEqualAdornments(Object expected, Object actual) in C:\dev\roslyn\src\EditorFeatures\Test2\IntelliSense\IntellisenseQuickInfoBuilderTests.vb:line 646
   at Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense.IntellisenseQuickInfoBuilderTests.VB$StateMachine_7_QuickInfoForTypeParameterReference.MoveNext() in C:\dev\roslyn\src\EditorFeatures\Test2\IntelliSense\IntellisenseQuickInfoBuilderTests.vb:line 595
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.<>c.<ThrowAsync>b__6_0(Object state)
Result Message:	
Actual and expected values differ. Expected shown in baseline of diff:
 New ContainerElement(
     ContainerElementStyle.Stacked Or ContainerElementStyle.VerticalPadding,
     New ContainerElement(
         ContainerElementStyle.Stacked,
         New ContainerElement(
             ContainerElementStyle.Wrapped,
             New ImageElement(New ImageId(KnownImageIds.ImageCatalogGuid, KnownImageIds.MethodPrivate)),
             New ClassifiedTextElement(
-                New ClassifiedTextRun(ClassificationTypeNames.Keyword, "voi"),
+                New ClassifiedTextRun(ClassificationTypeNames.Keyword, "void"),
                 New ClassifiedTextRun(ClassificationTypeNames.WhiteSpace, " "),
                 New ClassifiedTextRun(ClassificationTypeNames.ClassName, "MyClass"),
                 New ClassifiedTextRun(ClassificationTypeNames.Punctuation, "."),
                 New ClassifiedTextRun(ClassificationTypeNames.MethodName, "MyMethod"),
                 New ClassifiedTextRun(ClassificationTypeNames.Punctuation, "<"),
                 New ClassifiedTextRun(ClassificationTypeNames.Keyword, "int"),
                 New ClassifiedTextRun(ClassificationTypeNames.Punctuation, ">"),
                 New ClassifiedTextRun(ClassificationTypeNames.Punctuation, "("),
                 New ClassifiedTextRun(ClassificationTypeNames.Punctuation, ")"))),
         New ClassifiedTextElement(
             New ClassifiedTextRun(ClassificationTypeNames.Text, "The type parameter is"),
             New ClassifiedTextRun(ClassificationTypeNames.WhiteSpace, " "),
             New ClassifiedTextRun(ClassificationTypeNames.TypeParameterName, "T"),
             New ClassifiedTextRun(ClassificationTypeNames.Text, "."))))

Expected: True
Actual:   False
```

Prior to this change it was extremely difficult to construct the `expected` object unless you knew exactly the form that would be produced by the input text.