### PR TITLE
Async-enumerator methods honor the EnumeratorCancellation attribute

### DIFF
--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -182,7 +182,7 @@ IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken token)
     {
         result = new {StateMachineType}(InitialState);
     }
-    /* copy each parameter proxy, or copy the token parameter if it's not default for any parameter marked with [DefaultCancellation] attribute */
+    /* copy each parameter proxy, or copy the token parameter if it's not default for any parameter marked with [EnumeratorCancellation] attribute */
 }
 ```
 For a discussion of the threadID check, see https://github.com/dotnet/corefx/issues/3481

--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -182,7 +182,7 @@ IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken token)
     {
         result = new {StateMachineType}(InitialState);
     }
-    /* copy all of the parameter proxies */
+    /* copy each parameter proxy, or copy the token parameter if it's not default for any parameter marked with [DefaultCancellation] attribute */
 }
 ```
 For a discussion of the threadID check, see https://github.com/dotnet/corefx/issues/3481

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -16216,6 +16216,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The DefaultCancellationAttribute applied to parameter &apos;{0}&apos; will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method.
+        /// </summary>
+        internal static string WRN_UnconsumedDefaultCancellationAttributeUsage {
+            get {
+                return ResourceManager.GetString("WRN_UnconsumedDefaultCancellationAttributeUsage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method.
+        /// </summary>
+        internal static string WRN_UnconsumedDefaultCancellationAttributeUsage_Title {
+            get {
+                return ResourceManager.GetString("WRN_UnconsumedDefaultCancellationAttributeUsage_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Assuming assembly reference &apos;{0}&apos; used by &apos;{1}&apos; matches identity &apos;{2}&apos; of &apos;{3}&apos;, you may need to supply runtime policy.
         /// </summary>
         internal static string WRN_UnifyReferenceBldRev {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -16216,20 +16216,20 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The DefaultCancellationAttribute applied to parameter &apos;{0}&apos; will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method.
+        ///   Looks up a localized string similar to The EnumeratorCancellationAttribute applied to parameter &apos;{0}&apos; will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable.
         /// </summary>
-        internal static string WRN_UnconsumedDefaultCancellationAttributeUsage {
+        internal static string WRN_UnconsumedEnumeratorCancellationAttributeUsage {
             get {
-                return ResourceManager.GetString("WRN_UnconsumedDefaultCancellationAttributeUsage", resourceCulture);
+                return ResourceManager.GetString("WRN_UnconsumedEnumeratorCancellationAttributeUsage", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method.
+        ///   Looks up a localized string similar to The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable.
         /// </summary>
-        internal static string WRN_UnconsumedDefaultCancellationAttributeUsage_Title {
+        internal static string WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title {
             get {
-                return ResourceManager.GetString("WRN_UnconsumedDefaultCancellationAttributeUsage_Title", resourceCulture);
+                return ResourceManager.GetString("WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5883,6 +5883,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_NullReferenceIterationVariable_Title" xml:space="preserve">
 	<value>Possible null reference assignment to iteration variable</value>
   </data>
+  <data name="WRN_UnconsumedDefaultCancellationAttributeUsage" xml:space="preserve">
+    <value>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</value>
+  </data>
+  <data name="WRN_UnconsumedDefaultCancellationAttributeUsage_Title" xml:space="preserve">
+    <value>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</value>
+  </data>
   <data name="ERR_OverrideRefConstraintNotSatisfied" xml:space="preserve">
     <value>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5883,11 +5883,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_NullReferenceIterationVariable_Title" xml:space="preserve">
 	<value>Possible null reference assignment to iteration variable</value>
   </data>
-  <data name="WRN_UnconsumedDefaultCancellationAttributeUsage" xml:space="preserve">
-    <value>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</value>
+  <data name="WRN_UnconsumedEnumeratorCancellationAttributeUsage" xml:space="preserve">
+    <value>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</value>
   </data>
-  <data name="WRN_UnconsumedDefaultCancellationAttributeUsage_Title" xml:space="preserve">
-    <value>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</value>
+  <data name="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title" xml:space="preserve">
+    <value>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</value>
   </data>
   <data name="ERR_OverrideRefConstraintNotSatisfied" xml:space="preserve">
     <value>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1599,7 +1599,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_StaticLocalFunctionCannotCaptureVariable = 8421,
         ERR_StaticLocalFunctionCannotCaptureThis = 8422,
         ERR_AttributeNotOnEventAccessor = 8423,
-        WRN_UnconsumedDefaultCancellationAttributeUsage = 8424,
+        WRN_UnconsumedEnumeratorCancellationAttributeUsage = 8424,
         // available range
 
         #region diagnostics introduced for recursive patterns

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1599,8 +1599,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_StaticLocalFunctionCannotCaptureVariable = 8421,
         ERR_StaticLocalFunctionCannotCaptureThis = 8422,
         ERR_AttributeNotOnEventAccessor = 8423,
+        WRN_UnconsumedDefaultCancellationAttributeUsage = 8424,
+        // available range
+
         #region diagnostics introduced for recursive patterns
-        // 8501, // available
         ERR_WrongNumberOfSubpatterns = 8502,
         ERR_PropertyPatternNameMissing = 8503,
         ERR_MissingPattern = 8504,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_AsOperatorMayReturnNull:
                 case ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull:
                 case ErrorCode.WRN_ImplicitCopyInReadOnlyMember:
-                case ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage:
+                case ErrorCode.WRN_UnconsumedEnumeratorCancellationAttributeUsage:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -411,6 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_AsOperatorMayReturnNull:
                 case ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull:
                 case ErrorCode.WRN_ImplicitCopyInReadOnlyMember:
+                case ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -181,6 +181,7 @@
                 case ErrorCode.WRN_TupleBinopLiteralNameMismatch:
                 case ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter:
                 case ErrorCode.WRN_DefaultLiteralConvertedToNullIsNotIntended:
+                case ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage:
                 case ErrorCode.WRN_SwitchExpressionNotExhaustive:
                 case ErrorCode.WRN_CaseConstantNamedUnderscore:
                 case ErrorCode.WRN_IsTypeNamedUnderscore:

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -181,7 +181,7 @@
                 case ErrorCode.WRN_TupleBinopLiteralNameMismatch:
                 case ErrorCode.WRN_TypeParameterSameAsOuterMethodTypeParameter:
                 case ErrorCode.WRN_DefaultLiteralConvertedToNullIsNotIntended:
-                case ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage:
+                case ErrorCode.WRN_UnconsumedEnumeratorCancellationAttributeUsage:
                 case ErrorCode.WRN_SwitchExpressionNotExhaustive:
                 case ErrorCode.WRN_CaseConstantNamedUnderscore:
                 case ErrorCode.WRN_IsTypeNamedUnderscore:

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (isDebugBuild)
                         {
-                            // Calculate local debug id. 
+                            // Calculate local debug id.
                             //
                             // EnC: When emitting the baseline (gen 0) the id is stored in a custom debug information attached to the kickoff method.
                             //      When emitting a delta the id is only used to map to the existing field in the previous generation.
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        // The field needs to be public iff it is initialized directly from the kickoff method 
+                        // The field needs to be public iff it is initialized directly from the kickoff method
                         // (i.e. not for IEnumerable which loads the values from parameter proxies).
                         var proxyField = F.StateMachineField(typeMap.SubstituteType(parameter.Type).Type, parameter.Name, isPublic: !PreserveInitialParameterValuesAndThreadId);
                         proxiesBuilder.Add(parameter, new CapturedToStateMachineFieldReplacement(proxyField, isReusable: false));
@@ -374,7 +374,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             //    {
             //        result = new {StateMachineType}({initialState});
             //    }
-            //    result.parameter = this.parameterProxy; // copy all of the parameter proxies
+            //
+            //    // copy each parameter proxy
+            //    result.parameter = this.parameterProxy;
+            //
+            //    // Or, in async-iterators, for any parameter marked with [DefaultCancellation] attribute, conditionally copy GetAsyncEnumerator's cancellation token parameter instead
+            //    if (token.Equals(default))
+            //        result.parameter = this.parameterProxy;
+            //    else
+            //        result.parameter = token;
 
             // The implementation doesn't depend on the method body of the iterator method.
             // Only on its parameters and staticness.
@@ -451,16 +459,53 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CapturedSymbolReplacement proxy;
                 if (copyDest.TryGetValue(parameter, out proxy))
                 {
-                    bodyBuilder.Add(
-                        F.Assignment(
-                            proxy.Replacement(F.Syntax, stateMachineType => F.Local(resultVariable)),
-                            copySrc[parameter].Replacement(F.Syntax, stateMachineType => F.This())));
+                    // result.parameter = this.parameterProxy;
+                    BoundExpression left = proxy.Replacement(F.Syntax, stateMachineType => F.Local(resultVariable));
+                    BoundStatement copy = F.Assignment(
+                            left,
+                            copySrc[parameter].Replacement(F.Syntax, stateMachineType => F.This()));
+
+                    if (this.method.IsAsync)
+                    {
+                        ParameterSymbol tokenParameter = getEnumeratorMethod.Parameters[0];
+                        if (hasDefaultCancellationAttribute(parameter))
+                        {
+                            // For any parameter marked with [DefaultCancellation] attribute, conditionally copy GetAsyncEnumerator's cancellation token parameter instead
+                            // if (token.Equals(default))
+                            //     result.parameter = this.parameterProxy;
+                            // else
+                            //     result.parameter = token;
+
+                            copy = F.If(
+                                // if (token.Equals(default))
+                                F.Call(F.Parameter(tokenParameter), WellKnownMember.System_Threading_CancellationToken__Equals, F.Default(tokenParameter.Type)),
+                                // result.parameter = this.parameterProxy;
+                                copy,
+                                // result.parameter = token;
+                                F.Assignment(left, F.Parameter(tokenParameter)));
+                        }
+                    }
+
+                    bodyBuilder.Add(copy);
                 }
             }
 
             bodyBuilder.Add(F.Return(F.Local(resultVariable)));
             F.CloseMethod(F.Block(ImmutableArray.Create(resultVariable), bodyBuilder.ToImmutableAndFree()));
             return getEnumerator;
+
+            static bool hasDefaultCancellationAttribute(ParameterSymbol parameter)
+            {
+                foreach (var attribute in parameter.GetAttributes())
+                {
+                    if (attribute.IsTargetAttribute(parameter, AttributeDescription.DefaultCancellationAttribute))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -651,7 +651,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasAssertsFalseAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DefaultCancellationAttribute))
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.EnumeratorCancellationAttribute))
             {
                 ValidateCancellationTokenAttribute(arguments.AttributeSyntaxOpt, arguments.Diagnostics);
             }
@@ -928,7 +928,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (needsReporting())
             {
-                diagnostics.Add(ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage, node.Name.Location, CSharpSyntaxNode.Identifier.ValueText);
+                diagnostics.Add(ErrorCode.WRN_UnconsumedEnumeratorCancellationAttributeUsage, node.Name.Location, CSharpSyntaxNode.Identifier.ValueText);
             }
 
             bool needsReporting()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -651,6 +651,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 arguments.GetOrCreateData<ParameterWellKnownAttributeData>().HasAssertsFalseAttribute = true;
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.DefaultCancellationAttribute))
+            {
+                ValidateCancellationTokenAttribute(arguments.AttributeSyntaxOpt, arguments.Diagnostics);
+            }
         }
 
         private void DecodeDefaultParameterValueAttribute(AttributeDescription description, ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments)
@@ -918,6 +922,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             diagnostics.Add(node.Name.Location, useSiteDiagnostics);
+        }
+
+        private void ValidateCancellationTokenAttribute(AttributeSyntax node, DiagnosticBag diagnostics)
+        {
+            if (needsReporting())
+            {
+                diagnostics.Add(ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage, node.Name.Location, CSharpSyntaxNode.Identifier.ValueText);
+            }
+
+            bool needsReporting()
+            {
+                if (!Type.Equals(this.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Threading_CancellationToken)))
+                {
+                    return true;
+                }
+                else if (this.ContainingSymbol is MethodSymbol method &&
+                    method.IsAsync &&
+                    method.ReturnType.OriginalDefinition.Equals(this.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IAsyncEnumerable_T)))
+                {
+                    // Note: async methods that return this type must be iterators. This is enforced elsewhere
+                    return false;
+                }
+
+                return true;
+            }
         }
 
         internal override void PostDecodeWellKnownAttributes(ImmutableArray<CSharpAttributeData> boundAttributes, ImmutableArray<AttributeSyntax> allAttributeSyntaxNodes, DiagnosticBag diagnostics, AttributeLocation symbolPart, WellKnownAttributeData decodedData)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1737,14 +1737,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1737,6 +1737,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">Pole {0} {1}, které neumožňuje hodnotu null, není inicializované.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1737,14 +1737,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1737,6 +1737,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">Nicht-Nullable-{0} "{1}" wurde nicht initialisiert.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1739,6 +1739,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">Se ha anulado la inicialización del {0} "{1}" que no acepta valores NULL.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1739,14 +1739,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1738,14 +1738,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1738,6 +1738,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">Le {0} '{1}' non Nullable n'est pas initialisé.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1737,14 +1737,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1737,6 +1737,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">L'elemento {0} non nullable '{1}' non è inizializzato.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1737,14 +1737,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1737,6 +1737,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">Null 非許容 {0} '{1}' が初期化されていません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1737,14 +1737,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1737,6 +1737,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">nullable이 아닌 {0} '{1}'이(가) 초기화되지 않았습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1737,14 +1737,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1737,6 +1737,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">Element {0} „{1}” niedopuszczający wartości null jest niezainicjowany.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1737,14 +1737,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1737,6 +1737,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">O {0} não nulo '{1}' é não inicializado.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1737,6 +1737,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">Не инициализировано {0} "{1}", не допускающее значение NULL.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1737,14 +1737,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1738,6 +1738,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">Boş değer atanamaz {0} '{1}' başlatılmadı.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1738,14 +1738,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1778,14 +1778,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1778,6 +1778,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">未初始化不可以为 null 的 {0}“{1}”。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1737,14 +1737,14 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
-        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage">
+        <source>The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
-        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
-        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+      <trans-unit id="WRN_UnconsumedEnumeratorCancellationAttributeUsage_Title">
+        <source>The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</source>
+        <target state="new">The EnumeratorCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-iterator method returning IAsyncEnumerable</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1737,6 +1737,16 @@
         <target state="new">Unboxing a possibly null value.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage">
+        <source>The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute applied to parameter '{0}' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_UnconsumedDefaultCancellationAttributeUsage_Title">
+        <source>The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</source>
+        <target state="new">The DefaultCancellationAttribute will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_UninitializedNonNullableField">
         <source>Non-nullable {0} '{1}' is uninitialized.</source>
         <target state="translated">不可為 Null 的型別 {0} '{1}' 未初始化。</target>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -253,7 +253,6 @@ class C
 }";
             var expected = new[]
             {
-
                 // (4,45): error CS0234: The type or namespace name 'IAsyncEnumerable<>' does not exist in the namespace 'System.Collections.Generic' (are you missing an assembly reference?)
                 //     static async System.Collections.Generic.IAsyncEnumerable<int> M()
                 Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInNS, "IAsyncEnumerable<int>").WithArguments("IAsyncEnumerable<>", "System.Collections.Generic").WithLocation(4, 45),

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -5012,5 +5012,782 @@ public class MyEnumerable
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "42 43 Long Cancelled");
         }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_NoTokenPassedInGetAsyncEnumerator()
+        {
+            string source = @"
+using static System.Console;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async Task Main()
+    {
+        using CancellationTokenSource source = new CancellationTokenSource();
+        CancellationToken token = source.Token;
+        var enumerable = Iter(42, token);
+        await using var enumerator = enumerable.GetAsyncEnumerator(); // no token passed
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 42
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 43
+
+        source.Cancel();
+        try
+        {
+            await enumerator.MoveNextAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+            Write(""Cancelled"");
+        }
+    }
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [DefaultCancellation] CancellationToken token)
+    {
+        yield return value++;
+        await Task.Yield();
+        yield return value++;
+        token.ThrowIfCancellationRequested();
+        Write(""SKIPPED"");
+        yield return value++;
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "42 43 Cancelled");
+
+            // IL for GetAsyncEnumerator is verified by AsyncIteratorWithAwaitCompletedAndYield already
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_DefaultTokenPassedInGetAsyncEnumerator()
+        {
+            string source = @"
+using static System.Console;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async Task Main()
+    {
+        using CancellationTokenSource source = new CancellationTokenSource();
+        CancellationToken token = source.Token;
+        var enumerable = Iter(42, token);
+        await using var enumerator = enumerable.GetAsyncEnumerator(default); // default token passed
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 42
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 43
+
+        source.Cancel();
+        try
+        {
+            await enumerator.MoveNextAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+            Write(""Cancelled"");
+        }
+    }
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [DefaultCancellation] CancellationToken token)
+    {
+        yield return value++;
+        await Task.Yield();
+        yield return value++;
+        token.ThrowIfCancellationRequested();
+        Write(""SKIPPED"");
+        yield return value++;
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "42 43 Cancelled");
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_SomeTokenPassedInGetAsyncEnumerator()
+        {
+            string source = @"
+using static System.Console;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async Task Main()
+    {
+        using CancellationTokenSource source = new CancellationTokenSource();
+        CancellationToken token = source.Token;
+        var enumerable = Iter(42, default);
+        await using var enumerator = enumerable.GetAsyncEnumerator(token); // some token passed
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 42
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 43
+
+        source.Cancel();
+        try
+        {
+            await enumerator.MoveNextAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+            Write(""Cancelled"");
+        }
+    }
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [DefaultCancellation] CancellationToken token1)
+    {
+        yield return value++;
+        await Task.Yield();
+        yield return value++;
+        token1.ThrowIfCancellationRequested();
+        Write(""SKIPPED"");
+        yield return value++;
+    }
+}";
+            foreach (var options in new[] { TestOptions.DebugExe, TestOptions.ReleaseExe })
+            {
+                var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType }, options: options);
+                comp.VerifyDiagnostics();
+                var verifier = CompileAndVerify(comp, expectedOutput: "42 43 Cancelled");
+
+                // field for token1 gets overridden with value from GetAsyncEnumerator's token parameter
+                verifier.VerifyIL("C.<Iter>d__1.System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)", @"
+{
+  // Code size      103 (0x67)
+  .maxstack  2
+  .locals init (C.<Iter>d__1 V_0,
+                System.Threading.CancellationToken V_1)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<Iter>d__1.<>1__state""
+  IL_0006:  ldc.i4.s   -2
+  IL_0008:  bne.un.s   IL_002a
+  IL_000a:  ldarg.0
+  IL_000b:  ldfld      ""int C.<Iter>d__1.<>l__initialThreadId""
+  IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
+  IL_0015:  bne.un.s   IL_002a
+  IL_0017:  ldarg.0
+  IL_0018:  ldc.i4.s   -3
+  IL_001a:  stfld      ""int C.<Iter>d__1.<>1__state""
+  IL_001f:  ldarg.0
+  IL_0020:  stloc.0
+  IL_0021:  ldarg.0
+  IL_0022:  ldc.i4.0
+  IL_0023:  stfld      ""bool C.<Iter>d__1.<>w__disposeMode""
+  IL_0028:  br.s       IL_0032
+  IL_002a:  ldc.i4.s   -3
+  IL_002c:  newobj     ""C.<Iter>d__1..ctor(int)""
+  IL_0031:  stloc.0
+  IL_0032:  ldloc.0
+  IL_0033:  ldarg.0
+  IL_0034:  ldfld      ""int C.<Iter>d__1.<>3__value""
+  IL_0039:  stfld      ""int C.<Iter>d__1.value""
+  IL_003e:  ldarga.s   V_1
+  IL_0040:  ldloca.s   V_1
+  IL_0042:  initobj    ""System.Threading.CancellationToken""
+  IL_0048:  ldloc.1
+  IL_0049:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
+  IL_004e:  brfalse.s  IL_005e
+  IL_0050:  ldloc.0
+  IL_0051:  ldarg.0
+  IL_0052:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token1""
+  IL_0057:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
+  IL_005c:  br.s       IL_0065
+  IL_005e:  ldloc.0
+  IL_005f:  ldarg.1
+  IL_0060:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
+  IL_0065:  ldloc.0
+  IL_0066:  ret
+}
+");
+            }
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_SomeTokenPassedInGetAsyncEnumerator_ButNoAttribute()
+        {
+            string source = @"
+using static System.Console;
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async Task Main()
+    {
+        using CancellationTokenSource source = new CancellationTokenSource();
+        CancellationToken token = source.Token;
+        var enumerable = Iter(42, default);
+        await using var enumerator = enumerable.GetAsyncEnumerator(token); // some token passed
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 42
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 43
+
+        source.Cancel();
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 44
+    }
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, CancellationToken token1) // no attribute set
+    {
+        yield return value++;
+        await Task.Yield();
+        yield return value++;
+        token1.ThrowIfCancellationRequested();
+        Write(""REACHED "");
+        yield return value++;
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "42 43 REACHED 44");
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_SomeOtherTokenPassedInGetAsyncEnumerator()
+        {
+            string source = @"
+using static System.Console;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async Task Main()
+    {
+        using CancellationTokenSource source1 = new CancellationTokenSource();
+        source1.Cancel();
+        CancellationToken token1 = source1.Token;
+        var enumerable = Iter(default, 42);
+
+        using CancellationTokenSource source2 = new CancellationTokenSource();
+        CancellationToken token2 = source2.Token;
+        await using var enumerator = enumerable.GetAsyncEnumerator(token2); // some other token passed
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 42
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 43
+
+        source2.Cancel();
+        try
+        {
+            await enumerator.MoveNextAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+            Write(""Cancelled"");
+        }
+    }
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter([DefaultCancellation] CancellationToken token1, int value) // note: token is in first position
+    {
+        yield return value++;
+        await Task.Yield();
+        yield return value++;
+        token1.ThrowIfCancellationRequested();
+        Write(""SKIPPED"");
+        yield return value++;
+    }
+}";
+            foreach (var options in new[] { TestOptions.DebugExe, TestOptions.ReleaseExe })
+            {
+                var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType }, options: options);
+                comp.VerifyDiagnostics();
+                var verifier = CompileAndVerify(comp, expectedOutput: "42 43 Cancelled");
+
+                // field for token1 gets overridden with value from GetAsyncEnumerator's token parameter
+                verifier.VerifyIL("C.<Iter>d__1.System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)", @"
+{
+  // Code size      103 (0x67)
+  .maxstack  2
+  .locals init (C.<Iter>d__1 V_0,
+                System.Threading.CancellationToken V_1)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<Iter>d__1.<>1__state""
+  IL_0006:  ldc.i4.s   -2
+  IL_0008:  bne.un.s   IL_002a
+  IL_000a:  ldarg.0
+  IL_000b:  ldfld      ""int C.<Iter>d__1.<>l__initialThreadId""
+  IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
+  IL_0015:  bne.un.s   IL_002a
+  IL_0017:  ldarg.0
+  IL_0018:  ldc.i4.s   -3
+  IL_001a:  stfld      ""int C.<Iter>d__1.<>1__state""
+  IL_001f:  ldarg.0
+  IL_0020:  stloc.0
+  IL_0021:  ldarg.0
+  IL_0022:  ldc.i4.0
+  IL_0023:  stfld      ""bool C.<Iter>d__1.<>w__disposeMode""
+  IL_0028:  br.s       IL_0032
+  IL_002a:  ldc.i4.s   -3
+  IL_002c:  newobj     ""C.<Iter>d__1..ctor(int)""
+  IL_0031:  stloc.0
+  IL_0032:  ldarga.s   V_1
+  IL_0034:  ldloca.s   V_1
+  IL_0036:  initobj    ""System.Threading.CancellationToken""
+  IL_003c:  ldloc.1
+  IL_003d:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
+  IL_0042:  brfalse.s  IL_0052
+  IL_0044:  ldloc.0
+  IL_0045:  ldarg.0
+  IL_0046:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token1""
+  IL_004b:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
+  IL_0050:  br.s       IL_0059
+  IL_0052:  ldloc.0
+  IL_0053:  ldarg.1
+  IL_0054:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
+  IL_0059:  ldloc.0
+  IL_005a:  ldarg.0
+  IL_005b:  ldfld      ""int C.<Iter>d__1.<>3__value""
+  IL_0060:  stfld      ""int C.<Iter>d__1.value""
+  IL_0065:  ldloc.0
+  IL_0066:  ret
+}
+");
+            }
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_WrongParameterType()
+        {
+            string source = @"
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter([DefaultCancellation] int value)
+    {
+        yield return value++;
+        await Task.Yield();
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType });
+            comp.VerifyDiagnostics(
+                // (6,73): warning CS8424: The DefaultCancellationAttribute applied to parameter 'value' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method
+                //     static async System.Collections.Generic.IAsyncEnumerable<int> Iter([DefaultCancellation] int value)
+                Diagnostic(ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage, "DefaultCancellation").WithArguments("value").WithLocation(6, 73)
+                );
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_AsyncEnumerator()
+        {
+            string source = @"
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async System.Collections.Generic.IAsyncEnumerator<int> Iter([DefaultCancellation] CancellationToken value)
+    {
+        yield return 1;
+        await Task.Yield();
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType });
+            comp.VerifyDiagnostics(
+                // (7,73): warning CS8424: The DefaultCancellationAttribute applied to parameter 'value' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method
+                //     static async System.Collections.Generic.IAsyncEnumerator<int> Iter([DefaultCancellation] CancellationToken value)
+                Diagnostic(ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage, "DefaultCancellation").WithArguments("value").WithLocation(7, 73)
+                );
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_IteratorMethod()
+        {
+            string source = @"
+using System.Runtime.CompilerServices;
+using System.Threading;
+class C
+{
+    static System.Collections.Generic.IEnumerable<int> Iter([DefaultCancellation] CancellationToken token)
+    {
+        yield return 1;
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType });
+            comp.VerifyDiagnostics(
+                // (6,62): warning CS8424: The DefaultCancellationAttribute applied to parameter 'token' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method
+                //     static System.Collections.Generic.IEnumerable<int> Iter([DefaultCancellation] CancellationToken token)
+                Diagnostic(ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage, "DefaultCancellation").WithArguments("token").WithLocation(6, 62)
+                );
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_AsyncMethod()
+        {
+            string source = @"
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async Task Async([DefaultCancellation] CancellationToken token)
+    {
+        await Task.Yield();
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType });
+            comp.VerifyDiagnostics(
+                // (7,30): warning CS8424: The DefaultCancellationAttribute applied to parameter 'token' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method
+                //     static async Task Async([DefaultCancellation] CancellationToken token)
+                Diagnostic(ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage, "DefaultCancellation").WithArguments("token").WithLocation(7, 30)
+                );
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_RegularMethod()
+        {
+            string source = @"
+using System.Runtime.CompilerServices;
+using System.Threading;
+class C
+{
+    static void M([DefaultCancellation] CancellationToken token)
+    {
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType });
+            comp.VerifyDiagnostics(
+                // (6,20): warning CS8424: The DefaultCancellationAttribute applied to parameter 'token' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method
+                //     static void M([DefaultCancellation] CancellationToken token)
+                Diagnostic(ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage, "DefaultCancellation").WithArguments("token").WithLocation(6, 20)
+                );
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_Indexer()
+        {
+            string source = @"
+using System.Runtime.CompilerServices;
+using System.Threading;
+class C
+{
+    int this[[DefaultCancellation] CancellationToken key] => 0;
+}";
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType });
+            comp.VerifyDiagnostics(
+                // (6,15): warning CS8424: The DefaultCancellationAttribute applied to parameter 'key' will have no effect. The attribute is only effective on a parameter of type CancellationToken in an async-enumerable method
+                //     int this[[DefaultCancellation] CancellationToken key] => 0;
+                Diagnostic(ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage, "DefaultCancellation").WithArguments("key").WithLocation(6, 15)
+                );
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_TwoParameterHaveAttribute()
+        {
+            string source = @"
+using static System.Console;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async Task Main()
+    {
+        using CancellationTokenSource source = new CancellationTokenSource();
+        CancellationToken token = source.Token;
+        var enumerable = Iter(42, default, default);
+        await using var enumerator = enumerable.GetAsyncEnumerator(token); // some token passed
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 42
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 43
+
+        source.Cancel();
+        try
+        {
+            await enumerator.MoveNextAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+            Write(""Cancelled"");
+        }
+    }
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [DefaultCancellation] CancellationToken token1, [DefaultCancellation] CancellationToken token2)
+    {
+        yield return value++;
+        await Task.Yield();
+        yield return value++;
+        if (token1.IsCancellationRequested) Write(""token1 cancelled "");
+        if (token2.IsCancellationRequested) Write(""token2 cancelled "");
+        token2.ThrowIfCancellationRequested();
+        Write(""SKIPPED"");
+        yield return value++;
+    }
+}";
+            // TODO2 should we produce a warning here?
+            foreach (var options in new[] { TestOptions.DebugExe, TestOptions.ReleaseExe })
+            {
+                var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType }, options: options);
+                comp.VerifyDiagnostics();
+                var verifier = CompileAndVerify(comp, expectedOutput: "42 43 token1 cancelled token2 cancelled Cancelled");
+
+                // fields for token1 and token2 get overridden with value from token parameter
+                verifier.VerifyIL("C.<Iter>d__1.System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)", @"
+{
+  // Code size      142 (0x8e)
+  .maxstack  2
+  .locals init (C.<Iter>d__1 V_0,
+                System.Threading.CancellationToken V_1)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<Iter>d__1.<>1__state""
+  IL_0006:  ldc.i4.s   -2
+  IL_0008:  bne.un.s   IL_002a
+  IL_000a:  ldarg.0
+  IL_000b:  ldfld      ""int C.<Iter>d__1.<>l__initialThreadId""
+  IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
+  IL_0015:  bne.un.s   IL_002a
+  IL_0017:  ldarg.0
+  IL_0018:  ldc.i4.s   -3
+  IL_001a:  stfld      ""int C.<Iter>d__1.<>1__state""
+  IL_001f:  ldarg.0
+  IL_0020:  stloc.0
+  IL_0021:  ldarg.0
+  IL_0022:  ldc.i4.0
+  IL_0023:  stfld      ""bool C.<Iter>d__1.<>w__disposeMode""
+  IL_0028:  br.s       IL_0032
+  IL_002a:  ldc.i4.s   -3
+  IL_002c:  newobj     ""C.<Iter>d__1..ctor(int)""
+  IL_0031:  stloc.0
+  IL_0032:  ldloc.0
+  IL_0033:  ldarg.0
+  IL_0034:  ldfld      ""int C.<Iter>d__1.<>3__value""
+  IL_0039:  stfld      ""int C.<Iter>d__1.value""
+  IL_003e:  ldarga.s   V_1
+  IL_0040:  ldloca.s   V_1
+  IL_0042:  initobj    ""System.Threading.CancellationToken""
+  IL_0048:  ldloc.1
+  IL_0049:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
+  IL_004e:  brfalse.s  IL_005e
+  IL_0050:  ldloc.0
+  IL_0051:  ldarg.0
+  IL_0052:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token1""
+  IL_0057:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
+  IL_005c:  br.s       IL_0065
+  IL_005e:  ldloc.0
+  IL_005f:  ldarg.1
+  IL_0060:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
+  IL_0065:  ldarga.s   V_1
+  IL_0067:  ldloca.s   V_1
+  IL_0069:  initobj    ""System.Threading.CancellationToken""
+  IL_006f:  ldloc.1
+  IL_0070:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
+  IL_0075:  brfalse.s  IL_0085
+  IL_0077:  ldloc.0
+  IL_0078:  ldarg.0
+  IL_0079:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token2""
+  IL_007e:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token2""
+  IL_0083:  br.s       IL_008c
+  IL_0085:  ldloc.0
+  IL_0086:  ldarg.1
+  IL_0087:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token2""
+  IL_008c:  ldloc.0
+  IL_008d:  ret
+}
+");
+            }
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_MissingAttributeType()
+        {
+            string source = @"
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [DefaultCancellation] CancellationToken token1)
+    {
+        yield return value++;
+        await Task.Yield();
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(new[] { source });
+            comp.VerifyDiagnostics(
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using System.Runtime.CompilerServices;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Runtime.CompilerServices;").WithLocation(2, 1),
+                // (7,84): error CS0246: The type or namespace name 'DefaultCancellationAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                //     static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [DefaultCancellation] CancellationToken token1)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "DefaultCancellation").WithArguments("DefaultCancellationAttribute").WithLocation(7, 84),
+                // (7,84): error CS0246: The type or namespace name 'DefaultCancellation' could not be found (are you missing a using directive or an assembly reference?)
+                //     static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [DefaultCancellation] CancellationToken token1)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "DefaultCancellation").WithArguments("DefaultCancellation").WithLocation(7, 84)
+                );
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_ParameterProxyUntouched()
+        {
+            string source = @"
+using static System.Console;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async Task Main()
+    {
+        using CancellationTokenSource source1 = new CancellationTokenSource();
+        CancellationToken token1 = source1.Token;
+        var enumerable = Iter(42, token1);
+
+        using CancellationTokenSource source2 = new CancellationTokenSource();
+        CancellationToken token2 = source2.Token;
+        await using var enumerator = enumerable.GetAsyncEnumerator(token2); // some token passed
+        await EnumerateAsync(enumerator, source2);
+
+        await using var enumerator2 = enumerable.GetAsyncEnumerator(default); // we'll use token1 saved in the enumerable
+        await EnumerateAsync(enumerator2, default);
+    }
+    static async Task EnumerateAsync(System.Collections.Generic.IAsyncEnumerator<int> enumerator, CancellationTokenSource source)
+    {
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 42
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 43
+
+        if (source != default)
+            source.Cancel();
+        try
+        {
+            await enumerator.MoveNextAsync();
+            System.Console.Write($""{enumerator.Current} ""); // 44
+        }
+        catch (System.OperationCanceledException)
+        {
+            Write(""Cancelled "");
+        }
+    }
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [DefaultCancellation] CancellationToken token1)
+    {
+        yield return value++;
+        await Task.Yield();
+        yield return value++;
+        token1.ThrowIfCancellationRequested();
+        Write(""Reached "");
+        yield return value++;
+    }
+}";
+
+            // The parameter proxy is left untouched by our copying the token parameter of GetAsyncEnumerator
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "42 43 Cancelled 42 43 Reached 44");
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_Overridding()
+        {
+            string source = @"
+using static System.Console;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+public class Base
+{
+    public virtual async System.Collections.Generic.IAsyncEnumerable<int> Iter([DefaultCancellation] CancellationToken token1, int value)
+    {
+        yield return value++;
+        await Task.Yield();
+    }
+}
+public class C : Base
+{
+    static async Task Main()
+    {
+        var enumerable = new C().Iter(default, 42);
+
+        using CancellationTokenSource source = new CancellationTokenSource();
+        CancellationToken token = source.Token;
+        source.Cancel();
+        await using var enumerator = enumerable.GetAsyncEnumerator(token); // some token passed but unconsumed 
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current}""); // 42
+    }
+    public override async System.Collections.Generic.IAsyncEnumerable<int> Iter(CancellationToken token1, int value)
+    {
+        await Task.Yield();
+        token1.ThrowIfCancellationRequested();
+        Write(""Reached "");
+        yield return value;
+    }
+}";
+            // The overridden method lacks the DefaultCancellation attribute
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "Reached 42");
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_Overridding2()
+        {
+            string source = @"
+using static System.Console;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+public class Base
+{
+    public virtual async System.Collections.Generic.IAsyncEnumerable<int> Iter(CancellationToken token1, int value)
+    {
+        yield return value++;
+        await Task.Yield();
+    }
+}
+public class C : Base
+{
+    static async Task Main()
+    {
+        var enumerable = new C().Iter(default, 42);
+
+        using CancellationTokenSource source = new CancellationTokenSource();
+        CancellationToken token = source.Token;
+        await using var enumerator = enumerable.GetAsyncEnumerator(token); // some token passed
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 42
+
+        source.Cancel();
+        try
+        {
+            await enumerator.MoveNextAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+            Write(""Cancelled"");
+        }
+    }
+    public override async System.Collections.Generic.IAsyncEnumerable<int> Iter([DefaultCancellation] CancellationToken token1, int value)
+    {
+        yield return value++;
+        await Task.Yield();
+        token1.ThrowIfCancellationRequested();
+        Write(""SKIPPED"");
+        yield return value;
+    }
+}";
+            // The overridden method has the DefaultCancellation attribute
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, DefaultCancellationAttributeType }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "42 Cancelled");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -251,6 +251,7 @@ class X
                         case ErrorCode.WRN_IsTypeNamedUnderscore:
                         case ErrorCode.WRN_GivenExpressionNeverMatchesPattern:
                         case ErrorCode.WRN_GivenExpressionAlwaysMatchesConstant:
