### PR TITLE
A couple of tweaks around features that add parameter null-checks.

### DIFF
--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -45,12 +45,40 @@ class C
 {
     public C(string s)
     {
-        if (s == null)
+        if (s is null)
         {
             throw new ArgumentNullException(nameof(s));
         }
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestSimpleReferenceType_CSharp6()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System;
+
+class C
+{
+    public C([||]string s)
+    {
+    }
+}",
+@"
+using System;
+
+class C
+{
+    public C(string s)
+    {
+        if (s == null)
+        {
+            throw new ArgumentNullException(nameof(s));
+        }
+    }
+}", parameters: new TestParameters(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6)));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
@@ -73,7 +101,7 @@ class C
 {
     public C(int? i)
     {
-        if (i == null)
+        if (i is null)
         {
             throw new ArgumentNullException(nameof(i));
         }
@@ -193,7 +221,7 @@ class C
 
     partial void M(string s)
     {
-        if (s == null)
+        if (s is null)
         {
             throw new ArgumentNullException(nameof(s));
         }
@@ -223,7 +251,7 @@ class C
 {
     partial void M(string s)
     {
-        if (s == null)
+        if (s is null)
         {
             throw new ArgumentNullException(nameof(s));
         }
@@ -366,7 +394,7 @@ class C
 
     public C(string s)
     {
-        if (s == null)
+        if (s is null)
         {
             throw new ArgumentNullException(nameof(s));
         }
@@ -422,7 +450,7 @@ class C
 {
     public C(string s)
     {
-        if (s == null)
+        if (s is null)
         {
             throw new ArgumentNullException(nameof(s));
         }
@@ -451,7 +479,7 @@ class C
 {
     public C(string s)
     {
-        if (s == null)
+        if (s is null)
         {
             throw new ArgumentNullException(nameof(s));
         }
@@ -486,7 +514,7 @@ class C
     {
         int F(string s)
         {
-            if (s == null)
+            if (s is null)
             {
                 throw new ArgumentNullException(nameof(s));
             }
@@ -521,7 +549,7 @@ class C
     {
         void F(string s)
         {
-            if (s == null)
+            if (s is null)
             {
                 throw new ArgumentNullException(nameof(s));
             }
@@ -558,7 +586,7 @@ class C
     {
         Func<string, int> f = s =>
         {
-            if (s == null)
+            if (s is null)
             {
                 throw new ArgumentNullException(nameof(s));
             }
@@ -597,7 +625,7 @@ class C
     {
         Action<string> f = s =>
         {
-            if (s == null)
+            if (s is null)
             {
                 throw new ArgumentNullException(nameof(s));
             }
@@ -637,7 +665,7 @@ class C
         {
         }
 
-        if (s == null)
+        if (s is null)
         {
             throw new ArgumentNullException(nameof(s));
         }
@@ -668,7 +696,7 @@ class C
 {
     public C(string a, string s)
     {
-        if (a == null)
+        if (a is null)
         {
             throw new ArgumentNullException(nameof(a));
         }
@@ -864,7 +892,7 @@ class C
 {
     void F(string s)
     {
-        if (s == null)
+        if (s is null)
         {
             throw new ArgumentNullException(nameof(s));
         }
@@ -892,7 +920,7 @@ class C
 {
     public static C operator +(C c1, [||]string s)
     {
-        if (s == null)
+        if (s is null)
         {
             throw new ArgumentNullException(nameof(s));
         }
@@ -924,7 +952,7 @@ class C
     {
         Func<string, int> f = s =>
         {
-            if (s == null)
+            if (s is null)
             {
                 throw new ArgumentNullException(nameof(s));
             }
@@ -959,7 +987,7 @@ class C
     {
         Action<string> f = s =>
         {
-            if (s == null)
+            if (s is null)
             {
                 throw new ArgumentNullException(nameof(s));
             }
@@ -992,7 +1020,7 @@ class C
     {
         Func<string, int> f = (string s) =>
         {
-            if (s == null)
+            if (s is null)
             {
                 throw new ArgumentNullException(nameof(s));
             }
@@ -1027,7 +1055,7 @@ class C
     {
         Func<string, int> f = delegate (string s)
         {
-            if (s == null)
+            if (s is null)
             {
                 throw new ArgumentNullException(nameof(s));
             }
@@ -1064,7 +1092,7 @@ class C
     {
         void F(string s)
         {
-            if (s == null)
+            if (s is null)
             {
                 throw new ArgumentNullException(nameof(s));
             }
@@ -1220,7 +1248,7 @@ class C
 {
     public C(string s)
     {
-        if (s == null)
+        if (s is null)
             throw new ArgumentNullException(nameof(s));
     }
 }",
@@ -1247,7 +1275,7 @@ class C
 {
     public C(string s)
     {
-        if (s == null)
+        if (s is null)
         {
             throw new ArgumentNullException(nameof(s));
         }
@@ -1279,7 +1307,7 @@ class C
 {
     public int Foo(int[] array)
     {
-        if (array == null)
+        if (array is null)
         {
             throw new ArgumentNullException(nameof(array));
         }
@@ -1315,7 +1343,7 @@ class C
 {
     public int Foo(int[] array) /* Bar */
     {
-        if (array == null)
+        if (array is null)
         {
             throw new ArgumentNullException(nameof(array));
         }
@@ -1395,7 +1423,7 @@ class C
 {
     public void Foo(int[] array)
     {
-        if (array == null)
+        if (array is null)
         {
             throw new ArgumentNullException(nameof(array));
         }
@@ -1428,7 +1456,7 @@ class C
 {
     public C(string s)
     {
-        if (s == null)
+        if (s is null)
         {
             throw new ArgumentNullException(nameof(s));
         }

--- a/src/Features/Core/Portable/ConvertAnonymousTypeToClass/AbstractConvertAnonymousTypeToClassCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertAnonymousTypeToClass/AbstractConvertAnonymousTypeToClassCodeRefactoringProvider.cs
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             Document document, string className,
             ImmutableArray<IPropertySymbol> properties, CancellationToken cancellationToken)
         {
-            var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             // Next, see if any of the properties ended up using any type parameters from the
             // containing method/named-type.  If so, we'll need to generate a generic type so we can
@@ -297,8 +297,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             var namedTypeWithoutMembers = CreateNamedType(className, capturedTypeParameters, members: default);
 
             var generator = SyntaxGenerator.GetGenerator(document);
-            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            var constructor = CreateConstructor(compilation, tree.Options, className, properties, generator);
+            var constructor = CreateConstructor(semanticModel, className, properties, generator);
 
             // Generate Equals/GetHashCode.  Only readonly properties are suitable for these
             // methods.  We can defer to our existing language service for this so that we
@@ -392,7 +391,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
                    name: "", typeParameters: default, parameters: default, methodKind: kind);
 
         private static IMethodSymbol CreateConstructor(
-            Compilation compilation, ParseOptions parseOptions, string className,
+            SemanticModel semanticModel, string className,
             ImmutableArray<IPropertySymbol> properties, SyntaxGenerator generator)
         {
             // For every property, create a corresponding parameter, as well as an assignment
@@ -409,7 +408,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             });
 
             var assignmentStatements = generator.CreateAssignmentStatements(
-                compilation, parseOptions, parameters, parameterToPropMap, ImmutableDictionary<string, string>.Empty,
+                semanticModel, parameters, parameterToPropMap, ImmutableDictionary<string, string>.Empty,
                 addNullChecks: false, preferThrowExpression: false);
 
             var constructor = CodeGenerationSymbolFactory.CreateConstructorSymbol(

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -721,7 +721,6 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             INamedTypeSymbol tupleType, CancellationToken cancellationToken)
         {
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var compilation = semanticModel.Compilation;
 
             var fields = tupleType.TupleElements;
 
@@ -735,8 +734,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
                 scope, structName, typeParameters, members: default);
 
             var generator = SyntaxGenerator.GetGenerator(document);
-            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            var constructor = CreateConstructor(compilation, tree.Options, structName, fields, generator);
+            var constructor = CreateConstructor(semanticModel, structName, fields, generator);
 
             // Generate Equals/GetHashCode.  We can defer to our existing language service for this
             // so that we generate the same Equals/GetHashCode that our other IDE features generate.
@@ -835,7 +833,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
         }
 
         private static IMethodSymbol CreateConstructor(
-            Compilation compilation, ParseOptions options, string className,
+            SemanticModel semanticModel, string className,
             ImmutableArray<IFieldSymbol> fields, SyntaxGenerator generator)
         {
             // For every property, create a corresponding parameter, as well as an assignment
@@ -852,7 +850,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             });
 
             var assignmentStatements = generator.CreateAssignmentStatements(
-                compilation, options, parameters, parameterToPropMap, ImmutableDictionary<string, string>.Empty,
+                semanticModel, parameters, parameterToPropMap, ImmutableDictionary<string, string>.Empty,
                 addNullChecks: false, preferThrowExpression: false);
 
             var constructor = CodeGenerationSymbolFactory.CreateConstructorSymbol(

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -735,7 +735,8 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
                 scope, structName, typeParameters, members: default);
 
             var generator = SyntaxGenerator.GetGenerator(document);
-            var constructor = CreateConstructor(compilation, structName, fields, generator);
+            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var constructor = CreateConstructor(compilation, tree.Options, structName, fields, generator);
 
             // Generate Equals/GetHashCode.  We can defer to our existing language service for this
             // so that we generate the same Equals/GetHashCode that our other IDE features generate.
@@ -834,7 +835,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
         }
 
         private static IMethodSymbol CreateConstructor(
-            Compilation compilation, string className,
+            Compilation compilation, ParseOptions options, string className,
             ImmutableArray<IFieldSymbol> fields, SyntaxGenerator generator)
         {
             // For every property, create a corresponding parameter, as well as an assignment
@@ -851,7 +852,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             });
 
             var assignmentStatements = generator.CreateAssignmentStatements(
-                compilation, parameters, parameterToPropMap, ImmutableDictionary<string, string>.Empty,
+                compilation, options, parameters, parameterToPropMap, ImmutableDictionary<string, string>.Empty,
                 addNullChecks: false, preferThrowExpression: false);
 
             var constructor = CodeGenerationSymbolFactory.CreateConstructorSymbol(

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.ConstructorDelegatingCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.ConstructorDelegatingCodeAction.cs
@@ -61,6 +61,8 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 var options = await _document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
                 var useThrowExpressions = options.GetOption(CodeStyleOptions.PreferThrowExpression).Value;
 
+                var tree = await _document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+
                 for (var i = _state.DelegatedConstructor.Parameters.Length; i < _state.Parameters.Length; i++)
                 {
                     var symbolName = _state.SelectedMembers[i].Name;
@@ -71,7 +73,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                         factory.IdentifierName(symbolName));
 
                     factory.AddAssignmentStatements(
-                        compilation, parameter, fieldAccess,
+                        compilation, tree.Options, parameter, fieldAccess,
                         _addNullChecks, useThrowExpressions,
                         nullCheckStatements, assignStatements);
                 }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.ConstructorDelegatingCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.ConstructorDelegatingCodeAction.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 var project = _document.Project;
                 var languageServices = project.Solution.Workspace.Services.GetLanguageServices(_state.ContainingType.Language);
 
-                var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+                var semanticModel = await _document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 var factory = languageServices.GetService<SyntaxGenerator>();
                 var codeGenerationService = languageServices.GetService<ICodeGenerationService>();
 
@@ -61,8 +61,6 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 var options = await _document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
                 var useThrowExpressions = options.GetOption(CodeStyleOptions.PreferThrowExpression).Value;
 
-                var tree = await _document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-
                 for (var i = _state.DelegatedConstructor.Parameters.Length; i < _state.Parameters.Length; i++)
                 {
                     var symbolName = _state.SelectedMembers[i].Name;
@@ -73,7 +71,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                         factory.IdentifierName(symbolName));
 
                     factory.AddAssignmentStatements(
-                        compilation, tree.Options, parameter, fieldAccess,
+                        semanticModel, parameter, fieldAccess,
                         _addNullChecks, useThrowExpressions,
                         nullCheckStatements, assignStatements);
                 }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.FieldDelegatingCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.FieldDelegatingCodeAction.cs
@@ -59,14 +59,14 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 var compilation = await _document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var (fields, constructor) = factory.CreateFieldDelegatingConstructor(
                     compilation,
+                    syntaxTree.Options,
                     _state.ContainingType.Name,
                     _state.ContainingType,
                     _state.Parameters,
                     parameterToExistingFieldMap,
                     parameterToNewFieldMap: null,
                     addNullChecks: _addNullChecks,
-                    preferThrowExpression: preferThrowExpression,
-                    cancellationToken: cancellationToken);
+                    preferThrowExpression: preferThrowExpression);
 
                 // If the user has selected a set of members (i.e. TextSpan is not empty), then we will
                 // choose the right location (i.e. null) to insert the constructor.  However, if they're 

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.FieldDelegatingCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.FieldDelegatingCodeAction.cs
@@ -52,14 +52,13 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
 
                 var factory = _document.GetLanguageService<SyntaxGenerator>();
 
-                var syntaxTree = await _document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                var semanticModel = await _document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var syntaxTree = semanticModel.SyntaxTree;
                 var options = await _document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
                 var preferThrowExpression = options.GetOption(CodeStyleOptions.PreferThrowExpression).Value;
 
-                var compilation = await _document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var (fields, constructor) = factory.CreateFieldDelegatingConstructor(
-                    compilation,
-                    syntaxTree.Options,
+                    semanticModel,
                     _state.ContainingType.Name,
                     _state.ContainingType,
                     _state.Parameters,

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                     ? syntaxFactory.CreateFieldsForParameters(remainingParameters, parameterToNewFieldMap)
                     : ImmutableArray<IFieldSymbol>.Empty;
                 var assignStatements = syntaxFactory.CreateAssignmentStatements(
-                    _document.SemanticModel.Compilation, remainingParameters,
+                    _document.SemanticModel.Compilation, _document.SyntaxTree.Options, remainingParameters,
                     parameterToExistingFieldMap, parameterToNewFieldMap,
                     addNullChecks: false, preferThrowExpression: false);
 
@@ -253,12 +253,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
 
                 var syntaxTree = _document.SyntaxTree;
                 var (fields, constructor) = syntaxFactory.CreateFieldDelegatingConstructor(
-                    _document.SemanticModel.Compilation,
+                    _document.SemanticModel.Compilation, _document.SyntaxTree.Options,
                     _state.TypeToGenerateIn.Name,
                     _state.TypeToGenerateIn, parameters,
                     parameterToExistingFieldMap, parameterToNewFieldMap,
-                    addNullChecks: false, preferThrowExpression: false,
-                    cancellationToken: _cancellationToken);
+                    addNullChecks: false, preferThrowExpression: false);
 
                 var result = await codeGenerationService.AddMembersAsync(
                     _document.Project.Solution,

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                     ? syntaxFactory.CreateFieldsForParameters(remainingParameters, parameterToNewFieldMap)
                     : ImmutableArray<IFieldSymbol>.Empty;
                 var assignStatements = syntaxFactory.CreateAssignmentStatements(
-                    _document.SemanticModel.Compilation, _document.SyntaxTree.Options, remainingParameters,
+                    _document.SemanticModel, remainingParameters,
                     parameterToExistingFieldMap, parameterToNewFieldMap,
                     addNullChecks: false, preferThrowExpression: false);
 
@@ -253,7 +253,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
 
                 var syntaxTree = _document.SyntaxTree;
                 var (fields, constructor) = syntaxFactory.CreateFieldDelegatingConstructor(
-                    _document.SemanticModel.Compilation, _document.SyntaxTree.Options,
+                    _document.SemanticModel,
                     _state.TypeToGenerateIn.Name,
                     _state.TypeToGenerateIn, parameters,
                     parameterToExistingFieldMap, parameterToNewFieldMap,

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
@@ -203,7 +203,6 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 IList<TArgumentSyntax> argumentList, ArrayBuilder<ISymbol> members, GenerateTypeOptionsResult options = null)
             {
                 var factory = _semanticDocument.Document.GetLanguageService<SyntaxGenerator>();
-                var syntaxFactsService = _semanticDocument.Document.GetLanguageService<ISyntaxFactsService>();
 
                 var availableTypeParameters = _service.GetAvailableTypeParameters(_state, _semanticDocument.SemanticModel, _intoNamespace, _cancellationToken);
                 var parameterTypes = GetArgumentTypes(argumentList);
@@ -243,11 +242,10 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 if (!(parameters.Count == 0 && options != null && (options.TypeKind == TypeKind.Struct || options.TypeKind == TypeKind.Structure)))
                 {
                     var (fields, constructor) = factory.CreateFieldDelegatingConstructor(
-                        _semanticDocument.SemanticModel.Compilation,
+                        _semanticDocument.SemanticModel.Compilation, _semanticDocument.SyntaxTree.Options,
                         DetermineName(), null, parameters.ToImmutable(),
                         parameterToExistingFieldMap, parameterToNewFieldMap,
-                        addNullChecks: false, preferThrowExpression: false,
-                        cancellationToken: _cancellationToken);
+                        addNullChecks: false, preferThrowExpression: false);
                     members.AddRange(fields);
                     members.Add(constructor);
                 }

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 if (!(parameters.Count == 0 && options != null && (options.TypeKind == TypeKind.Struct || options.TypeKind == TypeKind.Structure)))
                 {
                     var (fields, constructor) = factory.CreateFieldDelegatingConstructor(
-                        _semanticDocument.SemanticModel.Compilation, _semanticDocument.SyntaxTree.Options,
+                        _semanticDocument.SemanticModel,
                         DetermineName(), null, parameters.ToImmutable(),
                         parameterToExistingFieldMap, parameterToNewFieldMap,
                         addNullChecks: false, preferThrowExpression: false);

--- a/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
@@ -260,18 +260,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
             Compilation compilation, SyntaxGenerator generator,
             IParameterSymbol parameter, ParseOptions options)
         {
-            var identifier = generator.IdentifierName(parameter.Name);
-            var nullExpr = generator.NullLiteralExpression();
-            var condition = generator.SupportsPatterns(options)
-                ? generator.IsPatternExpression(identifier, generator.ConstantPattern(nullExpr))
-                : generator.ReferenceEqualsExpression(identifier, nullExpr);
-
-            // generates: if (s == null) throw new ArgumentNullException(nameof(s))
-            return (TStatementSyntax)generator.IfStatement(
-               condition,
-                SpecializedCollections.SingletonEnumerable(
-                    generator.ThrowStatement(
-                        CreateArgumentNullException(compilation, generator, parameter))));
+            return (TStatementSyntax)generator.CreateNullCheckAndThrowStatement(compilation, parameter, options);
         }
 
         private static TStatementSyntax CreateStringCheckStatement(

--- a/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
@@ -198,12 +198,10 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                 return documentOpt;
             }
 
-            var options = functionDeclaration.SyntaxTree.Options;
-
             // If we can't, then just offer to add an "if (s == null)" statement.
             return await AddNullCheckStatementAsync(
                 document, parameter, functionDeclaration, method, blockStatementOpt,
-                (c, g) => CreateNullCheckStatement(c, g, parameter, options),
+                (s, g) => CreateNullCheckStatement(s, g, parameter),
                 cancellationToken).ConfigureAwait(false);
         }
 
@@ -218,7 +216,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
         {
             return await AddNullCheckStatementAsync(
                 document, parameter, functionDeclaration, method, blockStatementOpt,
-                (c, g) => CreateStringCheckStatement(c, g, parameter, methodName),
+                (s, g) => CreateStringCheckStatement(s.Compilation, g, parameter, methodName),
                 cancellationToken).ConfigureAwait(false);
         }
 
@@ -228,15 +226,14 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
             SyntaxNode functionDeclaration,
             IMethodSymbol method,
             IBlockOperation blockStatementOpt,
-            Func<Compilation, SyntaxGenerator, TStatementSyntax> generateNullCheck,
+            Func<SemanticModel, SyntaxGenerator, TStatementSyntax> generateNullCheck,
             CancellationToken cancellationToken)
         {
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var compilation = semanticModel.Compilation;
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             var editor = new SyntaxEditor(root, document.Project.Solution.Workspace);
-            var nullCheckStatement = generateNullCheck(compilation, editor.Generator);
+            var nullCheckStatement = generateNullCheck(semanticModel, editor.Generator);
 
             // We may be inserting a statement into a single-line container.  In that case,
             // we don't want the formatting engine to think this construct should stay single-line
@@ -256,12 +253,8 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
             return document.WithSyntaxRoot(newRoot);
         }
 
-        private static TStatementSyntax CreateNullCheckStatement(
-            Compilation compilation, SyntaxGenerator generator,
-            IParameterSymbol parameter, ParseOptions options)
-        {
-            return (TStatementSyntax)generator.CreateNullCheckAndThrowStatement(compilation, parameter, options);
-        }
+        private static TStatementSyntax CreateNullCheckStatement(SemanticModel semanticModel, SyntaxGenerator generator, IParameterSymbol parameter)
+            => (TStatementSyntax)generator.CreateNullCheckAndThrowStatement(semanticModel, parameter);
 
         private static TStatementSyntax CreateStringCheckStatement(
             Compilation compilation, SyntaxGenerator generator,

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -4318,6 +4318,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         internal override SyntaxNode IsPatternExpression(SyntaxNode expression, SyntaxNode pattern)
             => SyntaxFactory.IsPatternExpression((ExpressionSyntax)expression, (PatternSyntax)pattern);
 
+        internal override SyntaxNode ConstantPattern(SyntaxNode expression)
+            => SyntaxFactory.ConstantPattern((ExpressionSyntax)expression);
+
         internal override SyntaxNode DeclarationPattern(INamedTypeSymbol type, string name)
             => SyntaxFactory.DeclarationPattern(
                 type.GenerateTypeSyntax(),

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -2259,6 +2259,7 @@ namespace Microsoft.CodeAnalysis.Editing
         internal abstract bool SupportsPatterns(ParseOptions options);
         internal abstract SyntaxNode IsPatternExpression(SyntaxNode expression, SyntaxNode pattern);
         internal abstract SyntaxNode DeclarationPattern(INamedTypeSymbol type, string name);
+        internal abstract SyntaxNode ConstantPattern(SyntaxNode expression);
 
         #endregion
     }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -167,17 +167,14 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return false;
         }
 
-        public static SyntaxNode CreateThrowArgumentNullExpression(
-            this SyntaxGenerator factory,
-            Compilation compilation,
-            IParameterSymbol parameter)
-        {
-            return factory.ThrowExpression(
-                factory.ObjectCreationExpression(
-                    compilation.GetTypeByMetadataName("System.ArgumentNullException"),
-                    factory.NameOfExpression(
-                        factory.IdentifierName(parameter.Name))));
-        }
+        public static SyntaxNode CreateThrowArgumentNullExpression(this SyntaxGenerator factory, Compilation compilation, IParameterSymbol parameter)
+            => factory.ThrowExpression(CreateNewArgumentNullException(factory, compilation, parameter));
+
+        private static SyntaxNode CreateNewArgumentNullException(SyntaxGenerator factory, Compilation compilation, IParameterSymbol parameter)
+            => factory.ObjectCreationExpression(
+                compilation.GetTypeByMetadataName("System.ArgumentNullException"),
+                factory.NameOfExpression(
+                    factory.IdentifierName(parameter.Name)));
 
         public static SyntaxNode CreateNullCheckAndThrowStatement(
             this SyntaxGenerator factory,
@@ -194,8 +191,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return factory.IfStatement(
                condition,
                 SpecializedCollections.SingletonEnumerable(
-                    factory.ExpressionStatement(
-                        factory.CreateThrowArgumentNullExpression(semanticModel.Compilation, parameter))));
+                    factory.ThrowStatement(CreateNewArgumentNullException(
+                        factory, semanticModel.Compilation, parameter))));
         }
 
         public static ImmutableArray<SyntaxNode> CreateAssignmentStatements(

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -4190,6 +4190,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Throw New NotImplementedException()
         End Function
 
+        Friend Overrides Function ConstantPattern(expression As SyntaxNode) As SyntaxNode
+            Throw New NotImplementedException()
+        End Function
+
         Friend Overrides Function DeclarationPattern(type As INamedTypeSymbol, name As String) As SyntaxNode
             Throw New NotImplementedException()
         End Function


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/33963
Fixes: https://github.com/dotnet/roslyn/issues/24237

1. Unify the code used between 'generate constructor' and 'add parameter null check'.
2. Add parameter null check should use `x is null` when on C#7 and above.  It's the most simple and idiomatic way to check for `null` now.
3. Generate constructor should not add null-checks for nullable-struct parameters.  The fact that they're nullable indicates that null is ok.  If we add the null check, then the signature says 'null is ok' but we immediately throw.  The right thing there if hte user doesn't want null is to instead just not allow a nullable struct, forcing the caller to check first.
