### PR TITLE
Implement `where T: class` and `where T: struct` for overrides and explicit interface implementations.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8044,7 +8044,16 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly.
+        ///   Looks up a localized string similar to Type parameter &apos;{0}&apos; of method &apos;{1}&apos; declares a &apos;{2}&apos; constraint, but type parameter &apos;{3}&apos; of overridden or explicitly implemented method &apos;{4}&apos; is not constrained to a &apos;{2}&apos;..
+        /// </summary>
+        internal static string ERR_OverrideOrExpImplBadConstraints {
+            get {
+                return ResourceManager.GetString("ERR_OverrideOrExpImplBadConstraints", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a &apos;class&apos;, or a &apos;struct&apos; constraint..
         /// </summary>
         internal static string ERR_OverrideWithConstraints {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8044,11 +8044,20 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type parameter &apos;{0}&apos; of method &apos;{1}&apos; declares a &apos;{2}&apos; constraint, but type parameter &apos;{3}&apos; of overridden or explicitly implemented method &apos;{4}&apos; is not constrained to a &apos;{2}&apos;..
+        ///   Looks up a localized string similar to Method &apos;{0}&apos; specifies a &apos;class&apos; constraint for type parameter &apos;{1}&apos;, but corresponding type parameter &apos;{2}&apos; of overridden or explicitly implemented method &apos;{3}&apos; is not a reference type..
         /// </summary>
-        internal static string ERR_OverrideOrExpImplBadConstraints {
+        internal static string ERR_OverrideRefConstraintNotSatisfied {
             get {
-                return ResourceManager.GetString("ERR_OverrideOrExpImplBadConstraints", resourceCulture);
+                return ResourceManager.GetString("ERR_OverrideRefConstraintNotSatisfied", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Method &apos;{0}&apos; specifies a &apos;struct&apos; constraint for type parameter &apos;{1}&apos;, but corresponding type parameter &apos;{2}&apos; of overridden or explicitly implemented method &apos;{3}&apos; is not a non-nullable value type..
+        /// </summary>
+        internal static string ERR_OverrideValConstraintNotSatisfied {
+            get {
+                return ResourceManager.GetString("ERR_OverrideValConstraintNotSatisfied", resourceCulture);
             }
         }
         
@@ -11960,6 +11969,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to constraints for override and explicit interface implementation methods.
+        /// </summary>
+        internal static string IDS_OverrideWithConstraints {
+            get {
+                return ResourceManager.GetString("IDS_OverrideWithConstraints", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;path list&gt;.
         /// </summary>
         internal static string IDS_PathList {
@@ -15679,6 +15697,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string WRN_NullReferenceAssignment_Title {
             get {
                 return ResourceManager.GetString("WRN_NullReferenceAssignment_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Possible null reference assignment to iteration variable.
+        /// </summary>
+        internal static string WRN_NullReferenceIterationVariable {
+            get {
+                return ResourceManager.GetString("WRN_NullReferenceIterationVariable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Possible null reference assignment to iteration variable.
+        /// </summary>
+        internal static string WRN_NullReferenceIterationVariable_Title {
+            get {
+                return ResourceManager.GetString("WRN_NullReferenceIterationVariable_Title", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1381,7 +1381,7 @@
     <value>Cannot use attribute constructor '{0}' because it is has 'in' parameters.</value>
   </data>
   <data name="ERR_OverrideWithConstraints" xml:space="preserve">
-    <value>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</value>
+    <value>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</value>
   </data>
   <data name="ERR_AmbigOverride" xml:space="preserve">
     <value>The inherited members '{0}' and '{1}' have the same signature in type '{2}', so they cannot be overridden</value>
@@ -5882,5 +5882,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="WRN_NullReferenceIterationVariable_Title" xml:space="preserve">
 	<value>Possible null reference assignment to iteration variable</value>
+  </data>
+  <data name="ERR_OverrideOrExpImplBadConstraints" xml:space="preserve">
+    <value>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5883,7 +5883,13 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_NullReferenceIterationVariable_Title" xml:space="preserve">
 	<value>Possible null reference assignment to iteration variable</value>
   </data>
-  <data name="ERR_OverrideOrExpImplBadConstraints" xml:space="preserve">
-    <value>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</value>
+  <data name="ERR_OverrideRefConstraintNotSatisfied" xml:space="preserve">
+    <value>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</value>
+  </data>
+  <data name="ERR_OverrideValConstraintNotSatisfied" xml:space="preserve">
+    <value>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</value>
+  </data>
+  <data name="IDS_OverrideWithConstraints" xml:space="preserve">
+    <value>constraints for override and explicit interface implementation methods</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1693,8 +1693,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_FieldLikeEventCantBeReadOnly = 8662,
         ERR_PartialMethodReadOnlyDifference = 8663,
         ERR_ReadOnlyModMissingAccessor = 8664,
-        ERR_OverrideOrExpImplBadConstraints = 8665,
-
+        ERR_OverrideRefConstraintNotSatisfied = 8665,
+        ERR_OverrideValConstraintNotSatisfied = 8666,
 
         ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation = 8701,
         ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember = 8702,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1693,6 +1693,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_FieldLikeEventCantBeReadOnly = 8662,
         ERR_PartialMethodReadOnlyDifference = 8663,
         ERR_ReadOnlyModMissingAccessor = 8664,
+        ERR_OverrideOrExpImplBadConstraints = 8665,
 
 
         ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation = 8701,

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -177,9 +177,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureUnmanagedConstructedTypes = MessageBase + 12757,
         IDS_FeatureObsoleteOnPropertyAccessor = MessageBase + 12758,
         IDS_FeatureReadOnlyMembers = MessageBase + 12759,
-
-        IDS_DefaultInterfaceImplementation = MessageBase + 12800,
-        IDS_BaseTypeInBaseExpression = MessageBase + 12801,
+        IDS_DefaultInterfaceImplementation = MessageBase + 12760,
+        IDS_BaseTypeInBaseExpression = MessageBase + 12761,
+        IDS_OverrideWithConstraints = MessageBase + 12762,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -288,6 +288,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureReadOnlyMembers:
                 case MessageID.IDS_DefaultInterfaceImplementation: // semantic check
                 case MessageID.IDS_BaseTypeInBaseExpression:
+                case MessageID.IDS_OverrideWithConstraints: // semantic check
                     return LanguageVersion.CSharp8;
 
                 // C# 7.3 features.

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -249,6 +249,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _extensions.TryForceResolveAsNullableValueType();
         }
 
+        /// <summary>
+        /// If this is a lazy nullable type, forces this to be resolved as a nullable reference type, and return true.
+        /// Otherwise, return false.
+        /// </summary>
+        public bool TryForceResolveAsNullableReferenceType()
+        {
+            return _extensions.TryForceResolveAsNullableReferenceType();
+        }
+
         private TypeWithAnnotations AsNullableReferenceType() => _extensions.AsNullableReferenceType(this);
         public TypeWithAnnotations AsNotNullableReferenceType() => _extensions.AsNotNullableReferenceType(this);
 
@@ -774,6 +783,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal abstract void ReportDiagnosticsIfObsolete(TypeWithAnnotations type, Binder binder, SyntaxNode syntax, DiagnosticBag diagnostics);
 
             internal abstract bool TryForceResolveAsNullableValueType();
+
+            internal abstract bool TryForceResolveAsNullableReferenceType();
         }
 
         private sealed class NonLazyType : Extensions
@@ -868,6 +879,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return false;
             }
+
+            internal override bool TryForceResolveAsNullableReferenceType()
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -899,7 +915,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     if (!_underlying.Type.IsValueType)
                     {
-                        _resolved = _underlying.Type;
+                        TryForceResolveAsNullableReferenceType();
                     }
                     else
                     {
@@ -1038,6 +1054,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Interlocked.CompareExchange(ref _resolved,
                     _compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(ImmutableArray.Create(_underlying)),
                     null) is null;
+            }
+
+            internal override bool TryForceResolveAsNullableReferenceType()
+            {
+                _resolved = _underlying.Type;
+                return true;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -297,9 +297,14 @@
         <target state="translated">Výstupní proměnná nemůže být deklarovaná jako lokální proměnná podle odkazu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -880,6 +885,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Výstupní proměnná nemůže být deklarovaná jako lokální proměnná podle odkazu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3428,8 +3433,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">Omezení pro metody přepsání a explicitní implementace rozhraní se dědí ze základní metody, nejde je tedy zadat přímo.</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">Omezení pro metody přepsání a explicitní implementace rozhraní se dědí ze základní metody, nejde je tedy zadat přímo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Eine out-Variable kann nicht als lokales ref-Element deklariert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3428,8 +3433,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">Einschränkungen für Überschreibungs- und explizite Schnittstellenimplementierungsmethoden werden von der Basismethode geerbt und können daher nicht direkt angegeben werden.</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">Einschränkungen für Überschreibungs- und explizite Schnittstellenimplementierungsmethoden werden von der Basismethode geerbt und können daher nicht direkt angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -297,9 +297,14 @@
         <target state="translated">Eine out-Variable kann nicht als lokales ref-Element deklariert werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -880,6 +885,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;NULL&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -297,9 +297,14 @@
         <target state="translated">Una variable out no se puede declarar como ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -882,6 +887,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;NULL&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Una variable out no se puede declarar como ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3430,8 +3435,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">Las restricciones para métodos de invalidación y de implementación de interfaz explícita se heredan del método base; por tanto, no se pueden especificar directamente</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">Las restricciones para métodos de invalidación y de implementación de interfaz explícita se heredan del método base; por tanto, no se pueden especificar directamente</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Impossible de déclarer une variable out en tant que variable locale ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3429,8 +3434,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">Les contraintes pour les méthodes d'implémentation d'interface override et explicite sont héritées de la méthode de base et ne peuvent donc pas être spécifiées directement</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">Les contraintes pour les méthodes d'implémentation d'interface override et explicite sont héritées de la méthode de base et ne peuvent donc pas être spécifiées directement</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -297,9 +297,14 @@
         <target state="translated">Impossible de déclarer une variable out en tant que variable locale ref</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -881,6 +886,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;Null&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Non è possibile dichiarare una variabile out come variabile locale ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3428,8 +3433,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">I vincoli per i metodi di override e di implementazione esplicita di interfacce sono ereditati dal metodo base, pertanto non possono essere specificati in maniera diretta</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">I vincoli per i metodi di override e di implementazione esplicita di interfacce sono ereditati dal metodo base, pertanto non possono essere specificati in maniera diretta</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -297,9 +297,14 @@
         <target state="translated">Non è possibile dichiarare una variabile out come variabile locale ref</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -880,6 +885,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;Null&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -297,6 +297,11 @@
         <target state="translated">out 変数を ref ローカルと宣言することはできません</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3428,8 +3433,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">オーバーライドおよび明示的なインターフェイスの実装メソッドの制約は、基本メソッドから継承されるので、直接指定できません</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">オーバーライドおよび明示的なインターフェイスの実装メソッドの制約は、基本メソッドから継承されるので、直接指定できません</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -297,9 +297,14 @@
         <target state="translated">out 変数を ref ローカルと宣言することはできません</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -880,6 +885,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -297,6 +297,11 @@
         <target state="translated">출력 변수는 참조 로컬로 선언할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3428,8 +3433,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">재정의 및 명시적 인터페이스 구현 메서드에 대한 제약 조건은 기본 메서드에서 상속되므로 직접 지정할 수 없습니다.</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">재정의 및 명시적 인터페이스 구현 메서드에 대한 제약 조건은 기본 메서드에서 상속되므로 직접 지정할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -297,9 +297,14 @@
         <target state="translated">출력 변수는 참조 로컬로 선언할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -880,6 +885,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Zmiennej out nie można zadeklarować jako lokalnej zmiennej ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3428,8 +3433,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">Ograniczenia dla przesłoniętych i jawnych metod implementacji interfejsu są dziedziczone z metody podstawowej, dlatego nie mogą być określone bezpośrednio</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">Ograniczenia dla przesłoniętych i jawnych metod implementacji interfejsu są dziedziczone z metody podstawowej, dlatego nie mogą być określone bezpośrednio</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -297,9 +297,14 @@
         <target state="translated">Zmiennej out nie można zadeklarować jako lokalnej zmiennej ref</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -880,6 +885,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Uma variável out não pode ser declarada como uma referência local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3428,8 +3433,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">Restrições para métodos de substituição e implementação de interface explícita são herdadas do método base, por isso não podem ser especificadas diretamente</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">Restrições para métodos de substituição e implementação de interface explícita são herdadas do método base, por isso não podem ser especificadas diretamente</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -297,9 +297,14 @@
         <target state="translated">Uma variável out não pode ser declarada como uma referência local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -880,6 +885,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;nulo&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Выходная переменная не может быть объявлена как локальная переменная ref</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3428,8 +3433,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">Ограничения для переопределения и явные методы реализации интерфейса унаследованы от базового метода, поэтому они не могут быть указаны напрямую.</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">Ограничения для переопределения и явные методы реализации интерфейса унаследованы от базового метода, поэтому они не могут быть указаны напрямую.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -297,9 +297,14 @@
         <target state="translated">Выходная переменная не может быть объявлена как локальная переменная ref</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -880,6 +885,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;NULL&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Bir out değişkeni ref yerel değeri olarak bildirilemez</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3429,8 +3434,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">Geçersiz kılma ve açık arabirim uygulama yöntemlerinin kısıtlamaları temel yöntemden devralınır ve bu nedenle doğrudan belirtilemez</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">Geçersiz kılma ve açık arabirim uygulama yöntemlerinin kısıtlamaları temel yöntemden devralınır ve bu nedenle doğrudan belirtilemez</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -297,9 +297,14 @@
         <target state="translated">Bir out değişkeni ref yerel değeri olarak bildirilemez</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -881,6 +886,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -322,9 +322,14 @@
         <target state="translated">out 变量无法声明为 ref 局部变量</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -921,6 +926,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -322,6 +322,11 @@
         <target state="translated">out 变量无法声明为 ref 局部变量</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3469,8 +3474,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">重写和显式接口实现方法的约束是从基方法继承的，因此不能直接指定这些约束</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">重写和显式接口实现方法的约束是从基方法继承的，因此不能直接指定这些约束</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -297,6 +297,11 @@
         <target state="translated">out 變數不可宣告為 ref local</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
+        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
+        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
         <source>Both partial method declarations must be readonly or neither may be readonly</source>
         <target state="new">Both partial method declarations must be readonly or neither may be readonly</target>
@@ -3428,8 +3433,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_OverrideWithConstraints">
-        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly</source>
-        <target state="translated">覆寫及明確介面實作方法的條件約束，繼承自基底方法，所以無法直接指定。</target>
+        <source>Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.</source>
+        <target state="needs-review-translation">覆寫及明確介面實作方法的條件約束，繼承自基底方法，所以無法直接指定。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_AmbigOverride">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -297,9 +297,14 @@
         <target state="translated">out 變數不可宣告為 ref local</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_OverrideOrExpImplBadConstraints">
-        <source>Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</source>
-        <target state="new">Type parameter '{0}' of method '{1}' declares a '{2}' constraint, but type parameter '{3}' of overridden or explicitly implemented method '{4}' is not constrained to a '{2}'.</target>
+      <trans-unit id="ERR_OverrideRefConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</source>
+        <target state="new">Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_OverrideValConstraintNotSatisfied">
+        <source>Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</source>
+        <target state="new">Method '{0}' specifies a 'struct' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a non-nullable value type.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_PartialMethodReadOnlyDifference">
@@ -880,6 +885,11 @@
       <trans-unit id="IDS_NULL">
         <source>&lt;null&gt;</source>
         <target state="translated">&lt;null&gt;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_OverrideWithConstraints">
+        <source>constraints for override and explicit interface implementation methods</source>
+        <target state="new">constraints for override and explicit interface implementation methods</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_ThrowExpression">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -580,7 +580,7 @@ public class B : A
 {
     public override void M<T>() where T : System.Enum { }
 }").VerifyDiagnostics(
-                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.Enum { }
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(8, 33));
         }
@@ -599,7 +599,7 @@ public class B : A
 {
     public override void M<T>() where T : System.Enum { }
 }", references: new[] { reference }).VerifyDiagnostics(
-                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.Enum { }
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(4, 33));
         }
@@ -1095,7 +1095,7 @@ public class B : A
 {
     public override void M<T>() where T : System.Delegate { }
 }").VerifyDiagnostics(
-                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.Delegate { }
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(8, 33));
         }
@@ -1114,7 +1114,7 @@ public class B : A
 {
     public override void M<T>() where T : System.Delegate { }
 }", references: new[] { reference }).VerifyDiagnostics(
-                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.Delegate { }
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(4, 33));
         }
@@ -1580,7 +1580,7 @@ public class B : A
 {
     public override void M<T>() where T : System.MulticastDelegate { }
 }").VerifyDiagnostics(
-                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.MulticastDelegate { }
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(8, 33));
         }
@@ -1599,7 +1599,7 @@ public class B : A
 {
     public override void M<T>() where T : System.MulticastDelegate { }
 }", references: new[] { reference }).VerifyDiagnostics(
-                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.MulticastDelegate { }
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(4, 33));
         }
@@ -2277,7 +2277,7 @@ public class B : A
 {
     public override void M<T>() where T : unmanaged { }
 }").VerifyDiagnostics(
-                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : unmanaged { }
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(8, 33));
         }
@@ -2447,7 +2447,7 @@ public class B : A
 {
     public override void M<T>() where T : unmanaged { }
 }", references: new[] { reference }).VerifyDiagnostics(
-                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : unmanaged { }
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(4, 33));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -580,9 +580,9 @@ public class B : A
 {
     public override void M<T>() where T : System.Enum { }
 }").VerifyDiagnostics(
-                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                // (8,43): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.Enum { }
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(8, 33));
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "System.Enum").WithLocation(8, 43));
         }
 
         [Fact]
