### PR TITLE
`Equals` for generic methods should compare nullable annotations for type type arguments.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -416,8 +416,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             int arity = this.Arity;
             for (int i = 0; i < arity; i++)
             {
-                // TODO: what about annotations
-                if (!TypeSymbol.Equals(this.TypeArgumentsWithAnnotations[i].Type, other.TypeArgumentsWithAnnotations[i].Type, TypeCompareKind.ConsiderEverything2))
+                if (!this.TypeArgumentsWithAnnotations[i].Equals(other.TypeArgumentsWithAnnotations[i], TypeCompareKind.ConsiderEverything2))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -400,7 +400,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // This checks if the methods have the same definition and the type parameters on the containing types have been
             // substituted in the same way.
-            if (!TypeSymbol.Equals(this.ContainingType, other.ContainingType, TypeCompareKind.ConsiderEverything2)) return false;
+            if (!TypeSymbol.Equals(this.ContainingType, other.ContainingType, TypeCompareKind.ConsiderEverything)) return false;
 
             // If both are declarations, then we don't need to check type arguments
             // If exactly one is a declaration, then they re not equal
@@ -416,7 +416,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             int arity = this.Arity;
             for (int i = 0; i < arity; i++)
             {
-                if (!this.TypeArgumentsWithAnnotations[i].Equals(other.TypeArgumentsWithAnnotations[i], TypeCompareKind.ConsiderEverything2))
+                if (!this.TypeArgumentsWithAnnotations[i].Equals(other.TypeArgumentsWithAnnotations[i], TypeCompareKind.ConsiderEverything))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -68575,6 +68575,65 @@ class A<T1, T2> where T1 : class where T2 : class
         }
 
         [Fact]
+        [WorkItem(35083, "https://github.com/dotnet/roslyn/issues/35083")]
+        public void GenericSubstitution_07()
+        {
+            var source =
+@"
+class A
+{
+    void M1<T>()
+    {
+    }
+}
+";
+            var comp = CreateCompilation(new[] { source });
+            comp.VerifyDiagnostics();
+
+            var a = comp.GetTypeByMetadataName("A");
+            var m1 = a.GetMember<MethodSymbol>("M1");
+
+            var m11 = new[]
+                {
+                    m1.Construct(ImmutableArray.Create(TypeWithAnnotations.Create(a, NullableAnnotation.Annotated))),
+                    m1.Construct(ImmutableArray.Create(TypeWithAnnotations.Create(a, NullableAnnotation.NotAnnotated))),
+                    m1.Construct(ImmutableArray.Create(TypeWithAnnotations.Create(a, NullableAnnotation.Oblivious)))
+                };
+
+            var m12 = new[]
+                {
+                    m1.Construct(ImmutableArray.Create(TypeWithAnnotations.Create(a, NullableAnnotation.Annotated))),
+                    m1.Construct(ImmutableArray.Create(TypeWithAnnotations.Create(a, NullableAnnotation.NotAnnotated))),
+                    m1.Construct(ImmutableArray.Create(TypeWithAnnotations.Create(a, NullableAnnotation.Oblivious)))
+                };
+
+            for (int i = 0; i < m11.Length; i++)
+            {
+                var method1 = m11[i];
+
+                Assert.True(method1.Equals(method1));
+
+                for (int j = 0; j < m12.Length; j++)
+                {
+                    var method2 = m12[j];
+
+                    if (i == j)
+                    {
+                        Assert.True(method1.Equals(method2));
+                        Assert.True(method2.Equals(method1));
+                    }
+                    else
+                    {
+                        Assert.False(method1.Equals(method2));
+                        Assert.False(method2.Equals(method1));
+                    }
+
+                    Assert.Equal(method1.GetHashCode(), method2.GetHashCode());
+                }
+            }
+        }
+
+        [Fact]
         [WorkItem(30171, "https://github.com/dotnet/roslyn/issues/30171")]
         public void NonNullTypesContext_01()
         {


### PR DESCRIPTION
Fixes #35083.