### PR TITLE
Use the spans in view when doing a multi-selection.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CommentSelection/CSharpToggleLineCommentCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CommentSelection/CSharpToggleLineCommentCommandHandlerTests.cs
@@ -538,6 +538,31 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ToggleLineComment)]
+        public void AddComment_WithProjectionBuffer()
+        {
+            var surfaceMarkup = @"&lt; html &gt;@{|S1:|}";
+            var csharpMarkup =
+@"
+{|S1:class C
+{
+    void M()
+    {
+        [|var i = 1;|]
+    }
+}|}";
+            var expected =
+@"&lt; html &gt;@class C
+{
+    void M()
+    {
+[|        //var i = 1;|]
+    }
+}";
+
+            ToggleCommentWithProjectionBuffer(surfaceMarkup, csharpMarkup, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ToggleLineComment)]
         public void RemoveComment_CaretInCommentedLine()
         {
             var markup =
@@ -913,6 +938,31 @@ class C
 }";
 
             ToggleComment(markup, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ToggleLineComment)]
+        public void RemoveComment_WithProjectionBuffer()
+        {
+            var surfaceMarkup = @"&lt; html &gt;@{|S1:|}";
+            var csharpMarkup =
+@"
+{|S1:class C
+{
+    void M()
+    {
+        [|//var i = 1;|]
+    }
+}|}";
+            var expected =
+@"&lt; html &gt;@class C
+{
+    void M()
+    {
+[|        var i = 1;|]
+    }
+}";
+
+            ToggleCommentWithProjectionBuffer(surfaceMarkup, csharpMarkup, expected);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ToggleLineComment)]

--- a/src/EditorFeatures/Core/Implementation/CommentSelection/AbstractCommentSelectionBase.cs
+++ b/src/EditorFeatures/Core/Implementation/CommentSelection/AbstractCommentSelectionBase.cs
@@ -155,9 +155,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CommentSelection
                     }
                 }
 
-                var spansToSelect = trackingSnapshotSpans.Select(s => new Selection(s));
-                // Set the multi selection with the last selection as the primary after edits have been applied.
-                textView.GetMultiSelectionBroker().SetSelectionRange(spansToSelect, spansToSelect.Last());
+                // Set the multi selection after edits have been applied.
+                textView.SetMultiSelection(trackingSnapshotSpans);
             }
         }
 

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextViewExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextViewExtensions.cs
@@ -99,6 +99,16 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
             textView.Caret.MoveTo(isReversed ? spanInView.Start : spanInView.End);
         }
 
+        /// <summary>
+        /// Sets a multi selection with the last span as the primary selection.
+        /// Also maps up to the correct span in view before attempting to set the selection.
+        /// </summary>
+        public static void SetMultiSelection(this ITextView textView, IEnumerable<SnapshotSpan> spans)
+        {
+            var spansInView = spans.Select(s => new Selection(textView.GetSpanInView(s).Single()));
+            textView.GetMultiSelectionBroker().SetSelectionRange(spansInView, spansInView.Last());
+        }
+
         public static bool TryMoveCaretToAndEnsureVisible(this ITextView textView, SnapshotPoint point, IOutliningManagerService outliningManagerService = null, EnsureSpanVisibleOptions ensureSpanVisibleOptions = EnsureSpanVisibleOptions.None)
         {
             return textView.TryMoveCaretToAndEnsureVisible(new VirtualSnapshotPoint(point), outliningManagerService, ensureSpanVisibleOptions);

--- a/src/EditorFeatures/Test/CommentSelection/ToggleBlockCommentCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/CommentSelection/ToggleBlockCommentCommandHandlerTests.cs
@@ -890,6 +890,30 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ToggleBlockComment)]
+        public void AddComment_WithProjectionBuffer()
+        {
+            var surfaceMarkup = @"&lt; html &gt;@{|S1:|}";
+            var csharpMarkup =
+@"
+{|S1:class C
+{
+    void M()
+    {
+        [|var i = 1;|]
+    }
+}|}";
+            var expected =
+@"&lt; html &gt;@class C
+{
+    void M()
+    {
+        [|/*var i = 1;*/|]
+    }
+}";
+            ToggleCommentWithProjectionBuffer(surfaceMarkup, csharpMarkup, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ToggleBlockComment)]
         public void RemoveComment_AtBeginningOfFile()
         {
             var markup = @"[|/**/|]";
@@ -1362,6 +1386,30 @@ class C
 }";
 
             ToggleComment(markup, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ToggleBlockComment)]
+        public void RemoveComment_WithProjectionBuffer()
+        {
+            var surfaceMarkup = @"&lt; html &gt;@{|S1:|}";
+            var csharpMarkup =
+@"
+{|S1:class C
+{
+    void M()
+    {
+        [|/*var i = 1;*/|]
+    }
+}|}";
+            var expected =
+@"&lt; html &gt;@class C
+{
+    void M()
+    {
+        [|var i = 1;|]
+    }
+}";
+            ToggleCommentWithProjectionBuffer(surfaceMarkup, csharpMarkup, expected);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ToggleBlockComment)]


### PR DESCRIPTION
For #35285

<details><summary>Ask Mode template</summary>

### Customer scenario

Customer attempts to add/remove/toggle comment in javascript inside a cshtml file.

### Bugs this fixes

#35285

### Workarounds, if any

User can comment/uncomment manually.  If the user attempts to comment/uncomment with the commands, the cursor disappears.  This can be remedied by closing and re-opening the file.

### Risk

Low, small change.

### Performance impact

None

### Is this a regression from a previous update?

Yes

### Root cause analysis

The existing code was attempting to set the selection to the wrong (HTMLXProjection) buffer instead of the JS(TypeScript) buffer.  Fixed by retrieving the correct snapshot span in view before attempting to set the selection.

### How was the bug found?

Reported from VS feedback

</details>