### PR TITLE
Fix Value/Ref checks for pattern Index/Range

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -313,6 +313,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.IndexerAccess:
                     return CheckPropertyValueKind(node, expr, valueKind, checkingReceiver, diagnostics);
 
+                case BoundKind.IndexOrRangePatternIndexerAccess:
+                    if (((BoundIndexOrRangePatternIndexerAccess)expr).PatternSymbol.Kind == SymbolKind.Property)
+                    {
+                        // If this is an Index indexer PatternSymbol should be a property, pointing to the
+                        // pattern indexer. If it's a Range access, it will be a method, pointing to a Slice method
+                        return CheckPropertyValueKind(node, expr, valueKind, checkingReceiver, diagnostics);
+                    }
+                    break;
+
                 case BoundKind.EventAccess:
                     return CheckEventValueKind((BoundEventAccess)expr, valueKind, diagnostics);
             }
@@ -472,6 +481,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.Call:
                     var call = (BoundCall)expr;
                     return CheckCallValueKind(call, node, valueKind, checkingReceiver, diagnostics);
+
+                case BoundKind.IndexOrRangePatternIndexerAccess:
+                    var patternIndexer = (BoundIndexOrRangePatternIndexerAccess)expr;
+                    // Index access should have been handled with properties, above
+                    return CheckMethodReturnValueKind(
+                        (MethodSymbol)patternIndexer.PatternSymbol,
+                        patternIndexer.Syntax,
+                        node,
+                        valueKind,
+                        checkingReceiver,
+                        diagnostics);
 
                 case BoundKind.ConditionalOperator:
                     var conditional = (BoundConditionalOperator)expr;
@@ -2139,6 +2159,44 @@ moreArguments:
                         diagnostics,
                         isRefEscape: true);
 
+                case BoundKind.IndexOrRangePatternIndexerAccess:
+                    var patternIndexer = (BoundIndexOrRangePatternIndexerAccess)expr;
+                    RefKind refKind;
+                    ImmutableArray<ParameterSymbol> parameters;
+
+                    switch (patternIndexer.PatternSymbol)
+                    {
+                        case PropertySymbol p:
+                            refKind = p.RefKind;
+                            parameters = p.Parameters;
+                            break;
+                        case MethodSymbol m:
+                            refKind = m.RefKind;
+                            parameters = m.Parameters;
+                            break;
+                        default:
+                            throw ExceptionUtilities.Unreachable;
+                    }
+
+                    if (refKind == RefKind.None)
+                    {
+                        break;
+                    }
+
+                    return CheckInvocationEscape(
+                        patternIndexer.Syntax,
+                        patternIndexer.PatternSymbol,
+                        patternIndexer.Receiver,
+                        parameters,
+                        ImmutableArray.Create<BoundExpression>(patternIndexer.Argument),
+                        default,
+                        default,
+                        checkingReceiver,
+                        escapeFrom,
+                        escapeTo,
+                        diagnostics,
+                        isRefEscape: true);
+
                 case BoundKind.PropertyAccess:
                     var propertyAccess = (BoundPropertyAccess)expr;
                     var propertySymbol = propertyAccess.PropertySymbol;
@@ -2330,6 +2388,22 @@ moreArguments:
                         indexerAccess.Arguments,
                         indexerAccess.ArgumentRefKindsOpt,
                         indexerAccess.ArgsToParamsOpt,
+                        scopeOfTheContainingExpression,
+                        isRefEscape: false);
+
+                case BoundKind.IndexOrRangePatternIndexerAccess:
+                    var patternIndexer = (BoundIndexOrRangePatternIndexerAccess)expr;
+                    var parameters = patternIndexer.PatternSymbol is PropertySymbol p
+                        ? p.Parameters
+                        : ((MethodSymbol)patternIndexer.PatternSymbol).Parameters;
+
+                    return GetInvocationEscapeScope(
+                        patternIndexer.PatternSymbol,
+                        patternIndexer.Receiver,
+                        parameters,
+                        default,
+                        default,
+                        default,
                         scopeOfTheContainingExpression,
                         isRefEscape: false);
 
@@ -2648,6 +2722,30 @@ moreArguments:
                         indexerAccess.Arguments,
                         indexerAccess.ArgumentRefKindsOpt,
                         indexerAccess.ArgsToParamsOpt,
