### PR TITLE
Remove usage of QuietRestore

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -214,10 +214,6 @@ function BuildSolution() {
   $enableAnalyzers = !$skipAnalyzers
   $toolsetBuildProj = InitializeToolset
 
-  # Have to disable quiet restore during bootstrap builds to work around 
-  # an arcade bug
-  # https://github.com/dotnet/arcade/issues/2220
-  $quietRestore = !($ci -or ($bootstrapDir -ne ""))
   $testTargetFrameworks = if ($testCoreClr) { "netcoreapp3.0%3Bnetcoreapp2.1" } else { "" }
   
   $ibcSourceBranchName = GetIbcSourceBranchName
@@ -250,8 +246,6 @@ function BuildSolution() {
       /p:OfficialBuildId=$officialBuildId `
       /p:UseRoslynAnalyzers=$enableAnalyzers `
       /p:BootstrapBuildPath=$bootstrapDir `
-      /p:QuietRestore=$quietRestore `
-      /p:QuietRestoreBinaryLog=$binaryLog `
       /p:TestTargetFrameworks=$testTargetFrameworks `
       /p:TreatWarningsAsErrors=true `
       /p:VisualStudioIbcSourceBranchName=$ibcSourceBranchName `


### PR DESCRIPTION
Removes a workaround for nuget spewing a lot of output on restore. 
This has been now fixed in nuget. Restore now outputs a line per restored project, similarly to build.

```
>restore
Roslyn.sln:
  Restore completed in 43.27 ms for C:\Users\tomat\.nuget\packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19171.3\tools\Tools.proj.
  Restore completed in 40.41 ms for C:\R3\src\CodeStyle\VisualBasic\Analyzers\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.vbproj.
  Restore completed in 41.87 ms for C:\R3\src\CodeStyle\CSharp\Analyzers\Microsoft.CodeAnalysis.CSharp.CodeStyle.csproj.
...

>build
Roslyn.sln:
  CompilersBoundTreeGenerator -> C:\R3\artifacts\bin\CompilersBoundTreeGenerator\x64\Debug\netcoreapp2.1\BoundTreeGenerator.dll
  CSharpErrorFactsGenerator -> C:\R3\artifacts\bin\CSharpErrorFactsGenerator\x64\Debug\netcoreapp2.1\CSharpErrorFactsGenerator.dll
  CSharpSyntaxGenerator -> C:\R3\artifacts\bin\CSharpSyntaxGenerator\x64\Debug\netcoreapp2.1\CSharpSyntaxGenerator.dll
...
```

QuietRestore is a hack that is causing issues like https://github.com/dotnet/arcade/issues/2220.