### PR TITLE
More Pull Members Up MAS Fixes

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
@@ -184,7 +184,7 @@
                                             Focusable="True"
                                             ToolTipService.ShowOnDisabled="True"
                                             ToolTipService.IsEnabled="{Binding IsCheckable, Converter={StaticResource BooleanReverseConverter}, UpdateSourceTrigger=PropertyChanged}"
-                                            ToolTipService.ToolTip="{Binding ElementName=dialog, Path=InterfaceCannotHaveField}"/>
+                                            ToolTipService.ToolTip="{Binding HelpText}"/>
                                         <Image 
                                             x:Name="GlyphOfMember"
                                             Margin="8, 0, 5, 0"

--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
@@ -147,7 +147,11 @@
                     <DataGrid.Columns>
                         <DataGridTemplateColumn Width="*">
                             <DataGridTemplateColumn.Header>
-                                <StackPanel Orientation="Horizontal" Width="Auto">
+                                <StackPanel 
+                                    Orientation="Horizontal" 
+                                    Width="Auto"
+                                    AutomationProperties.Name="{Binding RelativeSource={RelativeSource AncestorType=vs:DialogWindow}, Path=MembersHeader}"
+                                    Name="Members>
                                     <self:SelectAllCheckBox
                                         AutomationProperties.Name="{Binding SelectAllCheckBoxAutomationText}"
                                         Margin="0, 0, 4, 0"
@@ -226,7 +230,7 @@
                     HorizontalAlignment="Center"
                     Margin="0, 4, 0, 0"
                     Width="Auto">
-                    <vs:DialogButton
+                    <Button
                         x:Name="SelecDependentsButton"
                         x:Uid="SelecDependentsButton"
                         Padding="{StaticResource ResourceKey=SelectDependantsAndSelectPublicButtonPadding}"
@@ -235,7 +239,7 @@
                         Margin="2, 2, 2, 7"
                         Width="Auto"
                         Height="Auto"/>
-                    <vs:DialogButton
+                    <Button
                         x:Name="SelectPublicButton"
                         x:Uid="SelectPublicButton"
                         Content="{Binding ElementName=dialog, Path=SelectPublic}"
@@ -252,7 +256,7 @@
             Margin="0, 5, 8, 0"
             HorizontalAlignment="Right"
             Orientation="Horizontal">
-            <vs:DialogButton
+            <Button
                 x:Name="OKButton"
                 x:Uid="OKButton"
                 Click="OKButton_Click"
@@ -263,7 +267,7 @@
                 Content="{Binding OK, ElementName=dialog}"
                 MinWidth="{StaticResource ResourceKey=ButtonWidth}"
                 MinHeight="{StaticResource ResourceKey=ButtonHeight}"/>
-            <vs:DialogButton
+            <Button
                 x:Name="CancelButton"
                 x:Uid="CancelButton"
                 Click="CancelButton_Click"

--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
@@ -149,9 +149,7 @@
                             <DataGridTemplateColumn.Header>
                                 <StackPanel 
                                     Orientation="Horizontal" 
-                                    Width="Auto"
-                                    AutomationProperties.Name="{Binding RelativeSource={RelativeSource AncestorType=vs:DialogWindow}, Path=MembersHeader}"
-                                    Name="Members>
+                                    Width="Auto">
                                     <self:SelectAllCheckBox
                                         AutomationProperties.Name="{Binding SelectAllCheckBoxAutomationText}"
                                         Margin="0, 0, 4, 0"

--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml.cs
@@ -25,7 +25,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PullMemberUp.Ma
         public string SelectDependents => ServicesVSResources.Select_Dependents;
         public string MembersHeader => ServicesVSResources.Members;
         public string MakeAbstractHeader => ServicesVSResources.Make_abstract;
-        public string InterfaceCannotHaveField => ServicesVSResources.Interface_cannot_have_field;
 
         public PullMemberUpDialogViewModel ViewModel { get; }
 

--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialogViewModel.cs
@@ -65,6 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PullMemberUp.Ma
                     foreach (var member in fields)
                     {
                         member.IsCheckable = !isInterface;
+                        member.HelpText = isInterface ? ServicesVSResources.Interface_cannot_have_field : string.Empty;
                     }
 
                     foreach (var member in makeAbstractEnabledCheckboxes)

--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialogViewModel.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PullMemberUp.Ma
                     foreach (var member in fields)
                     {
                         member.IsCheckable = !isInterface;
-                        member.HelpText = isInterface ? ServicesVSResources.Interface_cannot_have_field : string.Empty;
+                        member.TooltipText = isInterface ? ServicesVSResources.Interface_cannot_have_field : string.Empty;
                     }
 
                     foreach (var member in makeAbstractEnabledCheckboxes)