+                        checkingReceiver,
+                        escapeFrom,
+                        escapeTo,
+                        diagnostics,
+                        isRefEscape: false);
+
+                case BoundKind.IndexOrRangePatternIndexerAccess:
+                    var patternIndexer = (BoundIndexOrRangePatternIndexerAccess)expr;
+                    var patternSymbol = patternIndexer.PatternSymbol;
+                    var parameters = patternSymbol switch
+                    {
+                        PropertySymbol p => p.Parameters,
+                        MethodSymbol m => m.Parameters,
+                        _ => throw ExceptionUtilities.Unreachable,
+                    };
+
+                    return CheckInvocationEscape(
+                        patternIndexer.Syntax,
+                        patternSymbol,
+                        patternIndexer.Receiver,
+                        parameters,
+                        ImmutableArray.Create(patternIndexer.Argument),
+                        default,
+                        default,
                         checkingReceiver,
                         escapeFrom,
                         escapeTo,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7538,9 +7538,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (!candidate.IsStatic &&
                             candidate is PropertySymbol property &&
-                            property.GetOwnOrInheritedGetMethod() is MethodSymbol getMethod &&
-                            IsAccessible(getMethod, ref useSiteDiagnostics) &&
-                            getMethod.OriginalDefinition is var original &&
+                            IsAccessible(property, ref useSiteDiagnostics) &&
+                            property.OriginalDefinition is var original &&
                             original.ParameterCount == 1 &&
                             isIntNotByRef(original.Parameters[0]))
                         {
@@ -7548,9 +7547,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 syntax,
                                 receiverOpt,
                                 lengthOrCountProperty,
-                                getMethod,
+                                property,
                                 arguments[0],
-                                getMethod.ReturnType);
+                                property.Type);
                             cleanup(lookupResult, ref useSiteDiagnostics);
                             return true;
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7539,8 +7539,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (!candidate.IsStatic &&
                             candidate is PropertySymbol property &&
                             IsAccessible(property, ref useSiteDiagnostics) &&
-                            property.OriginalDefinition is var original &&
-                            original.ParameterCount == 1 &&
+                            property.OriginalDefinition is { ParameterCount: 1 } original &&
                             isIntNotByRef(original.Parameters[0]))
                         {
                             patternIndexerAccess = new BoundIndexOrRangePatternIndexerAccess(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1472,6 +1472,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         propertySymbol = indexerAccess.Indexer;
                     }
                     break;
+                case BoundKind.IndexOrRangePatternIndexerAccess:
+                    {
+                        var patternIndexer = (BoundIndexOrRangePatternIndexerAccess)expr;
+                        receiver = patternIndexer.Receiver;
+                        propertySymbol = (PropertySymbol)patternIndexer.PatternSymbol;
+                    }
+                    break;
                 default:
                     receiver = null;
                     propertySymbol = null;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1749,7 +1749,7 @@
 
     <Field Name="Receiver" Type="BoundExpression" Null="disallow" />
     <Field Name="LengthOrCountProperty" Type="PropertySymbol" Null="disallow" />
-    <Field Name="PatternMethod" Type="MethodSymbol" Null="disallow" />
+    <Field Name="PatternSymbol" Type="Symbol" Null="disallow" />
     <Field Name="Argument" Type="BoundExpression" Null="disallow" />
   </Node>
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1203,7 +1203,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 PropertySymbol p => GetReadMethod(p),
                 MethodSymbol m => m,
-                _ => throw ExceptionUtilities.Unreachable
+                _ => throw ExceptionUtilities.UnexpectedValue(node.PatternSymbol)
             };
             VisitReceiverAfterCall(node.Receiver, method);
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1199,7 +1199,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             var method = GetReadMethod(node.LengthOrCountProperty);
             VisitReceiverAfterCall(node.Receiver, method);
             VisitRvalue(node.Argument);
-            VisitReceiverAfterCall(node.Receiver, node.PatternMethod);
+            method = node.PatternSymbol switch
+            {
+                PropertySymbol p => GetReadMethod(p),
+                MethodSymbol m => m,
+                _ => throw ExceptionUtilities.Unreachable
+            };
+            VisitReceiverAfterCall(node.Receiver, method);
 
             return null;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4951,12 +4951,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 patternSymbol = AsMemberOfType(receiverType.Type, patternSymbol);
             }
 
-            LvalueResultType = patternSymbol switch
-            {
-                PropertySymbol p => p.TypeWithAnnotations,
-                MethodSymbol m => m.ReturnTypeWithAnnotations,
-                _ => throw ExceptionUtilities.Unreachable,
-            };
+            LvalueResultType = patternSymbol.GetTypeOrReturnType();
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4945,13 +4945,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var receiverType = VisitRvalueWithState(node.Receiver);
             VisitRvalue(node.Argument);
-            var patternMethod = node.PatternMethod;
+            var patternSymbol = node.PatternSymbol;
             if (!receiverType.HasNullType)
             {
-                patternMethod = (MethodSymbol)AsMemberOfType(receiverType.Type, patternMethod);
+                patternSymbol = AsMemberOfType(receiverType.Type, patternSymbol);
             }
 
