### PR TITLE
Nullable bug fixes

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (constraintTypes.Contains(c => type.Equals(c, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes)))
             {
                 // "Duplicate constraint '{0}' for type parameter '{1}'"
-                Error(diagnostics, ErrorCode.ERR_DuplicateBound, syntax, type.Type.SetUnknownNullabilityForReferenceTypes(), typeParameterName);
+                Error(diagnostics, ErrorCode.ERR_DuplicateBound, syntax, type.Type.SetObliviousNullabilityForReferenceTypes(), typeParameterName);
                 return false;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2453,7 +2453,7 @@ OuterBreak:
             {
                 // https://github.com/dotnet/roslyn/issues/30534: Should preserve
                 // distinct "not computed" state from initial binding.
-                return merged.SetUnknownNullabilityForReferenceTypes();
+                return merged.SetObliviousNullabilityForReferenceTypes();
             }
 
             return merged.MergeNullability(second, variance);
@@ -2785,7 +2785,7 @@ OuterBreak:
                 {
                     // https://github.com/dotnet/roslyn/issues/30534: Should preserve
                     // distinct "not computed" state from initial binding.
-                    type = type.SetUnknownNullabilityForReferenceTypes();
+                    type = type.SetObliviousNullabilityForReferenceTypes();
                 }
 
                 AddOrMergeCandidate(candidates, type, variance, conversions);
@@ -2799,7 +2799,7 @@ OuterBreak:
             ConversionsBase conversions)
         {
             Debug.Assert(conversions.IncludeNullability ||
-                newCandidate.SetUnknownNullabilityForReferenceTypes().Equals(newCandidate, TypeCompareKind.ConsiderEverything));
+                newCandidate.SetObliviousNullabilityForReferenceTypes().Equals(newCandidate, TypeCompareKind.ConsiderEverything));
 
             if (candidates.TryGetValue(newCandidate, out TypeWithAnnotations oldCandidate))
             {

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -286,7 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var expression = node.ExpressionOpt;
                 var type = (expression is null) ?
                     NoReturnExpression :
-                    expression.Type?.SetUnknownNullabilityForReferenceTypes();
+                    expression.Type?.SetObliviousNullabilityForReferenceTypes();
                 _builder.Add((node, TypeWithAnnotations.Create(type)));
                 return null;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1613,7 +1613,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 TypeWithAnnotations inferredType = (bestType is null)
-                    ? elementType.SetUnknownNullabilityForReferenceTypes()
+                    ? elementType.SetObliviousNullabilityForReferenceTypes()
                     : TypeWithAnnotations.Create(bestType);
 
                 if ((object)bestType != null)
@@ -2264,7 +2264,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (alternativeLValue, alternativeRValue) = visitConditionalRefOperand(alternativeState, node.Alternative);
                 Join(ref this.State, ref consequenceState);
 
-                TypeSymbol refResultType = node.Type.SetUnknownNullabilityForReferenceTypes();
+                TypeSymbol refResultType = node.Type.SetObliviousNullabilityForReferenceTypes();
                 if (IsNullabilityMismatch(consequenceLValue, alternativeLValue))
                 {
                     // l-value types must match
@@ -2341,7 +2341,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             NullableFlowState resultState;
             if (resultType is null)
             {
-                resultType = node.Type.SetUnknownNullabilityForReferenceTypes();
+                resultType = node.Type.SetObliviousNullabilityForReferenceTypes();
                 resultState = NullableFlowState.NotNull;
             }
             else

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -456,7 +456,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
             TypeSymbol inferredType =
                 BestTypeInferrer.InferBestType(placeholders, _conversions, ref useSiteDiagnostics) ??
-                node.Type.SetUnknownNullabilityForReferenceTypes();
+                node.Type.SetObliviousNullabilityForReferenceTypes();
             var inferredTypeWithAnnotations = TypeWithAnnotations.Create(inferredType);
 
             // Convert elements to best type to determine element top-level nullability and to report nested nullability warnings

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -436,12 +436,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var finalArray = builder.Peek().array.ElementType.ApplyNullableTransforms(stream);
             do
             {
-                var state = builder.Pop();
+                var (array, transform) = builder.Pop();
                 var elementType = TypeWithAnnotations.Create(finalArray,
-                    state.array.ElementTypeWithAnnotations.NullableAnnotation,
-                    state.array.ElementTypeWithAnnotations.CustomModifiers);
-                if (state.transform.HasValue &&
-                    elementType.ApplyNullableTransformShallow(state.transform.Value) is TypeWithAnnotations other)
+                    array.ElementTypeWithAnnotations.NullableAnnotation,
+                    array.ElementTypeWithAnnotations.CustomModifiers);
+                if (transform.HasValue &&
+                    elementType.ApplyNullableTransformShallow(transform.GetValueOrDefault()) is TypeWithAnnotations other)
                 {
                     elementType = other;
                 }
@@ -499,17 +499,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // Unwind the stack and rebuild the array chain.
-            var state = builder.Peek();
-            var finalArray = state.thisArray.ElementType.MergeNullability(state.otherArray.ElementType, variance);
+            var (thisArray, otherArray) = builder.Peek();
+            var finalArray = thisArray.ElementType.MergeNullability(otherArray.ElementType, variance);
             do
             {
-                state = builder.Pop();
+                (thisArray, otherArray) = builder.Pop();
                 var nullableAnnotation = NullableAnnotationExtensions.MergeNullableAnnotation(
-                    state.thisArray.ElementTypeWithAnnotations.NullableAnnotation,
-                    state.otherArray.ElementTypeWithAnnotations.NullableAnnotation,
+                    thisArray.ElementTypeWithAnnotations.NullableAnnotation,
+                    otherArray.ElementTypeWithAnnotations.NullableAnnotation,
                     variance);
-                var elementType = TypeWithAnnotations.Create(finalArray, nullableAnnotation, state.thisArray.ElementTypeWithAnnotations.CustomModifiers);
-                finalArray = state.thisArray.WithElementType(elementType);
+                var elementType = TypeWithAnnotations.Create(finalArray, nullableAnnotation, thisArray.ElementTypeWithAnnotations.CustomModifiers);
+                finalArray = thisArray.WithElementType(elementType);
             }
             while (builder.Count > 0);
 

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -410,7 +410,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override void AddNullableTransforms(ArrayBuilder<byte> transforms)
         {
-            ElementTypeWithAnnotations.AddNullableTransforms(transforms);
+            var elementType = ElementTypeWithAnnotations;
+            while (elementType.Type is ArrayTypeSymbol arrayType)
+            {
+                elementType.AddNullableTransformShallow(transforms);
+                elementType = arrayType.ElementTypeWithAnnotations;
+            }
+
+            elementType.AddNullableTransforms(transforms);
         }
 
         internal override (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData)
@@ -826,7 +833,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var innerArray = oldReturn.arrayType;
                 var elementType = state.arrayType.ElementTypeWithAnnotations;
                 elementType = TypeWithAnnotations.Create(oldReturn.arrayType, elementType.NullableAnnotation, elementType.CustomModifiers);
-                var result = elementType.ApplyNullableTransform(state.data.Current);
+                var result = elementType.ApplyNullableTransformShallow(state.data.Current);
                 if (!result.HasValue)
                 {
                     return (null, default);

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -833,7 +833,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var innerArray = oldReturn.arrayType;
                 var elementType = state.arrayType.ElementTypeWithAnnotations;
                 elementType = TypeWithAnnotations.Create(oldReturn.arrayType, elementType.NullableAnnotation, elementType.CustomModifiers);
-                var result = elementType.ApplyNullableTransformShallow(state.data.Current);
+
+                var currentTransform = state.data.CurrentTransform;
+                if (!currentTransform.HasValue)
+                {
+                    return (null, default);
+                }
+
+                var result = elementType.ApplyNullableTransformShallow(currentTransform.Value);
                 if (!result.HasValue)
                 {
                     return (null, default);

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -413,19 +413,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ElementTypeWithAnnotations.AddNullableTransforms(transforms);
         }
 
-        internal override bool ApplyNullableTransforms(byte defaultTransformFlag, ImmutableArray<byte> transforms, ref int position, out TypeSymbol result)
+        internal override (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData)
         {
-            TypeWithAnnotations oldElementType = ElementTypeWithAnnotations;
-            TypeWithAnnotations newElementType;
-
-            if (!oldElementType.ApplyNullableTransforms(defaultTransformFlag, transforms, ref position, out newElementType))
+            var result = ElementTypeWithAnnotations.ApplyNullableTransforms(transformData);
+            if (!result.HasValue)
             {
-                result = this;
-                return false;
+                return null;
             }
 
-            result = WithElementType(newElementType);
-            return true;
+            return (WithElementType(result.Value.type), result.Value.data);
         }
 
         internal override TypeSymbol SetObliviousNullabilityForReferenceTypes() =>

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -404,9 +404,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeWithAnnotations, TypeWithAnnotations> transform)
+        internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()
         {
-            return WithElementType(transform(ElementTypeWithAnnotations));
+            return WithElementType(ElementTypeWithAnnotations.SetObliviousNullabilityForReferenceTypes());
         }
 
         internal override TypeSymbol MergeNullability(TypeSymbol other, VarianceKind variance)

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -370,7 +370,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 var arrayElementType = array.ElementTypeWithAnnotations;
                 var otherElementType = other.ElementTypeWithAnnotations;
-                if (arrayElementType.Type is ArrayTypeSymbol nextArray)
+                if (arrayElementType.IsSZArray())
                 {
                     // Compare everything but the actual ArrayTypeSymbol instance. 
                     var otherTwa = TypeWithAnnotations.Create(arrayElementType.Type, otherElementType.NullableAnnotation, otherElementType.CustomModifiers);
@@ -379,7 +379,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         return false;
                     }
 
-                    array = nextArray;
+                    array = (ArrayTypeSymbol)arrayElementType.Type;
                     other = otherElementType.Type as ArrayTypeSymbol;
                 }
                 else

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -431,7 +431,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var previousArray = builder.Pop();
                 elementType = TypeWithAnnotations.Create(array, NullableAnnotation.Oblivious, previousArray.ElementTypeWithAnnotations.CustomModifiers);
-                array = (ArrayTypeSymbol)(previousArray.WithElementType(elementType));
+                array = previousArray.WithElementType(elementType);
             }
 
             builder.Free();

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeWithAnnotations, TypeWithAnnotations> transform)
+        internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()
         {
             return this;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -215,9 +215,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
         }
 
