### PR TITLE
Don't allow void to convert to object via user-defined conversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ClassifyConversionFromType(source, destination, ref useSiteDiagnostics);
         }
 
-        private bool TryGetVoidConversion(TypeSymbol source, TypeSymbol destination, out Conversion conversion)
+        private static bool TryGetVoidConversion(TypeSymbol source, TypeSymbol destination, out Conversion conversion)
         {
             var sourceIsVoid = source?.SpecialType == SpecialType.System_Void;
             var destIsVoid = destination.SpecialType == SpecialType.System_Void;
@@ -192,7 +192,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             conversion = default;
             return false;
-
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -182,6 +182,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(sourceExpression != null);
             Debug.Assert((object)destination != null);
 
+            if (sourceExpression.Type?.SpecialType == SpecialType.System_Void || destination.SpecialType == SpecialType.System_Void)
+            {
+                return Conversion.NoConversion;
+            }
+
             if (forCast)
             {
                 return ClassifyConversionFromExpressionForCast(sourceExpression, destination, ref useSiteDiagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -168,6 +168,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ClassifyConversionFromType(source, destination, ref useSiteDiagnostics);
         }
 
+        private bool TryGetVoidConversion(TypeSymbol source, TypeSymbol destination, out Conversion conversion)
+        {
+            var sourceIsVoid = source?.SpecialType == SpecialType.System_Void;
+            var destIsVoid = destination.SpecialType == SpecialType.System_Void;
+
+            if (sourceIsVoid && destIsVoid)
+            {
+                conversion = Conversion.Identity;
+                return true;
+            }
+
+            if (sourceIsVoid || destIsVoid)
+            {
+                conversion = Conversion.NoConversion;
+                return true;
+            }
+
+            conversion = default;
+            return false;
+
+        }
+
         /// <summary>
         /// Determines if the source expression is convertible to the destination type via
         /// any conversion: implicit, explicit, user-defined or built-in.
@@ -182,9 +204,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(sourceExpression != null);
             Debug.Assert((object)destination != null);
 
-            if (sourceExpression.Type?.SpecialType == SpecialType.System_Void || destination.SpecialType == SpecialType.System_Void)
+            if (TryGetVoidConversion(sourceExpression.Type, destination, out var conversion))
             {
-                return Conversion.NoConversion;
+                return conversion;
             }
 
             if (forCast)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -6027,10 +6027,7 @@ class C
                 Diagnostic(ErrorCode.ERR_NoVoidHere, "void").WithLocation(5, 17),
                 // (5,31): error CS8210: A tuple may not contain a value of type 'void'.
                 //         (int x, void y) = (1, Main());
-                Diagnostic(ErrorCode.ERR_VoidInTuple, "Main()").WithLocation(5, 31),
-                // (5,17): error CS0029: Cannot implicitly convert type 'void' to 'void'
-                //         (int x, void y) = (1, Main());
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "void y").WithArguments("void", "void").WithLocation(5, 17)
+                Diagnostic(ErrorCode.ERR_VoidInTuple, "Main()").WithLocation(5, 31)
                 );
             var main = comp.GetMember<MethodSymbol>("C.Main");
             var tree = comp.SyntaxTrees[0];
@@ -6113,10 +6110,7 @@ class C
                 Diagnostic(ErrorCode.ERR_NoVoidHere, "void").WithLocation(5, 17),
                 // (5,31): error CS0029: Cannot implicitly convert type 'int' to 'void'
                 //         (int x, void y) = (1, 2);
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "2").WithArguments("int", "void").WithLocation(5, 31),
-                // (5,17): error CS0029: Cannot implicitly convert type 'void' to 'void'
-                //         (int x, void y) = (1, 2);
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "void y").WithArguments("void", "void").WithLocation(5, 17)
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "2").WithArguments("int", "void").WithLocation(5, 31)
                 );
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
@@ -1621,31 +1621,6 @@ class C<T>
         }
 
         [Fact, WorkItem(34876, "https://github.com/dotnet/roslyn/pull/34876")]
-        public void Repro_34876_Fixed()
-        {
-            var source = @"
-struct S<T>
-{
-    public static implicit operator S<T>(T t) => new S<T>();
-    public ref S<T> GetPinnableReference() => throw null;
-
-    private static void M1() { }
-    private static unsafe void M2()
-    {
-    	fixed (S<object>* s = (S<object>) M1())
-        {
-        }
-    }
-}
-";
-            var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
-            comp.VerifyDiagnostics(
-                // (10,28): error CS0030: Cannot convert type 'void' to 'S<object>'
-                //     	fixed (S<object>* s = (S<object>) M1())
-                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(S<object>) M1()").WithArguments("void", "S<object>").WithLocation(10, 28));
-        }
-
-        [Fact, WorkItem(34876, "https://github.com/dotnet/roslyn/pull/34876")]
         public void Repro_34876_Cast()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
@@ -1599,7 +1599,7 @@ namespace System
         }
 
         [Fact, WorkItem(34876, "https://github.com/dotnet/roslyn/pull/34876")]
