### PR TITLE
Auto-generate assembly version of the build task assembly

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Microsoft.CodeAnalysis.BuildTasks</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
     <!-- CA1819 (Properties should not return arrays) disabled as it is very common across this project. -->
     <NoWarn>$(NoWarn);CA1819</NoWarn>
 


### PR DESCRIPTION
Opt into versioning policy that produces a different assembly version for every build.
This allows multiple versions of the task assembly to coexists within the same msbuild AppDomain.

Depends on Arcade change https://github.com/dotnet/arcade/pull/2615