-            LvalueResultType = patternMethod.ReturnTypeWithAnnotations;
+            LvalueResultType = patternSymbol switch
+            {
+                PropertySymbol p => p.TypeWithAnnotations,
+                MethodSymbol m => m.ReturnTypeWithAnnotations,
+                _ => throw ExceptionUtilities.Unreachable,
+            };
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -6676,19 +6676,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundIndexOrRangePatternIndexerAccess : BoundExpression
     {
-        public BoundIndexOrRangePatternIndexerAccess(SyntaxNode syntax, BoundExpression receiver, PropertySymbol lengthOrCountProperty, MethodSymbol patternMethod, BoundExpression argument, TypeSymbol type, bool hasErrors = false)
+        public BoundIndexOrRangePatternIndexerAccess(SyntaxNode syntax, BoundExpression receiver, PropertySymbol lengthOrCountProperty, Symbol patternSymbol, BoundExpression argument, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.IndexOrRangePatternIndexerAccess, syntax, type, hasErrors || receiver.HasErrors() || argument.HasErrors())
         {
 
             Debug.Assert((object)receiver != null, "Field 'receiver' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert((object)lengthOrCountProperty != null, "Field 'lengthOrCountProperty' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
-            Debug.Assert((object)patternMethod != null, "Field 'patternMethod' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert((object)patternSymbol != null, "Field 'patternSymbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert((object)argument != null, "Field 'argument' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert((object)type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
             this.Receiver = receiver;
             this.LengthOrCountProperty = lengthOrCountProperty;
-            this.PatternMethod = patternMethod;
+            this.PatternSymbol = patternSymbol;
             this.Argument = argument;
         }
 
@@ -6697,16 +6697,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public PropertySymbol LengthOrCountProperty { get; }
 
-        public MethodSymbol PatternMethod { get; }
+        public Symbol PatternSymbol { get; }
 
         public BoundExpression Argument { get; }
         public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitIndexOrRangePatternIndexerAccess(this);
 
-        public BoundIndexOrRangePatternIndexerAccess Update(BoundExpression receiver, PropertySymbol lengthOrCountProperty, MethodSymbol patternMethod, BoundExpression argument, TypeSymbol type)
+        public BoundIndexOrRangePatternIndexerAccess Update(BoundExpression receiver, PropertySymbol lengthOrCountProperty, Symbol patternSymbol, BoundExpression argument, TypeSymbol type)
         {
-            if (receiver != this.Receiver || lengthOrCountProperty != this.LengthOrCountProperty || patternMethod != this.PatternMethod || argument != this.Argument || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (receiver != this.Receiver || lengthOrCountProperty != this.LengthOrCountProperty || patternSymbol != this.PatternSymbol || argument != this.Argument || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundIndexOrRangePatternIndexerAccess(this.Syntax, receiver, lengthOrCountProperty, patternMethod, argument, type, this.HasErrors);
+                var result = new BoundIndexOrRangePatternIndexerAccess(this.Syntax, receiver, lengthOrCountProperty, patternSymbol, argument, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -6715,7 +6715,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override BoundExpression ShallowClone()
         {
-            var result = new BoundIndexOrRangePatternIndexerAccess(this.Syntax, this.Receiver, this.LengthOrCountProperty, this.PatternMethod, this.Argument, this.Type, this.HasErrors);
+            var result = new BoundIndexOrRangePatternIndexerAccess(this.Syntax, this.Receiver, this.LengthOrCountProperty, this.PatternSymbol, this.Argument, this.Type, this.HasErrors);
             result.CopyAttributes(this);
             return result;
         }
@@ -10085,7 +10085,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(receiver, node.LengthOrCountProperty, node.PatternMethod, argument, type);
+            return node.Update(receiver, node.LengthOrCountProperty, node.PatternSymbol, argument, type);
         }
         public override BoundNode VisitDynamicIndexerAccess(BoundDynamicIndexerAccess node)
         {
@@ -11517,7 +11517,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             new TreeDumperNode("receiver", null, new TreeDumperNode[] { Visit(node.Receiver, null) }),
             new TreeDumperNode("lengthOrCountProperty", node.LengthOrCountProperty, null),
-            new TreeDumperNode("patternMethod", node.PatternMethod, null),
+            new TreeDumperNode("patternSymbol", node.PatternSymbol, null),
             new TreeDumperNode("argument", null, new TreeDumperNode[] { Visit(node.Argument, null) }),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -797,6 +797,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.IndexerAccess:
                     return ((BoundIndexerAccess)expr).Indexer.RefKind != RefKind.None;
+
+                case BoundKind.IndexOrRangePatternIndexerAccess:
+                    var patternIndexer = (BoundIndexOrRangePatternIndexerAccess)expr;
+                    var refKind = patternIndexer.PatternSymbol is PropertySymbol p
+                        ? p.RefKind
+                        : ((MethodSymbol)patternIndexer.PatternSymbol).RefKind;
+                    return refKind != RefKind.None;
             }
 
             return false;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -800,9 +800,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.IndexOrRangePatternIndexerAccess:
                     var patternIndexer = (BoundIndexOrRangePatternIndexerAccess)expr;
-                    var refKind = patternIndexer.PatternSymbol is PropertySymbol p
-                        ? p.RefKind
-                        : ((MethodSymbol)patternIndexer.PatternSymbol).RefKind;
+                    var refKind = patternIndexer.PatternSymbol switch
+                    {
+                        PropertySymbol p => p.RefKind,
+                        MethodSymbol m => m.RefKind,
+                        _ => throw ExceptionUtilities.UnexpectedValue(patternIndexer.PatternSymbol)
+                    };
                     return refKind != RefKind.None;
             }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -17,6 +17,36 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         }
 
         [Fact]
+        public void SpanTaskReturn()
+        {
+            var src = @"
+using System;
+using System.Threading.Tasks;
+class C
+{
+    static void Throws(Action a)
+    {
+        try
+        {
+            a();
+        }
+        catch
+        {
+            Console.WriteLine(""throws"");
+        }
+    }
+
+    public static void Main()
+    {
+        string s = ""abcd"";
+        Throws(() => { var span = new Span<char>(s.ToCharArray())[0..10]; });
+    }
+}";
+            var comp = CreateCompilationWithIndexAndRangeAndSpan(src, TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: "throws");
+        }
+
+        [Fact]
         public void PatternIndexSetter()
         {
             var src = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -17,6 +17,444 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         }
 
         [Fact]
+        public void PatternIndexSetter()
+        {
+            var src = @"
+using System;
+struct S
+{
+    public int F;
+    public int Length => 1;
+    public int this[int i]
+    {
+        get => F;
+        set { F = value; }
+    }
+}
+class C
+{
+    static void Main()
+    {
+        S s = new S();
+        s.F = 0;
+        Console.WriteLine(s[^1]);
+        s[^1] = 2;
+        Console.WriteLine(s[^1]);
+        Console.WriteLine(s.F);
+    }
+}";
+            var comp = CreateCompilationWithIndexAndRange(src, TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"0
+2
+2");
+            verifier.VerifyIL("C.Main", @"
+{
+  // Code size      135 (0x87)
+  .maxstack  3
+  .locals init (S V_0, //s
+                int V_1,
+                int V_2,
+                System.Index V_3)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  ldc.i4.0
+  IL_000b:  stfld      ""int S.F""
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  dup
+  IL_0013:  call       ""int S.Length.get""
+  IL_0018:  stloc.1
+  IL_0019:  ldc.i4.1
+  IL_001a:  ldc.i4.1
+  IL_001b:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0020:  stloc.3
+  IL_0021:  ldloca.s   V_3
+  IL_0023:  ldloc.1
+  IL_0024:  call       ""int System.Index.GetOffset(int)""
+  IL_0029:  stloc.2
+  IL_002a:  ldloc.2
+  IL_002b:  call       ""int S.this[int].get""
+  IL_0030:  call       ""void System.Console.WriteLine(int)""
+  IL_0035:  ldloca.s   V_0
+  IL_0037:  dup
+  IL_0038:  call       ""int S.Length.get""
+  IL_003d:  stloc.2
+  IL_003e:  ldc.i4.1
+  IL_003f:  ldc.i4.1
+  IL_0040:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0045:  stloc.3
+  IL_0046:  ldloca.s   V_3
+  IL_0048:  ldloc.2
+  IL_0049:  call       ""int System.Index.GetOffset(int)""
+  IL_004e:  stloc.1
+  IL_004f:  ldloc.1
+  IL_0050:  ldc.i4.2
+  IL_0051:  call       ""void S.this[int].set""
+  IL_0056:  ldloca.s   V_0
+  IL_0058:  dup
+  IL_0059:  call       ""int S.Length.get""
+  IL_005e:  stloc.1
+  IL_005f:  ldc.i4.1
+  IL_0060:  ldc.i4.1
+  IL_0061:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0066:  stloc.3
+  IL_0067:  ldloca.s   V_3
+  IL_0069:  ldloc.1
+  IL_006a:  call       ""int System.Index.GetOffset(int)""
+  IL_006f:  stloc.2
+  IL_0070:  ldloc.2
+  IL_0071:  call       ""int S.this[int].get""
+  IL_0076:  call       ""void System.Console.WriteLine(int)""
+  IL_007b:  ldloc.0
+  IL_007c:  ldfld      ""int S.F""
+  IL_0081:  call       ""void System.Console.WriteLine(int)""
+  IL_0086:  ret
+}");
+        }
+
+        [Fact]
+        public void PatternIndexerRefReturn()
+        {
+            var comp = CreateCompilationWithIndexAndRangeAndSpan(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        Span<int> s = new int[] { 2, 4, 5, 6 };
+        Console.WriteLine(s[^2]);
+        ref int x = ref s[^2];
+        Console.WriteLine(x);
+        s[^2] = 9;
+        Console.WriteLine(s[^2]);
+        Console.WriteLine(x);
+    }
+}", TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"5
+5
+9
+9");
+            verifier.VerifyIL("C.Main", @"
+{
+  // Code size      188 (0xbc)
+  .maxstack  4
+  .locals init (System.Span<int> V_0, //s
+                int V_1,
+                int V_2,
+                System.Index V_3,
+                int V_4,
+                int V_5)
+  IL_0000:  ldc.i4.4
+  IL_0001:  newarr     ""int""
+  IL_0006:  dup
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.D033850C1A3F6F1209A6CD84146E8561DDC73C79""
+  IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0011:  call       ""System.Span<int> System.Span<int>.op_Implicit(int[])""
+  IL_0016:  stloc.0
+  IL_0017:  ldloca.s   V_0
+  IL_0019:  dup
+  IL_001a:  call       ""int System.Span<int>.Length.get""
+  IL_001f:  stloc.1
+  IL_0020:  ldc.i4.2
+  IL_0021:  ldc.i4.1
+  IL_0022:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0027:  stloc.3
+  IL_0028:  ldloca.s   V_3
+  IL_002a:  ldloc.1
+  IL_002b:  call       ""int System.Index.GetOffset(int)""
+  IL_0030:  stloc.2
+  IL_0031:  ldloc.2
+  IL_0032:  call       ""ref int System.Span<int>.this[int].get""
+  IL_0037:  ldind.i4
+  IL_0038:  call       ""void System.Console.WriteLine(int)""
+  IL_003d:  ldloca.s   V_0
+  IL_003f:  dup
+  IL_0040:  call       ""int System.Span<int>.Length.get""
+  IL_0045:  stloc.2
+  IL_0046:  ldc.i4.2
+  IL_0047:  ldc.i4.1
+  IL_0048:  newobj     ""System.Index..ctor(int, bool)""
+  IL_004d:  stloc.3
+  IL_004e:  ldloca.s   V_3
+  IL_0050:  ldloc.2
+  IL_0051:  call       ""int System.Index.GetOffset(int)""
+  IL_0056:  stloc.1
+  IL_0057:  ldloc.1
+  IL_0058:  call       ""ref int System.Span<int>.this[int].get""
+  IL_005d:  dup
+  IL_005e:  ldind.i4
+  IL_005f:  call       ""void System.Console.WriteLine(int)""
+  IL_0064:  ldloca.s   V_0
+  IL_0066:  dup
+  IL_0067:  call       ""int System.Span<int>.Length.get""
+  IL_006c:  stloc.s    V_4
+  IL_006e:  ldc.i4.2
+  IL_006f:  ldc.i4.1
+  IL_0070:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0075:  stloc.3
+  IL_0076:  ldloca.s   V_3
+  IL_0078:  ldloc.s    V_4
+  IL_007a:  call       ""int System.Index.GetOffset(int)""
+  IL_007f:  stloc.s    V_5
+  IL_0081:  ldloc.s    V_5
+  IL_0083:  call       ""ref int System.Span<int>.this[int].get""
+  IL_0088:  ldc.i4.s   9
+  IL_008a:  stind.i4
+  IL_008b:  ldloca.s   V_0
+  IL_008d:  dup
+  IL_008e:  call       ""int System.Span<int>.Length.get""
+  IL_0093:  stloc.s    V_5
+  IL_0095:  ldc.i4.2
+  IL_0096:  ldc.i4.1
+  IL_0097:  newobj     ""System.Index..ctor(int, bool)""
+  IL_009c:  stloc.3
+  IL_009d:  ldloca.s   V_3
+  IL_009f:  ldloc.s    V_5
+  IL_00a1:  call       ""int System.Index.GetOffset(int)""
+  IL_00a6:  stloc.s    V_4
+  IL_00a8:  ldloc.s    V_4
+  IL_00aa:  call       ""ref int System.Span<int>.this[int].get""
+  IL_00af:  ldind.i4
+  IL_00b0:  call       ""void System.Console.WriteLine(int)""
+  IL_00b5:  ldind.i4
+  IL_00b6:  call       ""void System.Console.WriteLine(int)""
+  IL_00bb:  ret
+}");
+        }
+
+        [Fact]
+        public void PatternIndexAndRangeSpanChar()
+        {
+            var comp = CreateCompilationWithIndexAndRangeAndSpan(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        ReadOnlySpan<char> s = ""abcdefg"";
+        Console.WriteLine(s[^2]);
+        var index = ^1;
+        Console.WriteLine(s[index]);
+        s = s[^2..];
+        Console.WriteLine(s[0]);
+        Console.WriteLine(s[1]);
+    }
+}", TestOptions.ReleaseExe); ;
+            var verifier = CompileAndVerify(comp, expectedOutput: @"f
+g
+f
+g");
+            verifier.VerifyIL(@"C.Main", @"
+{
+  // Code size      193 (0xc1)
+  .maxstack  4
+  .locals init (System.ReadOnlySpan<char> V_0, //s
+                System.Index V_1, //index
+                int V_2,
+                int V_3,
+                System.Index V_4,
+                System.ReadOnlySpan<char> V_5,
+                System.Range V_6,
+                int V_7)
+  IL_0000:  ldstr      ""abcdefg""
+  IL_0005:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(string)""
+  IL_000a:  stloc.0
+  IL_000b:  ldloca.s   V_0
+  IL_000d:  dup
+  IL_000e:  call       ""int System.ReadOnlySpan<char>.Length.get""
+  IL_0013:  stloc.2
+  IL_0014:  ldc.i4.2
+  IL_0015:  ldc.i4.1
+  IL_0016:  newobj     ""System.Index..ctor(int, bool)""
+  IL_001b:  stloc.s    V_4
+  IL_001d:  ldloca.s   V_4
+  IL_001f:  ldloc.2
+  IL_0020:  call       ""int System.Index.GetOffset(int)""
+  IL_0025:  stloc.3
+  IL_0026:  ldloc.3
+  IL_0027:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+  IL_002c:  ldind.u2
+  IL_002d:  call       ""void System.Console.WriteLine(char)""
+  IL_0032:  ldloca.s   V_1
+  IL_0034:  ldc.i4.1
+  IL_0035:  ldc.i4.1
+  IL_0036:  call       ""System.Index..ctor(int, bool)""
+  IL_003b:  ldloca.s   V_0
+  IL_003d:  dup
+  IL_003e:  call       ""int System.ReadOnlySpan<char>.Length.get""
+  IL_0043:  stloc.3
+  IL_0044:  ldloca.s   V_1
+  IL_0046:  ldloc.3
+  IL_0047:  call       ""int System.Index.GetOffset(int)""
+  IL_004c:  stloc.2
+  IL_004d:  ldloc.2
+  IL_004e:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+  IL_0053:  ldind.u2
+  IL_0054:  call       ""void System.Console.WriteLine(char)""
+  IL_0059:  ldloc.0
+  IL_005a:  stloc.s    V_5
+  IL_005c:  ldloca.s   V_5
+  IL_005e:  call       ""int System.ReadOnlySpan<char>.Length.get""
+  IL_0063:  stloc.2
+  IL_0064:  ldc.i4.2
+  IL_0065:  ldc.i4.1
+  IL_0066:  newobj     ""System.Index..ctor(int, bool)""
+  IL_006b:  call       ""System.Range System.Range.StartAt(System.Index)""
+  IL_0070:  stloc.s    V_6
+  IL_0072:  ldloca.s   V_6
+  IL_0074:  call       ""System.Index System.Range.Start.get""
+  IL_0079:  stloc.s    V_4
+  IL_007b:  ldloca.s   V_4
+  IL_007d:  ldloc.2
+  IL_007e:  call       ""int System.Index.GetOffset(int)""
+  IL_0083:  stloc.3
+  IL_0084:  ldloca.s   V_6
+  IL_0086:  call       ""System.Index System.Range.End.get""
+  IL_008b:  stloc.s    V_4
+  IL_008d:  ldloca.s   V_4
+  IL_008f:  ldloc.2
+  IL_0090:  call       ""int System.Index.GetOffset(int)""
+  IL_0095:  stloc.s    V_7
+  IL_0097:  ldloca.s   V_5
+  IL_0099:  ldloc.3
+  IL_009a:  ldloc.s    V_7
+  IL_009c:  ldloc.3
+  IL_009d:  sub
+  IL_009e:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.Slice(int, int)""
+  IL_00a3:  stloc.0
+  IL_00a4:  ldloca.s   V_0
+  IL_00a6:  ldc.i4.0
+  IL_00a7:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+  IL_00ac:  ldind.u2
+  IL_00ad:  call       ""void System.Console.WriteLine(char)""
+  IL_00b2:  ldloca.s   V_0
+  IL_00b4:  ldc.i4.1
+  IL_00b5:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+  IL_00ba:  ldind.u2
+  IL_00bb:  call       ""void System.Console.WriteLine(char)""
+  IL_00c0:  ret
+}");
+        }
+
+        [Fact]
+        public void PatternIndexAndRangeSpanInt()
+        {
+            var comp = CreateCompilationWithIndexAndRangeAndSpan(@"
+using System;
+class C
+{
+    static void Main()
+    {
+        Span<int> s = new int[] { 2, 4, 5, 6 };
+        Console.WriteLine(s[^2]);
+        var index = ^1;
+        Console.WriteLine(s[index]);
+        s = s[^2..];
+        Console.WriteLine(s[0]);
+        Console.WriteLine(s[1]);
+    }
+}", TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"5
+6
+5
+6");
+            verifier.VerifyIL("C.Main", @"
+{
+  // Code size      205 (0xcd)
+  .maxstack  4
+  .locals init (System.Span<int> V_0, //s
+                System.Index V_1, //index
+                int V_2,
+                int V_3,
+                System.Index V_4,
+                System.Span<int> V_5,
+                System.Range V_6,
+                int V_7)
+  IL_0000:  ldc.i4.4
+  IL_0001:  newarr     ""int""
+  IL_0006:  dup
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.D033850C1A3F6F1209A6CD84146E8561DDC73C79""
+  IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0011:  call       ""System.Span<int> System.Span<int>.op_Implicit(int[])""
+  IL_0016:  stloc.0
+  IL_0017:  ldloca.s   V_0
+  IL_0019:  dup
+  IL_001a:  call       ""int System.Span<int>.Length.get""
+  IL_001f:  stloc.2
+  IL_0020:  ldc.i4.2
+  IL_0021:  ldc.i4.1
+  IL_0022:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0027:  stloc.s    V_4
+  IL_0029:  ldloca.s   V_4
+  IL_002b:  ldloc.2
+  IL_002c:  call       ""int System.Index.GetOffset(int)""
+  IL_0031:  stloc.3
+  IL_0032:  ldloc.3
+  IL_0033:  call       ""ref int System.Span<int>.this[int].get""
+  IL_0038:  ldind.i4
+  IL_0039:  call       ""void System.Console.WriteLine(int)""
+  IL_003e:  ldloca.s   V_1
+  IL_0040:  ldc.i4.1
+  IL_0041:  ldc.i4.1
+  IL_0042:  call       ""System.Index..ctor(int, bool)""
+  IL_0047:  ldloca.s   V_0
+  IL_0049:  dup
+  IL_004a:  call       ""int System.Span<int>.Length.get""
+  IL_004f:  stloc.3
+  IL_0050:  ldloca.s   V_1
+  IL_0052:  ldloc.3
+  IL_0053:  call       ""int System.Index.GetOffset(int)""
+  IL_0058:  stloc.2
+  IL_0059:  ldloc.2
+  IL_005a:  call       ""ref int System.Span<int>.this[int].get""
+  IL_005f:  ldind.i4
+  IL_0060:  call       ""void System.Console.WriteLine(int)""
+  IL_0065:  ldloc.0
+  IL_0066:  stloc.s    V_5
+  IL_0068:  ldloca.s   V_5
+  IL_006a:  call       ""int System.Span<int>.Length.get""
+  IL_006f:  stloc.2
+  IL_0070:  ldc.i4.2
+  IL_0071:  ldc.i4.1
+  IL_0072:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0077:  call       ""System.Range System.Range.StartAt(System.Index)""
+  IL_007c:  stloc.s    V_6
+  IL_007e:  ldloca.s   V_6
+  IL_0080:  call       ""System.Index System.Range.Start.get""
+  IL_0085:  stloc.s    V_4
+  IL_0087:  ldloca.s   V_4
+  IL_0089:  ldloc.2
+  IL_008a:  call       ""int System.Index.GetOffset(int)""
+  IL_008f:  stloc.3
+  IL_0090:  ldloca.s   V_6
+  IL_0092:  call       ""System.Index System.Range.End.get""
+  IL_0097:  stloc.s    V_4
+  IL_0099:  ldloca.s   V_4
+  IL_009b:  ldloc.2
+  IL_009c:  call       ""int System.Index.GetOffset(int)""
+  IL_00a1:  stloc.s    V_7
+  IL_00a3:  ldloca.s   V_5
+  IL_00a5:  ldloc.3
+  IL_00a6:  ldloc.s    V_7
+  IL_00a8:  ldloc.3
+  IL_00a9:  sub
+  IL_00aa:  call       ""System.Span<int> System.Span<int>.Slice(int, int)""
+  IL_00af:  stloc.0
+  IL_00b0:  ldloca.s   V_0
+  IL_00b2:  ldc.i4.0
+  IL_00b3:  call       ""ref int System.Span<int>.this[int].get""
+  IL_00b8:  ldind.i4
+  IL_00b9:  call       ""void System.Console.WriteLine(int)""
+  IL_00be:  ldloca.s   V_0
+  IL_00c0:  ldc.i4.1
+  IL_00c1:  call       ""ref int System.Span<int>.this[int].get""
+  IL_00c6:  ldind.i4
+  IL_00c7:  call       ""void System.Console.WriteLine(int)""
+  IL_00cc:  ret
+}");
+        }
+
+        [Fact]
         public void RealIndexersPreferredToPattern()
         {
             var src = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/IndexAndRangeTests.cs
@@ -16,6 +16,71 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         private const string RangeAllSignature = "System.Range System.Range.All.get";
 
         [Fact]
+        public void SpanPatternRangeDelegate()
+        {
+            var src = @"
+using System;
+class C
+{
+    void Throws<T>(Func<T> f) { }
+    public static void Main()
+    {
+        string s = ""abcd"";
+        Throws(() => new Span<char>(s.ToCharArray())[0..1]);
+    }
+}";
+            var comp = CreateCompilationWithIndexAndRangeAndSpan(src, TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics(
+                // (9,9): error CS0306: The type 'Span<char>' may not be used as a type argument
+                //         Throws(() => new Span<char>(s.ToCharArray())[0..1]);
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "Throws").WithArguments("System.Span<char>").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void PatternIndexNoRefIndexer()
+        {
+            var src = @"
+struct S
+{
+    public int Length => 0;
+    public int this[int i] => 0;
+}
+class C
+{
+    void M(S s)
+    {
+        ref readonly int x = ref s[^2];
+    }
+}";
+            var comp = CreateCompilationWithIndexAndRange(src);
+            comp.VerifyDiagnostics(
+                // (11,34): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+                //         ref readonly int x = ref s[^2];
+                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "s[^2]").WithArguments("S.this[int]").WithLocation(11, 34));
+        }
+
+        [Fact]
+        public void PatternRangeSpanNoReturn()
+        {
+            var src = @"
+using System;
+class C
+{
+    Span<int> M()
+    {
+        Span<int> s1 = stackalloc int[10];
+        Span<int> s2 = s1[0..2];
+        return s2;
+    }
+}";
+            var comp = CreateCompilationWithIndexAndRangeAndSpan(src);
+            comp.VerifyDiagnostics(
+                // (9,16): error CS8352: Cannot use local 's2' in this context because it may expose referenced variables outside of their declaration scope
+                //         return s2;
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "s2").WithArguments("s2").WithLocation(9, 16));
+        }
+
+        [Fact]
         public void PatternIndexAndRangeLengthInaccessible()
         {
             var src = @"
@@ -122,9 +187,9 @@ class C
 }";
             var comp = CreateCompilationWithIndexAndRange(src);
             comp.VerifyDiagnostics(
-                // (12,15): error CS1503: Argument 1: cannot convert from 'System.Index' to 'int'
+                // (12,13): error CS0271: The property or indexer 'B.this[int]' cannot be used in this context because the get accessor is inaccessible
                 //         _ = b[^0];
-                Diagnostic(ErrorCode.ERR_BadArgType, "^0").WithArguments("1", "System.Index", "int").WithLocation(12, 15),
+                Diagnostic(ErrorCode.ERR_InaccessibleGetter, "b[^0]").WithArguments("B.this[int]").WithLocation(12, 13),
                 // (13,15): error CS1503: Argument 1: cannot convert from 'System.Range' to 'int'
                 //         _ = b[0..];
                 Diagnostic(ErrorCode.ERR_BadArgType, "0..").WithArguments("1", "System.Range", "int").WithLocation(13, 15)

--- a/src/Compilers/Test/Utilities/CSharp/TestSources.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestSources.cs
@@ -69,6 +69,13 @@ namespace System
         }
 
         public static implicit operator Span<T>(T[] array) => new Span<T>(array);
+
+        public Span<T> Slice(int offset, int length)
+        {
+            var copy = new T[length];
+            Array.Copy(arr, offset, copy, 0, length);
+            return new Span<T>(copy);
+        }
     }
 
     public readonly ref struct ReadOnlySpan<T>
@@ -135,6 +142,13 @@ namespace System
         public static implicit operator ReadOnlySpan<T>(T[] array) => array == null ? default : new ReadOnlySpan<T>(array);
 
         public static implicit operator ReadOnlySpan<T>(string stringValue) => string.IsNullOrEmpty(stringValue) ? default : new ReadOnlySpan<T>((T[])(object)stringValue.ToCharArray());
+
+        public ReadOnlySpan<T> Slice(int offset, int length)
+        {
+            var copy = new T[length];
+            Array.Copy(arr, offset, copy, 0, length);
+            return new ReadOnlySpan<T>(copy);
+        }
     }
 
     public readonly ref struct SpanLike<T>


### PR DESCRIPTION
When I implemented the Index and Range pattern support I forgot to
update the ref and ref-like checking behavior, which caused the
expressions to have the wrong behavior for certain operations and
potentially crash the compiler.

This change adds tests for ref returns and ref-like lifetimes and
implements the appropriate behavior.