@@ -599,9 +599,9 @@ public class B : A
 {
     public override void M<T>() where T : System.Enum { }
 }", references: new[] { reference }).VerifyDiagnostics(
-                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                // (4,43): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.Enum { }
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(4, 33));
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "System.Enum").WithLocation(4, 43));
         }
 
         [Fact]
@@ -1095,9 +1095,9 @@ public class B : A
 {
     public override void M<T>() where T : System.Delegate { }
 }").VerifyDiagnostics(
-                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                // (8,43): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.Delegate { }
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(8, 33));
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "System.Delegate").WithLocation(8, 43));
         }
 
         [Fact]
@@ -1114,9 +1114,9 @@ public class B : A
 {
     public override void M<T>() where T : System.Delegate { }
 }", references: new[] { reference }).VerifyDiagnostics(
-                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                // (4,43): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.Delegate { }
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(4, 33));
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "System.Delegate").WithLocation(4, 43));
         }
 
         [Fact]
@@ -1580,9 +1580,9 @@ public class B : A
 {
     public override void M<T>() where T : System.MulticastDelegate { }
 }").VerifyDiagnostics(
-                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                // (8,43): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.MulticastDelegate { }
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(8, 33));
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "System.MulticastDelegate").WithLocation(8, 43));
         }
 
         [Fact]
