### PR TITLE
Specially handle type parameters constrained to `Nullable<T>` in TypeSymbolExtensions.CanContainNull().

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -1912,7 +1912,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Don't even call this method if the expression cannot be nullable.
             Debug.Assert(
                 (object)exprType == null ||
-                exprType.IsNullableType() ||
+                exprType.IsNullableTypeOrTypeParameter() ||
                 !exprType.IsValueType ||
                 exprType.IsPointerType());
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static bool CanContainNull(this TypeSymbol type)
         {
             // unbound type parameters might contain null, even though they cannot be *assigned* null.
-            return !type.IsValueType || type.IsNullableType();
+            return !type.IsValueType || type.IsNullableTypeOrTypeParameter();
         }
 
         public static bool CanBeConst(this TypeSymbol typeSymbol)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
@@ -16,26 +16,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public bool MayBeNull => State == NullableFlowState.MaybeNull;
         public bool IsNotNull => State == NullableFlowState.NotNull;
 
-        private static bool CanContainNull(TypeSymbol type)
-        {
-            return type is null || !type.IsValueType || type.IsNullableTypeOrTypeParameter();
-        }
-
         public static TypeWithState ForType(TypeSymbol type)
         {
-            var state = CanContainNull(type) ? NullableFlowState.MaybeNull : NullableFlowState.NotNull;
+            var state = type?.CanContainNull() != false ? NullableFlowState.MaybeNull : NullableFlowState.NotNull;
             return new TypeWithState(type, state);
         }
 
         public static TypeWithState Create(TypeSymbol type, NullableFlowState defaultState)
         {
-            var state = defaultState == NullableFlowState.MaybeNull && CanContainNull(type) ? NullableFlowState.MaybeNull : NullableFlowState.NotNull;
+            var state = defaultState == NullableFlowState.MaybeNull && type?.CanContainNull() != false ? NullableFlowState.MaybeNull : NullableFlowState.NotNull;
             return new TypeWithState(type, state);
         }
 
         private TypeWithState(TypeSymbol type, NullableFlowState state)
         {
-            Debug.Assert(state == NullableFlowState.NotNull || CanContainNull(type));
+            Debug.Assert(state == NullableFlowState.NotNull || type?.CanContainNull() != false);
             Type = type;
             State = state;
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -81738,7 +81738,14 @@ class B2 : A<int?>
     {
         ((object?)x).ToString(); // 2
         object? y = x;
-        y.ToString(); // 3
+        y.ToString();
+    }
+
+    void F(int? x)
+    {
+        ((object?)x).ToString(); // 3
+        object? y = x;
+        y.ToString();
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
@@ -81749,9 +81756,9 @@ class B2 : A<int?>
                 // (18,10): warning CS8602: Dereference of a possibly null reference.
                 //         ((object?)x).ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(object?)x").WithLocation(18, 10),
-                // (20,9): warning CS8602: Dereference of a possibly null reference.
-                //         y.ToString(); // 3
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(20, 9)
+                // (25,10): warning CS8602: Dereference of a possibly null reference.
+                //         ((object?)x).ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(object?)x").WithLocation(25, 10)
                 );
         }
 


### PR DESCRIPTION
Fixes #34679.