### PR TITLE
Fix regression for switching on a constant value

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
@@ -63,7 +63,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Join(ref afterSwitchState, ref this.State);
             }
 
-            if (reachableLabels.Contains(node.BreakLabel) || node.DefaultLabel == null && IsTraditionalSwitch(node))
+            if (node.DecisionDag.ReachableLabels.Contains(node.BreakLabel) ||
+                (node.DefaultLabel == null && node.Expression.ConstantValue is null && IsTraditionalSwitch(node)))
             {
                 Join(ref afterSwitchState, ref initialState);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Join(ref afterSwitchState, ref this.State);
             }
 
-            if (node.DecisionDag.ReachableLabels.Contains(node.BreakLabel) ||
+            if (reachableLabels.Contains(node.BreakLabel) ||
                 (node.DefaultLabel == null && node.Expression.ConstantValue is null && IsTraditionalSwitch(node)))
             {
                 Join(ref afterSwitchState, ref initialState);

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
@@ -132,7 +132,7 @@ class C
         switch (S)
         {
             case ""def"":
-                return S;
+                return S; // 1
             default:
                 return S;
         }
@@ -143,7 +143,7 @@ class C
         switch (S)
         {
             case ""def"":
-                return S;
+                return S; // 2
         }
         // error
     }
@@ -152,24 +152,24 @@ class C
             var comp = CreateCompilation(src);
             comp.VerifyDiagnostics(
                 // (40,17): warning CS0162: Unreachable code detected
-                //                 return S;
+                //                 return S; // 1
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(40, 17),
                 // (46,26): error CS0161: 'C.M5()': not all code paths return a value
                 //     public static string M5()
                 Diagnostic(ErrorCode.ERR_ReturnExpected, "M5").WithArguments("C.M5()").WithLocation(46, 26),
                 // (51,17): warning CS0162: Unreachable code detected
-                //                 return S;
+                //                 return S; // 2
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(51, 17));
             comp = CreateCompilation(src, parseOptions: TestOptions.Regular7_3);
             comp.VerifyDiagnostics(
                 // (40,17): warning CS0162: Unreachable code detected
-                //                 return S;
+                //                 return S; // 1
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(40, 17),
                 // (46,26): error CS0161: 'C.M5()': not all code paths return a value
                 //     public static string M5()
                 Diagnostic(ErrorCode.ERR_ReturnExpected, "M5").WithArguments("C.M5()").WithLocation(46, 26),
                 // (51,17): warning CS0162: Unreachable code detected
-                //                 return S;
+                //                 return S; // 2
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(51, 17));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowTests.cs
@@ -90,6 +90,90 @@ public class DATest : DATestBase {
 }";
 
         [Fact]
+        [WorkItem(35011, "https://github.com/dotnet/roslyn/issues/35011")]
+        public void SwitchConstantUnreachable()
+        {
+            var src = @"
+class C
+{
+    const string S = ""abc"";
+
+    public static string M1()
+    {
+        switch (S)
+        {
+            case ""abc"":
+                return S;
+        }
+    }
+
+    public static string M2()
+    {
+        const string S2 = S + """";
+        switch (S)
+        {
+            case S2:
+                return S;
+        }
+    }
+
+    public static string M3()
+    {
+        const int I = 11;
+        switch (I)
+        {
+            case 11:
+                return S;
+        }
+    }
+
+    public static string M4()
+    {
+        switch (S)
+        {
+            case ""def"":
+                return S;
+            default:
+                return S;
+        }
+    }
+
+    public static string M5()
+    {
+        switch (S)
+        {
+            case ""def"":
+                return S;
+        }
+        // error
+    }
+}";
+
+            var comp = CreateCompilation(src);
+            comp.VerifyDiagnostics(
+                // (40,17): warning CS0162: Unreachable code detected
+                //                 return S;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(40, 17),
+                // (46,26): error CS0161: 'C.M5()': not all code paths return a value
+                //     public static string M5()
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "M5").WithArguments("C.M5()").WithLocation(46, 26),
+                // (51,17): warning CS0162: Unreachable code detected
+                //                 return S;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(51, 17));
+            comp = CreateCompilation(src, parseOptions: TestOptions.Regular7_3);
+            comp.VerifyDiagnostics(
+                // (40,17): warning CS0162: Unreachable code detected
+                //                 return S;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(40, 17),
+                // (46,26): error CS0161: 'C.M5()': not all code paths return a value
+                //     public static string M5()
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "M5").WithArguments("C.M5()").WithLocation(46, 26),
+                // (51,17): warning CS0162: Unreachable code detected
+                //                 return S;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(51, 17));
+        }
+
+        [Fact]
         public void General()
         {
             var source = prefix + @"


### PR DESCRIPTION
We made a change in #32818 to restore compatibility with C# 7.x
in rejecting certain switch statements even when we could prove
completeness with the new switch analysis. It looks like that
change just went a little too far, as we could do the analysis
if the argument to the switch expression was a constant. This
change removes the compat clause for switches with constant
values

Fixes #35011