### PR TITLE
Bugfix fix: "Replace method with property" removes a space

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -163,6 +163,29 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestMethodWithTrailingTrivia()
+        {
+            await TestWithAllCodeStyleOff(
+@"class C
+{
+    int [||]GetP();
+    bool M()
+    {
+        return GetP() == 0;
+    }
+}",
+@"class C
+{
+    int P { get; }
+
+    bool M()
+    {
+        return P == 0;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
         public async Task TestIndentation()
         {
             await TestWithAllCodeStyleOff(

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -186,6 +186,38 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestDelegateWithTrailingTrivia()
+        {
+            await TestWithAllCodeStyleOff(
+@"delegate int Mdelegate();
+class C
+{
+    int [||]GetP() => 0;
+
+    void M()
+    {
+        Mdelegate del = new Mdelegate(GetP );
+    }
+}",
+@"delegate int Mdelegate();
+class C
+{
+    int P
+    {
+        get
+        {
+            return 0;
+        }
+    }
+
+    void M()
+    {
+        Mdelegate del = new Mdelegate({|Conflict:P|} );
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
         public async Task TestIndentation()
         {
             await TestWithAllCodeStyleOff(

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -376,11 +376,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
                 return;
             }
 
+            var invocation = nameNode?.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+
             var newName = nameChanged
-                ? SyntaxFactory.IdentifierName(SyntaxFactory.Identifier(propertyName).WithTriviaFrom(nameToken))
+                ? SyntaxFactory.IdentifierName(SyntaxFactory.Identifier(propertyName).WithLeadingTrivia(nameToken.LeadingTrivia).WithTrailingTrivia(invocation?.ArgumentList?.CloseParenToken.TrailingTrivia))
                 : nameNode;
 
-            var invocation = nameNode?.FirstAncestorOrSelf<InvocationExpressionSyntax>();
             var invocationExpression = invocation?.Expression;
             if (!IsInvocationName(nameNode, invocationExpression))
             {

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -378,9 +378,21 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
 
             var invocation = nameNode?.FirstAncestorOrSelf<InvocationExpressionSyntax>();
 
-            var newName = nameChanged
-                ? SyntaxFactory.IdentifierName(SyntaxFactory.Identifier(propertyName).WithLeadingTrivia(nameToken.LeadingTrivia).WithTrailingTrivia(invocation?.ArgumentList?.CloseParenToken.TrailingTrivia))
-                : nameNode;
+            var newName = nameNode;
+            if (nameChanged)
+            {
+                if (invocation == null)
+                {
+                    newName = SyntaxFactory.IdentifierName(SyntaxFactory.Identifier(propertyName)
+                        .WithTriviaFrom(nameToken));
+                }
+                else
+                {
+                    newName = SyntaxFactory.IdentifierName(SyntaxFactory.Identifier(propertyName)
+                        .WithLeadingTrivia(nameToken.LeadingTrivia)
+                        .WithTrailingTrivia(invocation.ArgumentList?.CloseParenToken.TrailingTrivia));
+                }
+            }
 
             var invocationExpression = invocation?.Expression;
             if (!IsInvocationName(nameNode, invocationExpression))

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
                 {
                     newName = SyntaxFactory.IdentifierName(SyntaxFactory.Identifier(propertyName)
                         .WithLeadingTrivia(nameToken.LeadingTrivia)
-                        .WithTrailingTrivia(invocation.ArgumentList?.CloseParenToken.TrailingTrivia));
+                        .WithTrailingTrivia(invocation.ArgumentList.CloseParenToken.TrailingTrivia));
                 }
             }
 


### PR DESCRIPTION
Git Issue: https://github.com/dotnet/roslyn/issues/31830

Issue: Trivia after the bracket was not being considered as part of the rewrite.

Solution: Updated code to consider trivia after the bracket to be the trailing trivia.

Testing:
- Tested with different trivia: spaces, tabs, comments.
- Added new unit test
- Ran all relevant unit tests