### PR TITLE
Make bootstrap 32 bit in 32 bit CI

### DIFF
--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -268,7 +268,7 @@ function Run-MSBuild([string]$projectFilePath, [string]$buildArgs = "", [string]
 #
 # Important to not set $script:bootstrapDir here yet as we're actually in the process of
 # building the bootstrap.
-function Make-BootstrapBuild() {
+function Make-BootstrapBuild([switch]$force32 = $false) {
   Write-Host "Building bootstrap compiler"
 
   $dir = Join-Path $ArtifactsDir "Bootstrap"
@@ -277,8 +277,9 @@ function Make-BootstrapBuild() {
 
   $packageName = "Microsoft.Net.Compilers.Toolset"
   $projectPath = "src\NuGet\$packageName\$packageName.Package.csproj"
+  $force32Flag = if ($force32) { " /p:BOOTSTRAP32=true" } else { "" }
 
-  Run-MSBuild $projectPath "/restore /t:Pack /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP /p:PackageOutputPath=`"$dir`" /p:EnableNgenOptimization=false" -logFileName "Bootstrap" -configuration $bootstrapConfiguration
+  Run-MSBuild $projectPath "/restore /t:Pack /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP /p:PackageOutputPath=`"$dir`" /p:EnableNgenOptimization=false $force32Flag" -logFileName "Bootstrap" -configuration $bootstrapConfiguration
   $packageFile = Get-ChildItem -Path $dir -Filter "$packageName.*.nupkg"
   Unzip "$dir\$packageFile" $dir
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -596,7 +596,7 @@ try {
   }
 
   if ($bootstrap) {
-    $bootstrapDir = Make-BootstrapBuild
+    $bootstrapDir = Make-BootstrapBuild -force32:$test32
   }
 
   if ($restore -or $build -or $rebuild -or $pack -or $sign -or $publish -or $testCoreClr) {

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -24,6 +24,12 @@
       which has all of our global settings 
     -->
     <UserRuntimeConfig Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(OutputType)' == 'Exe'">$(RepositoryEngineeringDir)config\runtimeconfig.template.json</UserRuntimeConfig>
+
+    <!-- 
+      Bootstrap compiler should run as a 32 bit process on our 32 bit test runs. This will validate
+      the legacy JIT ability to handle the compiler. 
+    -->
+    <PlatformTarget Condition="'$(OutputType)' == 'Exe' AND '$(TargetFramework)' == 'net472' AND '$(BOOTSTRAP32)' == 'true'">x86</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(Language)' == 'CSharp' and '$(TargetFramework)' == 'net20'">


### PR DESCRIPTION
This changes our bootstrap compiler to run as a 32 bit process in the 32
bit CI runs. The intent of this runs is to validate we can function on
32 bit systems and that should extend to the compiler as well.

This can help us identify the rare cases where we emit code that doesn't
perform well on the 32 bit JIT, or just outright crashes.