### PR TITLE
Correctly report null reference possibility when GetEnumerator returns a potentially nullable Enumerator type.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1468,7 +1468,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (containingSlot >= 0)
                 {
-                    _ = ReportPossibleNullReceiverIfNeeded(node.Type, this.State[containingSlot], checkNullableValueType: false, node.Syntax);
+                    _ = ReportPossibleNullReceiverIfNeeded(node.Type, this.State[containingSlot], checkNullableValueType: false, node.Syntax, out _);
                 }
             }
         }
@@ -1740,7 +1740,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!node.Expression.Type.IsValueType);
             // https://github.com/dotnet/roslyn/issues/30598: Mark receiver as not null
             // after indices have been visited, and only if the receiver has not changed.
-            CheckPossibleNullReceiver(node.Expression);
+            CheckPossibleNullReceiver(node.Expression, out _);
 
             var type = ResultType.Type as ArrayTypeSymbol;
 
@@ -2517,7 +2517,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // https://github.com/dotnet/roslyn/issues/30598: Mark receiver as not null
                 // after arguments have been visited, and only if the receiver has not changed.
-                CheckPossibleNullReceiver(receiverOpt, checkNullableValueType);
+                CheckPossibleNullReceiver(receiverOpt, out _, checkNullableValueType);
             }
 
             return receiverType;
@@ -4346,7 +4346,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // That check should be handled when applying the method group conversion,
                 // when we have a specific method, to avoid reporting null receiver warnings
                 // for extension method delegates.
-                CheckPossibleNullReceiver(receiverOpt);
+                CheckPossibleNullReceiver(receiverOpt, out _);
             }
 
             SetNotNullResult(node);
@@ -4505,7 +4505,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (!invocation.InvokedAsExtensionMethod)
                     {
-                        CheckPossibleNullReceiver(right);
+                        CheckPossibleNullReceiver(right, out _);
                     }
                     else
                     {
@@ -4947,7 +4947,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var receiverType = VisitRvalueWithState(receiverOpt);
             // https://github.com/dotnet/roslyn/issues/30598: Mark receiver as not null
             // after indices have been visited, and only if the receiver has not changed.
-            CheckPossibleNullReceiver(receiverOpt);
+            CheckPossibleNullReceiver(receiverOpt, out _);
 
             var indexer = node.Indexer;
             if (!receiverType.HasNullType)
@@ -4996,7 +4996,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // https://github.com/dotnet/roslyn/issues/30598: For l-values, mark receiver as not null
                 // after RHS has been visited, and only if the receiver has not changed.
                 bool skipReceiverNullCheck = nullableOfTMember != SpecialMember.System_Nullable_T_get_Value;
-                CheckPossibleNullReceiver(receiverOpt, checkNullableValueType: !skipReceiverNullCheck);
+                CheckPossibleNullReceiver(receiverOpt, out _, checkNullableValueType: !skipReceiverNullCheck);
             }
 
             var type = member.GetTypeOrReturnType();
@@ -5062,7 +5062,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var expr = node.Expression;
             VisitRvalue(expr);
-            CheckPossibleNullReceiver(expr);
+            CheckPossibleNullReceiver(expr, out bool reportedDiagnostic);
+
+            if (reportedDiagnostic || node.EnumeratorInfoOpt == null)
+            {
+                return;
+            }
+
+            var enumeratorReturnType = node.EnumeratorInfoOpt.GetEnumeratorMethod.ReturnTypeWithAnnotations.ToTypeWithState();
+
+            if (enumeratorReturnType.State == NullableFlowState.MaybeNull)
+            {
+                ReportSafetyDiagnostic(ErrorCode.WRN_NullReferenceReceiver, expr.Syntax.GetLocation());
+            }
         }
 
         public override void VisitForEachIterationVariables(BoundForEachStatement node)
