### PR TITLE
intellisense should suggest event after readonly in a struct member declaration

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
@@ -378,5 +378,41 @@ class C
 
             await VerifyItemExistsAsync(text, "private");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(34774, "https://github.com/dotnet/roslyn/issues/34774")]
+        public async Task DontSuggestEventAfterReadonlyInClass()
+        {
+            var markup =
+@"class C {
+    readonly $$
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "event");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(34774, "https://github.com/dotnet/roslyn/issues/34774")]
+        public async Task DontSuggestEventAfterReadonlyInInterface()
+        {
+            var markup =
+@"interface C {
+    readonly $$
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "event");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(34774, "https://github.com/dotnet/roslyn/issues/34774")]
+        public async Task SuggestEventAfterReadonlyInStruct()
+        {
+            var markup =
+@"struct C {
+    readonly $$
+}
+";
+            await VerifyItemExistsAsync(markup, "event");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/EventKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/EventKeywordRecommender.cs
@@ -25,22 +25,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 SyntaxKind.UnsafeKeyword
             };
 
-        private static readonly ISet<SyntaxKind> s_validStructModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
+        private static readonly ISet<SyntaxKind> s_validStructModifiers = new HashSet<SyntaxKind>(s_validClassModifiers, SyntaxFacts.EqualityComparer)
             {
-                SyntaxKind.NewKeyword,
-                SyntaxKind.PublicKeyword,
-                SyntaxKind.ProtectedKeyword,
-                SyntaxKind.InternalKeyword,
-                SyntaxKind.PrivateKeyword,
-                SyntaxKind.StaticKeyword,
-                SyntaxKind.VirtualKeyword,
-                SyntaxKind.SealedKeyword,
-                SyntaxKind.OverrideKeyword,
-                SyntaxKind.AbstractKeyword,
-                SyntaxKind.ExternKeyword,
-                SyntaxKind.UnsafeKeyword,
                 SyntaxKind.ReadOnlyKeyword,
-        };
+            };
 
         public EventKeywordRecommender()
             : base(SyntaxKind.EventKeyword)

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/EventKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/EventKeywordRecommender.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
     internal class EventKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
     {
-        private static readonly ISet<SyntaxKind> s_validModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
+        private static readonly ISet<SyntaxKind> s_validClassModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
             {
                 SyntaxKind.NewKeyword,
                 SyntaxKind.PublicKeyword,
@@ -25,6 +25,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 SyntaxKind.UnsafeKeyword
             };
 
+        private static readonly ISet<SyntaxKind> s_validStructModifiers = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
+            {
+                SyntaxKind.NewKeyword,
+                SyntaxKind.PublicKeyword,
+                SyntaxKind.ProtectedKeyword,
+                SyntaxKind.InternalKeyword,
+                SyntaxKind.PrivateKeyword,
+                SyntaxKind.StaticKeyword,
+                SyntaxKind.VirtualKeyword,
+                SyntaxKind.SealedKeyword,
+                SyntaxKind.OverrideKeyword,
+                SyntaxKind.AbstractKeyword,
+                SyntaxKind.ExternKeyword,
+                SyntaxKind.UnsafeKeyword,
+                SyntaxKind.ReadOnlyKeyword,
+        };
+
         public EventKeywordRecommender()
             : base(SyntaxKind.EventKeyword)
         {
@@ -36,7 +53,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             return
                 context.IsGlobalStatementContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||
-                context.IsMemberDeclarationContext(validModifiers: s_validModifiers, validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructTypeDeclarations, canBePartial: false, cancellationToken: cancellationToken) ||
+                context.IsMemberDeclarationContext(validModifiers: s_validClassModifiers, validTypeDeclarations: SyntaxKindSet.ClassInterfaceTypeDeclarations, canBePartial: false, cancellationToken: cancellationToken) ||
+                context.IsMemberDeclarationContext(validModifiers: s_validStructModifiers, validTypeDeclarations: SyntaxKindSet.StructOnlyTypeDeclarations, canBePartial: false, cancellationToken: cancellationToken) ||
                 context.IsMemberAttributeContext(SyntaxKindSet.ClassInterfaceStructTypeDeclarations, cancellationToken);
         }
     }


### PR DESCRIPTION
…member declaration.

```csharp
struct C {
    readonly e //suggest event here
}
```

See https://github.com/dotnet/roslyn/issues/34774