### PR TITLE
Synchronize AnalyzerConfig documents when creating OOP solutions

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioSnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioSnapshotSerializationTests.cs
@@ -33,7 +33,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
                     var analyzerReference = analyzer.GetReference();
                     project = project.WithAnalyzerReferences(new AnalyzerReference[]
                     {
-                    analyzerReference,
+                        analyzerReference,
                     });
 
                     var checksum = await project.State.GetChecksumAsync(CancellationToken.None).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 *REMOVED*Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.DocumentId documentId, bool isSolutionClosing = false) -> void
+Microsoft.CodeAnalysis.AnalyzerConfigDocument
+Microsoft.CodeAnalysis.Project.AnalyzerConfigDocuments.get -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.AnalyzerConfigDocument>
+Microsoft.CodeAnalysis.Project.ContainsAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> bool
+Microsoft.CodeAnalysis.Project.GetAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> Microsoft.CodeAnalysis.AnalyzerConfigDocument
 Microsoft.CodeAnalysis.ProjectInfo.AnalyzerConfigDocuments.get -> System.Collections.Generic.IReadOnlyList<Microsoft.CodeAnalysis.DocumentInfo>
 Microsoft.CodeAnalysis.ProjectInfo.WithAnalyzerConfigDocuments(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.DocumentInfo> analyzerConfigDocuments) -> Microsoft.CodeAnalysis.ProjectInfo
 Microsoft.CodeAnalysis.Solution.AddAdditionalDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentInfos) -> Microsoft.CodeAnalysis.Solution

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -8,6 +8,7 @@ Microsoft.CodeAnalysis.ProjectInfo.WithAnalyzerConfigDocuments(System.Collection
 Microsoft.CodeAnalysis.Solution.AddAdditionalDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentInfos) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.AddAnalyzerConfigDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentInfos) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.ContainsAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> bool