-        internal override (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData)
+        internal override TypeSymbol ApplyNullableTransforms(NullableTransformStream stream)
         {
-            return (this, transformData);
+            return this;
         }
 
         internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -215,10 +215,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
         }
 
-        internal override bool ApplyNullableTransforms(byte defaultTransformFlag, ImmutableArray<byte> transforms, ref int position, out TypeSymbol result)
+        internal override (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData)
         {
-            result = this;
-            return true;
+            return (this, transformData);
         }
 
         internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -34,12 +34,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return metadataType;
             }
 
-            int position = 0;
-            TypeWithAnnotations result;
-            if (metadataType.ApplyNullableTransforms(defaultTransformFlag, nullableTransformFlags, ref position, out result) &&
-                (nullableTransformFlags.IsDefault || position == nullableTransformFlags.Length))
+            var data = new NullableTransformData(defaultTransformFlag, nullableTransformFlags);
+            var result = metadataType.ApplyNullableTransforms(new NullableTransformData(defaultTransformFlag, nullableTransformFlags));
+            if (result.HasValue && result.Value.data.IsDefaultOrEmpty)
             {
-                return result;
+                return result.Value.type;
             }
 
             // No NullableAttribute applied to the target symbol, or flags do not line-up, return unchanged metadataType.

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return metadataType;
             }
 