+                        case ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_MainIgnored:

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -251,7 +251,7 @@ class X
                         case ErrorCode.WRN_IsTypeNamedUnderscore:
                         case ErrorCode.WRN_GivenExpressionNeverMatchesPattern:
                         case ErrorCode.WRN_GivenExpressionAlwaysMatchesConstant:
-                        case ErrorCode.WRN_UnconsumedDefaultCancellationAttributeUsage:
+                        case ErrorCode.WRN_UnconsumedEnumeratorCancellationAttributeUsage:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_MainIgnored:

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -412,7 +412,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfExperimentalAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfExcludeFromCodeCoverageAttribute = { s_signature_HasThis_Void };
 
-        private static readonly byte[][] s_signaturesOfDefaultCancellationAttribute = { s_signature_HasThis_Void };
+        private static readonly byte[][] s_signaturesOfEnumeratorCancellationAttribute = { s_signature_HasThis_Void };
 
         // early decoded attributes:
         internal static readonly AttributeDescription OptionalAttribute = new AttributeDescription("System.Runtime.InteropServices", "OptionalAttribute", s_signaturesOfOptionalAttribute);
@@ -534,6 +534,6 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription NullableAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NullableAttribute", s_signaturesOfNullableAttribute);
         internal static readonly AttributeDescription ExperimentalAttribute = new AttributeDescription("Windows.Foundation.Metadata", "ExperimentalAttribute", s_signaturesOfExperimentalAttribute);
         internal static readonly AttributeDescription ExcludeFromCodeCoverageAttribute = new AttributeDescription("System.Diagnostics.CodeAnalysis", "ExcludeFromCodeCoverageAttribute", s_signaturesOfExcludeFromCodeCoverageAttribute);
