### PR TITLE
Apply hang mitigating timeouts in integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/AbstractCodeRefactorDialog_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/AbstractCodeRefactorDialog_InProc.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                         continue;
                     }
 
-                    WaitForApplicationIdle();
+                    WaitForApplicationIdle(Helper.HangMitigatingTimeout);
                     return;
                 }
             }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/CSharpInteractiveWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/CSharpInteractiveWindow_InProc.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             => new CSharpInteractiveWindow_InProc();
 
         protected override IInteractiveWindow AcquireInteractiveWindow()
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 var componentModel = GetComponentModel();
                 var vsInteractiveWindowProvider = componentModel.GetService<CSharpVsInteractiveWindowProvider>();

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
@@ -536,7 +536,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 try
                 {
                     var mainForm = (Form)designerHost.RootComponent;
-                    InvokeOnUIThread(() =>
+                    InvokeOnUIThread(cancellationToken =>
                     {
                         var newControl = (System.Windows.Forms.Button)designerHost.CreateComponent(typeof(System.Windows.Forms.Button), buttonName);
                         newControl.Parent = mainForm;
@@ -569,7 +569,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
                 try
                 {
-                    InvokeOnUIThread(() =>
+                    InvokeOnUIThread(cancellationToken =>
                     {
                         designerHost.DestroyComponent(designerHost.Container.Components[buttonName]);
                     });
@@ -621,7 +621,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
                 try
                 {
-                    InvokeOnUIThread(() =>
+                    InvokeOnUIThread(cancellationToken =>
                     {
                         var button = designerHost.Container.Components[buttonName];
                         var properties = TypeDescriptor.GetProperties(button);
@@ -663,7 +663,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
                 try
                 {
-                    InvokeOnUIThread(() =>
+                    InvokeOnUIThread(cancellationToken =>
                     {
                         var button = designerHost.Container.Components[buttonName];
                         var eventBindingService = (IEventBindingService)button.Site.GetService(typeof(IEventBindingService));
@@ -721,7 +721,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public List<string> GetF1Keywords()
         {
-            return InvokeOnUIThread(() =>
+            return InvokeOnUIThread(cancellationToken =>
             {
                 var results = new List<string>();
                 GetActiveVsTextView().GetBuffer(out var textLines);
@@ -766,7 +766,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         ///     [s1.Start, s1.Length, s2.Start, s2.Length, ...]
         /// </returns>
         public int[] GetTagSpans(string tagId)
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 var view = GetActiveTextView();
                 var tagAggregatorFactory = GetComponentModel().GetService<IViewTagAggregatorFactoryService>();
@@ -777,7 +777,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             });
 
         public void SendExplicitFocus()
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 var view = GetActiveVsTextView();
                 view.SendExplicitFocus();

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         {
             // The active text view might not have finished composing yet, waiting for the application to 'idle'
             // means that it is done pumping messages (including WM_PAINT) and the window should return the correct text view
-            WaitForApplicationIdle();
+            WaitForApplicationIdle(Helper.HangMitigatingTimeout);
 
             var activeVsTextView = (IVsUserData)GetActiveVsTextView();
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ErrorList_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ErrorList_InProc.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         private IVsEnumTaskItems GetErrorItems()
         {
-            return InvokeOnUIThread(() =>
+            return InvokeOnUIThread(cancellationToken =>
             {
                 var errorList = GetGlobalService<SVsErrorList, IVsTaskList>();
                 ErrorHandler.ThrowOnFailure(errorList.EnumTaskItems(out var items));

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ExtractInterfaceDialog_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ExtractInterfaceDialog_InProc.cs
@@ -29,11 +29,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                     {
                         // Thread.Yield is insufficient; something in the light bulb must be relying on a UI thread
                         // message at lower priority than the Background priority used in testing.
-                        WaitForApplicationIdle();
+                        WaitForApplicationIdle(Helper.HangMitigatingTimeout);
                         continue;
                     }
 
-                    WaitForApplicationIdle();
+                    WaitForApplicationIdle(Helper.HangMitigatingTimeout);
                     return;
                 }
             }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/FindReferencesWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/FindReferencesWindow_InProc.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public Reference[] GetContents(string windowCaption)
         {
-            return InvokeOnUIThread(() =>
+            return InvokeOnUIThread(cancellationToken =>
             {
                 // Find the tool window
                 var toolWindow = ((DTE2)GetDTE()).ToolWindows.GetToolWindow(windowCaption);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/GenerateTypeDialog_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/GenerateTypeDialog_InProc.cs
@@ -35,11 +35,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                     {
                         // Thread.Yield is insufficient; something in the light bulb must be relying on a UI thread
                         // message at lower priority than the Background priority used in testing.
-                        WaitForApplicationIdle();
+                        WaitForApplicationIdle(Helper.HangMitigatingTimeout);
                         continue;
                     }
 
-                    WaitForApplicationIdle();
+                    WaitForApplicationIdle(Helper.HangMitigatingTimeout);
                     return;
                 }
             }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
@@ -47,11 +47,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             }
         }
 
-        protected static void BeginInvokeOnUIThread(Action action)
-#pragma warning disable VSTHRD001 // Avoid legacy thread switching APIs
-            => CurrentApplicationDispatcher.BeginInvoke(action, DispatcherPriority.Background);
-#pragma warning restore VSTHRD001 // Avoid legacy thread switching APIs
-
         protected static void InvokeOnUIThread(Action<CancellationToken> action)
         {
             using var cancellationTokenSource = new CancellationTokenSource(Helper.HangMitigatingTimeout);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
@@ -52,24 +52,30 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             => CurrentApplicationDispatcher.BeginInvoke(action, DispatcherPriority.Background);
 #pragma warning restore VSTHRD001 // Avoid legacy thread switching APIs
 
-        protected static void InvokeOnUIThread(Action action)
+        protected static void InvokeOnUIThread(Action<CancellationToken> action)
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Helper.HangMitigatingTimeout);
 #pragma warning disable VSTHRD001 // Avoid legacy thread switching APIs
-            => CurrentApplicationDispatcher.Invoke(action, DispatcherPriority.Background);
+            CurrentApplicationDispatcher.Invoke(() => action(cancellationTokenSource.Token), DispatcherPriority.Background, cancellationToken: cancellationTokenSource.Token);
 #pragma warning restore VSTHRD001 // Avoid legacy thread switching APIs
+        }
 
-        protected static T InvokeOnUIThread<T>(Func<T> action)
+        protected static T InvokeOnUIThread<T>(Func<CancellationToken, T> action)
+        {
+            using var cancellationTokenSource = new CancellationTokenSource(Helper.HangMitigatingTimeout);
 #pragma warning disable VSTHRD001 // Avoid legacy thread switching APIs
-            => CurrentApplicationDispatcher.Invoke(action, DispatcherPriority.Background);
+            return CurrentApplicationDispatcher.Invoke(() => action(cancellationTokenSource.Token), DispatcherPriority.Background, cancellationToken: cancellationTokenSource.Token);
 #pragma warning restore VSTHRD001 // Avoid legacy thread switching APIs
+        }
 
         protected static TInterface GetGlobalService<TService, TInterface>()
             where TService : class
             where TInterface : class
-        => InvokeOnUIThread(() => (TInterface)ServiceProvider.GlobalProvider.GetService(typeof(TService)));
+        => InvokeOnUIThread(cancellationToken => (TInterface)ServiceProvider.GlobalProvider.GetService(typeof(TService)));
 
         protected static TService GetComponentModelService<TService>()
             where TService : class
-         => InvokeOnUIThread(() => GetComponentModel().GetService<TService>());
+         => InvokeOnUIThread(cancellationToken => GetComponentModel().GetService<TService>());
 
         protected static DTE GetDTE()
             => GetGlobalService<SDTE, DTE>();

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InProcComponent.cs
@@ -89,9 +89,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         /// <summary>
         /// Waiting for the application to 'idle' means that it is done pumping messages (including WM_PAINT).
         /// </summary>
-        protected static void WaitForApplicationIdle()
+        protected static void WaitForApplicationIdle(TimeSpan timeout)
 #pragma warning disable VSTHRD001 // Avoid legacy thread switching APIs
-            => CurrentApplicationDispatcher.Invoke(() => { }, DispatcherPriority.ApplicationIdle);
+            => CurrentApplicationDispatcher.InvokeAsync(() => { }, DispatcherPriority.ApplicationIdle).Wait(timeout);
 #pragma warning restore VSTHRD001 // Avoid legacy thread switching APIs
 
         protected static void WaitForSystemIdle()

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InteractiveWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/InteractiveWindow_InProc.cs
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void CloseWindow()
         {
-            InvokeOnUIThread(() =>
+            InvokeOnUIThread(cancellationToken =>
             {
                 var shell = GetGlobalService<SVsUIShell, IVsUIShell>();
                 if (ErrorHandler.Succeeded(shell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fFrameOnly, _windowId, out var windowFrame)))

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ObjectBrowserWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ObjectBrowserWindow_InProc.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public bool CloseWindow()
         {
-            return InvokeOnUIThread(() =>
+            return InvokeOnUIThread(cancellationToken =>
             {
                 var uiShell = GetGlobalService<SVsUIShell, IVsUIShell>();
                 if (ErrorHandler.Failed(uiShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fFrameOnly, new Guid(ToolWindowGuids.ObjectBrowser), out var frame)))

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/PickMembersDialog_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/PickMembersDialog_InProc.cs
@@ -35,11 +35,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                     {
                         // Thread.Yield is insufficient; something in the light bulb must be relying on a UI thread
                         // message at lower priority than the Background priority used in testing.
-                        WaitForApplicationIdle();
+                        WaitForApplicationIdle(Helper.HangMitigatingTimeout);
                         continue;
                     }
 
-                    WaitForApplicationIdle();
+                    WaitForApplicationIdle(Helper.HangMitigatingTimeout);
                     return;
                 }
             }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Shell_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Shell_InProc.cs
@@ -11,13 +11,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         public static Shell_InProc Create() => new Shell_InProc();
 
         public string GetActiveWindowCaption()
-            => InvokeOnUIThread(() => GetDTE().ActiveWindow.Caption);
+            => InvokeOnUIThread(cancellationToken => GetDTE().ActiveWindow.Caption);
 
         public IntPtr GetHWnd()
             => (IntPtr)GetDTE().MainWindow.HWnd;
 
         public bool IsActiveTabProvisional()
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 var shellMonitorSelection = GetGlobalService<SVsShellMonitorSelection, IVsMonitorSelection>();
                 if (!ErrorHandler.Succeeded(shellMonitorSelection.GetCurrentElementValue((uint)VSConstants.VSSELELEMID.SEID_DocumentFrame, out var windowFrameObject)))

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -1007,8 +1007,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public bool RestoreNuGetPackages(string projectName)
         {
+            using var cancellationTokenSource = new CancellationTokenSource(Helper.HangMitigatingTimeout);
+
             var solutionRestoreService = InvokeOnUIThread(() => GetComponentModel().GetExtensions<IVsSolutionRestoreService2>().Single());
-            return solutionRestoreService.NominateProjectAsync(GetProject(projectName).FullName, CancellationToken.None).Result;
+            var nominateProjectTask = solutionRestoreService.NominateProjectAsync(GetProject(projectName).FullName, cancellationTokenSource.Token);
+            nominateProjectTask.Wait(cancellationTokenSource.Token);
+            return nominateProjectTask.Result;
         }
 
         public void SaveAll()

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -371,7 +371,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             var directoriesToDelete = new List<string>();
             var dte = GetDTE();
 
-            InvokeOnUIThread(() =>
+            InvokeOnUIThread(cancellationToken =>
             {
                 if (dte.Solution != null)
                 {
@@ -489,7 +489,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
             public void Dispose()
             {
-                InvokeOnUIThread(() =>
+                InvokeOnUIThread(cancellationToken =>
                 {
                     ErrorHandler.ThrowOnFailure(_solution.UnadviseSolutionEvents(_cookie));
                 });
@@ -583,7 +583,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         {
             void SetText(string text)
             {
-                InvokeOnUIThread(() =>
+                InvokeOnUIThread(cancellationToken =>
                 {
                     // The active text view might not have finished composing yet, waiting for the application to 'idle'
                     // means that it is done pumping messages (including WM_PAINT) and the window should return the correct text view
@@ -891,7 +891,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void OpenFileWithDesigner(string projectName, string relativeFilePath)
         {
-            InvokeOnUIThread(() =>
+            InvokeOnUIThread(cancellationToken =>
             {
                 var filePath = GetAbsolutePathForProjectRelativeFilePath(projectName, relativeFilePath);
                 VsShellUtilities.OpenDocument(ServiceProvider.GlobalProvider, filePath, VSConstants.LOGVIEWID.Designer_guid, out _, out _, out var windowFrame, out _);
@@ -923,7 +923,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         private void CloseFile(string projectName, string relativeFilePath, Guid logicalView, bool saveFile)
         {
-            InvokeOnUIThread(() =>
+            InvokeOnUIThread(cancellationToken =>
             {
                 var filePath = GetAbsolutePathForProjectRelativeFilePath(projectName, relativeFilePath);
                 if (!VsShellUtilities.IsDocumentOpen(ServiceProvider.GlobalProvider, filePath, logicalView, out _, out _, out var windowFrame))
@@ -1009,7 +1009,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         {
             using var cancellationTokenSource = new CancellationTokenSource(Helper.HangMitigatingTimeout);
 
-            var solutionRestoreService = InvokeOnUIThread(() => GetComponentModel().GetExtensions<IVsSolutionRestoreService2>().Single());
+            var solutionRestoreService = InvokeOnUIThread(cancellationToken => GetComponentModel().GetExtensions<IVsSolutionRestoreService2>().Single());
             var nominateProjectTask = solutionRestoreService.NominateProjectAsync(GetProject(projectName).FullName, cancellationTokenSource.Token);
             nominateProjectTask.Wait(cancellationTokenSource.Token);
             return nominateProjectTask.Result;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -587,7 +587,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 {
                     // The active text view might not have finished composing yet, waiting for the application to 'idle'
                     // means that it is done pumping messages (including WM_PAINT) and the window should return the correct text view
-                    WaitForApplicationIdle();
+                    WaitForApplicationIdle(Helper.HangMitigatingTimeout);
 
                     var vsTextManager = GetGlobalService<SVsTextManager, IVsTextManager>();
                     var hresult = vsTextManager.GetActiveView(fMustHaveFocus: 1, pBuffer: null, ppView: out var vsTextView);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/StartPage_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/StartPage_InProc.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public bool IsEnabled()
         {
-            return InvokeOnUIThread(() =>
+            return InvokeOnUIThread(cancellationToken =>
             {
                 var property = GetProperty();
                 if (new Version(property.DTE.Version).Major == 16)
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void SetEnabled(bool enabled)
         {
-            InvokeOnUIThread(() =>
+            InvokeOnUIThread(cancellationToken =>
             {
                 var property = GetProperty();
                 if (new Version(property.DTE.Version).Major == 16)
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public bool CloseWindow()
         {
-            return InvokeOnUIThread(() =>
+            return InvokeOnUIThread(cancellationToken =>
             {
                 var uiShell = GetGlobalService<SVsUIShell, IVsUIShell>();
                 if (ErrorHandler.Failed(uiShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fFrameOnly, new Guid(ToolWindowGuids80.StartPage), out var frame)))

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -346,12 +346,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             }
         }
 
-        /// <summary>
-        /// Non-blocking version of <see cref="ExecuteOnActiveView"/>
-        /// </summary>
-        private void BeginInvokeExecuteOnActiveView(Action<IWpfTextView> action)
-            => BeginInvokeOnUIThread(GetExecuteOnActionViewCallback(action));
-
         private Func<IWpfTextView, Task> GetLightBulbApplicationAction(string actionName, FixAllScope? fixAllScope, bool willBlockUntilComplete)
         {
             return async view =>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void ShowLightBulb()
         {
-            InvokeOnUIThread(() =>
+            InvokeOnUIThread(cancellationToken =>
             {
                 var shell = GetGlobalService<SVsUIShell, IVsUIShell>();
                 var cmdGroup = typeof(VSConstants.VSStd2KCmdID).GUID;
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         protected abstract ITextBuffer GetBufferContainingCaret(IWpfTextView view);
 
         public string[] GetCurrentClassifications()
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 IClassifier classifier = null;
                 try
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         }
 
         protected T ExecuteOnActiveView<T>(Func<IWpfTextView, T> action)
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 var view = GetActiveTextView();
                 return action(view);
@@ -239,8 +239,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         protected void ExecuteOnActiveView(Action<IWpfTextView> action)
             => InvokeOnUIThread(GetExecuteOnActionViewCallback(action));
 
-        protected Action GetExecuteOnActionViewCallback(Action<IWpfTextView> action)
-            => () =>
+        protected Action<CancellationToken> GetExecuteOnActionViewCallback(Action<IWpfTextView> action)
+            => cancellationToken =>
             {
                 var view = GetActiveTextView();
                 action(view);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             => new VisualStudioWorkspace_InProc();
 
         public void SetOptionInfer(string projectName, bool value)
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 var convertedValue = value ? 1 : 0;
                 var project = GetProject(projectName);
@@ -48,14 +48,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             => _visualStudioWorkspace.Options.GetOption(FeatureOnOffOptions.PrettyListing, languageName);
 
         public void SetPrettyListing(string languageName, bool value)
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 _visualStudioWorkspace.Options = _visualStudioWorkspace.Options.WithChangedOption(
                     FeatureOnOffOptions.PrettyListing, languageName, value);
             });
 
         public void EnableQuickInfo(bool value)
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 _visualStudioWorkspace.Options = _visualStudioWorkspace.Options.WithChangedOption(
                     InternalFeatureOnOffOptions.QuickInfo, value);
@@ -124,14 +124,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         }
 
         public void CleanUpWorkspace()
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 LoadRoslynPackage();
                 _visualStudioWorkspace.TestHookPartialSolutionsDisabled = true;
             });
 
         public void CleanUpWaitingService()
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 var provider = GetComponentModel().DefaultExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>();
 
@@ -144,7 +144,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             });
 
         public void SetFeatureOption(string feature, string optionName, string language, string valueString)
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 var optionService = _visualStudioWorkspace.Services.GetService<IOptionService>();
                 var option = optionService.GetRegisteredOptions().FirstOrDefault(o => o.Feature == feature && o.Name == optionName);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc.cs
@@ -15,8 +15,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         public static VisualStudio_InProc Create()
             => new VisualStudio_InProc();
 
-        new public void WaitForApplicationIdle()
-            => InProcComponent.WaitForApplicationIdle();
+        public new void WaitForApplicationIdle(TimeSpan timeout)
+            => InProcComponent.WaitForApplicationIdle(timeout);
 
         new public void WaitForSystemIdle()
             => InProcComponent.WaitForSystemIdle();

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         }
 
         public void ActivateMainWindow()
-            => InvokeOnUIThread(() =>
+            => InvokeOnUIThread(cancellationToken =>
             {
                 var dte = GetDTE();
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc_Telemetry.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudio_InProc_Telemetry.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
     {
         public void EnableTestTelemetryChannel()
         {
-            InvokeOnUIThread(() =>
+            InvokeOnUIThread(cancellationToken =>
             {
                 TelemetryService.DetachTestChannel(LoggerTestChannel.Instance);
 
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void DisableTestTelemetryChannel()
         {
-            InvokeOnUIThread(() =>
+            InvokeOnUIThread(cancellationToken =>
             {
                 TelemetryService.DetachTestChannel(LoggerTestChannel.Instance);
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Input/SendKeys_InProc.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Input
 
         protected override void WaitForApplicationIdle(CancellationToken cancellationToken)
         {
-            _visualStudioInstance.WaitForApplicationIdle();
+            _visualStudioInstance.WaitForApplicationIdle(Helper.HangMitigatingTimeout);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
         public void WaitForApplicationIdle(CancellationToken cancellationToken)
         {
-            var task = Task.Factory.StartNew(() => _inProc.WaitForApplicationIdle(), cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            var task = Task.Factory.StartNew(() => _inProc.WaitForApplicationIdle(Helper.HangMitigatingTimeout), cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             task.Wait(cancellationToken);
         }
 


### PR DESCRIPTION
* WaitForApplicationIdle: Addresses hang observed in 3-Logs Debug Async 20190415.30.
* RestoreNuGetPackages: Addresses hang observed in 1-Logs Release Legacy 20190416.62.
* InvokeOnUIThread: Addresses hang observed in 1-Logs Debug Legacy 20190416.50.