-            var stream = NullableTransformStream.Create(defaultTransformFlag, nullableTransformFlags);
+            var stream = NullableTransformStream.GetInstance(defaultTransformFlag, nullableTransformFlags);
             TypeWithAnnotations result = metadataType.ApplyNullableTransforms(stream);
             if (stream.IsComplete)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NullableTypeDecoder.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             var data = new NullableTransformData(defaultTransformFlag, nullableTransformFlags);
             var result = metadataType.ApplyNullableTransforms(new NullableTransformData(defaultTransformFlag, nullableTransformFlags));
-            if (result.HasValue && result.Value.data.IsDefaultOrEmpty)
+            if (result.HasValue && !result.Value.data.HasUnusedTransforms)
             {
                 return result.Value.type;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -813,7 +813,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeWithAnnotations, TypeWithAnnotations> transform)
+        internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()
         {
             if (!IsGenericType)
             {
@@ -827,7 +827,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             for (int i = 0; i < allTypeArguments.Count; i++)
             {
                 TypeWithAnnotations oldTypeArgument = allTypeArguments[i];
-                TypeWithAnnotations newTypeArgument = transform(oldTypeArgument);
+                TypeWithAnnotations newTypeArgument = oldTypeArgument.SetObliviousNullabilityForReferenceTypes();
                 if (!oldTypeArgument.IsSameAs(newTypeArgument))
                 {
                     allTypeArguments[i] = newTypeArgument;

--- a/src/Compilers/CSharp/Portable/Symbols/NullableTransformStream.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NullableTransformStream.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    /// <summary>
+    /// Represents a sequence of <see cref="NullableAnnotation"/> to apply to a type. The sequence of
+    /// flags is specific to how the individual <see cref="TypeSymbol"/> walk their nested types.
+    /// </summary>
+    internal sealed class NullableTransformStream
+    {
+        private static readonly ObjectPool<NullableTransformStream> Pool = new ObjectPool<NullableTransformStream>(() => new NullableTransformStream(), Environment.ProcessorCount);
+
+        private ImmutableArray<byte> _transforms;
+
+        /// <summary>
+        /// When <see cref="_transforms"/> is the default value this will contain the transform to yield an infinite sequence
+        /// of. Otherwise it is the position in <see cref="_transforms"/> of the next value to yield.
+        /// </summary>
+        private int _positionOrDefault;
+
+        private bool IsDefault => _transforms.IsDefault;
+
+        /// <summary>
+        /// Returns whether or not there is data remaining in the series. When a single flag is used this
+        /// will always return false.
+        /// </summary>
+        public bool HasUnusedTransforms => !IsDefault && _positionOrDefault >= 0 && _positionOrDefault < _transforms.Length;
+        public bool HasInsufficientData => _positionOrDefault < 0;
+        public bool IsComplete => !HasUnusedTransforms && !HasInsufficientData;
+
+        private NullableTransformStream()
+        {
+
+        }
+
+        /// <summary>
+        /// Returns an infinite stream of the given transform value.
+        /// </summary>
+        public static NullableTransformStream GetInstance(byte defaultTransform)
+        {
+            Debug.Assert(defaultTransform >= 0);
+            var stream = Pool.Allocate();
+            stream._positionOrDefault = defaultTransform;
+            return stream;
+        }
+
+        /// <summary>
+        /// Returns a finite stream of the given transform values.
+        /// </summary>
+        public static NullableTransformStream GetInstance(ImmutableArray<byte> transforms)
+        {
+            var stream = Pool.Allocate();
+            stream._positionOrDefault = 0;
+            stream._transforms = transforms;
+            return stream;
+        }
+
+        public static NullableTransformStream GetInstance(byte defaultTransform, ImmutableArray<byte> transforms) =>
+            transforms.IsDefault ? GetInstance(defaultTransform) : GetInstance(transforms);
+
+        public static NullableTransformStream GetInstance(NullableAnnotation nullableAnnotation) =>
+            GetInstance((byte)nullableAnnotation);
+
+        public void Free()
+        {
+            _transforms = default;
+            Pool.Free(this);
+        }
+
+        public void SetHasInsufficientData()
+        {
+            _positionOrDefault = -1;
+            Debug.Assert(HasInsufficientData);
+            Debug.Assert(!IsComplete);
+        }
+
+        public byte? GetNextTransform()
+        {
+            if (IsDefault)
+            {
+                return (byte)_positionOrDefault;
+            }
+            else if (HasUnusedTransforms)
+            {
+                return _transforms[_positionOrDefault++];
+            }
+            else
+            {
+                SetHasInsufficientData();
+                return null;
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -268,9 +268,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeWithAnnotations, TypeWithAnnotations> transform)
+        internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()
         {
-            return WithPointedAtType(transform(PointedAtTypeWithAnnotations));
+            return WithPointedAtType(PointedAtTypeWithAnnotations.SetObliviousNullabilityForReferenceTypes());
         }
 
         internal override TypeSymbol MergeNullability(TypeSymbol other, VarianceKind variance)

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -253,19 +253,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             PointedAtTypeWithAnnotations.AddNullableTransforms(transforms);
         }
 
-        internal override bool ApplyNullableTransforms(byte defaultTransformFlag, ImmutableArray<byte> transforms, ref int position, out TypeSymbol result)
+        internal override (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData)
         {
-            TypeWithAnnotations oldPointedAtType = PointedAtTypeWithAnnotations;
-            TypeWithAnnotations newPointedAtType;
-
-            if (!oldPointedAtType.ApplyNullableTransforms(defaultTransformFlag, transforms, ref position, out newPointedAtType))
+            var result = PointedAtTypeWithAnnotations.ApplyNullableTransforms(transformData);
+            if (!result.HasValue)
             {
-                result = this;
-                return false;
+                return null;
             }
 
-            result = WithPointedAtType(newPointedAtType);
-            return true;
+            return (WithPointedAtType(result.Value.type), result.Value.data);
         }
 
         internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -253,15 +253,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             PointedAtTypeWithAnnotations.AddNullableTransforms(transforms);
         }
 
-        internal override (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData)
+        internal override TypeSymbol ApplyNullableTransforms(NullableTransformStream stream)
         {
-            var result = PointedAtTypeWithAnnotations.ApplyNullableTransforms(transformData);
-            if (!result.HasValue)
-            {
-                return null;
-            }
-
-            return (WithPointedAtType(result.Value.type), result.Value.data);
+            return WithPointedAtType(PointedAtTypeWithAnnotations.ApplyNullableTransforms(stream));
         }
 
         internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -94,10 +94,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // that the author did not write and did not validate.
             var flagsBuilder = ArrayBuilder<byte>.GetInstance();
             destinationType.AddNullableTransforms(flagsBuilder);
-            var result = resultType.ApplyNullableTransforms(new NullableTransformData(defaultState: 0, flagsBuilder.ToImmutableAndFree()));
-            Debug.Assert(result.HasValue && result.Value.data.IsDefaultOrEmpty);
+            var result = resultType.ApplyNullableTransforms(new NullableTransformData(defaultTransform: 0, flagsBuilder.ToImmutableAndFree()));
+            Debug.Assert(result.HasValue && !result.Value.data.HasUnusedTransforms);
 
-            resultType = result.HasValue && result.Value.data.IsDefaultOrEmpty ? result.Value.type : resultType;
+            resultType = result.HasValue && !result.Value.data.HasUnusedTransforms ? result.Value.type : resultType;
 
             Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes)); // Same custom modifiers as source type.
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -94,10 +94,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // that the author did not write and did not validate.
             var flagsBuilder = ArrayBuilder<byte>.GetInstance();
             destinationType.AddNullableTransforms(flagsBuilder);
-            int position = 0;
-            int length = flagsBuilder.Count;
-            bool transformResult = resultType.ApplyNullableTransforms(defaultTransformFlag: 0, flagsBuilder.ToImmutableAndFree(), ref position, out resultType);
-            Debug.Assert(transformResult && position == length);
+            var result = resultType.ApplyNullableTransforms(new NullableTransformData(defaultState: 0, flagsBuilder.ToImmutableAndFree()));
+            Debug.Assert(result.HasValue && result.Value.data.IsDefaultOrEmpty);
+
+            resultType = result.HasValue && result.Value.data.IsDefaultOrEmpty ? result.Value.type : resultType;
 
             Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes)); // Same custom modifiers as source type.
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // that the author did not write and did not validate.
             var flagsBuilder = ArrayBuilder<byte>.GetInstance();
             destinationType.AddNullableTransforms(flagsBuilder);