-        internal static readonly AttributeDescription DefaultCancellationAttribute = new AttributeDescription("System.Runtime.CompilerServices", "DefaultCancellationAttribute", s_signaturesOfDefaultCancellationAttribute);
+        internal static readonly AttributeDescription EnumeratorCancellationAttribute = new AttributeDescription("System.Runtime.CompilerServices", "EnumeratorCancellationAttribute", s_signaturesOfEnumeratorCancellationAttribute);
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -412,6 +412,8 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfExperimentalAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfExcludeFromCodeCoverageAttribute = { s_signature_HasThis_Void };
 
+        private static readonly byte[][] s_signaturesOfDefaultCancellationAttribute = { s_signature_HasThis_Void };
+
         // early decoded attributes:
         internal static readonly AttributeDescription OptionalAttribute = new AttributeDescription("System.Runtime.InteropServices", "OptionalAttribute", s_signaturesOfOptionalAttribute);
         internal static readonly AttributeDescription ComImportAttribute = new AttributeDescription("System.Runtime.InteropServices", "ComImportAttribute", s_signaturesOfComImportAttribute);
@@ -532,5 +534,6 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription NullableAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NullableAttribute", s_signaturesOfNullableAttribute);
         internal static readonly AttributeDescription ExperimentalAttribute = new AttributeDescription("Windows.Foundation.Metadata", "ExperimentalAttribute", s_signaturesOfExperimentalAttribute);
         internal static readonly AttributeDescription ExcludeFromCodeCoverageAttribute = new AttributeDescription("System.Diagnostics.CodeAnalysis", "ExcludeFromCodeCoverageAttribute", s_signaturesOfExcludeFromCodeCoverageAttribute);
