### PR TITLE
Implement design changes for "pattern" Index/Range indexers 

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7188,7 +7188,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!lookupResult.IsMultiViable)
             {
-                indexerAccessExpression = BadIndexerExpression(node, expr, analyzedArguments, lookupResult.Error, diagnostics);
+                if (TryBindIndexOrRangeIndexer(
+                    node,
+                    expr,
+                    analyzedArguments.Arguments,
+                    out var patternIndexerAccess))
+                {
+                    indexerAccessExpression = patternIndexerAccess;
+                }
+                else
+                {
+                    indexerAccessExpression = BadIndexerExpression(node, expr, analyzedArguments, lookupResult.Error, diagnostics);
+                }
             }
             else
             {
@@ -7350,22 +7361,33 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!analyzedArguments.HasErrors)
                 {
-                    // Dev10 uses the "this" keyword as the method name for indexers.
-                    var candidate = candidates[0];
-                    var name = candidate.IsIndexer ? SyntaxFacts.GetText(SyntaxKind.ThisKeyword) : candidate.Name;
+                    if (TryBindIndexOrRangeIndexer(
+                        syntax,
+                        receiverOpt,
+                        analyzedArguments.Arguments,
+                        out var patternIndexerAccess))
+                    {
+                        return patternIndexerAccess;
+                    }
+                    else
+                    {
+                        // Dev10 uses the "this" keyword as the method name for indexers.
+                        var candidate = candidates[0];
+                        var name = candidate.IsIndexer ? SyntaxFacts.GetText(SyntaxKind.ThisKeyword) : candidate.Name;
 
-                    overloadResolutionResult.ReportDiagnostics(
-                        binder: this,
-                        location: syntax.Location,
-                        nodeOpt: syntax,
-                        diagnostics: diagnostics,
-                        name: name,
-                        receiver: null,
-                        invokedExpression: null,
-                        arguments: analyzedArguments,
-                        memberGroup: candidates,
-                        typeContainingConstructor: null,
-                        delegateTypeBeingInvoked: null);
+                        overloadResolutionResult.ReportDiagnostics(
+                            binder: this,
+                            location: syntax.Location,
+                            nodeOpt: syntax,
+                            diagnostics: diagnostics,
+                            name: name,
+                            receiver: null,
+                            invokedExpression: null,
+                            arguments: analyzedArguments,
+                            memberGroup: candidates,
+                            typeContainingConstructor: null,
+                            delegateTypeBeingInvoked: null);
+                    }
                 }
 
                 ImmutableArray<BoundExpression> arguments = BuildArgumentsForErrorRecovery(analyzedArguments, candidates);
@@ -7436,6 +7458,224 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             overloadResolutionResult.Free();
             return propertyAccess;
