### PR TITLE
Ignore completion item span

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests_NoInteractive.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests_NoInteractive.cs
@@ -345,17 +345,17 @@ class C
 
                 var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
                 var service = CompletionService.GetService(document);
-                var completions = await service.GetCompletionsAndSetItemDocumentAsync(document, position);
+                var completions = await service.GetCompletionsAsync(document, position);
 
                 var item = completions.Items.First(i => i.DisplayText == "Beep");
                 var edit = testDocument.GetTextBuffer().CreateEdit();
                 edit.Delete(Span.FromBounds(position - 10, position));
                 edit.Apply();
 
-                document = workspace.CurrentSolution.GetDocument(testDocument.Id);
+                var currentDocument = workspace.CurrentSolution.GetDocument(testDocument.Id);
 
-                Assert.NotEqual(document, item.Document);
-                var description = service.GetDescriptionAsync(item.Document, item);
+                Assert.NotEqual(currentDocument, document);
+                var description = service.GetDescriptionAsync(document, item);
             }
         }
     }

--- a/src/EditorFeatures/Core.Wpf/Completion/Presentation/CompletionPresenterSession.cs
+++ b/src/EditorFeatures/Core.Wpf/Completion/Presentation/CompletionPresenterSession.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
 
     internal sealed class CompletionPresenterSession : ForegroundThreadAffinitizedObject, ICompletionPresenterSession
     {
+        public static readonly object DocumentKey = new object();
+
         internal static readonly object Key = new object();
 
         private readonly ICompletionBroker _completionBroker;
@@ -81,7 +83,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
             bool suggestionMode,
             bool isSoftSelected,
             ImmutableArray<CompletionItemFilter> completionItemFilters,
-            string filterText)
+            string filterText,
+            Document document)
         {
             AssertIsForeground();
 
@@ -132,6 +135,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
                 // so that we can call back into ourselves, get the items and add it to the
                 // session.
                 _editorSessionOpt.Properties.AddProperty(Key, this);
+                _editorSessionOpt.Properties.AddProperty(DocumentKey, document);
                 _editorSessionOpt.Start();
             }
 

--- a/src/EditorFeatures/Core.Wpf/Completion/Presentation/CompletionPresenterSession.cs
+++ b/src/EditorFeatures/Core.Wpf/Completion/Presentation/CompletionPresenterSession.cs
@@ -16,11 +16,14 @@ using RoslynCompletion = Microsoft.CodeAnalysis.Completion;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.Presentation
 {
-    using CompletionItem = Microsoft.CodeAnalysis.Completion.CompletionItem;
-
     internal sealed class CompletionPresenterSession : ForegroundThreadAffinitizedObject, ICompletionPresenterSession
     {
-        public static readonly object DocumentKey = new object();
+        /// <summary>
+        /// Used to allow us to stash away the original ITextSnapshot to an ICompletionSession
+        /// when we make it.  We can use this later to recover the original Document and provide
+        /// completion descriptions.
+        /// </summary>
+        public static readonly object TextSnapshotKey = new object();
 
         internal static readonly object Key = new object();
 
@@ -76,6 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
         }
 
         public void PresentItems(
+            ITextSnapshot textSnapshot,
             ITrackingSpan triggerSpan,
             IList<RoslynCompletion.CompletionItem> completionItems,
             RoslynCompletion.CompletionItem selectedItem,
@@ -83,8 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
             bool suggestionMode,
             bool isSoftSelected,
             ImmutableArray<CompletionItemFilter> completionItemFilters,
-            string filterText,
-            Document document)
+            string filterText)
         {
             AssertIsForeground();
 
@@ -135,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
                 // so that we can call back into ourselves, get the items and add it to the
                 // session.
                 _editorSessionOpt.Properties.AddProperty(Key, this);
-                _editorSessionOpt.Properties.AddProperty(DocumentKey, document);
+                _editorSessionOpt.Properties.AddProperty(TextSnapshotKey, textSnapshot);
                 _editorSessionOpt.Start();
             }
 

