### PR TITLE
Fix bootstrap on Linux/Mac

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -121,6 +121,8 @@ while [[ $# > 0 ]]; do
       ;;
     --bootstrap)
       bootstrap=true
+      # Bootstrap requires restore
+      restore=true
       ;;
     --skipanalyzers)
       skip_analyzers=true
@@ -226,11 +228,6 @@ function BuildSolution {
     disable_parallel_restore=true
   fi
 
-  local quiet_restore=""
-  if [[ "$ci" != true ]]; then
-    quiet_restore=true
-  fi
-
   local test=false
   local test_runtime=""
   local mono_tool=""
@@ -271,8 +268,6 @@ function BuildSolution {
     /p:UseRoslynAnalyzers=$enable_analyzers \
     /p:BootstrapBuildPath="$bootstrap_dir" \
     /p:ContinuousIntegrationBuild=$ci \
-    /p:QuietRestore=$quiet_restore \
-    /p:QuietRestoreBinaryLog="$binary_log" \
     /p:TreatWarningsAsErrors=true \
     /p:RestoreDisableParallel=$disable_parallel_restore \
     $test_runtime \


### PR DESCRIPTION
There are two problems here: in order for the bootstrap to change from the toolset compiler to the bootstrap compiler we need to re-run restore, which doesn't happen by default, and the 'quiet restore' function seems to cause node reuse so the MSBuild task doesn't get reloaded. Apparently NuGet has decreased noisiness of restore anyway, so it's not useful anymore.