### PR TITLE
Allow `ignore spaces around declaration` to work when `preserve single line statements` is set to false

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             for (int i = 0; i < list.Count; i++)
             {
-                if (list[i] != null && list[i].TextSpan.Start >= span.Start && list[i].TextSpan.End <= span.End)
+                if (list[i] != null && list[i].TextSpan.Start >= span.Start && list[i].TextSpan.End <= span.End && list[i].Option == SuppressOption.NoWrappingIfOnSingleLine)
                 {
                     list[i] = null;
                 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/WrappingFormattingRule.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             for (int i = 0; i < list.Count; i++)
             {
-                if (list[i] != null && list[i].TextSpan.Start >= span.Start && list[i].TextSpan.End <= span.End && list[i].Option == SuppressOption.NoWrappingIfOnSingleLine)
+                if (list[i] != null && list[i].TextSpan.Start >= span.Start && list[i].TextSpan.End <= span.End && list[i].Option.HasFlag(SuppressOption.NoWrappingIfOnSingleLine))
                 {
                     list[i] = null;
                 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -9162,5 +9162,56 @@ public unsafe class Test
 }}",
                 changedOptionSet: changedOptionSet);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(31868, "https://github.com/dotnet/roslyn/issues/31868")]
+        public async Task SpaceAroundDeclaration()
+        {
+            var changingOptions = new Dictionary<OptionKey, object>();
+            changingOptions.Add(CSharpFormattingOptions.SpacesIgnoreAroundVariableDeclaration, true);
+            await AssertFormatAsync(
+                @"
+class Program
+{
+    public void FixMyType()
+    {
+        var    myint    =    0;
+    }
+}",
+                @"
+class Program
+{
+    public void FixMyType()
+    {
+        var    myint    =    0;
+    }
+}", changedOptionSet: changingOptions);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(31868, "https://github.com/dotnet/roslyn/issues/31868")]
+        public async Task SpaceAroundDeclarationAndPreserveSingleLine()
+        {
+            var changingOptions = new Dictionary<OptionKey, object>();
+            changingOptions.Add(CSharpFormattingOptions.SpacesIgnoreAroundVariableDeclaration, true);
+            changingOptions.Add(CSharpFormattingOptions.WrappingKeepStatementsOnSingleLine, false);
+            await AssertFormatAsync(
+                @"
+class Program
+{
+    public void FixMyType()
+    {
+        var    myint    =    0;
+    }
+}",
+                @"
+class Program
+{
+    public void FixMyType()
+    {
+        var    myint    =    0;
+    }
+}", changedOptionSet: changingOptions);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/31868

**Who is impacted by this bug?**
Users who use Format Document and have these two settings in the .editorconfig
`csharp_space_around_declaration_statements = ignore`
`csharp_preserve_single_line_statements = false`

**What is the customer scenario and impact of the bug?**
If a user has these two settings in their .editorconfig:
`csharp_space_around_declaration_statements = ignore`
`csharp_preserve_single_line_statements = false`

When they **Format Document** the extra spaces around their declaration statements are removed when they should have been ignored.

**Expected**
Original spacing around the declaration statements should be left alone since user specified 
`csharp_space_around_declaration_statements = ignore`.  

Example,
```csharp
    public void FixMyType()
    {
        var     myint       = 0;
        var     myint2      = 1;
    }
```

 **Actual**
The original spacing is not maintained. It becomes,
```csharp
    public void FixMyType()
    {
        var myint = 0;
        var myint2 = 1;
    }
```

**What is the workaround?**
After using Format Document, manually redo spacing around declaration statements.

**How was the bug found?**
Developer Community issue

**If this fix is for a regression - what had regressed, when was the regression introduced, and why was the regression originally missed?**
Not a regression.  Repros in 15.9.11