+        internal static readonly AttributeDescription DefaultCancellationAttribute = new AttributeDescription("System.Runtime.CompilerServices", "DefaultCancellationAttribute", s_signaturesOfDefaultCancellationAttribute);
     }
 }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -491,6 +491,8 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_SwitchExpressionException__ctor,
         System_Runtime_CompilerServices_SwitchExpressionException__ctorObject,
 
+        System_Threading_CancellationToken__Equals,
+
         Count
 
         // Remember to update the AllWellKnownTypeMembers tests when making changes here

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3351,6 +3351,7 @@ namespace Microsoft.CodeAnalysis
                     1,                                                                                                                                         // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
                     (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.GenericMethodParameter, 0,
+
                  // System_Runtime_CompilerServices_ITuple__get_Item
                  (byte)(MemberFlags.PropertyGet | MemberFlags.Virtual),                                                                       // Flags
                  (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_ITuple - WellKnownType.ExtSentinel),   // DeclaringTypeId
@@ -3387,6 +3388,14 @@ namespace Microsoft.CodeAnalysis
                     1,                                                                                                                        // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Object,
+
+                // System_Threading_CancellationToken__Equals
+                (byte)MemberFlags.Method,                                                                                   // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_CancellationToken - WellKnownType.ExtSentinel), // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean, // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_CancellationToken - WellKnownType.ExtSentinel), // Argument: CancellationToken
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3813,6 +3822,7 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_InvalidOperationException__ctor
                 ".ctor",                                    // System_Runtime_CompilerServices_SwitchExpressionException__ctor
                 ".ctor",                                    // System_Runtime_CompilerServices_SwitchExpressionException__ctorObject
+                "Equals",                                   // System_Threading_CancellationToken__Equals
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -409,6 +409,17 @@ namespace System.Runtime.CompilerServices
 }
 ";
 
+        protected const string DefaultCancellationAttributeType = @"
+namespace System.Runtime.CompilerServices
+{
+    [System.AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public class DefaultCancellationAttribute : Attribute
+    {
+        public DefaultCancellationAttribute() { }
+    }
+}
+";
+
         protected static CSharpCompilationOptions WithNonNullTypesTrue(CSharpCompilationOptions options = null)
         {
             return WithNonNullTypes(options, NullableContextOptions.Enable);

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -409,13 +409,13 @@ namespace System.Runtime.CompilerServices
 }
 ";
 
-        protected const string DefaultCancellationAttributeType = @"
+        protected const string EnumeratorCancellationAttributeType = @"
 namespace System.Runtime.CompilerServices
 {
     [System.AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
-    public class DefaultCancellationAttribute : Attribute
+    public class EnumeratorCancellationAttribute : Attribute
     {
-        public DefaultCancellationAttribute() { }
+        public EnumeratorCancellationAttribute() { }
     }
 }
 ";


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/34407

Relates to https://github.com/dotnet/corefx/issues/37012 (corefx API proposal for `EnumeratorCancellationAttribute` type)
Relates to https://github.com/dotnet/roslyn/issues/24037 (umbrella for async-streams)