+Microsoft.CodeAnalysis.Solution.GetAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> Microsoft.CodeAnalysis.AnalyzerConfigDocument
 Microsoft.CodeAnalysis.Solution.RemoveAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.WithAnalyzerConfigDocumentTextLoader(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.TextLoader loader, Microsoft.CodeAnalysis.PreservationMode mode) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Workspace.CheckAnalyzerConfigDocumentIsInCurrentSolution(Microsoft.CodeAnalysis.DocumentId documentId) -> void

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 *REMOVED*Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.DocumentId documentId, bool isSolutionClosing = false) -> void
+Microsoft.CodeAnalysis.ProjectInfo.AnalyzerConfigDocuments.get -> System.Collections.Generic.IReadOnlyList<Microsoft.CodeAnalysis.DocumentInfo>
+Microsoft.CodeAnalysis.ProjectInfo.WithAnalyzerConfigDocuments(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.DocumentInfo> analyzerConfigDocuments) -> Microsoft.CodeAnalysis.ProjectInfo
 Microsoft.CodeAnalysis.Solution.AddAdditionalDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentInfos) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.AddAnalyzerConfigDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentInfos) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.ContainsAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> bool

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 *REMOVED*Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.DocumentId documentId, bool isSolutionClosing = false) -> void
+Microsoft.CodeAnalysis.Solution.AddAdditionalDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentInfos) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.AddAnalyzerConfigDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentInfos) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.ContainsAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> bool
 Microsoft.CodeAnalysis.Solution.RemoveAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> Microsoft.CodeAnalysis.Solution

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ Microsoft.CodeAnalysis.Solution.AddAnalyzerConfigDocuments(System.Collections.Im
 Microsoft.CodeAnalysis.Solution.ContainsAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> bool
 Microsoft.CodeAnalysis.Solution.GetAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> Microsoft.CodeAnalysis.AnalyzerConfigDocument
 Microsoft.CodeAnalysis.Solution.RemoveAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> Microsoft.CodeAnalysis.Solution
+Microsoft.CodeAnalysis.Solution.WithAnalyzerConfigDocumentText(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.Text.SourceText text, Microsoft.CodeAnalysis.PreservationMode mode = Microsoft.CodeAnalysis.PreservationMode.PreserveValue) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.WithAnalyzerConfigDocumentTextLoader(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.TextLoader loader, Microsoft.CodeAnalysis.PreservationMode mode) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Workspace.CheckAnalyzerConfigDocumentIsInCurrentSolution(Microsoft.CodeAnalysis.DocumentId documentId) -> void
 Microsoft.CodeAnalysis.Workspace.CheckAnalyzerConfigDocumentIsNotInCurrentSolution(Microsoft.CodeAnalysis.DocumentId documentId) -> void

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocument.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    public sealed class AnalyzerConfigDocument : TextDocument
+    {
+        internal AnalyzerConfigDocument(Project project, AnalyzerConfigDocumentState state)
+            : base(project, state)
+        {
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
@@ -48,6 +48,11 @@ namespace Microsoft.CodeAnalysis
             return (AnalyzerConfigDocumentState)base.UpdateText(loader, mode);
         }
 
+        public new AnalyzerConfigDocumentState UpdateText(SourceText text, PreservationMode mode)
+        {
+            return (AnalyzerConfigDocumentState)base.UpdateText(text, mode);
+        }
+
         protected override TextDocumentState UpdateText(ValueSource<TextAndVersion> newTextSource, PreservationMode mode, bool incremental)
         {
             return new AnalyzerConfigDocumentState(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// All the <see cref="AnalyzerConfigDocument"/>s associated with this project.
         /// </summary>
-        public IEnumerable<AnalyzerConfigDocument> AnalyzerConfigDocuments => _projectState.AnalyzerConfigDocumentStates.Select(s => GetAnalyzerConfigDocument(s.Key));
+        public IEnumerable<AnalyzerConfigDocument> AnalyzerConfigDocuments => _projectState.AnalyzerConfigDocumentIds.Select(GetAnalyzerConfigDocument);
 
         /// <summary>
         /// True if the project contains a document with the specified ID.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -119,6 +119,11 @@ namespace Microsoft.CodeAnalysis
         public IReadOnlyList<DocumentInfo> AdditionalDocuments { get; }
 
         /// <summary>
+        /// The list of analyzerconfig documents associated with this project.
+        /// </summary>
+        public IReadOnlyList<DocumentInfo> AnalyzerConfigDocuments { get; }
+
+        /// <summary>
         /// Type of the host object.
         /// </summary>
         public Type HostObjectType { get; }
@@ -132,6 +137,7 @@ namespace Microsoft.CodeAnalysis
             IEnumerable<MetadataReference> metadataReferences,
             IEnumerable<AnalyzerReference> analyzerReferences,
             IEnumerable<DocumentInfo> additionalDocuments,
+            IEnumerable<DocumentInfo> analyzerConfigDocuments,
             Type hostObjectType)
         {
             Attributes = attributes;
@@ -142,6 +148,7 @@ namespace Microsoft.CodeAnalysis
             MetadataReferences = metadataReferences.ToImmutableReadOnlyListOrEmpty();
             AnalyzerReferences = analyzerReferences.ToImmutableReadOnlyListOrEmpty();
             AdditionalDocuments = additionalDocuments.ToImmutableReadOnlyListOrEmpty();
+            AnalyzerConfigDocuments = analyzerConfigDocuments.ToImmutableReadOnlyListOrEmpty();
             HostObjectType = hostObjectType;
         }
 
@@ -189,6 +196,7 @@ namespace Microsoft.CodeAnalysis
                 metadataReferences,
                 analyzerReferences,
                 additionalDocuments,
+                analyzerConfigDocuments: null,
                 hostObjectType);
         }
 
@@ -259,6 +267,7 @@ namespace Microsoft.CodeAnalysis
             IEnumerable<MetadataReference> metadataReferences = null,
             IEnumerable<AnalyzerReference> analyzerReferences = null,
             IEnumerable<DocumentInfo> additionalDocuments = null,
+            IEnumerable<DocumentInfo> analyzerConfigDocuments = null,
             Optional<Type> hostObjectType = default)
         {
             var newAttributes = attributes ?? Attributes;
@@ -269,6 +278,7 @@ namespace Microsoft.CodeAnalysis
             var newMetadataReferences = metadataReferences ?? MetadataReferences;
             var newAnalyzerReferences = analyzerReferences ?? AnalyzerReferences;
             var newAdditionalDocuments = additionalDocuments ?? AdditionalDocuments;
+            var newAnalyzerConfigDocuments = analyzerConfigDocuments ?? AnalyzerConfigDocuments;
             var newHostObjectType = hostObjectType.HasValue ? hostObjectType.Value : HostObjectType;
 
             if (newAttributes == Attributes &&
@@ -279,6 +289,7 @@ namespace Microsoft.CodeAnalysis
                 newMetadataReferences == MetadataReferences &&
                 newAnalyzerReferences == AnalyzerReferences &&
                 newAdditionalDocuments == AdditionalDocuments &&
+                newAnalyzerConfigDocuments == AnalyzerConfigDocuments &&
                 newHostObjectType == HostObjectType)
             {
                 return this;
@@ -293,6 +304,7 @@ namespace Microsoft.CodeAnalysis
                 newMetadataReferences,
                 newAnalyzerReferences,
                 newAdditionalDocuments,
+                newAnalyzerConfigDocuments,
                 newHostObjectType);
         }
 