-            var stream = NullableTransformStream.Create(defaultTransform: 0, flagsBuilder.ToImmutableAndFree());
+            var stream = NullableTransformStream.GetInstance(flagsBuilder.ToImmutableAndFree());
             var result = resultType.ApplyNullableTransforms(stream);
             Debug.Assert(stream.IsComplete);
             resultType = stream.IsComplete ? result : resultType;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -94,10 +94,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // that the author did not write and did not validate.
             var flagsBuilder = ArrayBuilder<byte>.GetInstance();
             destinationType.AddNullableTransforms(flagsBuilder);
-            var result = resultType.ApplyNullableTransforms(new NullableTransformData(defaultTransform: 0, flagsBuilder.ToImmutableAndFree()));
-            Debug.Assert(result.HasValue && !result.Value.data.HasUnusedTransforms);
-
-            resultType = result.HasValue && !result.Value.data.HasUnusedTransforms ? result.Value.type : resultType;
+            var stream = NullableTransformStream.Create(defaultTransform: 0, flagsBuilder.ToImmutableAndFree());
+            var result = resultType.ApplyNullableTransforms(stream);
+            Debug.Assert(stream.IsComplete);
+            resultType = stream.IsComplete ? result : resultType;
 
             Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes)); // Same custom modifiers as source type.
 

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// The base class for all symbols (namespaces, classes, method, parameters, etc.) that are 
     /// exposed by the compiler.
     /// </summary>
