### PR TITLE
Breaking up a global lock

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -984,13 +984,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 protected override void AddAvailableSymbols(List<AssemblySymbol> assemblies)
                 {
-                    CachedSymbols.ForEach<PEAssemblySymbol>(peAssembly =>
+                    CachedSymbols.ForEach<PEAssemblySymbol, List<AssemblySymbol>>((peAssembly, assemblies) =>
                     {
                         if (IsMatchingAssembly(peAssembly))
                         {
                             assemblies.Add(peAssembly);
                         }
-                    });
+                    }, assemblies);
                 }
 
                 public override bool IsMatchingAssembly(AssemblySymbol candidateAssembly)

--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -984,13 +984,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 protected override void AddAvailableSymbols(List<AssemblySymbol> assemblies)
                 {
-                    CachedSymbols.ForEach<PEAssemblySymbol, List<AssemblySymbol>>((peAssembly, assemblies) =>
-                    {
-                        if (IsMatchingAssembly(peAssembly))
-                        {
-                            assemblies.Add(peAssembly);
-                        }
-                    }, assemblies);
+                    CachedSymbols.CopyTo<AssemblySymbol, AssemblyDataForFile>(
+                        assemblies,
+                        (assembly, me) => me.IsMatchingAssembly(assembly),
+                        this);
                 }
 
                 public override bool IsMatchingAssembly(AssemblySymbol candidateAssembly)

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -1413,7 +1413,7 @@ public class A
             var c = CreateCompilation("class C : A {}", new[] { refA2, refB }, assemblyName: "C");
             var symbolA2 = c.GetReferencedAssemblySymbol(refA2);
             Assert.True(symbolA2 is Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEAssemblySymbol, "PE symbol expected");
-            Assert.Equal(1, ((AssemblyMetadata)refA2.GetMetadataNoCopy()).CachedSymbols.WeakCount);
+            Assert.Equal(1, ((AssemblyMetadata)refA2.GetMetadataNoCopy()).CachedSymbols.CopyAll().Count);
 
             GC.KeepAlive(symbolA2);
 

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyMetadata.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyMetadata.cs
@@ -64,10 +64,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Cached assembly symbols.
         /// </summary>
-        /// <remarks>
-        /// Guarded by <see cref="CommonReferenceManager.SymbolCacheAndReferenceManagerStateGuard"/>.
-        /// </remarks>
-        internal readonly WeakList<IAssemblySymbol> CachedSymbols = new WeakList<IAssemblySymbol>();
+        internal readonly CachedAssemblySymbolList CachedSymbols = new CachedAssemblySymbolList();
 
         // creates a copy
         private AssemblyMetadata(AssemblyMetadata other, bool shareCachedSymbols)

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyMetadata.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyMetadata.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Cached assembly symbols.
         /// </summary>
-        internal readonly CachedAssemblySymbolList CachedSymbols = new CachedAssemblySymbolList();
+        internal readonly CachedAssemblySymbolList CachedSymbols;
 
         // creates a copy
         private AssemblyMetadata(AssemblyMetadata other, bool shareCachedSymbols)
@@ -73,6 +73,10 @@ namespace Microsoft.CodeAnalysis
             if (shareCachedSymbols)
             {
                 this.CachedSymbols = other.CachedSymbols;
+            }
+            else
+            {
+                CachedSymbols = new CachedAssemblySymbolList();
             }
 
             _lazyData = other._lazyData;
@@ -86,6 +90,7 @@ namespace Microsoft.CodeAnalysis
         {
             Debug.Assert(!modules.IsDefaultOrEmpty);
             _initialModules = modules;
+            CachedSymbols = new CachedAssemblySymbolList();
         }
 
         internal AssemblyMetadata(ModuleMetadata manifestModule, Func<string, ModuleMetadata> moduleFactory)
@@ -96,6 +101,7 @@ namespace Microsoft.CodeAnalysis
 
             _initialModules = ImmutableArray.Create(manifestModule);
             _moduleFactoryOpt = moduleFactory;
