### PR TITLE
Switch on enum type nested in generic type produces LangVersion error

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -210,8 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var requiredVersion = MessageID.IDS_FeatureRecursivePatterns.RequiredVersion();
                         if (Compilation.LanguageVersion < requiredVersion &&
-                            // A null pattern can be tested against a type that can be assigned null, even in C# 7.3
-                            !(expression.ConstantValue == ConstantValue.Null && inputType.CanBeAssignedNull()))
+                            !this.Conversions.ClassifyConversionFromExpression(expression, inputType, ref useSiteDiagnostics).IsImplicit)
                         {
                             diagnostics.Add(ErrorCode.ERR_ConstantPatternVsOpenType,
                                 expression.Syntax.Location, inputType, expression.Display, new CSharpRequiredLanguageVersion(requiredVersion));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
@@ -2317,5 +2317,31 @@ public class C
                 //         return t is "frog"; // 3
                 Diagnostic(ErrorCode.ERR_ConstantPatternVsOpenType, @"""frog""").WithArguments("T", "string", "preview").WithLocation(17, 21));
         }
+
+        [Fact]
+        [WorkItem(34905, "https://github.com/dotnet/roslyn/issues/34905")]
+        public void ConstantPatternVsUnconstrainedTypeParameter06()
+        {
+            var source =
+@"public class C<T>
+{
+    public enum E
+    {
+        V1, V2
+    }
+
+    public void M()
+    {
+        switch (default(E))
+        {
+            case E.V1:
+                break;
+        }
+    }
+}
+";
+            CreateCompilation(source, options: TestOptions.ReleaseDll).VerifyDiagnostics();
+            CreateCompilation(source, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular7_3).VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Fixes #34905

@dotnet/roslyn-compiler This is a fix for a serious regression that would be introduced in 16.1p2 (mea culpa) if not for this bug fix.
