### PR TITLE
Fully NGen CodeLens assembly until optimization training is complete

### DIFF
--- a/src/VisualStudio/CodeLens/Microsoft.VisualStudio.CodeAnalysis.CodeLens.csproj
+++ b/src/VisualStudio/CodeLens/Microsoft.VisualStudio.CodeAnalysis.CodeLens.csproj
@@ -8,7 +8,9 @@
     <RootNamespace>Microsoft.VisualStudio.CodeAnalysis.CodeLens</RootNamespace>
     <TargetFramework>net472</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Removing until training data includes data for this assembly.
     <ApplyPartialNgenOptimization>true</ApplyPartialNgenOptimization>
+    -->
 
     <!-- NuGet -->
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
As an alternative to https://github.com/dotnet/roslyn/pull/35106.

Try to fully NGen the CodeLens assembly in order to get a build fro 16.1 preview2.