@@ -304,6 +316,11 @@ namespace Microsoft.CodeAnalysis
         public ProjectInfo WithAdditionalDocuments(IEnumerable<DocumentInfo> additionalDocuments)
         {
             return With(additionalDocuments: additionalDocuments.ToImmutableReadOnlyListOrEmpty());
+        }
+
+        public ProjectInfo WithAnalyzerConfigDocuments(IEnumerable<DocumentInfo> analyzerConfigDocuments)
+        {
+            return With(analyzerConfigDocuments: analyzerConfigDocuments.ToImmutableReadOnlyListOrEmpty());
         }
 
         public ProjectInfo WithVersion(VersionStamp version)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -99,7 +99,9 @@ namespace Microsoft.CodeAnalysis
             var projectInfoFixed = FixProjectInfo(projectInfo);
 
             // We need to compute our AnalyerConfigDocumentStates first, since we use those to produce our DocumentStates
-            _analyzerConfigDocumentStates = ImmutableSortedDictionary.Create<DocumentId, AnalyzerConfigDocumentState>(DocumentIdComparer.Instance);
+            _analyzerConfigDocumentStates = ImmutableSortedDictionary.CreateRange(DocumentIdComparer.Instance,
+                projectInfoFixed.AnalyzerConfigDocuments.Select(d =>
+                    KeyValuePairUtil.Create(d.Id, new AnalyzerConfigDocumentState(d, solutionServices))));
             _lazyAnalyzerConfigSet = ComputeAnalyzerConfigSetValueSource(_analyzerConfigDocumentStates.Values);
 
             _documentIds = projectInfoFixed.Documents.Select(d => d.Id).ToImmutableList();
@@ -132,7 +134,10 @@ namespace Microsoft.CodeAnalysis
 
         private static ProjectInfo ClearAllDocumentsFromProjectInfo(ProjectInfo projectInfo)
         {
-            return projectInfo.WithDocuments(ImmutableArray<DocumentInfo>.Empty).WithAdditionalDocuments(ImmutableArray<DocumentInfo>.Empty);
+            return projectInfo
+                .WithDocuments(ImmutableArray<DocumentInfo>.Empty)
+                .WithAdditionalDocuments(ImmutableArray<DocumentInfo>.Empty)
+                .WithAnalyzerConfigDocuments(ImmutableArray<DocumentInfo>.Empty);
         }
 
         private ProjectInfo FixProjectInfo(ProjectInfo projectInfo)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -403,6 +403,11 @@ namespace Microsoft.CodeAnalysis
         public IReadOnlyList<DocumentId> AdditionalDocumentIds => _additionalDocumentIds;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+        // Regular documents and additionald documents have an ordering, and so we maintain lists of the IDs in order; in the case of analyzerconfig documents,
+        // we don't define a workspace ordering because they are ordered via fancier algorithms in the compiler based on directory depth.
+        public IEnumerable<DocumentId> AnalyzerConfigDocumentIds => _analyzerConfigDocumentStates.Keys;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
         public IImmutableDictionary<DocumentId, DocumentState> DocumentStates => _documentStates;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -408,6 +408,9 @@ namespace Microsoft.CodeAnalysis
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
         public IImmutableDictionary<DocumentId, TextDocumentState> AdditionalDocumentStates => _additionalDocumentStates;
 
