### PR TITLE
Use Machine.Arm64 instead of raw value

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case Platform.X64:
                         return Machine.Amd64;
                     case Platform.Arm64:
-                        return (Machine)0xAA64;//Machine.Arm64; https://github.com/dotnet/roslyn/issues/25185
+                        return Machine.Arm64;
                     case Platform.Itanium:
                         return Machine.IA64;
                     default:

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -103,8 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 Select Case DeclaringCompilation.Options.Platform
                     Case Platform.Arm64
-                        ' Use real enum instead of casting value https://github.com/dotnet/roslyn/issues/25185
-                        Return CType(CInt(&HAA64), System.Reflection.PortableExecutable.Machine)
+                        Return System.Reflection.PortableExecutable.Machine.Arm64
                     Case Platform.Arm
                         Return System.Reflection.PortableExecutable.Machine.ArmThumb2
                     Case Platform.X64


### PR DESCRIPTION
## Changes
- Use `Machine.Arm64` instead of raw value.

These cases were probably missed on #27023.