-    //   [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     internal abstract partial class Symbol : ISymbol, IFormattable
     {
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// The base class for all symbols (namespaces, classes, method, parameters, etc.) that are 
     /// exposed by the compiler.
     /// </summary>
-    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+    //   [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     internal abstract partial class Symbol : ISymbol, IFormattable
     {
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1431,15 +1431,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _underlyingType.AddNullableTransforms(transforms);
         }
 
-        internal override bool ApplyNullableTransforms(byte defaultTransformFlag, ImmutableArray<byte> transforms, ref int position, out TypeSymbol result)
+        internal override (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData)
         {
-            if (_underlyingType.ApplyNullableTransforms(defaultTransformFlag, transforms, ref position, out TypeSymbol underlying))
+            var result = _underlyingType.ApplyNullableTransforms(transformData);
+            if (!result.HasValue)
             {
-                result = this.WithUnderlyingType((NamedTypeSymbol)underlying);
-                return true;
+                return null;
             }
-            result = this;
-            return false;
+
+            return (WithUnderlyingType((NamedTypeSymbol)result.Value.type), result.Value.data);
         }
 
         internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1442,9 +1442,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeWithAnnotations, TypeWithAnnotations> transform)
+        internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()
         {
-            var underlyingType = (NamedTypeSymbol)_underlyingType.SetNullabilityForReferenceTypes(transform);
+            var underlyingType = (NamedTypeSymbol)_underlyingType.SetObliviousNullabilityForReferenceTypes();
             if ((object)underlyingType == _underlyingType)
             {
                 return this;

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1431,15 +1431,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _underlyingType.AddNullableTransforms(transforms);
         }
 
-        internal override (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData)
+        internal override TypeSymbol ApplyNullableTransforms(NullableTransformStream stream)
         {
-            var result = _underlyingType.ApplyNullableTransforms(transformData);
-            if (!result.HasValue)
-            {
-                return null;
-            }
-
-            return (WithUnderlyingType((NamedTypeSymbol)result.Value.type), result.Value.data);
+            return WithUnderlyingType((NamedTypeSymbol)_underlyingType.ApplyNullableTransforms(stream));
         }
 
         internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -677,7 +677,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal override TypeSymbol SetNullabilityForReferenceTypes(Func<TypeWithAnnotations, TypeWithAnnotations> transform)
+        internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()
         {
             return this;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -671,9 +671,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
         }
 
-        internal override (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData)
+        internal override TypeSymbol ApplyNullableTransforms(NullableTransformStream stream)
         {
-            return (this, transformData);
+            return this;
         }
 
         internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -671,10 +671,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
         }
 