--- a/src/EditorFeatures/Core.Wpf/Completion/Presentation/CustomCommitCompletion.cs
+++ b/src/EditorFeatures/Core.Wpf/Completion/Presentation/CustomCommitCompletion.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Wpf;
 using Microsoft.CodeAnalysis.Tags;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Roslyn.Utilities;
@@ -58,17 +57,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
                 // to give them something non-empty so they know to go get the async description.
                 "...";
 
-        public Task<CompletionDescription> GetDescriptionAsync(CancellationToken cancellationToken)
+        public Task<CompletionDescription> GetDescriptionAsync(Document document, CancellationToken cancellationToken)
         {
-            var service = CompletionService.GetService(this.CompletionItem.Document);
+            var service = CompletionService.GetService(document);
             return service == null ?
                 Task.FromResult(CompletionDescription.Empty) :
-                service.GetDescriptionAsync(this.CompletionItem.Document, this.CompletionItem, cancellationToken);
-        }
-
-        public string GetDescription_TestingOnly()
-        {
-            return GetDescriptionAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None).Text;
+                service.GetDescriptionAsync(document, this.CompletionItem, cancellationToken);
         }
 
         public override ImageMoniker IconMoniker => _imageMoniker;

--- a/src/EditorFeatures/Core.Wpf/Completion/Presentation/ToolTipProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Completion/Presentation/ToolTipProvider.cs
@@ -50,7 +50,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
                 return null;
             }
 
-            return new CancellableContentControl(this, item);
+            var document = context.Properties.GetProperty<Document>(CompletionPresenterSession.DocumentKey);
+            if (document == null)
+            {
+                return null;
+            }
+
+            return new CancellableContentControl(this, item, document);
         }
 
         private class CancellableContentControl : ContentControl
@@ -58,7 +64,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
             private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
             private readonly ToolTipProvider _toolTipProvider;
 
-            public CancellableContentControl(ToolTipProvider toolTipProvider, CustomCommitCompletion item)
+            public CancellableContentControl(
+                ToolTipProvider toolTipProvider,
+                CustomCommitCompletion item,
+                Document document)
             {
                 Debug.Assert(toolTipProvider._threadingContext.JoinableTaskContext.IsOnMainThread);
                 _toolTipProvider = toolTipProvider;
@@ -69,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
                 // Kick off the task to produce the new content.  When it completes, call back on 
                 // the UI thread to update the display.
                 var scheduler = TaskScheduler.FromCurrentSynchronizationContext();
-                item.GetDescriptionAsync(_cancellationTokenSource.Token)
+                item.GetDescriptionAsync(document, _cancellationTokenSource.Token)
                               .ContinueWith(ProcessDescription, _cancellationTokenSource.Token,
                                             TaskContinuationOptions.OnlyOnRanToCompletion, scheduler);
 

--- a/src/EditorFeatures/Core.Wpf/Completion/Presentation/ToolTipProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Completion/Presentation/ToolTipProvider.cs
@@ -12,7 +12,9 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
 using VSCompletion = Microsoft.VisualStudio.Language.Intellisense.Completion;
@@ -50,7 +52,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
                 return null;
             }
 
