### PR TITLE
Don't suggest static members in PropertySubPatternCompletionProvider

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders
@@ -669,6 +670,60 @@ class Program
             // Ignore browsability limiting attributes if the symbol is declared in source.
             await VerifyItemExistsAsync(markup, "P1");
             await VerifyItemExistsAsync(markup, "P2");
+        }
+
+        [Fact]
+        [WorkItem(33250, "https://github.com/dotnet/roslyn/issues/33250")]
+        public async Task StaticProperties_NotSuggested()
+        {
+            var markup =
+@"
+class Program
+{
+    void M()
+    {
+        _ = """" is { $$ }
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "Empty");
+        }
+
+        [Fact]
+        [WorkItem(33250, "https://github.com/dotnet/roslyn/issues/33250")]
+        public async Task StaticFields_NotSuggested()
+        {
+            var markup =
+@"
+class Program
+{
+    static int x = 42;
+
+    void M()
+    {
+        _ = this is { $$ }
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "x");
+        }
+
+
+        [Fact]
+        [WorkItem(33250, "https://github.com/dotnet/roslyn/issues/33250")]
+        public async Task ConstFields_NotSuggested()
+        {
+            var markup =
+@"
+class Program
+{
+    void M()
+    {
+        _ = 5 is { $$ }
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "MaxValue");
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
@@ -43,7 +43,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             IEnumerable<ISymbol> members = semanticModel.LookupSymbols(position, type);
             members = members.Where(m => m.CanBeReferencedByName &&
                 IsFieldOrReadableProperty(m) &&
-                !m.IsImplicitlyDeclared);
+                !m.IsImplicitlyDeclared && 
+                !m.IsStatic);
 
             // Filter out those members that have already been typed
             var propertyPatternClause = (PropertyPatternClauseSyntax)token.Parent;


### PR DESCRIPTION
This should be a relatively simple fix. It should prevent things like this being suggested by intellisense:

![image](https://user-images.githubusercontent.com/29174528/56614266-8fd32480-6610-11e9-9eba-f8f77da4705a.png)

See:  https://github.com/dotnet/roslyn/issues/33250