-        internal override bool ApplyNullableTransforms(byte defaultTransformFlag, ImmutableArray<byte> transforms, ref int position, out TypeSymbol result)
+        internal override (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData)
         {
-            result = this;
-            return true;
+            return (this, transformData);
         }
 
         internal override TypeSymbol SetObliviousNullabilityForReferenceTypes()

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -670,7 +670,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract void AddNullableTransforms(ArrayBuilder<byte> transforms);
 
-        internal abstract (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData);
+        internal abstract TypeSymbol ApplyNullableTransforms(NullableTransformStream stream);
 
         internal abstract TypeSymbol SetObliviousNullabilityForReferenceTypes();
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -670,7 +670,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract void AddNullableTransforms(ArrayBuilder<byte> transforms);
 
-        internal abstract bool ApplyNullableTransforms(byte defaultTransformFlag, ImmutableArray<byte> transforms, ref int position, out TypeSymbol result);
+        internal abstract (TypeSymbol type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData);
 
         internal abstract TypeSymbol SetObliviousNullabilityForReferenceTypes();
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -674,9 +674,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract TypeSymbol SetObliviousNullabilityForReferenceTypes();
 
-        private readonly static Func<TypeWithAnnotations, TypeWithAnnotations> s_setUnknownNullability =
-            (type) => type.SetObliviousNullabilityForReferenceTypes();
-
         /// <summary>
         /// Merges nested nullability from an otherwise identical type.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -672,15 +672,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract bool ApplyNullableTransforms(byte defaultTransformFlag, ImmutableArray<byte> transforms, ref int position, out TypeSymbol result);
 
-        internal abstract TypeSymbol SetNullabilityForReferenceTypes(Func<TypeWithAnnotations, TypeWithAnnotations> transform);
-
-        internal TypeSymbol SetUnknownNullabilityForReferenceTypes()
-        {
-            return SetNullabilityForReferenceTypes(s_setUnknownNullability);
-        }
+        internal abstract TypeSymbol SetObliviousNullabilityForReferenceTypes();
 
         private readonly static Func<TypeWithAnnotations, TypeWithAnnotations> s_setUnknownNullability =
-            (type) => type.SetUnknownNullabilityForReferenceTypes();
+            (type) => type.SetObliviousNullabilityForReferenceTypes();
 
         /// <summary>
         /// Merges nested nullability from an otherwise identical type.

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -634,7 +634,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return CreateNonLazyType(typeSymbol, NullableAnnotation.NotAnnotated, CustomModifiers);
         }
 
-        public TypeWithAnnotations SetUnknownNullabilityForReferenceTypes()
+        public TypeWithAnnotations SetObliviousNullabilityForReferenceTypes()
         {
             var typeSymbol = Type;
 
@@ -642,13 +642,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (!typeSymbol.IsValueType)
                 {
-                    typeSymbol = typeSymbol.SetUnknownNullabilityForReferenceTypes();
+                    typeSymbol = typeSymbol.SetObliviousNullabilityForReferenceTypes();
 
                     return CreateNonLazyType(typeSymbol, NullableAnnotation.Oblivious, CustomModifiers);
                 }
             }
 