+        }
+
+        private bool TryBindIndexOrRangeIndexer(
+            SyntaxNode syntax,
+            BoundExpression receiverOpt,
+            ArrayBuilder<BoundExpression> arguments,
+            out BoundIndexOrRangePatternIndexerAccess patternIndexerAccess)
+        {
+            // Verify a few things up-front, namely that we have a single argument
+            // to this indexer that has an Index or Range type and that there is
+            // a real receiver with a known type
+
+            if (arguments.Count != 1)
+            {
+                patternIndexerAccess = null;
+                return false;
+            }
+
+            var argType = arguments[0].Type;
+            bool argIsIndex = TypeSymbol.Equals(argType,
+                Compilation.GetWellKnownType(WellKnownType.System_Index),
+                TypeCompareKind.ConsiderEverything);
+            bool argIsRange = !argIsIndex || TypeSymbol.Equals(argType,
+                Compilation.GetWellKnownType(WellKnownType.System_Range),
+                TypeCompareKind.ConsiderEverything);
+
+            if ((!argIsIndex && !argIsRange) ||
+                !(receiverOpt?.Type is TypeSymbol receiverType))
+            {
+                patternIndexerAccess = null;
+                return false;
+            }
+
+            // SPEC:
+
+            // An indexer invocation with a single argument of System.Index or System.Range will
+            // succeed if the receiver type conforms to an appropriate pattern, namely
+
+            // 1. The receiver type's original definition has an accessible property getter that returns
+            //    an int and has the name Length or Count
+            // 2. For Index: Has an accessible indexer with a single int parameter
+            //    For Range: Has an accessible Slice method that takes two int parameters
+
+            PropertySymbol lengthOrCountProperty;
+
+            var lookupResult = LookupResult.GetInstance();
+            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+
+            // look for Length first
+            LookupMembersInType(
+                lookupResult,
+                receiverType,
+                WellKnownMemberNames.LengthPropertyName,
+                arity: 0,
+                basesBeingResolved: null,
+                LookupOptions.Default,
+                originalBinder: this,
+                diagnose: false,
+                useSiteDiagnostics: ref useSiteDiagnostics);
+
+            if (!lookupSatisfiesLengthPattern(out lengthOrCountProperty))
+            {
+                // Look for Count second
+                lookupResult.Clear();
+                useSiteDiagnostics?.Clear();
+                LookupMembersInType(
+                    lookupResult,
+                    receiverType,
+                    WellKnownMemberNames.CountPropertyName,
+                    arity: 0,
+                    basesBeingResolved: null,
+                    LookupOptions.Default,
+                    originalBinder: this,
+                    diagnose: false,
+                    ref useSiteDiagnostics);
+
+                if (!lookupSatisfiesLengthPattern(out lengthOrCountProperty))
+                {
+                    cleanup();
+                    patternIndexerAccess = null;
+                    return false;
+                }
+            }
+
+            Debug.Assert(lengthOrCountProperty is { });
+            lookupResult.Clear();
+            useSiteDiagnostics?.Clear();
+
+            if (argIsIndex)
+            {
+                // Look for `T this[int i]` indexer
+
+                LookupMembersInType(
+                    lookupResult,
+                    receiverType,
+                    WellKnownMemberNames.Indexer,
+                    arity: 0,
+                    basesBeingResolved: null,
+                    LookupOptions.Default,
+                    originalBinder: this,
+                    diagnose: false,
+                    ref useSiteDiagnostics);
+
+                if (lookupResult.IsMultiViable)
+                {
+                    foreach (var candidate in lookupResult.Symbols)
+                    {
+                        if (!candidate.IsStatic &&
+                            IsAccessible(candidate, ref useSiteDiagnostics) &&
+                            candidate is PropertySymbol property &&
+                            property.GetOwnOrInheritedGetMethod() is MethodSymbol getMethod &&
+                            getMethod.OriginalDefinition is var original &&
+                            original.ParameterCount == 1 &&
+                            isIntNotByRef(original.Parameters[0]))
+                        {
+                            patternIndexerAccess = new BoundIndexOrRangePatternIndexerAccess(
+                                syntax,
+                                receiverOpt,
+                                lengthOrCountProperty,
+                                getMethod,
+                                arguments[0],
+                                getMethod.ReturnType);
+                            cleanup();
+                            return true;
+                        }
+                    }
+                }
+            }
+            else if (receiverType.SpecialType == SpecialType.System_String)
+            {
+                Debug.Assert(argIsRange);
+                // Look for Substring
+                var substring = (MethodSymbol)Compilation.GetWellKnownTypeMember(WellKnownMember.System_String__Substring);
+                if (substring is { })
+                {
+                    patternIndexerAccess = new BoundIndexOrRangePatternIndexerAccess(
+                        syntax,
+                        receiverOpt,
+                        lengthOrCountProperty,
+                        substring,
+                        arguments[0],
+                        substring.ReturnType);
+                    cleanup();
+                    return true;
+                }
+            }
+            else
+            {
+                Debug.Assert(argIsRange);
+                // Look for `T Slice(int, int)` indexer
+
+                LookupMembersInType(
+                    lookupResult,
+                    receiverType,
+                    WellKnownMemberNames.SliceMethodName,
+                    arity: 0,
+                    basesBeingResolved: null,
+                    LookupOptions.Default,
+                    originalBinder: this,
+                    diagnose: false,
+                    ref useSiteDiagnostics);
+
+                if (lookupResult.IsMultiViable)
+                {
+                    foreach (var candidate in lookupResult.Symbols)
+                    {
+                        if (!candidate.IsStatic &&
+                            IsAccessible(candidate, ref useSiteDiagnostics) &&
+                            candidate is MethodSymbol method &&
+                            method.OriginalDefinition is var original &&
+                            original.ParameterCount == 2 &&
+                            isIntNotByRef(original.Parameters[0]) &&
+                            isIntNotByRef(original.Parameters[1]))
+                        {
+                            patternIndexerAccess = new BoundIndexOrRangePatternIndexerAccess(
+                                syntax,
+                                receiverOpt,
+                                lengthOrCountProperty,
+                                method,
+                                arguments[0],
+                                method.ReturnType);
+                            cleanup();
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            cleanup();
+            patternIndexerAccess = null;
+            return false;
+
+            bool isIntNotByRef(ParameterSymbol param)
+                => param.Type.SpecialType == SpecialType.System_Int32 &&
+                   param.RefKind == RefKind.None;
+
+            void cleanup()
+            {
+                lookupResult.Free();
+                useSiteDiagnostics = null;
+            }
+
+            bool lookupSatisfiesLengthPattern(out PropertySymbol valid)
+            {
+                if (lookupResult.IsSingleViable &&
+                    lookupResult.SingleSymbolOrDefault is PropertySymbol property &&
+                    property.GetOwnOrInheritedGetMethod().OriginalDefinition is MethodSymbol getMethod &&
+                    getMethod.ReturnType.SpecialType == SpecialType.System_Int32 &&
+                    getMethod.RefKind == RefKind.None &&
+                    !getMethod.IsStatic &&
+                    IsAccessible(getMethod, ref useSiteDiagnostics))
+                {
+                    valid = property;
+                    return true;
+                }
+                valid = null;
+                return false;
+            }
         }
 
         private ErrorPropertySymbol CreateErrorPropertySymbol(ImmutableArray<PropertySymbol> propertyGroup)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7561,7 +7561,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(argIsRange);
                 // Look for Substring
-                var substring = (MethodSymbol)Compilation.GetWellKnownTypeMember(WellKnownMember.System_String__Substring);
+                var substring = (MethodSymbol)Compilation.GetSpecialTypeMember(SpecialMember.System_String__Substring);
                 if (substring is { })
                 {
                     patternIndexerAccess = new BoundIndexOrRangePatternIndexerAccess(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7627,7 +7627,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 useSiteDiagnostics = null;
             }
 
-            bool isIntNotByRef(ParameterSymbol param)
+            static bool isIntNotByRef(ParameterSymbol param)
                 => param.Type.SpecialType == SpecialType.System_Int32 &&
                    param.RefKind == RefKind.None;
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1748,9 +1748,9 @@
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow" />
 
     <Field Name="Receiver" Type="BoundExpression" Null="disallow" />
-    <Field Name="LengthOrCountProperty" Type="PropertySymbol" />
-    <Field Name="PatternMethod" Type="MethodSymbol" />
-    <Field Name="Argument" Type="BoundExpression" />
+    <Field Name="LengthOrCountProperty" Type="PropertySymbol" Null="disallow" />
+    <Field Name="PatternMethod" Type="MethodSymbol" Null="disallow" />
+    <Field Name="Argument" Type="BoundExpression" Null="disallow" />
   </Node>
 
   <Node Name="BoundDynamicIndexerAccess" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1744,6 +1744,15 @@
     <Field Name="UseSetterForDefaultArgumentGeneration" Type="bool"/>
   </Node>
 
+  <Node Name="BoundIndexOrRangePatternIndexerAccess" Base="BoundExpression">
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow" />
+
+    <Field Name="Receiver" Type="BoundExpression" Null="disallow" />
+    <Field Name="LengthOrCountProperty" Type="PropertySymbol" />
+    <Field Name="PatternMethod" Type="MethodSymbol" />
+    <Field Name="Argument" Type="BoundExpression" />
+  </Node>
+
   <Node Name="BoundDynamicIndexerAccess" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -169,4 +169,9 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         protected override ImmutableArray<BoundNode> Children => ImmutableArray.Create<BoundNode>(this.Expression);
     }
+
+    internal partial class BoundIndexOrRangePatternIndexerAccess
+    {
+        protected override ImmutableArray<BoundNode> Children => ImmutableArray.Create<BoundNode>(Receiver, Argument);
+    }
 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1188,6 +1188,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitIndexOrRangePatternIndexerAccess(BoundIndexOrRangePatternIndexerAccess node)
+        {
+            // Index or Range pattern indexers evaluate the following in order:
+            // 1. The receiver
+            // 1. The Count or Length method off the receiver
+            // 2. The argument to the access
+            // 3. The pattern method
+            VisitRvalue(node.Receiver);
+            var method = GetReadMethod(node.LengthOrCountProperty);
+            VisitReceiverAfterCall(node.Receiver, method);
+            VisitRvalue(node.Argument);
+            VisitReceiverAfterCall(node.Receiver, node.PatternMethod);
+
+            return null;
+        }
+
         public override BoundNode VisitEventAssignmentOperator(BoundEventAssignmentOperator node)
         {
             VisitRvalue(node.ReceiverOpt);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4935,6 +4935,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitIndexOrRangePatternIndexerAccess(BoundIndexOrRangePatternIndexerAccess node)
+        {
+            var receiverType = VisitRvalueWithState(node.Receiver);
+            VisitRvalue(node.Argument);
+            var patternMethod = node.PatternMethod;
+            if (!receiverType.HasNullType)
+            {
+                patternMethod = (MethodSymbol)AsMemberOfType(receiverType.Type, patternMethod);
+            }
+
+            LvalueResultType = patternMethod.ReturnTypeWithAnnotations;
+            return null;
+        }
+
         public override BoundNode VisitEventAccess(BoundEventAccess node)
         {
             VisitMemberAccess(node, node.ReceiverOpt, node.EventSymbol);

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -572,6 +572,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Binary(BinaryOperatorKind.IntGreaterThanOrEqual, SpecialType(CodeAnalysis.SpecialType.System_Boolean), left, right);
         }
 
+        public BoundBinaryOperator IntSubtract(BoundExpression left, BoundExpression right)
+        {
+            return Binary(BinaryOperatorKind.IntSubtraction, SpecialType(CodeAnalysis.SpecialType.System_Int32), left, right);
+        }
+
         public BoundLiteral Literal(int value)
         {
             return new BoundLiteral(Syntax, ConstantValue.Create(value), SpecialType(Microsoft.CodeAnalysis.SpecialType.System_Int32)) { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -304,6 +304,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 case BoundKind.StackAllocArrayCreation:
                 case BoundKind.TypeExpression:
                 case BoundKind.TypeOrValueExpression:
+                case BoundKind.IndexOrRangePatternIndexerAccess:
 
                     Optional<object> constantValue = ConvertToOptional((boundNode as BoundExpression)?.ConstantValue);
                     bool isImplicit = boundNode.WasCompilerGenerated;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -17,6 +17,267 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         }
 
         [Fact]
+        public void PatternIndexList()
+        {
+            var src = @"
+using System;
+using System.Collections.Generic;
+class C
+{
+    static void Main()
+    {
+        var list = new List<int>() { 2, 4, 5, 6 };
+        Console.WriteLine(list[^2]);
+        var index = ^1;
+        Console.WriteLine(list[index]);
+    }
+}";
+            var verifier = CompileAndVerifyWithIndexAndRange(src, expectedOutput: @"5
+6");
+            verifier.VerifyIL("C.Main", @"
+{
+  // Code size      106 (0x6a)
+  .maxstack  4
+  .locals init (System.Index V_0, //index
+                int V_1,
+                int V_2,
+                System.Index V_3)
+  IL_0000:  newobj     ""System.Collections.Generic.List<int>..ctor()""
+  IL_0005:  dup
+  IL_0006:  ldc.i4.2
+  IL_0007:  callvirt   ""void System.Collections.Generic.List<int>.Add(int)""
+  IL_000c:  dup
+  IL_000d:  ldc.i4.4
+  IL_000e:  callvirt   ""void System.Collections.Generic.List<int>.Add(int)""
+  IL_0013:  dup
+  IL_0014:  ldc.i4.5
+  IL_0015:  callvirt   ""void System.Collections.Generic.List<int>.Add(int)""
+  IL_001a:  dup
+  IL_001b:  ldc.i4.6
+  IL_001c:  callvirt   ""void System.Collections.Generic.List<int>.Add(int)""
+  IL_0021:  dup
+  IL_0022:  dup
+  IL_0023:  callvirt   ""int System.Collections.Generic.List<int>.Count.get""
+  IL_0028:  stloc.1
+  IL_0029:  ldc.i4.2
+  IL_002a:  ldc.i4.1
+  IL_002b:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0030:  stloc.3
+  IL_0031:  ldloca.s   V_3
+  IL_0033:  ldloc.1
+  IL_0034:  call       ""int System.Index.GetOffset(int)""
+  IL_0039:  stloc.2
+  IL_003a:  ldloc.2
+  IL_003b:  callvirt   ""int System.Collections.Generic.List<int>.this[int].get""
+  IL_0040:  call       ""void System.Console.WriteLine(int)""
+  IL_0045:  ldloca.s   V_0
+  IL_0047:  ldc.i4.1
+  IL_0048:  ldc.i4.1
+  IL_0049:  call       ""System.Index..ctor(int, bool)""
+  IL_004e:  dup
+  IL_004f:  callvirt   ""int System.Collections.Generic.List<int>.Count.get""
+  IL_0054:  stloc.2
+  IL_0055:  ldloca.s   V_0
+  IL_0057:  ldloc.2
+  IL_0058:  call       ""int System.Index.GetOffset(int)""
+  IL_005d:  stloc.1
+  IL_005e:  ldloc.1
+  IL_005f:  callvirt   ""int System.Collections.Generic.List<int>.this[int].get""
+  IL_0064:  call       ""void System.Console.WriteLine(int)""
+  IL_0069:  ret
+}");
+        }
+
+        [Theory]
+        [InlineData("Length")]
+        [InlineData("Count")]
+        public void PatternRangeIndexers(string propertyName)
+        {
+            var src = @"
+using System;
+class C
+{
+    private int[] _f = { 2, 4, 5, 6 };
+    public int " + propertyName + @" => _f.Length;
+    public int[] Slice(int start, int length) => _f[start..length];
+    static void Main()
+    {
+        var c = new C();
+        foreach (var x in c[1..])
+        {
+            Console.WriteLine(x);
+        }
+        foreach (var x in c[..^2])
+        {
+            Console.WriteLine(x);
+        }
+    }
+}";
+            var verifier = CompileAndVerifyWithIndexAndRange(src, @"
+4
+5
+2
+4");
+            verifier.VerifyIL("C.Main", @"
+{
+  // Code size      197 (0xc5)
+  .maxstack  4
+  .locals init (C V_0, //c
+                int[] V_1,
+                int V_2,
+                int V_3,
+                System.Range V_4,
+                int V_5,
+                int V_6,
+                System.Index V_7)
+  IL_0000:  newobj     ""C..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  dup
+  IL_0008:  callvirt   ""int C." + propertyName + @".get""
+  IL_000d:  stloc.3
+  IL_000e:  ldc.i4.1
+  IL_000f:  call       ""System.Index System.Index.op_Implicit(int)""
+  IL_0014:  call       ""System.Range System.Range.StartAt(System.Index)""
+  IL_0019:  stloc.s    V_4
+  IL_001b:  ldloca.s   V_4
+  IL_001d:  call       ""System.Index System.Range.Start.get""
+  IL_0022:  stloc.s    V_7
+  IL_0024:  ldloca.s   V_7
+  IL_0026:  ldloc.3
+  IL_0027:  call       ""int System.Index.GetOffset(int)""
+  IL_002c:  stloc.s    V_5
+  IL_002e:  ldloca.s   V_4
+  IL_0030:  call       ""System.Index System.Range.End.get""
+  IL_0035:  stloc.s    V_7
+  IL_0037:  ldloca.s   V_7
+  IL_0039:  ldloc.3
+  IL_003a:  call       ""int System.Index.GetOffset(int)""
+  IL_003f:  stloc.s    V_6
+  IL_0041:  ldloc.s    V_5
+  IL_0043:  ldloc.s    V_6
+  IL_0045:  ldloc.s    V_5
+  IL_0047:  sub
+  IL_0048:  callvirt   ""int[] C.Slice(int, int)""
+  IL_004d:  stloc.1
+  IL_004e:  ldc.i4.0
+  IL_004f:  stloc.2
+  IL_0050:  br.s       IL_005e
+  IL_0052:  ldloc.1
+  IL_0053:  ldloc.2
+  IL_0054:  ldelem.i4
+  IL_0055:  call       ""void System.Console.WriteLine(int)""
+  IL_005a:  ldloc.2
+  IL_005b:  ldc.i4.1
+  IL_005c:  add
+  IL_005d:  stloc.2
+  IL_005e:  ldloc.2
+  IL_005f:  ldloc.1
+  IL_0060:  ldlen
+  IL_0061:  conv.i4
+  IL_0062:  blt.s      IL_0052
+  IL_0064:  ldloc.0
+  IL_0065:  dup
+  IL_0066:  callvirt   ""int C." + propertyName + @".get""
+  IL_006b:  stloc.s    V_6
+  IL_006d:  ldc.i4.2
+  IL_006e:  ldc.i4.1
+  IL_006f:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0074:  call       ""System.Range System.Range.EndAt(System.Index)""
+  IL_0079:  stloc.s    V_4
+  IL_007b:  ldloca.s   V_4
+  IL_007d:  call       ""System.Index System.Range.Start.get""
+  IL_0082:  stloc.s    V_7
+  IL_0084:  ldloca.s   V_7
+  IL_0086:  ldloc.s    V_6
+  IL_0088:  call       ""int System.Index.GetOffset(int)""
+  IL_008d:  stloc.s    V_5
+  IL_008f:  ldloca.s   V_4
+  IL_0091:  call       ""System.Index System.Range.End.get""
+  IL_0096:  stloc.s    V_7
+  IL_0098:  ldloca.s   V_7
+  IL_009a:  ldloc.s    V_6
+  IL_009c:  call       ""int System.Index.GetOffset(int)""
+  IL_00a1:  stloc.3
+  IL_00a2:  ldloc.s    V_5
+  IL_00a4:  ldloc.3
+  IL_00a5:  ldloc.s    V_5
+  IL_00a7:  sub
+  IL_00a8:  callvirt   ""int[] C.Slice(int, int)""
+  IL_00ad:  stloc.1
+  IL_00ae:  ldc.i4.0
+  IL_00af:  stloc.2
+  IL_00b0:  br.s       IL_00be
+  IL_00b2:  ldloc.1
+  IL_00b3:  ldloc.2
+  IL_00b4:  ldelem.i4
+  IL_00b5:  call       ""void System.Console.WriteLine(int)""
+  IL_00ba:  ldloc.2
+  IL_00bb:  ldc.i4.1
+  IL_00bc:  add
+  IL_00bd:  stloc.2
+  IL_00be:  ldloc.2
+  IL_00bf:  ldloc.1
+  IL_00c0:  ldlen
+  IL_00c1:  conv.i4
+  IL_00c2:  blt.s      IL_00b2
+  IL_00c4:  ret
+}");
+        }
+
+        [Theory]
+        [InlineData("Length")]
+        [InlineData("Count")]
+        public void PatternIndexIndexers(string propertyName)
+        {
+            var src = @"
+using System;
+class C
+{
+    private int[] _f = { 2, 4, 5, 6 };
+    public int " + propertyName + @" => _f.Length;
+    public int this[int x] => _f[x];
+    static void Main()
+    {
+        var c = new C();
+        Console.WriteLine(c[0]);
+        Console.WriteLine(c[^1]);
+    }
+}";
+            var verifier = CompileAndVerifyWithIndexAndRange(src, @"
+2
+6");
+            verifier.VerifyIL("C.Main", @"
+{
+  // Code size       53 (0x35)
+  .maxstack  3
+  .locals init (int V_0,
+                int V_1,
+                System.Index V_2)
+  IL_0000:  newobj     ""C..ctor()""
+  IL_0005:  dup
+  IL_0006:  ldc.i4.0
+  IL_0007:  callvirt   ""int C.this[int].get""
+  IL_000c:  call       ""void System.Console.WriteLine(int)""
+  IL_0011:  dup
+  IL_0012:  callvirt   ""int C." + propertyName + @".get""
+  IL_0017:  stloc.0
+  IL_0018:  ldc.i4.1
+  IL_0019:  ldc.i4.1
+  IL_001a:  newobj     ""System.Index..ctor(int, bool)""
+  IL_001f:  stloc.2
+  IL_0020:  ldloca.s   V_2
+  IL_0022:  ldloc.0
+  IL_0023:  call       ""int System.Index.GetOffset(int)""
+  IL_0028:  stloc.1
+  IL_0029:  ldloc.1
+  IL_002a:  callvirt   ""int C.this[int].get""
+  IL_002f:  call       ""void System.Console.WriteLine(int)""
+  IL_0034:  ret
+}");
+        }
+
+        [Fact]
         public void RefToArrayIndexIndexer()
         {
             var verifier = CompileAndVerifyWithIndexAndRange(@"
@@ -108,10 +369,10 @@ class C
 {
     public static void Main()
     {
-        MyString s = ""abcdef"";
+        string s = ""abcdef"";
         Console.WriteLine(s[^2..]);
     }
-}" + TestSources.StringWithIndexers, expectedOutput: "ef");
+}", expectedOutput: "ef");
         }
 
         [Fact]
@@ -123,10 +384,10 @@ class C
 {
     public static void Main()
     {
-        MyString s = ""abcdef"";
+        string s = ""abcdef"";
         Console.WriteLine(s[^4..^1]);
     }
-}" + TestSources.StringWithIndexers, expectedOutput: "cde");
+}", expectedOutput: "cde");
         }
 
         [Fact]
@@ -141,12 +402,12 @@ class C
         var s = ""abcdef"";
         M(s);
     }
-    public static void M(MyString s)
+    public static void M(string s)
     {
         Console.WriteLine(s[new Index(1, false)]);
         Console.WriteLine(s[new Index(1, false), ^1]);
     }
-}" + TestSources.StringWithIndexers);
+}");
             comp.VerifyDiagnostics(
                 // (13,27): error CS1501: No overload for method 'this' takes 2 arguments
                 //         Console.WriteLine(s[new Index(1, false), ^1]);
@@ -189,32 +450,49 @@ class C
     public static void Main()
     {
         var s = ""abcdef"";
-        M(s);
-    }
-    public static void M(MyString s)
-    {
         Console.WriteLine(s[new Index(1, false)]);
         Console.WriteLine(s[^1]);
     }
-}" + TestSources.StringWithIndexers, expectedOutput: @"b
+}", expectedOutput: @"b
 f");
-            verifier.VerifyIL("C.M", @"
+            verifier.VerifyIL("C.Main", @"
 {
-  // Code size       39 (0x27)
-  .maxstack  3
-  IL_0000:  ldarga.s   V_0
-  IL_0002:  ldc.i4.1
-  IL_0003:  ldc.i4.0
-  IL_0004:  newobj     ""System.Index..ctor(int, bool)""
-  IL_0009:  call       ""char MyString.this[System.Index].get""
-  IL_000e:  call       ""void System.Console.WriteLine(char)""
-  IL_0013:  ldarga.s   V_0
-  IL_0015:  ldc.i4.1
-  IL_0016:  ldc.i4.1
-  IL_0017:  newobj     ""System.Index..ctor(int, bool)""
-  IL_001c:  call       ""char MyString.this[System.Index].get""
-  IL_0021:  call       ""void System.Console.WriteLine(char)""
-  IL_0026:  ret
+  // Code size       77 (0x4d)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1,
+                System.Index V_2)
+  IL_0000:  ldstr      ""abcdef""
+  IL_0005:  dup
+  IL_0006:  dup
+  IL_0007:  callvirt   ""int string.Length.get""
+  IL_000c:  stloc.0
+  IL_000d:  ldc.i4.1
+  IL_000e:  ldc.i4.0
+  IL_000f:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0014:  stloc.2
+  IL_0015:  ldloca.s   V_2
+  IL_0017:  ldloc.0
+  IL_0018:  call       ""int System.Index.GetOffset(int)""
+  IL_001d:  stloc.1
+  IL_001e:  ldloc.1
+  IL_001f:  callvirt   ""char string.this[int].get""
+  IL_0024:  call       ""void System.Console.WriteLine(char)""
+  IL_0029:  dup
+  IL_002a:  callvirt   ""int string.Length.get""
+  IL_002f:  stloc.1
+  IL_0030:  ldc.i4.1
+  IL_0031:  ldc.i4.1
+  IL_0032:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0037:  stloc.2
+  IL_0038:  ldloca.s   V_2
+  IL_003a:  ldloc.1
+  IL_003b:  call       ""int System.Index.GetOffset(int)""
+  IL_0040:  stloc.0
+  IL_0041:  ldloc.0
+  IL_0042:  callvirt   ""char string.this[int].get""
+  IL_0047:  call       ""void System.Console.WriteLine(char)""
+  IL_004c:  ret
 }");
         }
 
@@ -228,23 +506,49 @@ class C
     public static void Main()
     {
         var s = ""abcdef"";
-        var result = M(s);
-        Console.WriteLine(result);
+        Console.WriteLine(s[1..3]);
     }
-    public static string M(MyString s) => s[1..3];
-}" + TestSources.StringWithIndexers, expectedOutput: "bc");
-            verifier.VerifyIL("C.M", @"
+}", expectedOutput: "bc");
+            verifier.VerifyIL("C.Main", @"
 {
-  // Code size       25 (0x19)
-  .maxstack  3
-  IL_0000:  ldarga.s   V_0
-  IL_0002:  ldc.i4.1
-  IL_0003:  call       ""System.Index System.Index.op_Implicit(int)""
-  IL_0008:  ldc.i4.3
-  IL_0009:  call       ""System.Index System.Index.op_Implicit(int)""
-  IL_000e:  newobj     ""System.Range..ctor(System.Index, System.Index)""
-  IL_0013:  call       ""string MyString.this[System.Range].get""
-  IL_0018:  ret
+  // Code size       82 (0x52)
+  .maxstack  4
+  .locals init (int V_0,
+                System.Range V_1,
+                int V_2,
+                int V_3,
+                System.Index V_4)
+  IL_0000:  ldstr      ""abcdef""
+  IL_0005:  dup
+  IL_0006:  callvirt   ""int string.Length.get""
+  IL_000b:  stloc.0
+  IL_000c:  ldloca.s   V_1
+  IL_000e:  ldc.i4.1
+  IL_000f:  call       ""System.Index System.Index.op_Implicit(int)""
+  IL_0014:  ldc.i4.3
+  IL_0015:  call       ""System.Index System.Index.op_Implicit(int)""
+  IL_001a:  call       ""System.Range..ctor(System.Index, System.Index)""
+  IL_001f:  ldloca.s   V_1
+  IL_0021:  call       ""System.Index System.Range.Start.get""
+  IL_0026:  stloc.s    V_4
+  IL_0028:  ldloca.s   V_4
+  IL_002a:  ldloc.0
+  IL_002b:  call       ""int System.Index.GetOffset(int)""
+  IL_0030:  stloc.2
+  IL_0031:  ldloca.s   V_1
+  IL_0033:  call       ""System.Index System.Range.End.get""
+  IL_0038:  stloc.s    V_4
+  IL_003a:  ldloca.s   V_4
+  IL_003c:  ldloc.0
+  IL_003d:  call       ""int System.Index.GetOffset(int)""
+  IL_0042:  stloc.3
+  IL_0043:  ldloc.2
+  IL_0044:  ldloc.3
+  IL_0045:  ldloc.2
+  IL_0046:  sub
+  IL_0047:  callvirt   ""string string.Substring(int, int)""
+  IL_004c:  call       ""void System.Console.WriteLine(string)""
+  IL_0051:  ret
 }");
         }
 
@@ -261,8 +565,8 @@ class C
         var result = M(s);
         Console.WriteLine(result);
     }
-    public static string M(MyString s) => s[1..];
-}" + TestSources.StringWithIndexers, expectedOutput: "bcdef");
+    public static string M(string s) => s[1..];
+}", expectedOutput: "bcdef");
         }
 
         [Fact]
@@ -278,8 +582,8 @@ class C
         var result = M(s);
         Console.WriteLine(result);
     }
