### PR TITLE
Improve naming of integration test runs

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -52,7 +52,7 @@ jobs:
         testRunner: XUnit
         testResultsFiles: $(Build.SourcesDirectory)\artifacts\TestResults\$(_configuration)\*.xml
         mergeTestResults: true
-        testRunTitle: 'Windows Visual Studio Integration $(_configuration)_$(_useLegacyCompletion)' 
+        testRunTitle: 'Integration $(_configuration) $(_completionName)' 
       condition: always()
 
     - task: PublishBuildArtifacts@1

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -52,14 +52,14 @@ jobs:
         testRunner: XUnit
         testResultsFiles: $(Build.SourcesDirectory)\artifacts\TestResults\$(_configuration)\*.xml
         mergeTestResults: true
-        testRunTitle: 'Integration $(_configuration) $(_completionName)' 
+        testRunTitle: '$(System.JobAttempt)-Integration $(_configuration) $(_completionName)' 
       condition: always()
 
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(_configuration)'
-        ArtifactName: 'Logs $(_configuration) $(_completionName) $(Build.BuildNumber)'
+        ArtifactName: '$(System.JobAttempt)-Logs $(_configuration) $(_completionName) $(Build.BuildNumber)'
         publishLocation: Container
       continueOnError: true
       condition: not(succeeded())
@@ -68,7 +68,7 @@ jobs:
       displayName: Publish Screenshots
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin\Microsoft.VisualStudio.LanguageServices.IntegrationTests\$(_configuration)\net472\xUnitResults'
-        ArtifactName: 'Screenshots $(_configuration) $(_completionName) $(Build.BuildNumber)'
+        ArtifactName: '$(System.JobAttempt)-Screenshots $(_configuration) $(_completionName) $(Build.BuildNumber)'
         publishLocation: Container
       continueOnError: true
       condition: not(succeeded())

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -19,16 +19,16 @@ pr:
 - dev16.1-preview2-vs-deps
 
 jobs:
-- job: Windows_VisualStudio_Integration_Tests
+- job: VS_Integration
   pool: dotnet-external-vs2019-preview
   strategy:
     maxParallel: 4
     matrix:
-      debug:
+      debug_async:
         _configuration: Debug
         _useLegacyCompletion: false
         _completionName: Async
-      release:
+      release_async:
         _configuration: Release
         _useLegacyCompletion: false
         _completionName: Async


### PR DESCRIPTION
### Build legs

Build leg names are shorter and clearer:

```diff
- Windows_VisualStudio_Integration_Tests debug
+ VS_Integration debug_async
```

![image](https://user-images.githubusercontent.com/1408396/55978553-a44d0f80-5c55-11e9-86ee-1b4fbe8d3f15.png) ![image](https://user-images.githubusercontent.com/1408396/55978521-939c9980-5c55-11e9-9ce4-be7bc260d9df.png)

### Artifacts

Artifacts now have the job attempt number in the name:

```diff
- Logs Debug Async 00000000.00
+ 1-Logs Debug Async 00000000.00
```

![image](https://user-images.githubusercontent.com/1408396/55993553-01a48900-5c75-11e9-999b-55b15daaa692.png)
![image](https://user-images.githubusercontent.com/1408396/55993526-f4879a00-5c74-11e9-819f-8633276def6a.png)

### Test results

Test results now show Async/Legacy instead of false/true, and have the job attempt number in the name

```diff
- Windows Visual Studio Integration Debug_false
+ 1-Integration Debug Async
```

![image](https://user-images.githubusercontent.com/1408396/55993569-0b2df100-5c75-11e9-98f5-e92802da2285.png)
![image](https://user-images.githubusercontent.com/1408396/55993507-e76aab00-5c74-11e9-830d-89ff6249147c.png)
