### PR TITLE
Make sure to add the new namespace for declaring documents in IChangeNamespaceService

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/SyncNamespace/SyncNamespaceTests_ChangeNamespace.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/SyncNamespace/SyncNamespaceTests_ChangeNamespace.cs
@@ -322,8 +322,7 @@ namespace Foo
 </Workspace>";
 
             var expectedSourceOriginal =
-@"
-using Foo;
+@"using Foo;
 using Foo.Bar;
 using Foo.Bar.Baz;
 
@@ -380,8 +379,7 @@ namespace Foo
 </Workspace>";
 
             var expectedSourceOriginal =
-@"
-using Foo;
+@"using Foo;
 using Foo.Bar;
 using Foo.Bar.Baz;
 
@@ -695,8 +693,7 @@ namespace [||]{declaredNamespace}
 </Workspace>";
 
             var expectedSourceOriginal =
-@"
-using System;
+@"using System;
 
 // Comments before declaration.
 // Comments after opening brace
@@ -973,8 +970,7 @@ namespace Foo
 </Workspace>";
 
             var expectedSourceOriginal =
-@"
-using Foo;
+@"using Foo;
 using Foo.Bar;
 using Foo.Bar.Baz;
 

--- a/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
@@ -417,7 +417,9 @@ targetNamespace: "B");
     {
     }
 }",
-expectedMarkup: @"namespace A
+expectedMarkup: @"using B;
+
+namespace A
 {
     class MyClass : IMyClass
     {
@@ -621,7 +623,9 @@ expectedSuccess: false);
     {
     }
 }",
-expectedMarkup: @"namespace A
+expectedMarkup: @"using B;
+
+namespace A
 {
     class MyClass : IMyClass
     {
@@ -940,5 +944,43 @@ expectedNamespaceName: "A  .    B   .   C");
     }
 }",
 expectedNamespaceName: "A  .    B   .   C");
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.MoveToNamespace)]
+        [WorkItem(34736, "https://github.com/dotnet/roslyn/issues/34736")]
+        public Task MoveToNamespace_MoveType_Usings()
+            => TestMoveToNamespaceAsync(
+@"namespace One
+{
+    using Two;
+    class C1
+    {
+        private C2 c2;
+    }
+}
+
+namespace [||]Two
+{
+    class C2
+    {
+
+    }
+}",
+expectedMarkup: @"namespace One
+{
+    using Three;
+    class C1
+    {
+        private C2 c2;
+    }
+}
+
+namespace {|Warning:Three|}
+{
+    class C2
+    {
+
+    }
+}",
+targetNamespace: "Three");
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                 var solutionAfterImportsRemoved = await RemoveUnnecessaryImportsAsync(
                     solutionAfterFirstMerge,
                     documentIds,
-                    ImmutableArray.CreateRange(CreateAllContainingNamespaces(declaredNamespace).Concat(targetNamespace)),
+                    GetAllNamespaceImportsForDeclaringDocument(declaredNamespace, targetNamespace),
                     cancellationToken).ConfigureAwait(false);
 
                 solutionAfterImportsRemoved = await RemoveUnnecessaryImportsAsync(
@@ -324,14 +324,16 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
             return @namespace?.Split(s_dotSeparator).ToImmutableArray() ?? default;
         }
 
-        private static ImmutableArray<string> CreateAllContainingNamespaces(string @namespace)
+        private static ImmutableArray<string> GetAllNamespaceImportsForDeclaringDocument(string oldNamespace, string newNamespace)
         {
-            var parts = GetNamespaceParts(@namespace);
+            var parts = GetNamespaceParts(oldNamespace);
             var builder = ArrayBuilder<string>.GetInstance();
             for (var i = 1; i <= parts.Length; ++i)
             {
                 builder.Add(string.Join(".", parts.Take(i)));
             }
+
+            builder.Add(newNamespace);
 
             return builder.ToImmutableAndFree();
         }
@@ -552,8 +554,7 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
             Debug.Assert(containersToAddImports.Length > 0);
 
             // Need to import all containing namespaces of old namespace and add them to the document (if it's not global namespace)
-            var namesToImport = ImmutableArray.CreateRange(CreateAllContainingNamespaces(oldNamespace)
-                                                            .Concat(newNamespace));
+            var namesToImport = GetAllNamespaceImportsForDeclaringDocument(oldNamespace, newNamespace);
 
             var optionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var placeSystemNamespaceFirst = optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, document.Project.Language);

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                 var solutionAfterImportsRemoved = await RemoveUnnecessaryImportsAsync(
                     solutionAfterFirstMerge,
                     documentIds,
-                    CreateAllContainingNamespaces(declaredNamespace),
+                    ImmutableArray.CreateRange(CreateAllContainingNamespaces(declaredNamespace).Concat(targetNamespace)),
                     cancellationToken).ConfigureAwait(false);
 
                 solutionAfterImportsRemoved = await RemoveUnnecessaryImportsAsync(
@@ -552,7 +552,8 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
             Debug.Assert(containersToAddImports.Length > 0);
 
             // Need to import all containing namespaces of old namespace and add them to the document (if it's not global namespace)
-            var namesToImport = CreateAllContainingNamespaces(oldNamespace);
+            var namesToImport = ImmutableArray.CreateRange(CreateAllContainingNamespaces(oldNamespace)
+                                                            .Concat(newNamespace));
 
             var optionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var placeSystemNamespaceFirst = optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, document.Project.Language);

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -554,6 +554,7 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
             Debug.Assert(containersToAddImports.Length > 0);
 
             // Need to import all containing namespaces of old namespace and add them to the document (if it's not global namespace)
+            // as well as the new namespace in case it's needed
             var namesToImport = GetAllNamespaceImportsForDeclaringDocument(oldNamespace, newNamespace);
 
             var optionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -554,7 +554,9 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
             Debug.Assert(containersToAddImports.Length > 0);
 
             // Need to import all containing namespaces of old namespace and add them to the document (if it's not global namespace)
-            // as well as the new namespace in case it's needed
+            // Include the new namespace in case there are multiple namespace declarations in
+            // the declaring document. They may need a using statement added to correctly keep
+            // references to the type inside it's new namespace
             var namesToImport = GetAllNamespaceImportsForDeclaringDocument(oldNamespace, newNamespace);
 
             var optionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Declaring documents were getting old namespace parts added to ensure they didn't lose references, but not the new namespace. This would result in the document not having the correct usings if it ended up having two namespaces. 

Fixes #34736