-    public static string M(MyString s) => s[..^2];
-}" + TestSources.StringWithIndexers, expectedOutput: "abcd");
+    public static string M(string s) => s[..^2];
+}", expectedOutput: "abcd");
         }
 
         [Fact]
@@ -1514,6 +1818,7 @@ partial class Program
     }
 }", options: TestOptions.ReleaseExe), expectedOutput: "YES");
         }
+
 
         private const string PrintIndexesAndRangesCode = @"
 partial class Program

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IFromEndIndexOperation_IRangeOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IFromEndIndexOperation_IRangeOperation.cs
@@ -12,6 +12,102 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         // https://github.com/dotnet/roslyn/issues/31545
 
         [Fact]
+        public void PatternIndexAndRangeIndexer()
+        {
+            var src = @"
+class C
+{
+    public int Length => 0;
+    public int this[int i] => i;
+    public int Slice(int i, int j) => i;
+    public void M()
+    /*<bind*/{
+        _ = this[^0];
+        _ = this[0..];
+    }/*</bind>*/
+}";
+            var comp = CreateCompilationWithIndexAndRange(src);
+            const string expectedOperationTree = @"
+IBlockOperation (2 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+  IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: '_ = this[^0];')
+    Expression: 
+      ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: '_ = this[^0]')
+        Left: 
+          IDiscardOperation (Symbol: System.Int32 _) (OperationKind.Discard, Type: System.Int32) (Syntax: '_')
+        Right: 
+          IOperation:  (OperationKind.None, Type: null) (Syntax: 'this[^0]')
+            Children(2):
+                IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
+                IUnaryOperation (UnaryOperatorKind.Hat) (OperationKind.Unary, Type: System.Index) (Syntax: '^0')
+                  Operand: 
+                    ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+  IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: '_ = this[0..];')
+    Expression: 
+      ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: '_ = this[0..]')
+        Left: 
+          IDiscardOperation (Symbol: System.Int32 _) (OperationKind.Discard, Type: System.Int32) (Syntax: '_')
+        Right: 
+          IOperation:  (OperationKind.None, Type: null) (Syntax: 'this[0..]')
+            Children(2):
+                IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
+                IRangeOperation (OperationKind.Range, Type: System.Range) (Syntax: '0..')
+                  LeftOperand: 
+                    IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: System.Index System.Index.op_Implicit(System.Int32 value)) (OperationKind.Conversion, Type: System.Index, IsImplicit) (Syntax: '0')
+                      Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: System.Index System.Index.op_Implicit(System.Int32 value))
+                      Operand: 
+                        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+                  RightOperand: 
+                    null";
+            VerifyOperationTreeAndDiagnosticsForTest<BlockSyntax>(comp, expectedOperationTree, DiagnosticDescription.None);
+
+            VerifyOperationTreeAndDiagnosticsForTest<BlockSyntax>(comp, expectedOperationTree, DiagnosticDescription.None);
+
+            var expectedFlowGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+Block[B1] - Block
+    Predecessors: [B0]
+    Statements (2)
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: '_ = this[^0];')
+          Expression: 
+            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: '_ = this[^0]')
+              Left: 
+                IDiscardOperation (Symbol: System.Int32 _) (OperationKind.Discard, Type: System.Int32) (Syntax: '_')
+              Right: 
+                IOperation:  (OperationKind.None, Type: null) (Syntax: 'this[^0]')
+                  Children(2):
+                      IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
+                      IUnaryOperation (UnaryOperatorKind.Hat) (OperationKind.Unary, Type: System.Index) (Syntax: '^0')
+                        Operand: 
+                          ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: '_ = this[0..];')
+          Expression: 
+            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: '_ = this[0..]')
+              Left: 
+                IDiscardOperation (Symbol: System.Int32 _) (OperationKind.Discard, Type: System.Int32) (Syntax: '_')
+              Right: 
+                IOperation:  (OperationKind.None, Type: null) (Syntax: 'this[0..]')
+                  Children(2):
+                      IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
+                      IRangeOperation (OperationKind.Range, Type: System.Range) (Syntax: '0..')
+                        LeftOperand: 
+                          IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: System.Index System.Index.op_Implicit(System.Int32 value)) (OperationKind.Conversion, Type: System.Index, IsImplicit) (Syntax: '0')
+                            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: System.Index System.Index.op_Implicit(System.Int32 value))
+                              (ImplicitUserDefined)
+                            Operand: 
+                              ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+                        RightOperand: 
+                          null
+    Next (Regular) Block[B2]
+Block[B2] - Exit
+    Predecessors: [B1]
+    Statements (0)";
+
+            VerifyFlowGraphForTest<BlockSyntax>(comp, expectedFlowGraph);
+        }
+
+        [Fact]
         public void FromEndIndexFlow_01()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -1324,16 +1324,15 @@ public class MyClass
         public void NullableRangeIndexer()
         {
             var text = @"
-using System;
 #nullable enable
 class Program
 {
-    void M(int[] x, MyString m)
+    void M(int[] x, string m)
     {
         var y = x[1..3];
         var z = m[1..3];
     }
-}" + TestSources.GetSubArray + TestSources.StringWithIndexers;
+}" + TestSources.GetSubArray;
             CreateCompilationWithIndexAndRange(text).VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -17,6 +17,45 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class SemanticTests : CSharpTestBase
     {
         [Fact]
+        public void PatternIndexAndRangeIndexers()
+        {
+            var comp = CreateCompilationWithIndexAndRange(@"
+class C
+{
+    int Length => 0;
+    int this[int i] => i;
+    char Slice(int i, int j) => 'a';
+    void M()
+    {
+        _ = this[^0];
+        _ = this[0..];
+    }
+}");
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var root = tree.GetCompilationUnitRoot();
+
+            var accesses = root.DescendantNodes().OfType<ElementAccessExpressionSyntax>().ToList();
+            var indexerAccess = accesses[0];
+
+            var typeInfo = model.GetTypeInfo(indexerAccess);
+            Assert.Equal(SpecialType.System_Int32, typeInfo.Type.SpecialType);
+            var symbolInfo = model.GetSymbolInfo(indexerAccess);
+            Assert.Null(symbolInfo.Symbol);
+            Assert.Empty(symbolInfo.CandidateSymbols);
+
+            indexerAccess = accesses[1];
+
+            typeInfo = model.GetTypeInfo(indexerAccess);
+            Assert.Equal(SpecialType.System_Char, typeInfo.Type.SpecialType);
+            symbolInfo = model.GetSymbolInfo(indexerAccess);
+            Assert.Null(symbolInfo.Symbol);
+            Assert.Empty(symbolInfo.CandidateSymbols);
+        }
+
+        [Fact]
         public void RefReassignSymbolInfo()
         {
             var comp = CreateCompilation(@"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -911,6 +911,8 @@ namespace System
                     case WellKnownMember.System_Range__StartAt:
                     case WellKnownMember.System_Range__EndAt:
                     case WellKnownMember.System_Range__get_All:
+                    case WellKnownMember.System_Range__get_Start:
+                    case WellKnownMember.System_Range__get_End:
                     case WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__GetSubArray_T:
                     case WellKnownMember.System_Runtime_CompilerServices_AsyncIteratorStateMachineAttribute__ctor:
                     case WellKnownMember.System_IAsyncDisposable__DisposeAsync:

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -47,9 +47,11 @@ abstract Microsoft.CodeAnalysis.Diagnostics.SymbolStartAnalysisContext.RegisterO
 abstract Microsoft.CodeAnalysis.Diagnostics.SymbolStartAnalysisContext.RegisterOperationBlockStartAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext> action) -> void
 abstract Microsoft.CodeAnalysis.Diagnostics.SymbolStartAnalysisContext.RegisterSymbolEndAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.SymbolAnalysisContext> action) -> void
 abstract Microsoft.CodeAnalysis.Diagnostics.SymbolStartAnalysisContext.RegisterSyntaxNodeAction<TLanguageKindEnum>(System.Action<Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext> action, System.Collections.Immutable.ImmutableArray<TLanguageKindEnum> syntaxKinds) -> void
+const Microsoft.CodeAnalysis.WellKnownMemberNames.CountPropertyName = "Count" -> string
 const Microsoft.CodeAnalysis.WellKnownMemberNames.DisposeAsyncMethodName = "DisposeAsync" -> string
 const Microsoft.CodeAnalysis.WellKnownMemberNames.DisposeMethodName = "Dispose" -> string
 const Microsoft.CodeAnalysis.WellKnownMemberNames.GetAsyncEnumeratorMethodName = "GetAsyncEnumerator" -> string
+const Microsoft.CodeAnalysis.WellKnownMemberNames.LengthPropertyName = "Length" -> string
 const Microsoft.CodeAnalysis.WellKnownMemberNames.MoveNextAsyncMethodName = "MoveNextAsync" -> string
 Microsoft.CodeAnalysis.Compilation.HasImplicitConversion(Microsoft.CodeAnalysis.ITypeSymbol fromType, Microsoft.CodeAnalysis.ITypeSymbol toType) -> bool
 Microsoft.CodeAnalysis.Compilation.IsSymbolAccessibleWithin(Microsoft.CodeAnalysis.ISymbol symbol, Microsoft.CodeAnalysis.ISymbol within, Microsoft.CodeAnalysis.ITypeSymbol throughType = null) -> bool
@@ -191,6 +193,7 @@ Microsoft.CodeAnalysis.Operations.ITryOperation.ExitLabel.get -> Microsoft.CodeA
 Microsoft.CodeAnalysis.Operations.IUsingOperation.Locals.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ILocalSymbol>
 Microsoft.CodeAnalysis.Operations.UnaryOperatorKind.Hat = 7 -> Microsoft.CodeAnalysis.Operations.UnaryOperatorKind
 Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier = 64 -> Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions
+const Microsoft.CodeAnalysis.WellKnownMemberNames.SliceMethodName = "Slice" -> string
 override Microsoft.CodeAnalysis.FlowAnalysis.CaptureId.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.FlowAnalysis.CaptureId.GetHashCode() -> int
 static Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph.Create(Microsoft.CodeAnalysis.Operations.IBlockOperation body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph

--- a/src/Compilers/Core/Portable/SpecialMember.cs
+++ b/src/Compilers/Core/Portable/SpecialMember.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis
         System_String__Length,
         System_String__Chars,
         System_String__Format,
+        System_String__Substring,
 
         System_Double__IsNaN,
         System_Single__IsNaN,

--- a/src/Compilers/Core/Portable/SpecialMembers.cs
+++ b/src/Compilers/Core/Portable/SpecialMembers.cs
@@ -137,6 +137,15 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
                     (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Object,
 
+                // System_String__Substring
+                (byte)MemberFlags.Method,                                                                                   // Flags
+                (byte)SpecialType.System_String,                                                                            // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String, // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
                 // System_Double__IsNaN
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)SpecialType.System_Double,                                                                            // DeclaringTypeId
@@ -1005,6 +1014,7 @@ namespace Microsoft.CodeAnalysis
                 "get_Length",                               // System_String__Length
                 "get_Chars",                                // System_String__Chars
                 "Format",                                   // System_String__Format
+                "Substring",                                // System_String__Substring
                 "IsNaN",                                    // System_Double__IsNaN
                 "IsNaN",                                    // System_Single__IsNaN
                 "Combine",                                  // System_Delegate__Combine

--- a/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
@@ -323,5 +323,20 @@ namespace Microsoft.CodeAnalysis
         /// The required name for the <c>DisposeAsync</c> method used in an await using statement.
         /// </summary>
         public const string DisposeAsyncMethodName = "DisposeAsync";
+
+        /// <summary>
+        /// The required name for the <c>Count</c> property used in a pattern-based Index or Range indexer.
+        /// </summary>
+        public const string CountPropertyName = "Count";
+
+        /// <summary>
+        /// The required name for the <c>Length</c> property used in a pattern-based Index or Range indexer.
+        /// </summary>
+        public const string LengthPropertyName = "Length";
+
+        /// <summary>
+        /// The required name for the <c>Slice</c> method used in a pattern-based Range indexer.
+        /// </summary>
+        public const string SliceMethodName = "Slice";
     }
 }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -414,6 +414,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_TupleElementNamesAttribute__ctorTransformNames,
 
         System_String__Format_IFormatProvider,
+        System_String__Substring,
 
         Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
         Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles,
@@ -451,6 +452,8 @@ namespace Microsoft.CodeAnalysis
         System_Range__StartAt,
         System_Range__EndAt,
         System_Range__get_All,
+        System_Range__get_Start,
+        System_Range__get_End,
 
         System_Runtime_CompilerServices_AsyncIteratorStateMachineAttribute__ctor,
 

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -414,7 +414,6 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_TupleElementNamesAttribute__ctorTransformNames,
 
         System_String__Format_IFormatProvider,
-        System_String__Substring,
 
         Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
         Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2875,6 +2875,15 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
                     (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Object,
 
+                // System_String__Substring
+                (byte)MemberFlags.Method,                                                                                   // Flags
+                (byte)SpecialType.System_String,                                                                            // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String, // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
                 // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                                                    // Flags
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation - WellKnownType.ExtSentinel),  // DeclaringTypeId
@@ -3104,6 +3113,20 @@ namespace Microsoft.CodeAnalysis
                  0,                                                                                                                                             // Arity
                      0,                                                                                                                                         // Method Signature
                      (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Range - WellKnownType.ExtSentinel),
+
+                 // System_Range__get_Start
+                 (byte)MemberFlags.PropertyGet,
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Range - WellKnownType.ExtSentinel),                                               // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                     0,                                                                                                                                         // Method Signature
+                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Index - WellKnownType.ExtSentinel),
+
+                 // System_Range__get_End
+                 (byte)MemberFlags.PropertyGet,
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Range - WellKnownType.ExtSentinel),                                               // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                     0,                                                                                                                                         // Method Signature
+                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Index - WellKnownType.ExtSentinel),
 
                 // System_Runtime_CompilerServices_AsyncIteratorStateMachineAttribute__ctor
                 (byte)MemberFlags.Constructor,                                                                              // Flags