@@ -1599,9 +1599,9 @@ public class B : A
 {
     public override void M<T>() where T : System.MulticastDelegate { }
 }", references: new[] { reference }).VerifyDiagnostics(
-                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                // (4,43): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : System.MulticastDelegate { }
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(4, 33));
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "System.MulticastDelegate").WithLocation(4, 43));
         }
 
         [Fact]
@@ -2277,9 +2277,9 @@ public class B : A
 {
     public override void M<T>() where T : unmanaged { }
 }").VerifyDiagnostics(
-                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                // (8,43): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : unmanaged { }
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(8, 33));
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "unmanaged").WithLocation(8, 43));
         }
 
         [Fact]
@@ -2447,9 +2447,9 @@ public class B : A
 {
     public override void M<T>() where T : unmanaged { }
 }", references: new[] { reference }).VerifyDiagnostics(
-                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                // (4,43): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     public override void M<T>() where T : unmanaged { }
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(4, 33));
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "unmanaged").WithLocation(4, 43));
         }
 
         [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10782")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -10620,9 +10620,6 @@ class B : A
 ";
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             compilation.VerifyDiagnostics(
-                // (11,38): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
-                //     public override void M1<T>(T? x) where T : struct
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(11, 38),
                 // (11,26): error CS0115: 'B.M1<T>(T?)': no suitable method found to override
                 //     public override void M1<T>(T? x) where T : struct
                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M1").WithArguments("B.M1<T>(T?)").WithLocation(11, 26),
@@ -12358,7 +12355,7 @@ class B : IA
                 );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         [WorkItem(28684, "https://github.com/dotnet/roslyn/issues/28684")]
         public void ImplementingNonNullWithNullable_02()
         {
@@ -12378,7 +12375,7 @@ class B : IA
     }
 
 " + NonNullTypesOff() + @"
-    S?[] IA.M2<S>()
+    S?[] IA.M2<S>() where S : class
     {
         return new S?[] {};
     }
@@ -12387,32 +12384,23 @@ class B : IA
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             compilation.VerifyDiagnostics(
                 // (17,6): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
-                //     S?[] IA.M2<S>()
+                //     S?[] IA.M2<S>() where S : class
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(17, 6),
-                // (17,13): error CS0539: 'B.M2<S>()' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     S?[] IA.M2<S>()
-                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M2").WithArguments("B.M2<S>()").WithLocation(17, 13),
+                // (17,13): warning CS8616: Nullability of reference types in return type doesn't match implemented member 'T[] IA.M2<T>()'.
+                //     S?[] IA.M2<S>() where S : class
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation, "M2").WithArguments("T[] IA.M2<T>()").WithLocation(17, 13),
                 // (11,11): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
                 //     string?[] IA.M1()
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(11, 11),
                 // (11,18): warning CS8616: Nullability of reference types in return type doesn't match implemented member 'string[] IA.M1()'.
                 //     string?[] IA.M1()
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation, "M1").WithArguments("string[] IA.M1()").WithLocation(11, 18),
-                // (8,11): error CS0535: 'B' does not implement interface member 'IA.M2<T>()'
-                // class B : IA
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "IA").WithArguments("B", "IA.M2<T>()").WithLocation(8, 11),
-                // (17,13): error CS0453: The type 'S' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                //     S?[] IA.M2<S>()
-                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M2").WithArguments("System.Nullable<T>", "T", "S").WithLocation(17, 13),
                 // (13,26): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
                 //         return new string?[] {};
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(13, 26),
                 // (19,21): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
                 //         return new S?[] {};