+            CachedSymbols = new CachedAssemblySymbolList();
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/MetadataReference/CachedAssemblySymbolList.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/CachedAssemblySymbolList.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal sealed class CachedAssemblySymbolList
+    {
+        private readonly object _guard = new object();
+        private readonly WeakList<IAssemblySymbol> _cachedSymbols = new WeakList<IAssemblySymbol>();
+
+        internal void ForEach<T>(Action<T> action)
+            where T : class, IAssemblySymbol
+        {
+            lock (_guard)
+            {
+                for (int i = 0; i < _cachedSymbols.WeakCount; i++)
+                {
+                    if (_cachedSymbols.GetWeakReference(i).TryGetTarget(out IAssemblySymbol assemblySymbol) &&
+                        assemblySymbol is T typedSymbol)
+                    {
+                        action(typedSymbol);
+                    }
+                }
+            }
+        }
+
+        internal void Add(IAssemblySymbol peAssembly)
+        {
+            lock (_guard)
+            {
+                _cachedSymbols.Add(peAssembly);
+            }
+        }
+
+        internal List<IAssemblySymbol> CopyAll()
+        {
+            var list = new List<IAssemblySymbol>();
+            lock (_guard)
+            {
+                for (int i = 0; i < _cachedSymbols.WeakCount; i++)
+                {
+                    if (_cachedSymbols.GetWeakReference(i).TryGetTarget(out IAssemblySymbol assemblySymbol))
+                    {
+                        list.Add(assemblySymbol);
+                    }
+                }
+            }
+
+            return list;
+        }
+
+    }
+}

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis
 
         protected abstract AssemblyData CreateAssemblyDataForFile(
             PEAssembly assembly,
-            WeakList<IAssemblySymbol> cachedSymbols,
+            CachedAssemblySymbolList cachedSymbols,
             DocumentationProvider documentationProvider,
             string sourceAssemblySimpleName,
             MetadataImportOptions importOptions,
@@ -313,7 +313,6 @@ namespace Microsoft.CodeAnalysis
                     {
                         case MetadataImageKind.Assembly:
                             var assemblyMetadata = (AssemblyMetadata)metadata;
-                            WeakList<IAssemblySymbol> cachedSymbols = assemblyMetadata.CachedSymbols;
 
                             if (assemblyMetadata.IsValidAssembly())
                             {
@@ -335,7 +334,7 @@ namespace Microsoft.CodeAnalysis
 
                                 var asmData = CreateAssemblyDataForFile(
                                     assembly,
-                                    cachedSymbols,
+                                    assemblyMetadata.CachedSymbols,
                                     peReference.DocumentationProvider,
                                     SimpleAssemblyName,
                                     compilation.Options.MetadataImportOptions,

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
@@ -20,7 +20,6 @@ namespace Microsoft.CodeAnalysis
         /// - Compilation.lazyAssemblySymbol
         /// - Compilation.referenceManager
         /// - ReferenceManager state
-        /// - <see cref="AssemblyMetadata.CachedSymbols"/>
         /// - <see cref="Compilation.RetargetingAssemblySymbols"/>
         /// 
         /// All the above data should be updated at once while holding this lock.

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -853,12 +853,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Protected Overrides Sub AddAvailableSymbols(assemblies As List(Of AssemblySymbol))
                     Dim internalsMayBeVisibleToCompilation = Me.InternalsMayBeVisibleToCompilation
 
-                    CachedSymbols.ForEach(Of PEAssemblySymbol)(
-                        Sub(peAssembly)
+                    CachedSymbols.ForEach(Of PEAssemblySymbol, List(Of AssemblySymbol))(
+                        Sub(peAssembly, list)
                             If IsMatchingAssembly(peAssembly) Then
-                                assemblies.Add(peAssembly)
+                                list.Add(peAssembly)
                             End If
-                        End Sub)
+                        End Sub, assemblies)
                 End Sub
 
                 Public Overrides Function IsMatchingAssembly(candidateAssembly As AssemblySymbol) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -853,12 +853,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Protected Overrides Sub AddAvailableSymbols(assemblies As List(Of AssemblySymbol))
                     Dim internalsMayBeVisibleToCompilation = Me.InternalsMayBeVisibleToCompilation
 
-                    CachedSymbols.ForEach(Of PEAssemblySymbol, List(Of AssemblySymbol))(
-                        Sub(peAssembly, list)
-                            If IsMatchingAssembly(peAssembly) Then
-                                list.Add(peAssembly)
-                            End If
-                        End Sub, assemblies)
+                    CachedSymbols.CopyTo(Of AssemblySymbol, AssemblyDataForFile)(
+                        assemblies,
+                        Function(assembly, this) this.IsMatchingAssembly(assembly),
+                        Me)
                 End Sub
 
                 Public Overrides Function IsMatchingAssembly(candidateAssembly As AssemblySymbol) As Boolean

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
@@ -1075,7 +1075,7 @@ End Class
             c.VerifyDiagnostics()
             Dim symbolA2 = c.GetReferencedAssemblySymbol(refA2)
             Assert.True(TypeOf symbolA2 Is VisualBasic.Symbols.Metadata.PE.PEAssemblySymbol, "PE symbol expected")
-            Assert.Equal(1, (DirectCast(refA2.GetMetadataNoCopy(), AssemblyMetadata)).CachedSymbols.WeakCount)
+            Assert.Equal(1, (DirectCast(refA2.GetMetadataNoCopy(), AssemblyMetadata)).CachedSymbols.CopyAll().Count)
 
             GC.KeepAlive(symbolA2)
 


### PR DESCRIPTION
The compiler will weakly cache `AssemblySymbol` instances for a given
`AssemblyMetadata` instance. The cache is shared across both the C# and
VB consumers. The implementation is a `WeakList<IAssemblySymbol>`
instance guarded by `lock` statements on all acesses.

The object used to guard the cache though was
`SymbolCacheAndReferenceManagerStateGuard`. This is a global object
which meant access to cached symbols for any assembly on one thread
blocked access to all assemblies on all other threads. VS Thread Watson
data showed this is a hot lock in certain customer code path.

This change fixes contention here by moving the lock to be specific to a
given `AssemblyMetadata` instance. This means the contention is
essentially limited to symbols for a specific assembly.