-            var document = context.Properties.GetProperty<Document>(CompletionPresenterSession.DocumentKey);
+            var textSnapshot = context.Properties.GetProperty<ITextSnapshot>(CompletionPresenterSession.TextSnapshotKey);
+            var document = textSnapshot?.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
             {
                 return null;

--- a/src/EditorFeatures/Core/Extensibility/Completion/ICompletionPresenterSession.cs
+++ b/src/EditorFeatures/Core/Extensibility/Completion/ICompletionPresenterSession.cs
@@ -11,10 +11,10 @@ namespace Microsoft.CodeAnalysis.Editor
     internal interface ICompletionPresenterSession : IIntelliSensePresenterSession
     {
         void PresentItems(
-            ITrackingSpan triggerSpan, IList<CompletionItem> items, CompletionItem selectedItem,
+            ITextSnapshot textSnapshot, ITrackingSpan triggerSpan,
+            IList<CompletionItem> items, CompletionItem selectedItem,
             CompletionItem suggestionModeItem, bool suggestionMode, bool isSoftSelected,
-            ImmutableArray<CompletionItemFilter> completionItemFilters,
-            string filterText, Document document);
+            ImmutableArray<CompletionItemFilter> completionItemFilters, string filterText);
 
         void SelectPreviousItem();
         void SelectNextItem();

--- a/src/EditorFeatures/Core/Extensibility/Completion/ICompletionPresenterSession.cs
+++ b/src/EditorFeatures/Core/Extensibility/Completion/ICompletionPresenterSession.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor
             ITrackingSpan triggerSpan, IList<CompletionItem> items, CompletionItem selectedItem,
             CompletionItem suggestionModeItem, bool suggestionMode, bool isSoftSelected,
             ImmutableArray<CompletionItemFilter> completionItemFilters,
-            string filterText);
+            string filterText, Document document);
 
         void SelectPreviousItem();
         void SelectNextItem();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
     {
         internal const string RoslynItem = nameof(RoslynItem);
         internal const string TriggerSnapshot = nameof(TriggerSnapshot);
+        internal const string CompletionListSpan = nameof(CompletionListSpan);
         internal const string InsertionText = nameof(InsertionText);
         internal const string HasSuggestionItemOptions = nameof(HasSuggestionItemOptions);
         internal const string Description = nameof(Description);
@@ -224,6 +225,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             // Have to store the snapshot to reuse it in some projections related scenarios
             // where data and session in further calls are able to provide other snapshots.
             session.Properties.AddProperty(TriggerSnapshot, triggerLocation.Snapshot);
+
+            // Store around the span this completion list applies to.  We'll use this later
+            // to pass this value in when we're committing a completion list item.
+            session.Properties.AddProperty(CompletionListSpan, completionList.Span);
 
             // This is a code supporting original completion scenarios: 
             // Controller.Session_ComputeModel: if completionList.SuggestionModeItem != null, then suggestionMode = true

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_ComputeModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_ComputeModel.cs
@@ -103,8 +103,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
                         // TODO(cyrusn): We're calling into extensions, we need to make ourselves resilient
                         // to the extension crashing.
-                        var completionList = await _completionService.GetCompletionsAndSetItemDocumentAsync(
-                            _documentOpt, _subjectBufferCaretPosition, _trigger, _roles, _options, cancellationToken).ConfigureAwait(false);
+                        var completionList = _documentOpt == null
+                            ? null
+                            : await _completionService.GetCompletionsAsync(
+                                _documentOpt, _subjectBufferCaretPosition, _trigger, _roles, _options, cancellationToken).ConfigureAwait(false);
                         if (completionList == null)
                         {
                             Logger.Log(FunctionId.Completion_ModelComputer_DoInBackground,

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
@@ -147,11 +147,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             {
                 var selectedItem = modelOpt.SelectedItemOpt;
 
-                // set viewSpan = null if the selectedItem is not from the completion list
-                // All items from the completion list have .Document set to current document 
-                // in CompletionService.GetCompletionsAndSetItemDocumentAsync
+                // set viewSpan = null if the selectedItem is not from the completion list.
                 // https://github.com/dotnet/roslyn/issues/23891
-                var viewSpan = selectedItem == null || selectedItem.Document == null
+                var viewSpan = selectedItem == null || modelOpt.TriggerDocument == null
                     ? (ViewTextSpan?)null
                     : modelOpt.GetViewBufferSpan(selectedItem.Span);
 
@@ -163,7 +161,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 sessionOpt.PresenterSession.PresentItems(
                     triggerSpan, modelOpt.FilteredItems, selectedItem,
                     modelOpt.SuggestionModeItem, modelOpt.UseSuggestionMode,
-                    modelOpt.IsSoftSelection, modelOpt.CompletionItemFilters, modelOpt.FilterText);
+                    modelOpt.IsSoftSelection, modelOpt.CompletionItemFilters,
+                    modelOpt.FilterText, modelOpt.TriggerDocument);
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
@@ -159,10 +159,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                               .CreateTrackingSpan(SpanTrackingMode.EdgeInclusive);
 
                 sessionOpt.PresenterSession.PresentItems(
-                    triggerSpan, modelOpt.FilteredItems, selectedItem,
+                    modelOpt.TriggerSnapshot, triggerSpan, modelOpt.FilteredItems, selectedItem,
                     modelOpt.SuggestionModeItem, modelOpt.UseSuggestionMode,
                     modelOpt.IsSoftSelection, modelOpt.CompletionItemFilters,
-                    modelOpt.FilterText, modelOpt.TriggerDocument);
+                    modelOpt.FilterText);
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
@@ -161,8 +161,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 sessionOpt.PresenterSession.PresentItems(
                     modelOpt.TriggerSnapshot, triggerSpan, modelOpt.FilteredItems, selectedItem,
                     modelOpt.SuggestionModeItem, modelOpt.UseSuggestionMode,
-                    modelOpt.IsSoftSelection, modelOpt.CompletionItemFilters,
-                    modelOpt.FilterText);
+                    modelOpt.IsSoftSelection, modelOpt.CompletionItemFilters, modelOpt.FilterText);
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     Contract.ThrowIfNull(completionService, nameof(completionService));
 
                     completionChange = completionService.GetChangeAsync(
-                        triggerDocument, item, commitChar, CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+                        triggerDocument, item, model.OriginalList.Span, commitChar, CancellationToken.None).WaitAndGetResult(CancellationToken.None);
                     var textChange = completionChange.TextChange;
 
                     var triggerSnapshotSpan = new SnapshotSpan(triggerSnapshot, textChange.Span.ToSpan());

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestCompletionPresenterSession.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestCompletionPresenterSession.vb
@@ -27,15 +27,15 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Me._testState = testState
         End Sub
 
-        Public Sub PresentItems(triggerSpan As ITrackingSpan,
+        Public Sub PresentItems(textSnapshot As ITextSnapshot,
+                                triggerSpan As ITrackingSpan,
                                 completionItems As IList(Of CompletionItem),
                                 selectedItem As CompletionItem,
                                 suggestionModeItem As CompletionItem,
                                 suggestionMode As Boolean,
                                 isSoftSelected As Boolean,
                                 completionItemFilters As ImmutableArray(Of CompletionItemFilter),
-                                filterText As String,
-                                document As Document) Implements ICompletionPresenterSession.PresentItems
+                                filterText As String) Implements ICompletionPresenterSession.PresentItems
             _testState.CurrentCompletionPresenterSession = Me
             Me.TriggerSpan = triggerSpan
             Me.CompletionItems = completionItems

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestCompletionPresenterSession.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestCompletionPresenterSession.vb
@@ -34,7 +34,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                 suggestionMode As Boolean,
                                 isSoftSelected As Boolean,
                                 completionItemFilters As ImmutableArray(Of CompletionItemFilter),
-                                filterText As String) Implements ICompletionPresenterSession.PresentItems
+                                filterText As String,
+                                document As Document) Implements ICompletionPresenterSession.PresentItems
             _testState.CurrentCompletionPresenterSession = Me
             Me.TriggerSpan = triggerSpan
             Me.CompletionItems = completionItems

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -76,14 +76,6 @@ namespace Microsoft.CodeAnalysis.Completion
         /// </summary>
         public CompletionItemRules Rules { get; }
 
