### PR TITLE
Implement an alternative way to break cycles while calculating IsValueType/IsReferenceType for a type parameter.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -1150,12 +1150,12 @@ hasRelatedInterfaces:
 
         private static bool IsReferenceType(TypeParameterSymbol typeParameter, ImmutableArray<TypeWithAnnotations> constraintTypes)
         {
-            return typeParameter.HasReferenceTypeConstraint || typeParameter.IsReferenceTypeFromConstraintTypes(constraintTypes, ConsList<TypeParameterSymbol>.Empty);
+            return typeParameter.HasReferenceTypeConstraint || typeParameter.IsReferenceTypeFromConstraintTypes(constraintTypes);
         }
 
         private static bool IsValueType(TypeParameterSymbol typeParameter, ImmutableArray<TypeWithAnnotations> constraintTypes)
         {
-            return typeParameter.HasValueTypeConstraint || typeParameter.IsValueTypeFromConstraintTypes(constraintTypes, ConsList<TypeParameterSymbol>.Empty);
+            return typeParameter.HasValueTypeConstraint || typeParameter.IsValueTypeFromConstraintTypes(constraintTypes);
         }
 
         private static TypeParameterDiagnosticInfo GenerateConflictingConstraintsError(TypeParameterSymbol typeParameter, TypeSymbol deducedBase, bool classConflict)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -413,9 +413,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private TypeParameterBounds GetBounds(ConsList<TypeParameterSymbol> inProgress, bool early)
         {
-            // https://github.com/dotnet/roslyn/issues/30081: Re-enable asserts.
-            //Debug.Assert(!inProgress.ContainsReference(this));
-            //Debug.Assert(!inProgress.Any() || ReferenceEquals(inProgress.Head.ContainingSymbol, this.ContainingSymbol));
+            Debug.Assert(!inProgress.ContainsReference(this));
+            Debug.Assert(!inProgress.Any() || ReferenceEquals(inProgress.Head.ContainingSymbol, this.ContainingSymbol));
 
             var currentBounds = _lazyBounds;
             if (currentBounds == TypeParameterBounds.Unset)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -215,9 +215,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private TypeParameterBounds GetBounds(ConsList<TypeParameterSymbol> inProgress, bool early)
         {
-            // https://github.com/dotnet/roslyn/issues/30081: Re-enable asserts.
-            //Debug.Assert(!inProgress.ContainsReference(this));
-            //Debug.Assert(!inProgress.Any() || ReferenceEquals(inProgress.Head.ContainingSymbol, this.ContainingSymbol));
+            Debug.Assert(!inProgress.ContainsReference(this));
+            Debug.Assert(!inProgress.Any() || ReferenceEquals(inProgress.Head.ContainingSymbol, this.ContainingSymbol));
 
             var currentBounds = _lazyBounds;
             if (!currentBounds.IsSet(early))

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Duplicates and cycles are removed, although the collection may include
         /// redundant constraints where one constraint is a base type of another.
         /// </summary>
-        internal ImmutableArray<TypeWithAnnotations> GetConstraintTypesNoUseSiteDiagnostics(ConsList<TypeParameterSymbol> inProgress, bool early)
+        internal ImmutableArray<TypeWithAnnotations> GetConstraintTypesNoUseSiteDiagnostics(bool early)
         {
             // We could call EnsureAllConstraintsAreResolved(early) directly rather than splitting
             // this into two separate calls. However, the split between early and late must be explicit
@@ -87,11 +87,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 this.EnsureAllConstraintsAreResolved(early);
             }
-            return this.GetConstraintTypes(inProgress, early);
+
+            return this.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty, early);
         }
 
         internal ImmutableArray<TypeWithAnnotations> ConstraintTypesNoUseSiteDiagnostics =>
