### PR TITLE
Fix applying code actions that change AdditionalDocuments

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
             }
 
             if (changedDocuments.Any(id => newSolution.GetDocument(id).HasInfoChanged(oldSolution.GetDocument(id))) ||
-                changedAdditionalDocuments.Any(id => newSolution.GetDocument(id).HasInfoChanged(oldSolution.GetDocument(id))))
+                changedAdditionalDocuments.Any(id => newSolution.GetAdditionalDocument(id).HasInfoChanged(oldSolution.GetAdditionalDocument(id))))
             {
                 return null;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -41,10 +41,13 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// True if the info of the document change (name, folders, file path; not the content)
         /// </summary>
-        internal bool HasInfoChanged(Document otherDocument)
+        internal override bool HasInfoChanged(TextDocument otherTextDocument)
         {
-            return DocumentState.Attributes != otherDocument.DocumentState.Attributes
-                || DocumentState.SourceCodeKind != otherDocument.SourceCodeKind;
+            var otherDocument = otherTextDocument as Document ??
+                throw new ArgumentException($"{nameof(otherTextDocument)} isn't a regular document.", nameof(otherTextDocument));
+
+            return base.HasInfoChanged(otherDocument) ||
+                   DocumentState.SourceCodeKind != otherDocument.SourceCodeKind;
         }
 
         internal bool HasTextChanged(Document otherDocument)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
@@ -116,5 +116,13 @@ namespace Microsoft.CodeAnalysis
         {
             return State.GetTopLevelChangeTextVersionAsync(cancellationToken);
         }
+
+        /// <summary>
+        /// True if the info of the document change (name, folders, file path; not the content)
+        /// </summary>
+        internal virtual bool HasInfoChanged(TextDocument otherTextDocument)
+        {
+            return State.Attributes != otherTextDocument.State.Attributes;
+        }
     }
 }


### PR DESCRIPTION
Some code was accidentally calling GetDocument with an additional document ID; this didn't end well.