### PR TITLE
Remove experimentation from toggle comment features.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CommentSelection/AbstractToggleBlockCommentBase.cs
+++ b/src/EditorFeatures/Core/Implementation/CommentSelection/AbstractToggleBlockCommentBase.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CommentSelection;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -59,14 +58,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
 
         public VSCommanding.CommandState GetCommandState(ToggleBlockCommentCommandArgs args)
         {
-            if (Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
-            {
-                var experimentationService = workspace.Services.GetRequiredService<IExperimentationService>();
-                if (!experimentationService.IsExperimentEnabled(WellKnownExperimentNames.RoslynToggleBlockComment))
-                {
-                    return VSCommanding.CommandState.Unspecified;
-                }
-            }
             return GetCommandState(args.SubjectBuffer);
         }
 
@@ -90,12 +81,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
                 m[LengthString] = subjectBuffer.CurrentSnapshot.Length;
             }), cancellationToken))
             {
-                var experimentationService = document.Project.Solution.Workspace.Services.GetRequiredService<IExperimentationService>();
-                if (!experimentationService.IsExperimentEnabled(WellKnownExperimentNames.RoslynToggleBlockComment))
-                {
-                    return s_emptyCommentSelectionResult;
-                }
-
                 var navigator = _navigatorSelectorService.GetTextStructureNavigator(subjectBuffer);
 
                 var commentInfo = await service.GetInfoAsync(document, selectedSpans.First().Span.ToTextSpan(), cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/Implementation/CommentSelection/ToggleLineCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/CommentSelection/ToggleLineCommentCommandHandler.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CommentSelection;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -48,14 +47,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
 
         public VSCommanding.CommandState GetCommandState(ToggleLineCommentCommandArgs args)
         {
-            if (Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
-            {
-                var experimentationService = workspace.Services.GetRequiredService<IExperimentationService>();
-                if (!experimentationService.IsExperimentEnabled(WellKnownExperimentNames.RoslynToggleLineComment))
-                {
-                    return VSCommanding.CommandState.Unspecified;
-                }
-            }
             return GetCommandState(args.SubjectBuffer);
         }
 
@@ -77,12 +68,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
                 m[LengthString] = subjectBuffer.CurrentSnapshot.Length;
             }), cancellationToken))
             {
-                var experimentationService = document.Project.Solution.Workspace.Services.GetRequiredService<IExperimentationService>();
-                if (!experimentationService.IsExperimentEnabled(WellKnownExperimentNames.RoslynToggleLineComment))
-                {
-                    return s_emptyCommentSelectionResult;
-                }
-
                 var commentInfo = await service.GetInfoAsync(document, selectedSpans.First().Span.ToTextSpan(), cancellationToken).ConfigureAwait(false);
                 if (commentInfo.SupportsSingleLineComment)
                 {

--- a/src/EditorFeatures/TestUtilities/CommentSelection/AbstractToggleCommentTestBase.cs
+++ b/src/EditorFeatures/TestUtilities/CommentSelection/AbstractToggleCommentTestBase.cs
@@ -3,16 +3,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Experiments;
-using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Text;
@@ -37,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.CommentSelection
         protected void ToggleCommentMultiple(string markup, string[] expectedText)
         {
             var exportProvider = ExportProviderCache
-                .GetOrCreateExportProviderFactory(TestExportProvider.EntireAssemblyCatalogWithCSharpAndVisualBasic.WithPart(typeof(MockToggleCommentExperimentationService)))
+                .GetOrCreateExportProviderFactory(TestExportProvider.EntireAssemblyCatalogWithCSharpAndVisualBasic)
                 .CreateExportProvider();
 
             using (var workspace = GetWorkspace(markup, exportProvider))
@@ -83,17 +79,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.CommentSelection
                 textView.Selection.Select(new VirtualSnapshotPoint(snapshot, spans.First().Start),
                                           new VirtualSnapshotPoint(snapshot, spans.Last().End));
                 textView.Caret.MoveTo(new SnapshotPoint(snapshot, spans.Last().End));
-            }
-        }
-
-        [ExportWorkspaceService(typeof(IExperimentationService), WorkspaceKind.Test), Shared]
-        [PartNotDiscoverable]
-        private class MockToggleCommentExperimentationService : IExperimentationService
-        {
-            public bool IsExperimentEnabled(string experimentName)
-            {
-                return WellKnownExperimentNames.RoslynToggleBlockComment.Equals(experimentName)
-                    || WellKnownExperimentNames.RoslynToggleLineComment.Equals(experimentName);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -25,8 +25,6 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string PartialLoadMode = "Roslyn.PartialLoadMode";
         public const string TypeImportCompletion = "Roslyn.TypeImportCompletion";
         public const string TargetTypedCompletionFilter = "Roslyn.TargetTypedCompletionFilter";
-        public const string RoslynToggleBlockComment = "Roslyn.ToggleBlockComment";
-        public const string RoslynToggleLineComment = "Roslyn.ToggleLineComment";
         public const string NativeEditorConfigSupport = "Roslyn.NativeEditorConfigSupport";
     }
 }


### PR DESCRIPTION
@genlu @dpoeschl since master-vs-deps is now targeting 16.2, I'm removing the experimentation from these features all together.  Toggle block comment is already fully dialed up (for preview 2) and toggle line comment will be fully dialed up shortly for preview 3