-                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(19, 21),
-                // (19,20): error CS0453: The type 'S' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                //         return new S?[] {};
-                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "S?").WithArguments("System.Nullable<T>", "T", "S").WithLocation(19, 20)
+                Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(19, 21)
                 );
         }
 
@@ -12756,7 +12744,7 @@ class B : A
                 );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void Overriding_26()
         {
             var source = @"
@@ -12774,7 +12762,7 @@ class A
 
 class B : A
 {
-    public override void M1<T>(T? x)
+    public override void M1<T>(T? x) where T : class
     {
     }
 
@@ -12802,7 +12790,7 @@ class B : A
             Assert.False(m2.OverriddenMethod.ReturnType.IsNullableType());
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void Overriding_27()
         {
             var source = @"
@@ -12869,7 +12857,7 @@ class C<T> {}
             Assert.False(((NamedTypeSymbol)m5.OverriddenMethod.Parameters[0].Type).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0].IsNullableType());
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void Overriding_28()
         {
             var source = @"
@@ -12929,7 +12917,7 @@ class B : A
                 TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.AllNullableIgnoreOptions));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         [WorkItem(28684, "https://github.com/dotnet/roslyn/issues/28684")]
         public void Overriding_29()
         {
@@ -12985,7 +12973,7 @@ class B : A
                 );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void Overriding_30()
         {
             var source = @"
@@ -13042,7 +13030,7 @@ class B : A
                 TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.AllNullableIgnoreOptions));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         [WorkItem(28684, "https://github.com/dotnet/roslyn/issues/28684")]
         public void Overriding_31()
         {
@@ -13063,7 +13051,7 @@ class B : A
     }
 
 " + NonNullTypesOff() + @"
