### PR TITLE
Add new optprof test for training

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -4,6 +4,12 @@
       "name": "Roslyn.VisualStudio.Setup.vsix",
       "tests": [
         {
+          "container": "ManagedLangs",
+          "testCases": [
+            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+          ]
+        },
+        {
           "container": "TeamEng",
           "testCases": [
             "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble"
@@ -52,6 +58,12 @@
       "name": "Microsoft.CodeAnalysis.Compilers.vsix",
       "tests": [
         {
+          "container": "ManagedLangs",
+          "testCases": [
+            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+          ]
+        },
+        {
           "container": "TeamEng",
           "testCases": [
             "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble"
@@ -76,6 +88,12 @@
         }
       ],
       "tests": [
+        {
+          "container": "ManagedLangs",
+          "testCases": [
+            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+          ]
+        },
         {
           "container": "TeamEng",
           "testCases": [
@@ -119,6 +137,12 @@
         }
       ],
       "tests": [
+        {
+          "container": "ManagedLangs",
+          "testCases": [
+            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+          ]
+        },
         {
           "container": "TeamEng",
           "testCases": [


### PR DESCRIPTION
We have ported DDRIT.RPS.ManagedLangs to OptProf in this PR
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS/pullrequest/177588?_a=overview

@bradselw Is there anything else needs to be done before merging this?

FYI @jaredpar @tmat @bradselw @dotnet/roslyn-infrastructure 