@@ -5335,7 +5347,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitAwaitExpression(BoundAwaitExpression node)
         {
             var result = base.VisitAwaitExpression(node);
-            CheckPossibleNullReceiver(node.Expression);
+            CheckPossibleNullReceiver(node.Expression, out _);
             if (node.Type.IsValueType || node.HasErrors || node.AwaitableInfo.GetResult is null)
             {
                 SetNotNullResult(node);
@@ -5537,7 +5549,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var receiver = node.Receiver;
             VisitRvalue(receiver);
-            CheckPossibleNullReceiver(receiver);
+            CheckPossibleNullReceiver(receiver, out _);
 
             Debug.Assert(node.Type.IsDynamic());
             var result = TypeWithAnnotations.Create(node.Type);
@@ -5567,7 +5579,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 @event = (EventSymbol)AsMemberOfType(ResultType.Type, @event);
                 // https://github.com/dotnet/roslyn/issues/30598: Mark receiver as not null
                 // after arguments have been visited, and only if the receiver has not changed.
-                CheckPossibleNullReceiver(receiverOpt);
+                CheckPossibleNullReceiver(receiverOpt, out _);
             }
             VisitRvalue(node.Argument);
             // https://github.com/dotnet/roslyn/issues/31018: Check for delegate mismatch.
@@ -5656,7 +5668,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             VisitRvalue(receiver);
             // https://github.com/dotnet/roslyn/issues/30598: Mark receiver as not null
             // after indices have been visited, and only if the receiver has not changed.
-            CheckPossibleNullReceiver(receiver);
+            CheckPossibleNullReceiver(receiver, out _);
             VisitArgumentsEvaluate(node.Arguments, node.ArgumentRefKindsOpt);
             Debug.Assert(node.Type.IsDynamic());
             var result = TypeWithAnnotations.Create(node.Type, NullableAnnotation.Oblivious);
@@ -5664,9 +5676,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        private void CheckPossibleNullReceiver(BoundExpression receiverOpt, bool checkNullableValueType = false)
+        private void CheckPossibleNullReceiver(BoundExpression receiverOpt, out bool reportedDiagnostic, bool checkNullableValueType = false)
         {
             Debug.Assert(!this.IsConditionalState);
+            reportedDiagnostic = false;
             if (receiverOpt != null && this.State.Reachable)
             {
                 var resultTypeSymbol = ResultType.Type;
@@ -5677,7 +5690,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 #if DEBUG
                 Debug.Assert(receiverOpt.Type is null || AreCloseEnough(receiverOpt.Type, resultTypeSymbol));
 #endif
-                if (!ReportPossibleNullReceiverIfNeeded(resultTypeSymbol, ResultType.State, checkNullableValueType, receiverOpt.Syntax))
+                if (!ReportPossibleNullReceiverIfNeeded(resultTypeSymbol, ResultType.State, checkNullableValueType, receiverOpt.Syntax, out reportedDiagnostic))
                 {
                     return;
                 }
@@ -5687,8 +5700,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         // Returns false if the type wasn't interesting
-        private bool ReportPossibleNullReceiverIfNeeded(TypeSymbol type, NullableFlowState state, bool checkNullableValueType, SyntaxNode syntax)
+        private bool ReportPossibleNullReceiverIfNeeded(TypeSymbol type, NullableFlowState state, bool checkNullableValueType, SyntaxNode syntax, out bool reportedDiagnostic)
         {
+            reportedDiagnostic = false;
             if (state.MayBeNull())
             {
                 bool isValueType = type.IsValueType;
@@ -5698,6 +5712,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 ReportSafetyDiagnostic(isValueType ? ErrorCode.WRN_NullableValueTypeMayBeNull : ErrorCode.WRN_NullReferenceReceiver, syntax);
+                reportedDiagnostic = true;
             }
 
             return true;
@@ -5833,7 +5848,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitLockStatement(BoundLockStatement node)
         {
             VisitRvalue(node.Argument);
-            CheckPossibleNullReceiver(node.Argument);
+            CheckPossibleNullReceiver(node.Argument, out _);
             VisitStatement(node.Body);
             return null;
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -51182,7 +51182,7 @@ class Enumerable : IEnumerable
 }
 class C
 {
-    static void F(Enumerable e)
+    static void F1(Enumerable e)
     {
         foreach (var x in e) // 1
         {
@@ -51194,18 +51194,80 @@ class C
         {
         }
     }
+    static void F2(Enumerable? e)
+    {
+        foreach (var x in e) // 3
+        {
+        }
+    }
 }";
             var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
 
-            // Missing diagnostic at `// 1`
-            // https://github.com/dotnet/roslyn/issues/29972: Should report WRN_NullReferenceReceiver using Enumerable.GetEnumerator.
-
             comp.VerifyDiagnostics(
+                // (10,27): warning CS8602: Dereference of a possibly null reference.
+                //         foreach (var x in e) // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "e").WithLocation(10, 27),
                 // (13,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var y in (IEnumerable?)e) // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable?)e").WithLocation(13, 27)
-                );
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable?)e").WithLocation(13, 27),
+                // (22,27): warning CS8602: Dereference of a possibly null reference.
+                //         foreach (var x in e) // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "e").WithLocation(22, 27));
         }
+
+        [Fact]
+        [WorkItem(29972, "https://github.com/dotnet/roslyn/issues/29972")]
+        public void ForEach_17()
+        {
+            var source =
+@"
+class C
+{
+    void M1<EnumerableType, EnumeratorType, T>(EnumerableType e)
+            where EnumerableType : Enumerable<EnumeratorType, T>
+            where EnumeratorType : I<T>?
+    {
+        foreach (var t in e) // 1
+        {
+            t.ToString(); // 2
+        }
+    }
+    void M2<EnumerableType, EnumeratorType, T>(EnumerableType e)
+            where EnumerableType : Enumerable<EnumeratorType, T>
+            where EnumeratorType : I<T>
+    {
+        foreach (var t in e)
+        {
+            t.ToString(); // 3
+        }
+    }
+}
+
+interface Enumerable<E, T> where E : I<T>?
+{
+	E GetEnumerator();
+}
+
+interface I<T>
+{
+	T Current { get; }
+    bool MoveNext();
+}
+";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (8,27): warning CS8602: Dereference of a possibly null reference.
+                //         foreach (var t in e) // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "e").WithLocation(8, 27),
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
+                //             t.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(10, 13),
+                // (19,13): warning CS8602: Dereference of a possibly null reference.
+                //             t.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(19, 13));
+        }
+
 
         [Fact]
         public void ForEach_UnconstrainedTypeParameter()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -51268,6 +51268,31 @@ interface I<T>
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t").WithLocation(19, 13));
         }
 
+        [Fact]
+        [WorkItem(34667, "https://github.com/dotnet/roslyn/issues/34667")]
+        public void ForEach_18()
+        {
+            var source =
+@"
+using System.Collections.Generic;
+
+class Program
+{
+    static void Main() { }
+
+    static void Foo(IEnumerable<object[]?[]> source)
+    {
+        foreach (object[][] item in source) { }
+    }
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (10,29): warning CS8619: Nullability of reference types in value of type 'object[]?[]' doesn't match target type 'object[][]'.
+                //         foreach (object[][] item in source) { }
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "item").WithArguments("object[]?[]", "object[][]").WithLocation(10, 29));
+        }
+
 
         [Fact]
         public void ForEach_UnconstrainedTypeParameter()


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/29972.
Fixes https://github.com/dotnet/roslyn/issues/34667 (was previously fixed in https://github.com/dotnet/roslyn/pull/34926, this just adds a test).