+        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+        public IImmutableDictionary<DocumentId, AnalyzerConfigDocumentState> AnalyzerConfigDocumentStates => _analyzerConfigDocumentStates;
+
         public bool ContainsDocument(DocumentId documentId)
         {
             return _documentStates.ContainsKey(documentId);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -675,14 +675,14 @@ namespace Microsoft.CodeAnalysis
                 documentStates: _documentStates.AddRange(documents.Select(d => KeyValuePairUtil.Create(d.Id, d))));
         }
 
-        public ProjectState AddAdditionalDocument(TextDocumentState document)
+        public ProjectState AddAdditionalDocuments(ImmutableArray<TextDocumentState> documents)
         {
-            Debug.Assert(!this.AdditionalDocumentStates.ContainsKey(document.Id));
+            Debug.Assert(!documents.Any(d => this.AdditionalDocumentStates.ContainsKey(d.Id)));
 
             return this.With(
                 projectInfo: this.ProjectInfo.WithVersion(this.Version.GetNewerVersion()),
-                additionalDocumentIds: _additionalDocumentIds.Add(document.Id),
-                additionalDocumentStates: _additionalDocumentStates.Add(document.Id, document));
+                additionalDocumentIds: _additionalDocumentIds.AddRange(documents.Select(d => d.Id)),
+                additionalDocumentStates: _additionalDocumentStates.AddRange(documents.Select(d => KeyValuePairUtil.Create(d.Id, d))));
         }
 
         public ProjectState AddAnalyzerConfigDocuments(ImmutableArray<AnalyzerConfigDocumentState> documents)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -189,6 +189,19 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Gets the additional document in this solution with the specified document ID.