--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpSymbolViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpSymbolViewModel.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PullMemberUp.Ma
         private bool _isCheckable;
         private bool _makeAbstract;
         private bool _isMakeAbstractCheckable;
+        private string _helpText;
         public string MakeAbstractCheckBoxAutomationText => string.Format(ServicesVSResources.Make_0_abstract, Symbol.Name);
         public string RowSelectionAutomationText => ServicesVSResources.Select_member;
 
@@ -36,6 +37,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PullMemberUp.Ma
         /// Indicates whether this member checkable.
         /// </summary>
         public bool IsCheckable { get => _isCheckable; set => SetProperty(ref _isCheckable, value, nameof(IsCheckable)); }
+
+        /// <summary>
+        /// Accessibility HelpText, useful to provide context for screen readers
+        /// </summary>
+        public string HelpText { get => _helpText; set => SetProperty(ref _helpText, value, nameof(HelpText)); }
 
         /// <summary>
         /// The content of tooltip.

--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpSymbolViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpSymbolViewModel.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PullMemberUp.Ma
         private bool _isCheckable;
         private bool _makeAbstract;
         private bool _isMakeAbstractCheckable;
-        private string _helpText;
+        private string _tooltipText;
         public string MakeAbstractCheckBoxAutomationText => string.Format(ServicesVSResources.Make_0_abstract, Symbol.Name);
         public string RowSelectionAutomationText => ServicesVSResources.Select_member;
 
@@ -39,9 +39,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PullMemberUp.Ma
         public bool IsCheckable { get => _isCheckable; set => SetProperty(ref _isCheckable, value, nameof(IsCheckable)); }
 
         /// <summary>
-        /// Accessibility HelpText, useful to provide context for screen readers
+        /// Tooltip text, also used as HelpText for screen readers. Should be empty
+        /// when no tool tip should be shown
         /// </summary>
-        public string HelpText { get => _helpText; set => SetProperty(ref _helpText, value, nameof(HelpText)); }
+        public string TooltipText { get => _tooltipText; set => SetProperty(ref _tooltipText, value, nameof(TooltipText)); }
 
         /// <summary>
         /// The content of tooltip.

--- a/src/VisualStudio/Core/Test/PullMemberUp/PullMemberUpViewModelTest.vb
+++ b/src/VisualStudio/Core/Test/PullMemberUp/PullMemberUpViewModelTest.vb
@@ -232,6 +232,7 @@ class MyClass : Level1BaseClass, Level1Interface
 
             For Each member In viewModel.Members.Where(Function(memberViewModel) memberViewModel.Symbol.IsKind(SymbolKind.Field))
                 Assert.False(member.IsCheckable)
+                Assert.False(String.IsNullOrEmpty(member.HelpText))
             Next
         End Function
 
@@ -278,6 +279,7 @@ class MyClass : Level1BaseClass, Level1Interface
             viewModel.SelectedDestination = baseTypeTree(0)
             For Each member In viewModel.Members.Where(Function(memberViewModel) memberViewModel.Symbol.IsKind(SymbolKind.Field))
                 Assert.True(member.IsCheckable)
+                Assert.True(String.IsNullOrEmpty(member.HelpText))
             Next
         End Function
 

--- a/src/VisualStudio/Core/Test/PullMemberUp/PullMemberUpViewModelTest.vb
+++ b/src/VisualStudio/Core/Test/PullMemberUp/PullMemberUpViewModelTest.vb
@@ -232,7 +232,7 @@ class MyClass : Level1BaseClass, Level1Interface
 
             For Each member In viewModel.Members.Where(Function(memberViewModel) memberViewModel.Symbol.IsKind(SymbolKind.Field))
                 Assert.False(member.IsCheckable)
-                Assert.False(String.IsNullOrEmpty(member.HelpText))
+                Assert.False(String.IsNullOrEmpty(member.TooltipText))
             Next
         End Function
 
@@ -279,7 +279,7 @@ class MyClass : Level1BaseClass, Level1Interface
             viewModel.SelectedDestination = baseTypeTree(0)
             For Each member In viewModel.Members.Where(Function(memberViewModel) memberViewModel.Symbol.IsKind(SymbolKind.Field))
                 Assert.True(member.IsCheckable)
-                Assert.True(String.IsNullOrEmpty(member.HelpText))
+                Assert.True(String.IsNullOrEmpty(member.TooltipText))
             Next
         End Function
 


### PR DESCRIPTION
* Use `Button` instead of `vs:Button` to handle high contrast better
* Dynamically set the help text so screen readers don't always read that something is invalid for an interface