### PR TITLE
Fix `nameof(MethodName)` not classifying MethodName

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -2291,6 +2291,34 @@ struct Type<T>
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task NameOfLocalMethod()
+        {
+            await TestAsync(
+@"class C
+{
+    void goo()
+    {
+        var x = nameof(M);
+
+        void M()
+        {
+        }
+
+        void M(int a)
+        {
+        }
+
+        void M(string s)
+        {
+        }
+    }
+}",
+                Keyword("var"),
+                Keyword("nameof"),
+                Method("M"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task MethodCalledNameOfInScope()
         {
             await TestAsync(

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
@@ -68,7 +68,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             ArrayBuilder<ClassifiedSpan> result,
             CancellationToken cancellationToken)
         {
-            if (symbolInfo.CandidateReason == CandidateReason.Ambiguous)
+            if (symbolInfo.CandidateReason == CandidateReason.Ambiguous ||
+                symbolInfo.CandidateReason == CandidateReason.MemberGroup)
             {
                 return TryClassifyAmbiguousSymbol(name, symbolInfo, semanticModel, result, cancellationToken);
             }


### PR DESCRIPTION
Treat CandidateReason MemberGroup the same as Abiguous when classifyng NameSyntax

Fixes https://github.com/dotnet/roslyn/issues/35246


<details><summary>Ask Mode template</summary>

### Customer scenario

A customer uses a `nameof` expression to get the name of a method. The user expects to see the referenced method colorized the same as other method names, however the method name will be the default identifier color.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/35246

### Workarounds, if any

None

### Risk

Low

### Performance impact

Low

### Is this a regression from a previous update?

No

### Root cause analysis

When a method name is not referenced as part of an invocation expression the semantic classifier will not classify it. It will be syntactically classified as an Identifier.

### How was the bug found?

Reported through developer community against a preview release

</details>