+        /// </summary>
+        public AnalyzerConfigDocument GetAnalyzerConfigDocument(DocumentId documentId)
+        {
+            if (documentId != null && this.ContainsAnalyzerConfigDocument(documentId))
+            {
+                return this.GetProject(documentId.ProjectId).GetAnalyzerConfigDocument(documentId);
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Gets the document in this solution with the specified syntax tree.
         /// </summary>
         public Document GetDocument(SyntaxTree syntaxTree)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1028,6 +1028,21 @@ namespace Microsoft.CodeAnalysis
         /// Creates a new solution instance with the analyzer config document specified updated to have the text
         /// supplied by the text loader.
         /// </summary>
+        public Solution WithAnalyzerConfigDocumentText(DocumentId documentId, SourceText text, PreservationMode mode = PreservationMode.PreserveValue)
+        {
+            var newState = _state.WithAnalyzerConfigDocumentText(documentId, text, mode);
+            if (newState == _state)
+            {
+                return this;
+            }
+
+            return new Solution(newState);
+        }
+
+        /// <summary>
+        /// Creates a new solution instance with the analyzer config document specified updated to have the text
+        /// supplied by the text loader.
+        /// </summary>
         public Solution WithAnalyzerConfigDocumentTextLoader(DocumentId documentId, TextLoader loader, PreservationMode mode)
         {
             var newState = _state.WithAnalyzerConfigDocumentTextLoader(documentId, loader, mode);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -776,7 +776,12 @@ namespace Microsoft.CodeAnalysis
 
         public Solution AddAdditionalDocument(DocumentInfo documentInfo)
         {
-            var newState = _state.AddAdditionalDocument(documentInfo);
+            return AddAdditionalDocuments(ImmutableArray.Create(documentInfo));
+        }
+
+        public Solution AddAdditionalDocuments(ImmutableArray<DocumentInfo> documentInfos)
+        {
+            var newState = _state.AddAdditionalDocuments(documentInfos);
             if (newState == _state)
             {
                 return this;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1382,6 +1382,33 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Creates a new solution instance with the document specified updated to have the text
+        /// specified.
+        /// </summary>
+        public SolutionState WithAnalyzerConfigDocumentText(DocumentId documentId, SourceText text, PreservationMode mode = PreservationMode.PreserveValue)
+        {
+            if (documentId == null)
+            {
+                throw new ArgumentNullException(nameof(documentId));
+            }
+
+            if (text == null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            CheckContainsAnalyzerConfigDocument(documentId);
+
+            var oldDocument = this.GetAnalyzerConfigDocumentState(documentId);
+            if (oldDocument.TryGetText(out var oldText) && text == oldText)
+            {
+                return this;
+            }
+
+            return this.WithAnalyzerConfigDocumentState(oldDocument.UpdateText(text, mode), textChanged: true);
+        }
+
+        /// <summary>
+        /// Creates a new solution instance with the document specified updated to have the text
         /// and version specified.
         /// </summary>
         public SolutionState WithDocumentText(DocumentId documentId, TextAndVersion textAndVersion, PreservationMode mode = PreservationMode.PreserveValue)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1196,27 +1196,11 @@ namespace Microsoft.CodeAnalysis
             return newSolutionState;
         }
 
-        public SolutionState AddAdditionalDocument(DocumentInfo documentInfo)
+        public SolutionState AddAdditionalDocuments(ImmutableArray<DocumentInfo> documentInfos)
         {
-            if (documentInfo == null)
-            {
-                throw new ArgumentNullException(nameof(documentInfo));
-            }
-
-            CheckContainsProject(documentInfo.Id.ProjectId);
-            CheckNotContainsAdditionalDocument(documentInfo.Id);
-
-            var oldProject = this.GetProjectState(documentInfo.Id.ProjectId);
-
-            var state = new TextDocumentState(
-                documentInfo,
-                _solutionServices);
-
-            var newProject = oldProject.AddAdditionalDocument(state);
-            var documentStates = SpecializedCollections.SingletonEnumerable(newProject.GetAdditionalDocumentState(documentInfo.Id));
-
-            return this.ForkProject(newProject,
-                    newFilePathToDocumentIdsMap: CreateFilePathToDocumentIdsMapWithAddedDocuments(documentStates));
+            return AddDocumentsToMultipleProjects(documentInfos,
+                (documentInfo, project) => new TextDocumentState(documentInfo, _solutionServices),
+                (projectState, documents) => (projectState.AddAdditionalDocuments(documents), translationAction: null));
         }
 
         public SolutionState AddAnalyzerConfigDocuments(ImmutableArray<DocumentInfo> documentInfos)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -111,6 +111,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         public AnalyzerReferenceChecksumCollection AnalyzerReferences => (AnalyzerReferenceChecksumCollection)Children[6];
 
         public TextDocumentChecksumCollection AdditionalDocuments => (TextDocumentChecksumCollection)Children[7];
+        public AnalyzerConfigDocumentChecksumCollection AnalyzerConfigDocuments => (AnalyzerConfigDocumentChecksumCollection)Children[8];
 
         public void Find(
             ProjectState state,
@@ -168,11 +169,17 @@ namespace Microsoft.CodeAnalysis.Serialization
                 result[AdditionalDocuments.Checksum] = AdditionalDocuments;
             }
 
+            if (searchingChecksumsLeft.Remove(AnalyzerConfigDocuments.Checksum))
+            {
+                result[AnalyzerConfigDocuments.Checksum] = AnalyzerConfigDocuments;
+            }
+
             Find(state.DocumentStates, searchingChecksumsLeft, result, cancellationToken);
             Find(state.ProjectReferences, ProjectReferences, searchingChecksumsLeft, result, cancellationToken);
             Find(state.MetadataReferences, MetadataReferences, searchingChecksumsLeft, result, cancellationToken);
             Find(state.AnalyzerReferences, AnalyzerReferences, searchingChecksumsLeft, result, cancellationToken);
             Find(state.AdditionalDocumentStates, searchingChecksumsLeft, result, cancellationToken);
+            Find(state.AnalyzerConfigDocumentStates, searchingChecksumsLeft, result, cancellationToken);
         }
 
         private static void Find<T>(

--- a/src/Workspaces/CoreTestUtilities/Extensions.cs
+++ b/src/Workspaces/CoreTestUtilities/Extensions.cs
@@ -50,6 +50,11 @@ namespace Microsoft.CodeAnalysis.UnitTests.Execution
         {
             return new ChecksumObjectCollection<DocumentStateChecksums>(service, collection);
         }
+
+        public static ChecksumObjectCollection<DocumentStateChecksums> ToDocumentObjects(this AnalyzerConfigDocumentChecksumCollection collection, IRemotableDataService service)
+        {
+            return new ChecksumObjectCollection<DocumentStateChecksums>(service, collection);
+        }
     }
 
     /// <summary>

--- a/src/Workspaces/Remote/Core/Services/ChecksumSynchronizer.cs
+++ b/src/Workspaces/Remote/Core/Services/ChecksumSynchronizer.cs
@@ -69,6 +69,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                     await CollectChecksumChildrenAsync(checksums, projectChecksumObject.Documents, cancellationToken).ConfigureAwait(false);
                     await CollectChecksumChildrenAsync(checksums, projectChecksumObject.AdditionalDocuments, cancellationToken).ConfigureAwait(false);
+                    await CollectChecksumChildrenAsync(checksums, projectChecksumObject.AnalyzerConfigDocuments, cancellationToken).ConfigureAwait(false);
                 }
 
                 await _assetService.SynchronizeAssetsAsync(checksums, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 project = await UpdateDocumentsAsync(project, oldProjectChecksums.Documents, newProjectChecksums.Documents, additionalText: false).ConfigureAwait(false);
             }
 
-            // changed analyzer references
+            // changed additional documents
             if (oldProjectChecksums.AdditionalDocuments.Checksum != newProjectChecksums.AdditionalDocuments.Checksum)
             {
                 project = await UpdateDocumentsAsync(project, oldProjectChecksums.AdditionalDocuments, newProjectChecksums.AdditionalDocuments, additionalText: true).ConfigureAwait(false);
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 olds.Object.UnionWith(oldChecksums);
                 news.Object.UnionWith(newChecksums);
 
-                // remove projects that exist in both side
+                // remove documents that exist in both side
                 olds.Object.ExceptWith(newChecksums);
                 news.Object.ExceptWith(oldChecksums);
 

--- a/src/Workspaces/Remote/Core/Shared/Extensions.cs
+++ b/src/Workspaces/Remote/Core/Shared/Extensions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Remote.Shared
 
             projectChecksums.Find(project.State, Flatten(projectChecksums), map, cancellationToken);
 
-            foreach (var document in project.Documents.Concat(project.AdditionalDocuments))
+            foreach (var document in project.Documents.Concat(project.AdditionalDocuments).Concat(project.AnalyzerConfigDocuments))
             {
                 await document.AppendAssetMapAsync(map, cancellationToken).ConfigureAwait(false);
             }

--- a/src/Workspaces/Remote/Core/Shared/SimpleAssetSource.cs
+++ b/src/Workspaces/Remote/Core/Shared/SimpleAssetSource.cs
@@ -32,10 +32,11 @@ namespace Microsoft.CodeAnalysis.Remote.Shared
                 if (_map.TryGetValue(checksum, out var data))
                 {
                     list.Add(ValueTuple.Create(checksum, data));
-                    continue;
                 }
-
-                Debug.Fail("How?");
+                else
+                {
+                    Debug.Fail($"Unable to find asset for {checksum}");
+                }
             }
 
             return Task.FromResult<IList<(Checksum, object)>>(list);

--- a/src/Workspaces/Remote/Core/TestUtils.cs
+++ b/src/Workspaces/Remote/Core/TestUtils.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Remote.DebugUtil
                     var projectChecksums = await assetService.GetAssetAsync<ProjectStateChecksums>(projectChecksum, CancellationToken.None).ConfigureAwait(false);
                     set.AppendChecksums(projectChecksums);
 
-                    foreach (var documentChecksum in projectChecksums.Documents.Concat(projectChecksums.AdditionalDocuments))
+                    foreach (var documentChecksum in projectChecksums.Documents.Concat(projectChecksums.AdditionalDocuments).Concat(projectChecksums.AnalyzerConfigDocuments))
                     {
                         var documentChecksums = await assetService.GetAssetAsync<DocumentStateChecksums>(documentChecksum, CancellationToken.None).ConfigureAwait(false);
                         set.AppendChecksums(documentChecksums);


### PR DESCRIPTION
This adds support for synchronizing AnalyzerConfig documents out to OOP process. It also adds a bunch of Workspace methods for manipulating AnalyzerConfig documents that I forgot to add in the previous pull request.

Commit-at-a-time recommended but won't be too bad if you do it all at once.