### PR TITLE
Ensure we refresh ruleset severities after a ruleset change

### DIFF
--- a/src/VisualStudio/CSharp/Test/Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.csproj
+++ b/src/VisualStudio/CSharp/Test/Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.csproj
@@ -61,6 +61,7 @@
     <PackageReference Include="EnvDTE80" Version="$(EnvDTE80Version)" />
     <PackageReference Include="Microsoft.VisualStudio.InteractiveWindow" Version="$(MicrosoftVisualStudioInteractiveWindowVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="$(MicrosoftVisualStudioTelemetryVersion)" />
+    <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\1.1.2\runtimes\win7-x86\native\e_sqlite3.dll">

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/AnalyzersTests.cs
@@ -271,10 +271,11 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
             }
         }
 
-        [WpfFact]
+        [WpfTheory]
+        [CombinatorialData]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         [WorkItem(33505, "https://github.com/dotnet/roslyn/pull/33505")]
-        public void RuleSet_FileChangingOnDiskRefreshes()
+        public void RuleSet_FileChangingOnDiskRefreshes(bool useCpsProject)
         {
             string ruleSetSource = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <RuleSet Name=""Ruleset1"" Description=""Test""  ToolsVersion=""12.0"">
@@ -286,8 +287,16 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
             {
                 File.WriteAllText(ruleSetFile.Path, ruleSetSource);
 
-                var project = CSharpHelpers.CreateCSharpProject(environment, "Test");
-                ((IAnalyzerHost)project).SetRuleSetFile(ruleSetFile.Path);
+                if (useCpsProject)
+                {
+                    CSharpHelpers.CreateCSharpCPSProject(environment, "Test", binOutputPath: null, $"/ruleset:\"{ruleSetFile.Path}\"");
+                }
+                else
+                {
+                    // Test legacy project handling
+                    var project = CSharpHelpers.CreateCSharpProject(environment, "Test");
+                    ((IAnalyzerHost)project).SetRuleSetFile(ruleSetFile.Path);
+                }
 
                 var options = (CSharpCompilationOptions)environment.GetUpdatedCompilationOptionOfSingleProject();
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
@@ -226,8 +226,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     return;
                 }
 
-                // The IRuleSetFile held by _ruleSetFile is now out of date. Our model is we now request a new one which will have up-to-date values.
+                // The IRuleSetFile held by _ruleSetFile is now out of date. We'll dispose our old one first so as to let go of any old cached values.
+                // Then, we must reparse: in the case where the command line we have from the project system includes a /ruleset, the computation of the
+                // effective values was potentially done by the act of parsing the command line. Even though the command line didn't change textually,
+                // the effective result did. Then we call UpdateProjectOptions_NoLock to reapply any values; that will also re-acquire the new ruleset
+                // includes in the IDE so we can be watching for changes again.
                 DisposeOfRuleSetFile_NoLock();
+                ReparseCommandLine_NoLock();
                 UpdateProjectOptions_NoLock();
             }
         }


### PR DESCRIPTION
If a ruleset file changed, we didn't always reapply the new values in the IDE. For legacy projects the IDE is taking the ruleset files and applying them to the compilation; for CPS projects that's being done when we call into the compiler to parse the command line string. We forgot to reparse the command line string, so CPS projects wouldn't refresh until some other command line string changed or the project was unloaded or reloaded.

Fixes https://github.com/dotnet/roslyn/issues/35164

<details><summary>Ask Mode template</summary>

### Customer scenario

If the customer changes a rulesetfile inside a CPS project, the changed severities won't be used in the IDE until some later point where we evict our cached values.

### Bugs this fixes

Fixes https://github.com/dotnet/roslyn/issues/35164

### Workarounds, if any

Workaround would be to unload and reload the project.

### Risk

Low.

### Performance impact

Low, since this is an uncommon code path being touched.

### Is this a regression from a previous update?

Yes, it was probably broken in 16.0 when we rewrote our project system integration.

### Root cause analysis

We didn't have any unit tests for this particular issue. We did fix some bugs around this general area but it seems this snuck through when we fixed the other bugs.

A unit test has been added.

### How was the bug found?

Customer report.

</details>