### PR TITLE
Create mapping from NotificationOption to EditorConfig severity string.

### DIFF
--- a/src/Workspaces/Core/Portable/Extensions/NotificationOptionExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/NotificationOptionExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                 ReportDiagnostic.Info => EditorConfigSeverityStrings.Suggestion,
                 ReportDiagnostic.Warn => EditorConfigSeverityStrings.Warning,
                 ReportDiagnostic.Error => EditorConfigSeverityStrings.Error,
-                _ => throw ExceptionUtilities.Unreachable
+                _ => throw ExceptionUtilities.UnexpectedValue(notificationOption.Severity)
             };
         }
     }

--- a/src/Workspaces/Core/Portable/Extensions/NotificationOptionExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/NotificationOptionExtensions.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeStyle
 {
@@ -6,14 +8,15 @@ namespace Microsoft.CodeAnalysis.CodeStyle
     {
         public static string ToEditorConfigString(this NotificationOption notificationOption)
         {
-            if (notificationOption == NotificationOption.Silent)
+            return notificationOption.Severity switch
             {
-                return nameof(NotificationOption.Silent).ToLowerInvariant();
-            }
-            else
-            {
-                return notificationOption.ToString().ToLowerInvariant();
-            }
+                ReportDiagnostic.Suppress => EditorConfigSeverityStrings.None,
+                ReportDiagnostic.Hidden => EditorConfigSeverityStrings.Silent,
+                ReportDiagnostic.Info => EditorConfigSeverityStrings.Suggestion,
+                ReportDiagnostic.Warn => EditorConfigSeverityStrings.Warning,
+                ReportDiagnostic.Error => EditorConfigSeverityStrings.Error,
+                _ => throw ExceptionUtilities.Unreachable
+            };
         }
     }
 }


### PR DESCRIPTION
This PR is being created to simplify #30760

`notificationOption.ToString().ToLowerInvariant();` would return a localized string instead of the correct severity string.