-            GetConstraintTypesNoUseSiteDiagnostics(ConsList<TypeParameterSymbol>.Empty, early: false);
+            GetConstraintTypesNoUseSiteDiagnostics(early: false);
 
         internal ImmutableArray<TypeWithAnnotations> ConstraintTypesWithDefinitionUseSiteDiagnostics(ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
@@ -394,54 +395,43 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract TypeSymbol GetDeducedBaseType(ConsList<TypeParameterSymbol> inProgress);
 
-        private bool ConstraintImpliesReferenceType(TypeSymbol constraint, ConsList<TypeParameterSymbol> inProgress)
-        {
-            if (constraint.TypeKind == TypeKind.TypeParameter)
-            {
-                var typeParameter = ((TypeParameterSymbol)constraint);
-
-                if (inProgress.ContainsReference(typeParameter))
-                {
-                    return false;
-                }
-
-                var constraints = typeParameter.GetConstraintTypesNoUseSiteDiagnostics(inProgress, early: true);
-                return IsReferenceTypeFromConstraintTypes(constraints, inProgress);
-            }
-            else if (!constraint.IsReferenceType)
-            {
-                return false;
-            }
-            else
-            {
-                switch (constraint.TypeKind)
-                {
-                    case TypeKind.Interface:
-                        return false; // can be satisfied by value types
-                    case TypeKind.Error:
-                        return false;
-                }
-
-                switch (constraint.SpecialType)
-                {
-                    case SpecialType.System_Object:
-                    case SpecialType.System_ValueType:
-                    case SpecialType.System_Enum:
-                        return false; // can be satisfied by value types
-                }
-
-                return true;
-            }
-        }
-
         // From typedesc.cpp :
         // > A recursive helper that helps determine whether this variable is constrained as ObjRef.
         // > Please note that we do not check the gpReferenceTypeConstraint special constraint here
         // > because this property does not propagate up the constraining hierarchy.
         // > (e.g. "class A<S, T> where S : T, where T : class" does not guarantee that S is ObjRef)
-        internal bool IsReferenceTypeFromConstraintTypes(ImmutableArray<TypeWithAnnotations> constraintTypes, ConsList<TypeParameterSymbol> inProgress)
+        internal bool IsReferenceTypeFromConstraintTypes(ImmutableArray<TypeWithAnnotations> constraintTypes)
         {
-            return AnyConstraintTypes(constraintTypes, inProgress, (type, arg) => ConstraintImpliesReferenceType(type.Type, arg));
+            return AnyConstraintTypes(constraintTypes,
+                                      (typeParameter) => false,
+                                      (constraint) =>
+                                      {
+                                          Debug.Assert(!constraint.IsTypeParameter());
+                                          if (!constraint.IsReferenceType)
+                                          {
+                                              return false;
+                                          }
+                                          else
+                                          {
+                                              switch (constraint.TypeKind)
+                                              {
+                                                  case TypeKind.Interface:
+                                                      return false; // can be satisfied by value types
+                                                  case TypeKind.Error:
+                                                      return false;
+                                              }
+
+                                              switch (constraint.SpecialType)
+                                              {
+                                                  case SpecialType.System_Object:
+                                                  case SpecialType.System_ValueType:
+                                                  case SpecialType.System_Enum:
+                                                      return false; // can be satisfied by value types
+                                              }
+
+                                              return true;
+                                          }
+                                      });
         }
 
         internal static bool? IsNotNullableIfReferenceTypeFromConstraintTypes(ImmutableArray<TypeWithAnnotations> constraintTypes)
@@ -494,45 +484,79 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal bool IsValueTypeFromConstraintTypes(ImmutableArray<TypeWithAnnotations> constraintTypes, ConsList<TypeParameterSymbol> inProgress)
+        internal bool IsValueTypeFromConstraintTypes(ImmutableArray<TypeWithAnnotations> constraintTypes)
         {
-            return AnyConstraintTypes(constraintTypes, inProgress, (type, arg) => type.GetIsValueType(arg));
+            return AnyConstraintTypes(constraintTypes,
+                                      (typeParameter) => typeParameter.HasValueTypeConstraint,
+                                      (constraint) =>
+                                      {
+                                          Debug.Assert(!constraint.IsTypeParameter());
+                                          return constraint.IsValueType;
+                                      });
         }
 
         private bool AnyConstraintTypes(
             ImmutableArray<TypeWithAnnotations> constraintTypes,
-            ConsList<TypeParameterSymbol> inProgress,
-            Func<TypeWithAnnotations, ConsList<TypeParameterSymbol>, bool> predicate)
+            Func<TypeParameterSymbol, bool> predicate1,
+            Func<TypeSymbol, bool> predicate2)
         {
             if (constraintTypes.IsEmpty)
             {
                 return false;
             }
-            inProgress = inProgress.Prepend(this);
-            foreach (var constraintType in constraintTypes)
+
+            bool result = false;
+            ConsList<TypeParameterSymbol> inProgress = ConsList<TypeParameterSymbol>.Empty.Push(this);
+            var stack = ArrayBuilder<TypeWithAnnotations>.GetInstance(constraintTypes.Length);
+            stack.AddRange(constraintTypes);
+
+            do
             {
-                if (predicate(constraintType, inProgress))
+                TypeWithAnnotations constraintType = stack.Pop();
+                TypeSymbol type = constraintType.IsResolved ? constraintType.Type : constraintType.DefaultType;
+
+                if (type.IsTypeParameter())
+                {
+                    var typeParameter = (TypeParameterSymbol)type;
+
+                    if (inProgress.ContainsReference(typeParameter))
+                    {
+                        continue;
+                    }
+
+                    if (predicate1(typeParameter))
+                    {
+                        result = true;
+                        break;
+                    }
+
+                    inProgress = inProgress.Prepend(typeParameter);
+                    stack.AddRange(typeParameter.GetConstraintTypesNoUseSiteDiagnostics(early: true));
+                }
+                else if (predicate2(type))
+                {
+                    result = true;
+                    break;
+                }
+            }
+            while (stack.Count != 0);
+
+            stack.Free();
+            return result;
+        }
+
+        public sealed override bool IsReferenceType
+        {
+            get
+            {
+                if (this.HasReferenceTypeConstraint)
                 {
                     return true;
                 }
-            }
-            return false;
-        }
 