@@ -3731,6 +3754,7 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Runtime_CompilerServices_TupleElementNamesAttribute__ctorTransformNames
 
                 "Format",                                   // System_String__Format_IFormatProvider
+                "Substring",                                // System_String__Substring
 
                 "CreatePayload",                            // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile
                 "CreatePayload",                            // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles
@@ -3763,6 +3787,8 @@ namespace Microsoft.CodeAnalysis
                 "StartAt",                                  // System_Range__StartAt
                 "EndAt",                                    // System_Range__StartAt
                 "get_All",                                  // System_Range__get_All
+                "get_Start",                                // System_Range__get_Start
+                "get_End",                                  // System_Range__get_End
 
                 ".ctor",                                    // System_Runtime_CompilerServices_AsyncIteratorStateMachineAttribute__ctor
 

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2875,15 +2875,6 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
                     (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Object,
 
-                // System_String__Substring
-                (byte)MemberFlags.Method,                                                                                   // Flags
-                (byte)SpecialType.System_String,                                                                            // DeclaringTypeId
-                0,                                                                                                          // Arity
-                    2,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String, // Return Type
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
-
                 // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                                                    // Flags
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation - WellKnownType.ExtSentinel),  // DeclaringTypeId
@@ -3754,7 +3745,6 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Runtime_CompilerServices_TupleElementNamesAttribute__ctorTransformNames
 
                 "Format",                                   // System_String__Format_IFormatProvider
