### PR TITLE
made featureflag and experiementation service to use different name.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CommentSelection/AbstractToggleBlockCommentBase.cs
+++ b/src/EditorFeatures/Core/Implementation/CommentSelection/AbstractToggleBlockCommentBase.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
             if (Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
             {
                 var experimentationService = workspace.Services.GetRequiredService<IExperimentationService>();
-                if (!experimentationService.IsExperimentEnabled(WellKnownExperimentNames.RoslynToggleBlockComment))
+                if (!experimentationService.IsExperimentEnabled(WellKnownExperimentNames.ToggleBlockComment))
                 {
                     return VSCommanding.CommandState.Unspecified;
                 }
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
             }), cancellationToken))
             {
                 var experimentationService = document.Project.Solution.Workspace.Services.GetRequiredService<IExperimentationService>();
-                if (!experimentationService.IsExperimentEnabled(WellKnownExperimentNames.RoslynToggleBlockComment))
+                if (!experimentationService.IsExperimentEnabled(WellKnownExperimentNames.ToggleBlockComment))
                 {
                     return s_emptyCommentSelectionResult;
                 }

--- a/src/EditorFeatures/Test/CommentSelection/AbstractToggleBlockCommentTestBase.cs
+++ b/src/EditorFeatures/Test/CommentSelection/AbstractToggleBlockCommentTestBase.cs
@@ -86,9 +86,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CommentSelection
         [ExportWorkspaceService(typeof(IExperimentationService), WorkspaceKind.Test), Shared]
         private class MockToggleBlockCommentExperimentationService : IExperimentationService
         {
-            public bool IsExperimentEnabled(string experimentName)
+            public bool IsExperimentEnabled(ExperimentName experimentName)
             {
-                return WellKnownExperimentNames.RoslynToggleBlockComment.Equals(experimentName);
+                return WellKnownExperimentNames.ToggleBlockComment.Equals(experimentName);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -3,25 +3,64 @@
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Experiments
 {
     internal interface IExperimentationService : IWorkspaceService
     {
-        bool IsExperimentEnabled(string experimentName);
+        bool IsExperimentEnabled(ExperimentName experimentName);
     }
 
     [ExportWorkspaceService(typeof(IExperimentationService)), Shared]
     internal class DefaultExperimentationService : IExperimentationService
     {
-        public bool IsExperimentEnabled(string experimentName) => false;
+        public bool IsExperimentEnabled(ExperimentName experimentName) => false;
     }
 
     internal static class WellKnownExperimentNames
     {
-        public const string RoslynOOP64bit = nameof(RoslynOOP64bit);
-        public const string CompletionAPI = nameof(CompletionAPI);
-        public const string PartialLoadMode = "Roslyn.PartialLoadMode";
-        public const string RoslynToggleBlockComment = "Roslyn.ToggleBlockComment";
+        public readonly static ExperimentName RoslynOOP64bit = nameof(RoslynOOP64bit);
+        public readonly static ExperimentName CompletionAPI = nameof(CompletionAPI);
+        public readonly static ExperimentName PartialLoadMode = nameof(PartialLoadMode);
+        public readonly static ExperimentName ToggleBlockComment = nameof(ToggleBlockComment);
+    }
+
+    internal struct ExperimentName
+    {
+        public const string DefaultPrefix = "Roslyn.";
+
+        /// <summary>
+        /// experiement name
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// experiment name with a prefix
+        /// 
+        /// we need this since some experimentation service requires certain prefix in its name.
+        /// </summary>
+        public string NameWithPrefix { get; }
+
+        /// <summary>
+        /// create name and name with a prefix from given experiement name
+        /// </summary>
+        public ExperimentName(string experimentName)
+            : this(experimentName, DefaultPrefix + experimentName)
+        {
+        }
+
+        public ExperimentName(string name, string nameWithPrefix)
+        {
+            Contract.ThrowIfFalse(nameWithPrefix.IndexOf(".") > 0);
+
+            Name = name;
+            NameWithPrefix = nameWithPrefix;
+        }
+
+        public static implicit operator ExperimentName(string experimentName)
+        {
+            return new ExperimentName(experimentName);
+        }
     }
 }


### PR DESCRIPTION
featureflag service and experiementation service prohits 2 services to use same name for some reason. and we can't change that policy

but we would like to seamlessly move from feature flags to experiementation service without code change to test new feature/idea

so, now we use 2 different name for 2 services.