### PR TITLE
Add version check to enable the pattern-based Index & Range indexers

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7470,7 +7470,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // to this indexer that has an Index or Range type and that there is
             // a real receiver with a known type
 
-            if (arguments.Count != 1)
+            if (!Compilation.IsFeatureEnabled(MessageID.IDS_FeatureIndexOperator) ||
+                arguments.Count != 1)
             {
                 patternIndexerAccess = null;
                 return false;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/IndexAndRangeTests.cs
@@ -16,6 +16,31 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         private const string RangeAllSignature = "System.Range System.Range.All.get";
 
         [Fact]
+        public void PatternIndexRangeLangVer()
+        {
+            var src = @"
+using System;
+class C
+{
+    void M(string s, Index i, Range r)
+    {
+        _ = s[i];
+        _ = s[r];
+    }
+}";
+            var comp = CreateCompilationWithIndexAndRange(src);
+            comp.VerifyDiagnostics();
+            comp = CreateCompilationWithIndexAndRange(src, parseOptions: TestOptions.Regular7_3);
+            comp.VerifyDiagnostics(
+                // (7,15): error CS1503: Argument 1: cannot convert from 'System.Index' to 'int'
+                //         _ = s[i];
+                Diagnostic(ErrorCode.ERR_BadArgType, "i").WithArguments("1", "System.Index", "int").WithLocation(7, 15),
+                // (8,15): error CS1503: Argument 1: cannot convert from 'System.Range' to 'int'
+                //         _ = s[r];
+                Diagnostic(ErrorCode.ERR_BadArgType, "r").WithArguments("1", "System.Range", "int").WithLocation(8, 15));
+        }
+
+        [Fact]
         public void SpanPatternRangeDelegate()
         {
             var src = @"


### PR DESCRIPTION
This is a "forward compatibility" bug, where a user could write code in an older language version that works when it should have failed, thus causing them to accidentally break users on older compiler versions.