### PR TITLE
Allow the simplification of using directives where the global alias is specified

### DIFF
--- a/src/EditorFeatures/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -3994,6 +3994,146 @@ namespace Root
 }", compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, warningLevel: warningLevel));
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestGlobalAliasSimplifiesInUsingDirective()
+        {
+            await TestInRegularAndScriptAsync(
+                "using [|global::System.IO|];",
+                "using System.IO;");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [InlineData("Boolean")]
+        [InlineData("Char")]
+        [InlineData("String")]
+        [InlineData("Int8")]
+        [InlineData("UInt8")]
+        [InlineData("Int16")]
+        [InlineData("UInt16")]
+        [InlineData("Int32")]
+        [InlineData("UInt32")]
+        [InlineData("Int64")]
+        [InlineData("UInt64")]
+        [InlineData("Float32")]
+        [InlineData("Float64")]
+        public async Task TestGlobalAliasSimplifiesInUsingAliasDirective(string typeName)
+        {
+            await TestInRegularAndScriptAsync(
+                $"using My{typeName} = [|global::System.{typeName}|];",
+                $"using My{typeName} = System.{typeName};");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestGlobalAliasSimplifiesInUsingStaticDirective()
+        {
+            await TestInRegularAndScriptAsync(
+                "using static [|global::System.Math|];",
+                "using static System.Math;");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestGlobalAliasSimplifiesInUsingDirectiveInNamespace()
+        {
+            await TestInRegularAndScriptAsync(
+@"namespace N
+{
+    using [|global::System.IO|];
+}",
+@"namespace N
+{
+    using System.IO;
+}");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [InlineData("Boolean")]
+        [InlineData("Char")]
+        [InlineData("String")]
+        [InlineData("Int8")]
+        [InlineData("UInt8")]
+        [InlineData("Int16")]
+        [InlineData("UInt16")]
+        [InlineData("Int32")]
+        [InlineData("UInt32")]
+        [InlineData("Int64")]
+        [InlineData("UInt64")]
+        [InlineData("Float32")]
+        [InlineData("Float64")]
+        public async Task TestGlobalAliasSimplifiesInUsingAliasDirectiveWithinNamespace(string typeName)
+        {
+            await TestInRegularAndScriptAsync(
+$@"namespace N
+{{
+    using My{typeName} = [|global::System.{typeName}|];
+}}",
+$@"namespace N
+{{
+    using My{typeName} = System.{typeName};
+}}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestGlobalAliasSimplifiesInUsingStaticDirectiveInNamespace()
+        {
+            await TestInRegularAndScriptAsync(
+@"namespace N
+{
+    using static [|global::System.Math|];
+}",
+@"namespace N
+{
+    using static System.Math;
+}");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [InlineData("Boolean")]
+        [InlineData("Char")]
+        [InlineData("String")]
+        [InlineData("Int8")]
+        [InlineData("UInt8")]
+        [InlineData("Int16")]
+        [InlineData("UInt16")]
+        [InlineData("Int32")]
+        [InlineData("UInt32")]
+        [InlineData("Int64")]
+        [InlineData("UInt64")]
+        [InlineData("Float32")]
+        [InlineData("Float64")]
+        public async Task TestDoesNotSimplifyUsingAliasDirectiveToPrimitiveType(string typeName)
+        {
+            await TestMissingAsync(
+$@"using System;
+ namespace N
+{{
+    using My{typeName} = [|{typeName}|];
+}}");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [InlineData("Boolean")]
+        [InlineData("Char")]
+        [InlineData("String")]
+        [InlineData("Int8")]
+        [InlineData("UInt8")]
+        [InlineData("Int16")]
+        [InlineData("UInt16")]
+        [InlineData("Int32")]
+        [InlineData("UInt32")]
+        [InlineData("Int64")]
+        [InlineData("UInt64")]
+        [InlineData("Float32")]
+        [InlineData("Float64")]
+        public async Task TestDoesNotSimplifyUsingAliasDirectiveToPrimitiveType2(string typeName)
+        {
+            await TestMissingAsync(
+$@"
+namespace N
+{{
+    using My{typeName} = [|System.{typeName}|];
+}}");
+        }
+
         private async Task TestWithPredefinedTypeOptionsAsync(string code, string expected, int index = 0)
         {
             await TestInRegularAndScriptAsync(code, expected, index: index, options: PreferIntrinsicTypeEverywhere);

--- a/src/EditorFeatures/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -4035,11 +4035,13 @@ namespace Root
         public async Task TestGlobalAliasSimplifiesInUsingDirectiveInNamespace()
         {
             await TestInRegularAndScriptAsync(
-@"namespace N
+@"using System;
+namespace N
 {
     using [|global::System.IO|];
 }",
-@"namespace N
+@"using System;
+namespace N
 {
     using System.IO;
 }");
@@ -4062,11 +4064,13 @@ namespace Root
         public async Task TestGlobalAliasSimplifiesInUsingAliasDirectiveWithinNamespace(string typeName)
         {
             await TestInRegularAndScriptAsync(
-$@"namespace N
+$@"using System;
+namespace N
 {{
     using My{typeName} = [|global::System.{typeName}|];
 }}",
-$@"namespace N
+$@"using System;
+namespace N
 {{
     using My{typeName} = System.{typeName};
 }}");
@@ -4076,11 +4080,13 @@ $@"namespace N
         public async Task TestGlobalAliasSimplifiesInUsingStaticDirectiveInNamespace()
         {
             await TestInRegularAndScriptAsync(
-@"namespace N
+@"using System;
+namespace N
 {
     using static [|global::System.Math|];
 }",
-@"namespace N
+@"using System;
+namespace N
 {
     using static System.Math;
 }");
@@ -4104,7 +4110,7 @@ $@"namespace N
         {
             await TestMissingAsync(
 $@"using System;
- namespace N
+namespace N
 {{
     using My{typeName} = [|{typeName}|];
 }}");
@@ -4127,7 +4133,7 @@ $@"using System;
         public async Task TestDoesNotSimplifyUsingAliasDirectiveToPrimitiveType2(string typeName)
         {
             await TestMissingAsync(
-$@"
+$@"using System;
 namespace N
 {{
     using My{typeName} = [|System.{typeName}|];

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -2312,9 +2312,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         private static bool IsGlobalAliasQualifiedName(NameSyntax name)
         {
             // Checks whether the `global::` alias is applied to the name
-            return name is AliasQualifiedNameSyntax aliasName
-                ? aliasName.Alias.Identifier.IsKind(SyntaxKind.GlobalKeyword)
-                : false;
+            return name is AliasQualifiedNameSyntax aliasName &&
+                aliasName.Alias.Identifier.IsKind(SyntaxKind.GlobalKeyword);
         }
 
         private static bool IsInScriptClass(SemanticModel model, NameSyntax name)

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -2282,7 +2282,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         private static bool IsNonReducableQualifiedNameInUsingDirective(SemanticModel model, NameSyntax name, TypeSyntax reducedName)
         {
             // Whereas most of the time we do not want to reduce namespace names, We will
-            // make and exceptions for namespaces with the global:: alias.
+            // make an exception for namespaces with the global:: alias.
             return IsQualifiedNameInUsingDirective(model, name, reducedName) &&
                 !IsGlobalAliasQualifiedName(name);
         }

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -2008,7 +2008,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
         // Note: The caller needs to verify that replacement doesn't change semantics of the original expression.
         private static bool TrySimplifyMemberAccessOrQualifiedName(
-        ExpressionSyntax left,
+            ExpressionSyntax left,
             ExpressionSyntax right,
             SemanticModel semanticModel,
             OptionSet optionSet,
@@ -2271,12 +2271,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 IsAmbiguousCast(name, reducedName) ||
                 IsNullableTypeInPointerExpression(name, reducedName) ||
                 name.IsNotNullableReplaceable(reducedName) ||
-                IsQualifiedNameInUsingDirective(semanticModel, name, reducedName))
+                IsNonReducableQualifiedNameInUsingDirective(semanticModel, name, reducedName))
             {
                 return false;
             }
 
             return true;
+        }
+
+        private static bool IsNonReducableQualifiedNameInUsingDirective(SemanticModel model, NameSyntax name, TypeSyntax reducedName)
+        {
+            // Whereas most of the time we do not want to reduce namespace names, We will
+            // make and exceptions for namespaces with the global:: alias.
+            return IsQualifiedNameInUsingDirective(model, name, reducedName) &&
+                !IsGlobalAliasQualifiedName(name);
         }
 
         private static bool IsQualifiedNameInUsingDirective(SemanticModel model, NameSyntax name, TypeSyntax reducedName)
@@ -2299,6 +2307,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             return false;
+        }
+
+        private static bool IsGlobalAliasQualifiedName(NameSyntax name)
+        {
+            // Checks whether the `global::` alias is applied to the name
+            return name is AliasQualifiedNameSyntax aliasName
+                ? aliasName.Alias.Identifier.IsKind(SyntaxKind.GlobalKeyword)
+                : false;
         }
 
         private static bool IsInScriptClass(SemanticModel model, NameSyntax name)


### PR DESCRIPTION
This PR is being created to simplify https://github.com/dotnet/roslyn/pull/30760

UsingDirectives that are expanded using `Simplifier.Expand` are given the `global::` alias which is not removed when calling `Simplifier.ReduceAsync`.