-        /// <summary>
-        /// The <see cref="Document"/> that this <see cref="CompletionItem"/> was
-        /// created for.  Not available to clients.  Only used by the Completion
-        /// subsystem itself for things like being able to go back to the originating
-        /// Document when doing things like getting descriptions.
-        /// </summary>
-        internal Document Document { get; set; }
-
         private CompletionItem(
             string displayText,
             string filterText,

--- a/src/Features/Core/Portable/Completion/CompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CompletionProvider.cs
@@ -57,6 +57,9 @@ namespace Microsoft.CodeAnalysis.Completion
             return Task.FromResult(CompletionChange.Create(new TextChange(item.Span, item.DisplayText)));
         }
 
+        internal virtual Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, TextSpan completionListSpan, char? commitKey, CancellationToken cancellationToken)
+            => GetChangeAsync(document, item, commitKey, cancellationToken);
+
         /// <summary>
         /// True if the provider produces snippet items.
         /// </summary>

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -177,32 +177,5 @@ namespace Microsoft.CodeAnalysis.Completion
 
             return bestItems.ToImmutableAndFree();
         }
-
-        internal async Task<CompletionList> GetCompletionsAndSetItemDocumentAsync(
-            Document documentOpt, int caretPosition, CompletionTrigger trigger = default,
-            ImmutableHashSet<string> roles = null, OptionSet options = null, CancellationToken cancellationToken = default)
-        {
-            if (documentOpt == null)
-            {
-                return null;
-            }
-
-            var completions = await this.GetCompletionsAsync(
-                documentOpt, caretPosition, trigger, roles, options, cancellationToken).ConfigureAwait(false);
-            if (completions != null)
-            {
-                foreach (var item in completions.Items)
-                {
-                    item.Document = documentOpt;
-                }
-
-                if (completions.SuggestionModeItem != null)
-                {
-                    completions.SuggestionModeItem.Document = documentOpt;
-                }
-            }
-
-            return completions;
-        }
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -124,6 +124,13 @@ namespace Microsoft.CodeAnalysis.Completion
             return Task.FromResult(CompletionChange.Create(new TextChange(item.Span, item.DisplayText)));
         }
 