-        internal bool GetIsReferenceType(ConsList<TypeParameterSymbol> inProgress)
-        {
-            if (inProgress.ContainsReference(this))
-            {
-                return false;
+                return IsReferenceTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(early: true));
             }
-            if (this.HasReferenceTypeConstraint)
-            {
-                return true;
-            }
-            return IsReferenceTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(inProgress, early: true), inProgress);
         }
-
-        public sealed override bool IsReferenceType => GetIsReferenceType(ConsList<TypeParameterSymbol>.Empty);
 
         protected bool? CalculateIsNotNullableIfReferenceType()
         {
@@ -570,20 +594,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // https://github.com/dotnet/roslyn/issues/26198 Should this API be exposed through ITypeParameterSymbol?
         internal abstract bool? IsNotNullableIfReferenceType { get; }
 
-        internal bool GetIsValueType(ConsList<TypeParameterSymbol> inProgress)
+        public sealed override bool IsValueType
         {
-            if (inProgress.ContainsReference(this))
+            get
             {
-                return false;
-            }
-            if (this.HasValueTypeConstraint)
-            {
-                return true;
-            }
-            return IsValueTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(inProgress, early: true), inProgress);
-        }
+                if (this.HasValueTypeConstraint)
+                {
+                    return true;
+                }
 
-        public sealed override bool IsValueType => GetIsValueType(ConsList<TypeParameterSymbol>.Empty);
+                return IsValueTypeFromConstraintTypes(this.GetConstraintTypesNoUseSiteDiagnostics(early: true));
+            }
+        }
 
         internal sealed override ManagedKind ManagedKind
         {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -300,10 +300,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _extensions.IsStatic(DefaultType);
         public bool IsRestrictedType(bool ignoreSpanLikeTypes = false) =>
             _extensions.IsRestrictedType(DefaultType, ignoreSpanLikeTypes);
-        internal bool GetIsReferenceType(ConsList<TypeParameterSymbol> inProgress) =>
-            _extensions.GetIsReferenceType(DefaultType, inProgress);
-        internal bool GetIsValueType(ConsList<TypeParameterSymbol> inProgress) =>
-            _extensions.GetIsValueType(DefaultType, inProgress);
 
         public string ToDisplayString(SymbolDisplayFormat format = null)
         {
@@ -785,9 +781,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal abstract TypeSymbol GetNullableUnderlyingTypeOrSelf(TypeSymbol typeSymbol);
 
-            internal abstract bool GetIsReferenceType(TypeSymbol typeSymbol, ConsList<TypeParameterSymbol> inProgress);
-            internal abstract bool GetIsValueType(TypeSymbol typeSymbol, ConsList<TypeParameterSymbol> inProgress);
-
             internal abstract TypeSymbol AsTypeSymbolOnly(TypeSymbol typeSymbol);
 
             internal abstract SpecialType GetSpecialType(TypeSymbol typeSymbol);
@@ -829,24 +822,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             internal override bool IsSZArray(TypeSymbol typeSymbol) => typeSymbol.IsSZArray();
 
             internal override TypeSymbol GetNullableUnderlyingTypeOrSelf(TypeSymbol typeSymbol) => typeSymbol.StrippedType();
-
-            internal override bool GetIsReferenceType(TypeSymbol typeSymbol, ConsList<TypeParameterSymbol> inProgress)
-            {
-                if (typeSymbol.TypeKind == TypeKind.TypeParameter)
-                {
-                    return ((TypeParameterSymbol)typeSymbol).GetIsReferenceType(inProgress);
-                }
-                return typeSymbol.IsReferenceType;
-            }
-
-            internal override bool GetIsValueType(TypeSymbol typeSymbol, ConsList<TypeParameterSymbol> inProgress)
-            {
-                if (typeSymbol.TypeKind == TypeKind.TypeParameter)
-                {
-                    return ((TypeParameterSymbol)typeSymbol).GetIsValueType(inProgress);
-                }
-                return typeSymbol.IsValueType;
-            }
 
             internal override TypeWithAnnotations WithModifiers(TypeWithAnnotations type, ImmutableArray<CustomModifier> customModifiers)
             {
@@ -946,16 +921,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 return _resolved;
-            }
-
-            internal override bool GetIsReferenceType(TypeSymbol typeSymbol, ConsList<TypeParameterSymbol> inProgress)
-            {
-                return _underlying.GetIsReferenceType(inProgress);
-            }
-
-            internal override bool GetIsValueType(TypeSymbol typeSymbol, ConsList<TypeParameterSymbol> inProgress)
-            {
-                return _underlying.GetIsValueType(inProgress);
             }
 
             internal override TypeSymbol GetNullableUnderlyingTypeOrSelf(TypeSymbol typeSymbol) => _underlying.Type;


### PR DESCRIPTION
Fixes #30081.