### PR TITLE
Revert two step initialization of base type in PENamedTypeSymbol.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -65,8 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private NamedTypeSymbol _lazyBaseType = ErrorTypeSymbol.UnknownResultType;
         private ImmutableArray<NamedTypeSymbol> _lazyInterfaces = default(ImmutableArray<NamedTypeSymbol>);
-        private NamedTypeSymbol _lazyDeclaredBaseTypeWithoutNullability = ErrorTypeSymbol.UnknownResultType;
-        private NamedTypeSymbol _lazyDeclaredBaseTypeWithNullability = ErrorTypeSymbol.UnknownResultType;
+        private NamedTypeSymbol _lazyDeclaredBaseType = ErrorTypeSymbol.UnknownResultType;
         private ImmutableArray<NamedTypeSymbol> _lazyDeclaredInterfaces = default(ImmutableArray<NamedTypeSymbol>);
 
         private Tuple<CultureInfo, string> _lazyDocComment;
@@ -427,33 +426,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<TypeSymbol> basesBeingResolved)
         {
-            return GetDeclaredBaseType(ignoreNullability: false);
+            return GetDeclaredBaseType();
         }
 
-        private NamedTypeSymbol GetDeclaredBaseType(bool ignoreNullability)
+        private NamedTypeSymbol GetDeclaredBaseType()
         {
-            if (ReferenceEquals(_lazyDeclaredBaseTypeWithoutNullability, ErrorTypeSymbol.UnknownResultType))
+            if (ReferenceEquals(_lazyDeclaredBaseType, ErrorTypeSymbol.UnknownResultType))
             {
-                Interlocked.CompareExchange(ref _lazyDeclaredBaseTypeWithoutNullability, MakeDeclaredBaseType(), ErrorTypeSymbol.UnknownResultType);
+                Interlocked.CompareExchange(ref _lazyDeclaredBaseType, MakeDeclaredBaseType(), ErrorTypeSymbol.UnknownResultType);
             }
 
-            if (ignoreNullability)
-            {
-                return _lazyDeclaredBaseTypeWithoutNullability;
-            }
-
-            if (ReferenceEquals(_lazyDeclaredBaseTypeWithNullability, ErrorTypeSymbol.UnknownResultType))
-            {
-                var declaredBase = _lazyDeclaredBaseTypeWithoutNullability;
-                if ((object)declaredBase != null)
-                {
-                    declaredBase = (NamedTypeSymbol)NullableTypeDecoder.TransformType(
-                        TypeWithAnnotations.Create(declaredBase), _handle, ContainingPEModule).Type;
-                }
-                Interlocked.CompareExchange(ref _lazyDeclaredBaseTypeWithNullability, declaredBase, ErrorTypeSymbol.UnknownResultType);
-            }
-
-            return _lazyDeclaredBaseTypeWithNullability;
+            return _lazyDeclaredBaseType;
         }
 
         internal override ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<TypeSymbol> basesBeingResolved)
@@ -479,9 +462,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     {
                         TypeSymbol decodedType = new MetadataDecoder(moduleSymbol, this).GetTypeOfToken(token);
                         decodedType = DynamicTypeDecoder.TransformType(decodedType, 0, _handle, moduleSymbol);
-                        return (NamedTypeSymbol)TupleTypeDecoder.DecodeTupleTypesIfApplicable(decodedType,
-                                                                                              _handle,
-                                                                                              moduleSymbol);
+                        decodedType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(decodedType,
+                                                                                    _handle,
+                                                                                    moduleSymbol);
+                        return (NamedTypeSymbol)NullableTypeDecoder.TransformType(TypeWithAnnotations.Create(decodedType),
+                                                                                  _handle,
+                                                                                  moduleSymbol).Type;
                     }
                 }
                 catch (BadImageFormatException mrEx)
@@ -1617,7 +1603,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     }
                     else
                     {
-                        TypeSymbol @base = GetDeclaredBaseType(ignoreNullability: true);
+                        TypeSymbol @base = GetDeclaredBaseType();
 
                         result = TypeKind.Class;
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -33274,6 +33274,48 @@ class C : Base
         }
 
         [Fact]
+        public void Base_02()
+        {
+            var source0 =
+@"public abstract class A<T>
+{
+}
+public class B<T> : A<T?> where T : B<T>
+{
+}";
+            var comp0 = CreateCompilation(source0, options: WithNonNullTypesTrue());
+            comp0.VerifyDiagnostics();
+
+            CompileAndVerify(comp0, sourceSymbolValidator: symbolValidator, symbolValidator: symbolValidator);
+            void symbolValidator(ModuleSymbol m)
+            {
+                var b = m.GlobalNamespace.GetTypeMember("B");
+                Assert.Equal("A<T?>", b.BaseTypeNoUseSiteDiagnostics.ToTestDisplayString(true));
+            }
+        }
+
+        [Fact]
+        public void Base_03()
+        {
+            var source0 =
+@"public abstract class A<T>
+{
+}
+public class B<T> : A<T> where T : B<T>
+{
+}";
+            var comp0 = CreateCompilation(source0, options: WithNonNullTypesTrue());
+            comp0.VerifyDiagnostics();
+
+            CompileAndVerify(comp0, sourceSymbolValidator: symbolValidator, symbolValidator: symbolValidator);
+            void symbolValidator(ModuleSymbol m)
+            {
+                var b = m.GlobalNamespace.GetTypeMember("B");
+                Assert.Equal("A<T!>", b.BaseTypeNoUseSiteDiagnostics.ToTestDisplayString(true));
+            }
+        }
+
+        [Fact]
         public void TypeOf_01()
         {
             CSharpCompilation c = CreateCompilation(new[] { @"
@@ -68153,7 +68195,6 @@ public class A2<T> where T : class, IEquatable<T?> { }
 
             MetadataReference ref0 = comp0.ToMetadataReference();
             var comp = CreateCompilation(source, references: new[] { ref0 });
-            // https://github.com/dotnet/roslyn/issues/30003: Should report a nullability mismatch warning for A2<string>().
             comp.VerifyDiagnostics(
                 // (5,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
                 //         new A2<string?>(); // 2
@@ -68173,7 +68214,6 @@ public class A2<T> where T : class, IEquatable<T?> { }
                 );
             ref0 = comp0.ToMetadataReference();
             comp = CreateCompilation(source, references: new[] { ref0 });
-            // https://github.com/dotnet/roslyn/issues/30003: Should report same warnings as other two cases.
             comp.VerifyDiagnostics(
                 // (5,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
                 //         new A2<string?>(); // 2
@@ -68186,7 +68226,6 @@ public class A2<T> where T : class, IEquatable<T?> { }
             ref0 = comp0.EmitToImageReference();
 
             comp = CreateCompilation(source, references: new[] { ref0 });
-            // https://github.com/dotnet/roslyn/issues/30003: Should report a nullability mismatch warning for A2<string>().
             comp.VerifyDiagnostics(
                 // (5,22): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
                 //         new A2<string?>(); // 2


### PR DESCRIPTION
Related to #28834.

Also, remove obsolete comments from a test. Closes #30003.