-    public override void M2<T>(T?[] x) where T ; class
+    public override void M2<T>(T?[] x) where T : class
     {
     }
 }
@@ -13086,7 +13074,7 @@ class B : A
                 );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         [WorkItem(29847, "https://github.com/dotnet/roslyn/issues/29847")]
         public void Overriding_32()
         {
@@ -14397,7 +14385,7 @@ public partial class C3 : I1<A?> {}
 C3.M");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void Implementing_22()
         {
             var source = @"
@@ -14436,37 +14424,16 @@ class B : IA
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
 
             compilation.VerifyDiagnostics(
-                // (23,13): error CS0539: 'B.M2<S>()' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     S?[] IA.M2<S>() 
-                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M2").WithArguments("B.M2<S>()").WithLocation(23, 13),
-                // (28,14): error CS0539: 'B.M3<S>()' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     S?[]? IA.M3<S>() 
-                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M3").WithArguments("B.M3<S>()").WithLocation(28, 14),
+                // (23,13): warning CS8616: Nullability of reference types in return type doesn't match implemented member 'T[] IA.M2<T>()'.
+                //     S?[] IA.M2<S>() where S : class
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation, "M2").WithArguments("T[] IA.M2<T>()").WithLocation(23, 13),
                 // (18,18): warning CS8616: Nullability of reference types in return type doesn't match implemented member 'string[] IA.M1()'.
                 //     string?[] IA.M1()
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation, "M1").WithArguments("string[] IA.M1()").WithLocation(18, 18),
-                // (16,11): error CS0535: 'B' does not implement interface member 'IA.M3<T>()'
-                // class B : IA
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "IA").WithArguments("B", "IA.M3<T>()").WithLocation(16, 11),
-                // (16,11): error CS0535: 'B' does not implement interface member 'IA.M2<T>()'
-                // class B : IA
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "IA").WithArguments("B", "IA.M2<T>()").WithLocation(16, 11),
-                // (23,13): error CS0453: The type 'S' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                //     S?[] IA.M2<S>() 
-                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M2").WithArguments("System.Nullable<T>", "T", "S").WithLocation(23, 13),
-                // (28,14): error CS0453: The type 'S' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                //     S?[]? IA.M3<S>() 
-                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "M3").WithArguments("System.Nullable<T>", "T", "S").WithLocation(28, 14),
-                // (25,20): error CS0453: The type 'S' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                //         return new S?[] {};
-                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "S?").WithArguments("System.Nullable<T>", "T", "S").WithLocation(25, 20),
-                // (30,20): error CS0453: The type 'S' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                //         return new S?[] {};
-                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "S?").WithArguments("System.Nullable<T>", "T", "S").WithLocation(30, 20)
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation, "M1").WithArguments("string[] IA.M1()").WithLocation(18, 18)
                 );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void Implementing_23()
         {
 
@@ -14530,7 +14497,7 @@ class B : IA
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void Implementing_24()
         {
             var source = @"
@@ -14940,7 +14907,7 @@ class A
             compilation.VerifyDiagnostics();
         }
 
-        [Fact()]
+        [Fact]
         public void Test1()
         {
             CSharpCompilation c = CreateCompilation(
@@ -41054,7 +41021,7 @@ class C : I
             Assert.Empty(implementations);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void ExplicitImplementations_LazyMethodChecks_01()
         {
             var source =
@@ -57339,12 +57306,9 @@ class B : IA
                 // (10,26): error CS0453: The type 'T11' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
                 //     void IA.F1<T11>(T11? t1) where T11 : class?
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "t1").WithArguments("System.Nullable<T>", "T", "T11").WithLocation(10, 26),
-                // (10,30): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (10,30): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 //     void IA.F1<T11>(T11? t1) where T11 : class?
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(10, 30),
-                // (14,29): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
-                //     void IA.F2<T22>(T22 t2) where T22 : class
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(14, 29));
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(10, 30));
 
             var bf1 = (MethodSymbol)comp.GlobalNamespace.GetMember("B.IA.F1");
             Assert.Equal("void B.F1<T11>(T11? t1)", bf1.ToDisplayString(SymbolDisplayFormat.TestFormatWithConstraints));
@@ -60195,7 +60159,7 @@ class C {
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "object").WithArguments("object generic type constraint").WithLocation(12, 20));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void Constraints_152()
         {
             var source =
@@ -60213,7 +60177,7 @@ class A<T>
 
 class B : A<int>
 {
-    public override void F1<T11>(T11? t1) where T : class
+    public override void F1<T11>(T11? t1) where T11 : class
     {
     }
 
@@ -60286,7 +60250,7 @@ class B : A<int>
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void Constraints_153()
         {
             var source1 =
@@ -60357,7 +60321,7 @@ class B : A<int>
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void Constraints_154()
         {
             var source1 =
@@ -60431,7 +60395,7 @@ class B : A<int>
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/34798")]
+        [Fact]
         public void Constraints_155()
         {
             var source =
@@ -60449,11 +60413,11 @@ class A<T>
 
 class B : A<int>
 {
-    public override void F1<T11>(T11? t1) where T11 : class?
+    public override void F1<T11>(T11? t1) where T11 : class
     {
     }
 
-    public override void F2<T22>(T22 t2) where T22 : class
+    public override void F2<T22>(T22 t2)
     {
     }
 }
@@ -89110,6 +89074,360 @@ class Derived<T> : Base<T> where T : class
 
             Assert.False(dGoo.Parameters[0].Type.IsNullableType());
             Assert.True(dGoo.Parameters[0].TypeWithAnnotations.NullableAnnotation == NullableAnnotation.Annotated);
+        }
+
+        [Fact]
+        public void ImplementMethodTakingNullableClassParameter_WithMethodTakingNullableClassParameter1()
+        {
+            var source = @"
+#nullable enable
+interface I
+{
+    void Goo<T>(T? value) where T : class;
+}
+
+class C1 : I
+{
+    public void Goo<T>(T? value) where T : class { }
+}
+
+class C2 : I
+{
+    void I.Goo<T>(T? value) where T : class { }
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var c2Goo = (MethodSymbol)comp.GetMember("C2.I.Goo");
+
+            Assert.True(c2Goo.Parameters[0].Type.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, c2Goo.Parameters[0].TypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void ImplementMethodTakingNullableClassParameter_WithMethodTakingNullableClassParameter2()
+        {
+            var source = @"
+#nullable enable
+interface I
+{
+    void Goo<T>(T?[] value) where T : class;
+}
+
+class C1 : I
+{
+    public void Goo<T>(T?[] value) where T : class { }
+}
+
+class C2 : I
+{
+    void I.Goo<T>(T?[] value) where T : class { }
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var c2Goo = (MethodSymbol)comp.GetMember("C2.I.Goo");
+
+            Assert.True(((ArrayTypeSymbol)c2Goo.Parameters[0].Type).ElementType.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, ((ArrayTypeSymbol)c2Goo.Parameters[0].Type).ElementTypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void ImplementMethodTakingNullableClassParameter_WithMethodTakingNullableClassParameter3()
+        {
+            var source = @"
+#nullable enable
+interface I
+{
+    void Goo<T>((T a, T? b)? value) where T : class;
+}
+
+class C1 : I
+{
+    public void Goo<T>((T a, T? b)? value) where T : class { }
+}
+
+class C2 : I
+{
+    void I.Goo<T>((T a, T? b)? value) where T : class { }
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var c2Goo = (MethodSymbol)comp.GetMember("C2.I.Goo");
+
+            Assert.True(c2Goo.Parameters[0].Type.IsNullableType());
+            var tuple = c2Goo.Parameters[0].Type.GetMemberTypeArgumentsNoUseSiteDiagnostics()[0];
+            Assert.True(tuple.TupleElements[0].Type.IsReferenceType);
+            Assert.Equal(NullableAnnotation.NotAnnotated, tuple.TupleElements[0].TypeWithAnnotations.NullableAnnotation);
+            Assert.True(tuple.TupleElements[1].Type.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, tuple.TupleElements[1].TypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void ImplementMethodReturningNullableClassParameter_WithMethodReturningNullableClass1()
+        {
+            var source = @"
+#nullable enable
+interface I
+{
+    T? Goo<T>() where T : class;
+}
+
+class C1 : I
+{
+    public T? Goo<T>() where T : class => default;
+}
+
+class C2 : I
+{
+    T? I.Goo<T>() where T : class => default;
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var c2Goo = (MethodSymbol)comp.GetMember("C2.I.Goo");
+
+            Assert.True(c2Goo.ReturnType.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, c2Goo.ReturnTypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void ImplementMethodReturningNullableClassParameter_WithMethodReturningNullableClass2()
+        {
+            var source = @"
+#nullable enable
+interface I
+{
+    T?[] Goo<T>() where T : class;
+}
+
+class C1 : I
+{
+    public T?[] Goo<T>() where T : class => default!;
+}
+
+class C2 : I
+{
+    T?[] I.Goo<T>() where T : class => default!;
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var c2Goo = (MethodSymbol)comp.GetMember("C2.I.Goo");
+
+            Assert.True(((ArrayTypeSymbol)c2Goo.ReturnType).ElementType.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, ((ArrayTypeSymbol)c2Goo.ReturnType).ElementTypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void ImplementMethodReturningNullableClassParameter_WithMethodReturningNullableClass3()
+        {
+            var source = @"
+#nullable enable
+interface I
+{
+    (T a, T? b)? Goo<T>() where T : class;
+}
+
+class C1 : I
+{
+    public (T a, T? b)? Goo<T>() where T : class => default;
+}
+
+class C2 : I
+{
+    (T a, T? b)? I.Goo<T>() where T : class => default;
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var c2Goo = (MethodSymbol)comp.GetMember("C2.I.Goo");
+
+            Assert.True(c2Goo.ReturnType.IsNullableType());
+            var tuple = c2Goo.ReturnType.GetMemberTypeArgumentsNoUseSiteDiagnostics()[0];
+            Assert.True(tuple.TupleElements[0].Type.IsReferenceType);
+            Assert.Equal(NullableAnnotation.NotAnnotated, tuple.TupleElements[0].TypeWithAnnotations.NullableAnnotation);
+            Assert.True(tuple.TupleElements[1].Type.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, tuple.TupleElements[1].TypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void OverrideMethodTakingNullableClassParameter_WithMethodTakingNullableClassParameter1()
+        {
+            var source = @"
+#nullable enable
+abstract class Base
+{
+    public abstract void Goo<T>(T? value) where T : class;
+}
+
+class Derived : Base
+{
+    public override void Goo<T>(T? value) where T : class { }
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var dGoo = (MethodSymbol)comp.GetMember("Derived.Goo");
+
+            Assert.True(dGoo.Parameters[0].Type.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, dGoo.Parameters[0].TypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void OverrideMethodTakingNullableClassParameter_WithMethodTakingNullableClassParameter2()
+        {
+            var source = @"
+#nullable enable
+abstract class Base
+{
+    public abstract void Goo<T>(T?[] value) where T : class;
+}
+
+class Derived : Base
+{
+    public override void Goo<T>(T?[] value) where T : class { }
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var dGoo = (MethodSymbol)comp.GetMember("Derived.Goo");
+
+            Assert.True(((ArrayTypeSymbol)dGoo.Parameters[0].Type).ElementType.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, ((ArrayTypeSymbol)dGoo.Parameters[0].Type).ElementTypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void OverrideMethodTakingNullableClassParameter_WithMethodTakingNullableClassParameter3()
+        {
+            var source = @"
+#nullable enable
+abstract class Base
+{
+    public abstract void Goo<T>((T a, T? b)? value) where T : class;
+}
+
+class Derived : Base
+{
+    public override void Goo<T>((T a, T? b)? value) where T : class { }
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var dGoo = (MethodSymbol)comp.GetMember("Derived.Goo");
+
+            Assert.True(dGoo.Parameters[0].Type.IsNullableType());
+            var tuple = dGoo.Parameters[0].Type.GetMemberTypeArgumentsNoUseSiteDiagnostics()[0];
+            Assert.True(tuple.TupleElements[0].Type.IsReferenceType);
+            Assert.Equal(NullableAnnotation.NotAnnotated, tuple.TupleElements[0].TypeWithAnnotations.NullableAnnotation);
+            Assert.True(tuple.TupleElements[1].Type.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, tuple.TupleElements[1].TypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void OverrideMethodReturningNullableClassParameter_WithMethodReturningNullableClass1()
+        {
+            var source = @"
+#nullable enable
+abstract class Base
+{
+    public abstract T? Goo<T>() where T : class;
+}
+
+class Derived : Base
+{
+    public override T? Goo<T>() where T : class => default;
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var dGoo = (MethodSymbol)comp.GetMember("Derived.Goo");
+
+            Assert.True(dGoo.ReturnType.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, dGoo.ReturnTypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void OverrideMethodReturningNullableClassParameter_WithMethodReturningNullableClass2()
+        {
+            var source = @"
+#nullable enable
+abstract class Base
+{
+    public abstract T?[] Goo<T>() where T : class;
+}
+
+class Derived : Base
+{
+    public override T?[] Goo<T>() where T : class => default!;
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var dGoo = (MethodSymbol)comp.GetMember("Derived.Goo");
+
+            Assert.True(((ArrayTypeSymbol)dGoo.ReturnType).ElementType.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, ((ArrayTypeSymbol)dGoo.ReturnType).ElementTypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void OverrideMethodReturningNullableClassParameter_WithMethodReturningNullableClass3()
+        {
+            var source = @"
+#nullable enable
+abstract class Base
+{
+    public abstract (T a, T? b)? Goo<T>() where T : class;
+}
+
+class Derived : Base
+{
+    public override (T a, T? b)? Goo<T>() where T : class => default;
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var dGoo = (MethodSymbol)comp.GetMember("Derived.Goo");
+
+            Assert.True(dGoo.ReturnType.IsNullableType());
+            var tuple = dGoo.ReturnType.GetMemberTypeArgumentsNoUseSiteDiagnostics()[0];
+            Assert.True(tuple.TupleElements[0].Type.IsReferenceType);
+            Assert.Equal(NullableAnnotation.NotAnnotated, tuple.TupleElements[0].TypeWithAnnotations.NullableAnnotation);
+            Assert.True(tuple.TupleElements[1].Type.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, tuple.TupleElements[1].TypeWithAnnotations.NullableAnnotation);
+        }
+
+        [Fact]
+        public void OverrideMethod_WithMultipleClassAndStructConstraints()
+        {
+            var source = @"
+using System.IO;
+
+#nullable enable
+abstract class Base
+{
+    public abstract T? Goo<T, U, V>(U? u, (V?, U?) vu) where T : Stream where U : struct where V : class;
+}
+
+class Derived : Base
+{
+    public override T? Goo<T, U, V>(U? u, (V?, U?) vu) where T : class where U : struct where V : class => default!;
+}
+";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var dGoo = (MethodSymbol)comp.GetMember("Derived.Goo");
+
+            Assert.True(dGoo.ReturnType.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, dGoo.ReturnTypeWithAnnotations.NullableAnnotation);
+
+            Assert.True(dGoo.Parameters[0].Type.IsNullableType());
+
+            var tuple = dGoo.Parameters[1].Type;
+            Assert.True(tuple.TupleElements[0].Type.IsReferenceType);
+            Assert.Equal(NullableAnnotation.Annotated, tuple.TupleElements[0].TypeWithAnnotations.NullableAnnotation);
+            Assert.True(tuple.TupleElements[1].Type.IsNullableType());
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -948,20 +948,16 @@ abstract class B : A, I
     internal override abstract void M4<T>() where T : struct;
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (14,20): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (14,20): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(14, 20),
-                // (15,22): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (15,22): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(15, 22),
-                // (16,37): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(16, 37),
-                // (17,36): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (17,36): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(17, 36),
-                // (18,45): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                // (18,45): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
                 Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(18, 45),
                 // (19,37): error CS0115: 'B.M4<T>()': no suitable method found to override
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M4").WithArguments("B.M4<T>()").WithLocation(19, 37),
-                // (19,45): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(19, 45));
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M4").WithArguments("B.M4<T>()").WithLocation(19, 37));
         }
 
         [WorkItem(862094, "DevDiv/Personal")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -948,15 +948,20 @@ abstract class B : A, I
     internal override abstract void M4<T>() where T : struct;
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (14,20): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(14, 20),
-                // (15,22): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(15, 22),
-                // (17,36): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(17, 36),
-                // (18,45): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
-                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(18, 45),
+                // (14,30): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                //     void I.M1<T>() where T : I { }
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "I").WithLocation(14, 30),
+                // (15,32): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                //     void I.M2<T,U>() where U : T { }
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "T").WithLocation(15, 32),
+                // (17,46): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                //     internal override void M2<T>() where T : new() { }
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "new()").WithLocation(17, 46),
+                // (18,55): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly, except for either a 'class', or a 'struct' constraint.
+                //     internal override abstract void M3<U>() where U : A;
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "A").WithLocation(18, 55),
                 // (19,37): error CS0115: 'B.M4<T>()': no suitable method found to override
+                //     internal override abstract void M4<T>() where T : struct;
                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M4").WithArguments("B.M4<T>()").WithLocation(19, 37));
         }
 


### PR DESCRIPTION
Closes #34798.
Closes #29847.