+        internal virtual Task<CompletionChange> GetChangeAsync(
+            Document document, CompletionItem item, TextSpan completionListSpan,
+            char? commitCharacter = null, CancellationToken cancellationToken = default)
+        {
+            return GetChangeAsync(document, item, commitCharacter, cancellationToken);
+        }
+
         /// <summary>
         /// Given a list of completion items that match the current code typed by the user,
         /// returns the item that is considered the best match, and whether or not that

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -124,6 +124,14 @@ namespace Microsoft.CodeAnalysis.Completion
             return Task.FromResult(CompletionChange.Create(new TextChange(item.Span, item.DisplayText)));
         }
 
+        /// <summary>
+        /// Preferred overload of <see cref="GetChangeAsync(Document, CompletionItem, char?,
+        /// CancellationToken)"/>.
+        ///
+        /// This overload is passed the value of <see cref="CompletionContext.CompletionListSpan"/>
+        /// which should be used to determine what span should be updated in the original <paramref
+        /// name="document"/> passed in.
+        /// </summary>
         internal virtual Task<CompletionChange> GetChangeAsync(
             Document document, CompletionItem item, TextSpan completionListSpan,
             char? commitCharacter = null, CancellationToken cancellationToken = default)

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -487,6 +487,16 @@ namespace Microsoft.CodeAnalysis.Completion
             }
         }
 
+        internal override async Task<CompletionChange> GetChangeAsync(
+            Document document, CompletionItem item, TextSpan completionListSpan,
+            char? commitKey, CancellationToken cancellationToken)
+        {
+            var provider = GetProvider(item);
+            return provider != null
+                ? await provider.GetChangeAsync(document, item, completionListSpan, commitKey, cancellationToken).ConfigureAwait(false)
+                : CompletionChange.Create(new TextChange(completionListSpan, item.DisplayText));
+        }
+
         bool IEqualityComparer<ImmutableHashSet<string>>.Equals(ImmutableHashSet<string> x, ImmutableHashSet<string> y)
         {
             if (x == y)


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/34952

This is currently mutable, which makes sharing completion items hard.  Now, instead, we just track the completion span we are told on the completion context and pass that along at the end when making changes. That helps ensure completion items can be safely shared across invocations.