### PR TITLE
Add DeclareAsNullable refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/DeclareAsNullable/DeclareAsNullableRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/DeclareAsNullable/DeclareAsNullableRefactoringTests.cs
@@ -1,0 +1,410 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.DeclareAsNullable;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.DeclareAsNullable
+{
+    // TODO:
+    // a.b.c.s$$ == null
+    // somet$$hing?.x
+    // symbol not from this project
+
+    [Trait(Traits.Feature, Traits.Features.CodeActionsDeclaredAsNullable)]
+    public class DeclareAsNullableRefactoringTests : AbstractCSharpCodeActionTest
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new DeclareAsNullableCodeRefactoringProvider();
+
+        private static readonly TestParameters s_nullableFeature = new TestParameters(parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+
+        [Fact]
+        public async Task TestParameterEqualsNull()
+        {
+            var code = @"
+class C
+{
+    static void M(string s)
+    {
+        if (s [|==|] null)
+        {
+            return;
+        }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void M(string? s)
+    {
+        if (s == null)
+        {
+            return;
+        }
+    }
+}";
+
+            await TestInRegularAndScript1Async(code, expected, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestAlreadyNullableRefType()
+        {
+            var code = @"
+class C
+{
+    static void M(string? s)
+    {
+        if (s [|==|] null)
+        {
+            return;
+        }
+    }
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestNullableValueType()
+        {
+            var code = @"
+class C
+{
+    static void M(int? s)
+    {
+        if (s [|==|] null)
+        {
+            return;
+        }
+    }
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestCursorOnEquals()
+        {
+            var code = @"
+class C
+{
+    static void M(string s)
+    {
+        if (s ==[||] null)
+        {
+            return;
+        }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void M(string? s)
+    {
+        if (s == null)
+        {
+            return;
+        }
+    }
+}";
+
+            await TestInRegularAndScript1Async(code, expected, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestCursorOnNull()
+        {
+            var code = @"
+class C
+{
+    static void M(string s)
+    {
+        if (s == [||]null)
+        {
+            return;
+        }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void M(string? s)
+    {
+        if (s == null)
+        {
+            return;
+        }
+    }
+}";
+
+            await TestInRegularAndScript1Async(code, expected, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestParameterNotEqualsNull()
+        {
+            var code = @"
+class C
+{
+    static void M(string s)
+    {
+        if (s [|!=|] null)
+        {
+            return;
+        }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void M(string? s)
+    {
+        if (s != null)
+        {
+            return;
+        }
+    }
+}";
+
+            await TestInRegularAndScript1Async(code, expected, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestNullEqualsParameter()
+        {
+            var code = @"
+class C
+{
+    static void M(string s)
+    {
+        if (null [|==|] s)
+        {
+            return;
+        }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void M(string? s)
+    {
+        if (null == s)
+        {
+            return;
+        }
+    }
+}";
+
+            await TestInRegularAndScript1Async(code, expected, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestLocalEqualsNull()
+        {
+            var code = @"
+class C
+{
+    static void M()
+    {
+        string s = M2();
+        if (s [|==|] null)
+        {
+            return;
+        }
+    }
+    static string M2() => throw null;
+}";
+
+            var expected = @"
+class C
+{
+    static void M()
+    {
+        string? s = M2();
+        if (s == null)
+        {
+            return;
+        }
+    }
+    static string M2() => throw null;
+}";
+
+            await TestInRegularAndScript1Async(code, expected, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestFieldEqualsNull()
+        {
+            var code = @"
+class C
+{
+    string field;
+    static void M(C c)
+    {
+        if (c.field [|==|] null)
+        {
+            return;
+        }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    string? field;
+    static void M(C c)
+    {
+        if (c.field == null)
+        {
+            return;
+        }
+    }
+}";
+
+            await TestInRegularAndScript1Async(code, expected, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestMultiLocalEqualsNull()
+        {
+            var code = @"
+class C
+{
+    static void M()
+    {
+        string s = M2(), y = M2();
+        if (s [|==|] null)
+        {
+            return;
+        }
+    }
+    static string M2() => throw null;
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestPropertyEqualsNull()
+        {
+            var code = @"
+class C
+{
+    string s { get; set; }
+    static void M()
+    {
+        if (s [|==|] null)
+        {
+            return;
+        }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    string? s { get; set; }
+    static void M()
+    {
+        if (s == null)
+        {
+            return;
+        }
+    }
+}";
+
+            await TestInRegularAndScript1Async(code, expected, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestMethodEqualsNull()
+        {
+            var code = @"
+class C
+{
+    static void M()
+    {
+        if (M2() [|==|] null)
+        {
+            return;
+        }
+    }
+    static string M2() => throw null;
+}";
+
+            var expected = @"
+class C
+{
+    static void M()
+    {
+        if (M2() == null)
+        {
+            return;
+        }
+    }
+    static string? M2() => throw null;
+}";
+
+            await TestInRegularAndScript1Async(code, expected, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestGenericMethodEqualsNull()
+        {
+            var code = @"
+class C
+{
+    static void M()
+    {
+        if (M2<string>() [|==|] null)
+        {
+            return;
+        }
+    }
+    static T M2<T>() => throw null;
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, parameters: s_nullableFeature);
+        }
+
+        [Fact]
+        public async Task TestPartialMethodEqualsNull()
+        {
+            var code = @"
+partial class C
+{
+    void M()
+    {
+        if (M2() [|==|] null)
+        {
+            return;
+        }
+    }
+    partial string M2();
+}
+partial class C
+{
+    partial string M2() => throw null;
+}";
+
+            await TestMissingInRegularAndScriptAsync(code, parameters: s_nullableFeature);
+        }
+
+        private Task TestMissingInRegularAndScriptAsync(string initialMarkup, IDictionary<OptionKey, object> options)
+        {
+            return TestMissingInRegularAndScriptAsync(initialMarkup, parameters: new TestParameters(options: options));
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -315,6 +315,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Declare as nullable.
+        /// </summary>
+        internal static string Declare_as_nullable {
+            get {
+                return ResourceManager.GetString("Declare as nullable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to deconstruction.
         /// </summary>
         internal static string deconstruction {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -449,6 +449,9 @@
   <data name="Use_explicit_type_instead_of_var" xml:space="preserve">
     <value>Use explicit type instead of 'var'</value>
   </data>
+  <data name="Declare as nullable" xml:space="preserve">
+    <value>Declare as nullable</value>
+  </data>
   <data name="Use_explicit_type" xml:space="preserve">
     <value>Use explicit type</value>
   </data>

--- a/src/Features/CSharp/Portable/CodeRefactorings/DeclareAsNullable/DeclareAsNullableCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/DeclareAsNullable/DeclareAsNullableCodeRefactoringProvider.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Text;
+using System.Diagnostics;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.DeclareAsNullable
+{
+    /// <summary>
+    /// If you apply a null test on a symbol that isn't nullable, then we'll help you make that symbol nullable.
+    /// For example: `nonNull == null`, `nonNull?.Property`
+    /// </summary>
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.DeclareAsNullable), Shared]
+    internal class DeclareAsNullableCodeRefactoringProvider : CodeRefactoringProvider
+    {
+        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var document = context.Document;
+            var textSpan = context.Span;
+            var cancellationToken = context.CancellationToken;
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            var symbolToFix = await TryGetSymbolToFix(root, textSpan, document, cancellationToken).ConfigureAwait(false);
+            if (symbolToFix == null ||
+                symbolToFix.Locations.Length != 1 ||
+                !symbolToFix.IsNonImplicitAndFromSource())
+            {
+                return;
+            }
+
+            if (!IsFixableType(symbolToFix))
+            {
+                return;
+            }
+
+            var declarationLocation = symbolToFix.Locations[0];
+            var node = declarationLocation.FindNode(getInnermostNodeForTie: true, cancellationToken);
+
+            var typeToFix = TryGetTypeToFix(node);
+            if (typeToFix == null || typeToFix is NullableTypeSyntax)
+            {
+                return;
+            }
+
+            context.RegisterRefactoring(
+                new MyCodeAction(
+                    CSharpFeaturesResources.Declare_as_nullable,
+                    c => UpdateDocumentAsync(document, typeToFix, c)));
+        }
+
+        private bool IsFixableType(ISymbol symbolToFix)
+        {
+            ITypeSymbol type = null;
+            switch (symbolToFix)
+            {
+                case IParameterSymbol parameter:
+                    type = parameter.Type;
+                    break;
+                case ILocalSymbol local:
+                    type = local.Type;
+                    break;
+                case IPropertySymbol property:
+                    type = property.Type;
+                    break;
+                case IMethodSymbol method when method.IsDefinition:
+                    type = method.ReturnType;
+                    break;
+                case IFieldSymbol field:
+                    type = field.Type;
+                    break;
+                default:
+                    return false;
+            }
+
+            return type?.IsReferenceType == true;
+        }
+
+        private TypeSyntax TryGetTypeToFix(SyntaxNode node)
+        {
+            switch (node)
+            {
+                case ParameterSyntax parameter:
+                    return parameter.Type;
+
+                case VariableDeclaratorSyntax declarator:
+                    if (declarator.IsParentKind(SyntaxKind.VariableDeclaration))
+                    {
+                        var declaration = (VariableDeclarationSyntax)declarator.Parent;
+                        return declaration.Variables.Count == 1 ? declaration.Type : null;
+                    }
+                    return null;
+
+                case PropertyDeclarationSyntax property:
+                    return property.Type;
+
+                case MethodDeclarationSyntax method:
+                    if (method.Modifiers.Any(SyntaxKind.PartialKeyword))
+                    {
+                        return null;
+                    }
+                    return method.ReturnType;
+            }
+
+            return null;
+        }
+
+        private async Task<ISymbol> TryGetSymbolToFix(SyntaxNode root, TextSpan textSpan, Document document, CancellationToken cancellationToken)
+        {
+            var token = root.FindToken(textSpan.Start);
+
+            if (!token.IsKind(SyntaxKind.EqualsEqualsToken, SyntaxKind.ExclamationEqualsToken, SyntaxKind.NullKeyword))
+            {
+                return null;
+            }
+
+            BinaryExpressionSyntax equals;
+            if (token.Parent.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression))
+            {
+                equals = (BinaryExpressionSyntax)token.Parent;
+            }
+            else if (token.Parent.IsKind(SyntaxKind.NullLiteralExpression) && token.Parent.IsParentKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression))
+            {
+                equals = (BinaryExpressionSyntax)token.Parent.Parent;
+            }
+            else
+            {
+                return null;
+            }
+
+            ExpressionSyntax value;
+            if (equals.Right.IsKind(SyntaxKind.NullLiteralExpression))
+            {
+                value = equals.Left;
+            }
+            else if (equals.Left.IsKind(SyntaxKind.NullLiteralExpression))
+            {
+                value = equals.Right;
+            }
+            else
+            {
+                return null;
+            }
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+            return semanticModel.GetSymbolInfo(value).Symbol;
+        }
+
+        private static async Task<Document> UpdateDocumentAsync(Document document, TypeSyntax typeToFix, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var editor = new SyntaxEditor(root, document.Project.Solution.Workspace);
+
+            var fixedType = SyntaxFactory.NullableType(typeToFix.WithoutTrivia()).WithTriviaFrom(typeToFix);
+            editor.ReplaceNode(typeToFix, fixedType);
+
+            var newRoot = editor.GetChangedRoot();
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
+                base(title, createChangedDocument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -642,6 +642,11 @@
         <target state="new">Convert to 'for'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Declare as nullable">
+        <source>Declare as nullable</source>
+        <target state="new">Declare as nullable</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         public const string MoveTypeToFile = "Move Type To File Code Action Provider";
         public const string ReplaceDocCommentTextWithTag = "Replace Documentation Comment Text With Tag Code Action Provider";
         public const string UseExplicitType = "Use Explicit Type Code Action Provider";
+        public const string DeclareAsNullable = "Declare As Nullable Code Action Provider";
         public const string UseExpressionBody = "Use Expression Body Code Action Provider";
     }
 }

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -117,6 +117,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsUseExpressionBody = "CodeActions.UseExpressionBody";
             public const string CodeActionsUseImplicitType = "CodeActions.UseImplicitType";
             public const string CodeActionsUseExplicitType = "CodeActions.UseExplicitType";
+            public const string CodeActionsDeclaredAsNullable = "CodeActions.DeclaredAsNullable";
             public const string CodeActionsUseExplicitTupleName = "CodeActions.UseExplicitTupleName";
             public const string CodeActionsUseFrameworkType = "CodeActions.UseFrameworkType";
             public const string CodeActionsUseIsNullCheck = "CodeActions.UseIsNullCheck";


### PR DESCRIPTION
The purpose for this refactoring is to assist in migrating a project to use the nullable feature.
When we see a comparison of a non-nullable with `null` (such as `nonNullable == null` or `nonNullable != null`), there is a good chance that `nonNullable` should in fact be declared as nullable instead. This refactoring helps do that with one click.
Note this is only a good chance, because such null checks could also be defensive programming, especially when it comes to public APIs (you declare them as non-nullable, but check anyways).

![image](https://user-images.githubusercontent.com/12466233/39670718-8077c4d0-50bf-11e8-8400-879f1d3cd328.png)

From discussion with Chuck, I will switch this to an analyzer/fixer so that it's more discoverable. But I won't offer a FixAll.

This PR was recreated from https://github.com/dotnet/roslyn/pull/26661 after the target branch was closed, so the first round of comments are in the original PR (sorry about that)