-                "Substring",                                // System_String__Substring
 
                 "CreatePayload",                            // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile
                 "CreatePayload",                            // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles

--- a/src/Compilers/Test/Utilities/CSharp/TestSources.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestSources.cs
@@ -385,40 +385,5 @@ namespace System.Runtime.CompilerServices
         }
     }
 }";
-
-        // The references we use for System.String do not have an indexer for
-        // System.Index and System.Range, so this wrapper mimics the behavior
-        public const string StringWithIndexers = @"
-internal readonly struct MyString
-{
-    private readonly string _s;
-    public MyString(string s)
-    {
-        _s = s;
-    }
-    public static implicit operator MyString(string s) => new MyString(s);
-    public static implicit operator string(MyString m) => m._s;
-
-    public int Length => _s.Length;
-
-    public char this[int index] => _s[index];
-
-    public char this[Index index]
-    {
-        get
-        {
-            int actualIndex = index.GetOffset(Length);
-            return this[actualIndex];
-        }
-    }
-
-    public string this[Range range] => Substring(range);
-
-    public string Substring(Range range)
-    {
-        (int start, int length) = range.GetOffsetAndLength(Length);
-        return _s.Substring(start, length);
-    }
-}";
     }
 }

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -825,6 +825,8 @@ End Namespace
                          WellKnownMember.System_Range__EndAt,
                          WellKnownMember.System_Range__get_All,
                          WellKnownMember.System_Range__StartAt,
+                         WellKnownMember.System_Range__get_End,
+                         WellKnownMember.System_Range__get_Start,
                          WellKnownMember.System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_ITuple__get_Item,
                          WellKnownMember.System_Runtime_CompilerServices_ITuple__get_Length,

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -688,6 +688,8 @@ End Namespace
                          WellKnownMember.System_Range__EndAt,
                          WellKnownMember.System_Range__get_All,
                          WellKnownMember.System_Range__StartAt,
+                         WellKnownMember.System_Range__get_End,
+                         WellKnownMember.System_Range__get_Start,
                          WellKnownMember.System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_ITuple__get_Item,
                          WellKnownMember.System_Runtime_CompilerServices_ITuple__get_Length,


### PR DESCRIPTION
Implements most of the design changes specified in
https://github.com/dotnet/csharplang/blob/c229cae634bd59a6a13b9ed464a4cab782a95e5d/proposals/index-range-changes.md

This PR focuses on getting the simple end-to-end scenario working,
not focusing entirely on codegen quality. I expect to follow-up later
with the optimizations mentioned about eliminating use of the
Index/Range helpers entirely if they can be elided.