-            var newTypeSymbol = typeSymbol.SetUnknownNullabilityForReferenceTypes();
+            var newTypeSymbol = typeSymbol.SetObliviousNullabilityForReferenceTypes();
 
             if ((object)newTypeSymbol != typeSymbol)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -1045,7 +1045,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// will always return false.
         /// </summary>
         public bool HasUnusedTransforms => !IsDefault && _positionOrDefault >= 0 && _positionOrDefault < _transforms.Length;
-        public bool HasInsufficientData => !IsDefault && _positionOrDefault < 0;
+        public bool HasInsufficientData => _positionOrDefault < 0;
         public bool IsComplete => !HasUnusedTransforms && !HasInsufficientData;
 
         private NullableTransformStream()
@@ -1055,6 +1055,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public static NullableTransformStream Create(byte defaultTransform)
         {
+            Debug.Assert(defaultTransform >= 0);
             var stream = Pool.Allocate();
             stream._positionOrDefault = defaultTransform;
             return stream;
@@ -1083,7 +1084,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public void SetHasInsufficientData()
         {
             _positionOrDefault = -1;
-            Debug.Assert(HasInsufficientData && !HasUnusedTransforms);
+            Debug.Assert(HasInsufficientData);
+            Debug.Assert(!IsComplete);
         }
 
         public byte? GetNextTransform()

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return (object)type != null;
         }
 
-        public void AddNullableTransforms(ArrayBuilder<byte> transforms)
+        public void AddNullableTransformShallow(ArrayBuilder<byte> transforms)
         {
             var typeSymbol = Type;
             byte flag;
@@ -563,7 +563,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             transforms.Add(flag);
-            typeSymbol.AddNullableTransforms(transforms);
+        }
+
+        public void AddNullableTransforms(ArrayBuilder<byte> transforms)
+        {
+            AddNullableTransformShallow(transforms);
+            Type.AddNullableTransforms(transforms);
         }
 
         public (TypeWithAnnotations type, NullableTransformData data)? ApplyNullableTransforms(NullableTransformData transformData)
@@ -590,7 +595,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 newType = newType.WithTypeAndModifiers(newTypeSymbol, newType.CustomModifiers);
             }
 
-            if (newType.ApplyNullableTransform(transformFlag) is TypeWithAnnotations finalType)
+            if (newType.ApplyNullableTransformShallow(transformFlag) is TypeWithAnnotations finalType)
             {
                 return (finalType, newResult.Value.data);
             }
@@ -598,7 +603,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return null;
         }
 
-        public TypeWithAnnotations? ApplyNullableTransform(byte transformFlag)
+        public TypeWithAnnotations? ApplyNullableTransformShallow(byte transformFlag)
         {
             switch ((NullableAnnotation)transformFlag)
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -34551,6 +34551,7 @@ class C
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b2").WithArguments("B", "IOut<object>").WithLocation(19, 13));
         }
 
+        [WorkItem(29898, "https://github.com/dotnet/roslyn/issues/29898")]
         [Fact]
         public void ImplicitConversions_07()
         {
@@ -34576,7 +34577,7 @@ class C
     }
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/29898: Report warning for `G(z)`?
+            // https://github.com/dotnet/roslyn/issues/29605: Report warning for `G(z)`?
             comp.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -36,11 +36,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
             var x = c.GetMembers("x").Single() as FieldSymbol;
             var type = x.Type;
             type.GetHashCode();
-            foreachArray(x => Assert.Equal(NullableAnnotation.NotAnnotated, x.ElementTypeWithAnnotations.NullableAnnotation));
+            foreachElement(annotation => Assert.Equal(NullableAnnotation.NotAnnotated, annotation));
             type = type.SetObliviousNullabilityForReferenceTypes();
-            foreachArray(x => Assert.Equal(NullableAnnotation.Oblivious, x.ElementTypeWithAnnotations.NullableAnnotation));
+            foreachElement(annotation => Assert.Equal(NullableAnnotation.Oblivious, annotation));
 
