### PR TITLE
Don't provide sync namespace refactoring in generated code

### DIFF
--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractSyncNamespaceCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractSyncNamespaceCodeRefactoringProvider.cs
@@ -22,6 +22,12 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.SyncNamespace
             var textSpan = context.Span;
             var cancellationToken = context.CancellationToken;
 
+            var workspace = document.Project.Solution.Workspace;
+            if (workspace.Kind == WorkspaceKind.MiscellaneousFiles || document.IsGeneratedCode(cancellationToken))
+            {
+                return;
+            }
+
             var state = await State.CreateAsync(this, document, textSpan, cancellationToken).ConfigureAwait(false);
             if (state == null)
             {


### PR DESCRIPTION
Fix a feedback item
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/836395

While working on this, I noticed a few other refactoring are also provided in generated code, e.g. extract interface, change namespace, etc., that either have no effect or crash with similar error. We might need to fix those as well.

@dotnet/roslyn-ide 