-        public void Repro_34876()
+        public void GenericOperatorVoidConversion()
         {
             var source = @"
 class C<T>
@@ -1621,7 +1621,7 @@ class C<T>
         }
 
         [Fact, WorkItem(34876, "https://github.com/dotnet/roslyn/pull/34876")]
-        public void Repro_34876_Cast()
+        public void GenericOperatorVoidConversion_Cast()
         {
             var source = @"
 class C<T>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
@@ -1621,6 +1621,31 @@ class C<T>
         }
 
         [Fact, WorkItem(34876, "https://github.com/dotnet/roslyn/pull/34876")]
+        public void Repro_34876_Fixed()
+        {
+            var source = @"
+struct S<T>
+{
+    public static implicit operator S<T>(T t) => new S<T>();
+    public ref S<T> GetPinnableReference() => throw null;
+
+    private static void M1() { }
+    private static unsafe void M2()
+    {
+    	fixed (S<object>* s = (S<object>) M1())
+        {
+        }
+    }
+}
+";
+            var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(
+                // (10,28): error CS0030: Cannot convert type 'void' to 'S<object>'
+                //     	fixed (S<object>* s = (S<object>) M1())
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(S<object>) M1()").WithArguments("void", "S<object>").WithLocation(10, 28));
+        }
+
+        [Fact, WorkItem(34876, "https://github.com/dotnet/roslyn/pull/34876")]
         public void Repro_34876_Cast()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
@@ -1614,26 +1614,32 @@ class C<T>
 }
 ";
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (9,16): error CS0029: Cannot implicitly convert type 'void' to 'C<object>'
+                //         return M1();
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "M1()").WithArguments("void", "C<object>").WithLocation(9, 16));
         }
 
         [Fact, WorkItem(34876, "https://github.com/dotnet/roslyn/pull/34876")]
-        public void Repro_34876_String()
+        public void Repro_34876_Cast()
         {
             var source = @"
 class C<T>
 {
-    public static implicit operator C<T>(T t) => new C<T>();
+    public static explicit operator C<T>(T t) => new C<T>();
 
     private static void M1() { }
-    private static C<string> M2()
+    private static C<object> M2()
     {
-        return M1();
+        return (C<object>) M1();
     }
 }
 ";
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (9,16): error CS0030: Cannot convert type 'void' to 'C<object>'
+                //         return (C<object>) M1();
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(C<object>) M1()").WithArguments("void", "C<object>").WithLocation(9, 16));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
@@ -1597,5 +1597,43 @@ namespace System
 ";
             CreateEmptyCompilation(source).VerifyDiagnostics();
         }
+
+        [Fact, WorkItem(34876, "https://github.com/dotnet/roslyn/pull/34876")]
+        public void Repro_34876()
+        {
+            var source = @"
+class C<T>
+{
+    public static implicit operator C<T>(T t) => new C<T>();
+
+    private static void M1() { }
+    private static C<object> M2()
+    {
+        return M1();
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem(34876, "https://github.com/dotnet/roslyn/pull/34876")]
+        public void Repro_34876_String()
+        {
+            var source = @"
+class C<T>
+{
+    public static implicit operator C<T>(T t) => new C<T>();
+
+    private static void M1() { }
+    private static C<string> M2()
+    {
+        return M1();
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/OperatorsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/OperatorsTests.vb
@@ -1124,6 +1124,34 @@ BC30452: Operator '/' is not defined for types 'A14' and 'A14'.
 </expected>)
         End Sub
 
+        <Fact(), WorkItem(34872, "https://github.com/dotnet/roslyn/issues/34872")>
+        Public Sub GenericOperatorVoidConversion()
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40(
+<compilation name="C">
+    <file name="a.vb"><![CDATA[
+Public Class C(Of T)
+    Public Shared Widening Operator CType(t As T) As C(Of T)
+        Return New C(Of T)
+	End Operator
+
+    Public Sub M()
+    End Sub
+
+    Public Function M2() As C(Of Object)
+		Return M()
+	End Function
+End Class
+    ]]></file>
+</compilation>)
+
+            CompilationUtils.AssertTheseDiagnostics(compilation,
+<expected><![CDATA[
+BC30491: Expression does not produce a value.
+		Return M()
+         ~~~
+]]></expected>)
+        End Sub
+
         <Fact()>
         Public Sub Operators8()
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40(


### PR DESCRIPTION
Fixes #34872

If anyone can think of any more cases that ensure we catch attempts to convert to/from void it would be appreciated.