### PR TITLE
Fix exception in PasteTrackingService.RegisterPastedTextSpan

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeRefactorings/AddMissingImports/CSharpAddMissingImportsRefactoringProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeRefactorings/AddMissingImports/CSharpAddMissingImportsRefactoringProviderTests.cs
@@ -36,6 +36,10 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             if (!pastedTextSpan.IsEmpty)
             {
                 var pasteTrackingService = workspace.ExportProvider.GetExportedValue<PasteTrackingService>();
+
+                // This tests the paste tracking service's resiliancy to failing when multiple pasted spans are
+                // registered consecutively and that the last registered span wins.
+                pasteTrackingService.RegisterPastedTextSpan(hostDocument.TextBuffer, default);
                 pasteTrackingService.RegisterPastedTextSpan(hostDocument.TextBuffer, pastedTextSpan);
             }
 

--- a/src/EditorFeatures/Core/Implementation/PasteTracking/PasteTrackingService.cs
+++ b/src/EditorFeatures/Core/Implementation/PasteTracking/PasteTrackingService.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.PasteTracking
             // Any change to the TextBuffer will remove the pasted text span.
             // This includes consecutive paste operations which will fire the
             // Changed event prior to the handler registering a new text span.
-            textBuffer.Properties.AddProperty(_pastedTextSpanKey, textSpan);
+            textBuffer.Properties[_pastedTextSpanKey] = textSpan;
             textBuffer.Changed += RemovePastedTextSpan;
 
             return;

--- a/src/EditorFeatures/VisualBasicTest/CodeRefactorings/AddMissingImports/VisualBasicAddMissingImportsRefactoringProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeRefactorings/AddMissingImports/VisualBasicAddMissingImportsRefactoringProviderTests.vb
@@ -28,6 +28,10 @@ Namespace Microsoft.CodeAnalysis.AddMissingImports
 
             If Not pastedTextSpan.IsEmpty Then
                 Dim PasteTrackingService = Workspace.ExportProvider.GetExportedValue(Of PasteTrackingService)()
+
+                ' This tests the paste tracking service's resiliancy to failing when multiple pasted spans are
+                ' registered consecutively And that the last registered span wins.
+                PasteTrackingService.RegisterPastedTextSpan(hostDocument.TextBuffer, Nothing)
                 PasteTrackingService.RegisterPastedTextSpan(hostDocument.TextBuffer, pastedTextSpan)
             End If
 


### PR DESCRIPTION
To handle multiple text spans being register consecutively, use the Properties indexer instead of the `Add` method to update the pasted span.

Fixes #33776


<details><summary>Ask Mode template</summary>

### Customer scenario

In rare instances a customer will paste code, then because of a delay in the editor updating, the user will paste the same code a second time. These consecutive pastes during the delay will cause the tracking span from the first paste to not be cleared before registering the second span. A gold bar will inform the user of an unhandled exception.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/33776

### Workarounds, if any

None

### Risk

Low

### Performance impact

Low

### Is this a regression from a previous update?

No

### Root cause analysis

The PasteTrackingService stores the pasted textspan on the TextBuffer's Properties collection. When registering it invokes the Add() method which will thrown an exception if the given key is already present. This is not normally an issue because the act of pasting changes the TextBuffer which will remove the key in advance. However in the rare case of the delay scenario, the text span is registered before the key is cleared.

### How was the bug found?

Reported through internal dogfooding

</details>