-            void foreachArray(Action<ArrayTypeSymbol> action)
+            void foreachElement(Action<NullableAnnotation> action)
             {
                 var arrayType = (ArrayTypeSymbol)type;
                 do
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
                     var next = arrayType.ElementType as ArrayTypeSymbol;
                     if (next is object)
                     {
-                        action(arrayType);
+                        action(arrayType.ElementTypeWithAnnotations.NullableAnnotation);
                     }
                     arrayType = next;
                 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
             Assert.Equal(x.Type.SetObliviousNullabilityForReferenceTypes(), x.Type.SetObliviousNullabilityForReferenceTypes());
 
             verifyElementAnnotation(x.Type.MergeNullability(x.Type.SetObliviousNullabilityForReferenceTypes(), VarianceKind.None), NullableAnnotation.NotAnnotated);
+            verifyElementAnnotation(x.Type.ApplyNullableTransforms(new NullableTransformData(NullableAnnotation.Oblivious)).Value.type, NullableAnnotation.Oblivious);
 
             static void verifyElementAnnotation(TypeSymbol type, NullableAnnotation annotation)
             {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 
             verifyElementAnnotation(x.Type.MergeNullability(x.Type.SetObliviousNullabilityForReferenceTypes(), VarianceKind.None), NullableAnnotation.NotAnnotated);
 
-            var stream = NullableTransformStream.Create(NullableAnnotation.Oblivious);
+            var stream = NullableTransformStream.GetInstance(NullableAnnotation.Oblivious);
             verifyElementAnnotation(x.Type.ApplyNullableTransforms(stream), NullableAnnotation.Oblivious);
             Assert.True(stream.IsComplete);
             stream.Free();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -36,8 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
             var arr = x.Type;
 
             arr.GetHashCode();
-            // https://github.com/dotnet/roslyn/issues/30023: StackOverflowException in SetUnknownNullabilityForReferenceTypes.
-            //arr.SetUnknownNullabilityForReferenceTypes();
+            arr.SetObliviousNullabilityForReferenceTypes();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -36,11 +36,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
             var x = c.GetMembers("x").Single() as FieldSymbol;
             var type = x.Type;
             type.GetHashCode();
-            foreachElement(annotation => Assert.Equal(NullableAnnotation.NotAnnotated, annotation));
+            verifyElementAnnotation(NullableAnnotation.NotAnnotated);
             type = type.SetObliviousNullabilityForReferenceTypes();
-            foreachElement(annotation => Assert.Equal(NullableAnnotation.Oblivious, annotation));
+            verifyElementAnnotation(NullableAnnotation.Oblivious);
 
-            void foreachElement(Action<NullableAnnotation> action)
+            void verifyElementAnnotation(NullableAnnotation annotation)
             {
                 var arrayType = (ArrayTypeSymbol)type;
                 do
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
                     var next = arrayType.ElementType as ArrayTypeSymbol;
                     if (next is object)
                     {
-                        action(arrayType.ElementTypeWithAnnotations.NullableAnnotation);
+                        Assert.Equal(annotation, arrayType.ElementTypeWithAnnotations.NullableAnnotation);
                     }
                     arrayType = next;
                 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -45,7 +45,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
             Assert.Equal(x.Type.SetObliviousNullabilityForReferenceTypes(), x.Type.SetObliviousNullabilityForReferenceTypes());
 
             verifyElementAnnotation(x.Type.MergeNullability(x.Type.SetObliviousNullabilityForReferenceTypes(), VarianceKind.None), NullableAnnotation.NotAnnotated);
-            verifyElementAnnotation(x.Type.ApplyNullableTransforms(new NullableTransformData(NullableAnnotation.Oblivious)).Value.type, NullableAnnotation.Oblivious);
+
+            var stream = NullableTransformStream.Create(NullableAnnotation.Oblivious);
+            verifyElementAnnotation(x.Type.ApplyNullableTransforms(stream), NullableAnnotation.Oblivious);
+            Assert.True(stream.IsComplete);
+            stream.Free();
 
             var builder = ArrayBuilder<byte>.GetInstance();
             x.Type.AddNullableTransforms(builder);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -45,6 +46,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 
             verifyElementAnnotation(x.Type.MergeNullability(x.Type.SetObliviousNullabilityForReferenceTypes(), VarianceKind.None), NullableAnnotation.NotAnnotated);
             verifyElementAnnotation(x.Type.ApplyNullableTransforms(new NullableTransformData(NullableAnnotation.Oblivious)).Value.type, NullableAnnotation.Oblivious);
+
+            var builder = ArrayBuilder<byte>.GetInstance();
+            x.Type.AddNullableTransforms(builder);
+            Assert.Equal(10240, builder.Count);
+            builder.Free();
 
             static void verifyElementAnnotation(TypeSymbol type, NullableAnnotation annotation)
             {


### PR DESCRIPTION
This comprises the following changes:

1. Renames `SetUnknownNullability*` to `SetObliviousNullability*` 
1. Fixes a stack overflow in `SetObliviousNullabilityForReferenceTypes` (#30023).
1. Completes the duplication of #29898 to #29605 by updating a comment


