### PR TITLE
Update foreach based on nullable analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -494,8 +494,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (builder.CollectionConversion.IsImplicit &&
                  (IsIEnumerable(builder.CollectionType) ||
                   IsIEnumerableT(builder.CollectionType.OriginalDefinition, IsAsync, Compilation))) ||
-                // To compat behavior, we can enumerate over System.String even if it's not IEnumerable. That will
-                // store an explicit reference conversion in the bound nodes, but that conversion won't be emitted.
+                // For compat behavior, we can enumerate over System.String even if it's not IEnumerable. That will
+                // result in an explicit reference conversion in the bound nodes, but that conversion won't be emitted.
                 (builder.CollectionConversion.Kind == ConversionKind.ExplicitReference && collectionExpr.Type.SpecialType == SpecialType.System_String));
 
             return new BoundForEachStatement(

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -488,6 +488,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors |= GetAwaitDisposeAsyncInfo(ref builder, diagnostics);
             }
 
+            Debug.Assert(
+                hasErrors ||
+                builder.CollectionConversion.IsIdentity ||
+                (builder.CollectionConversion.IsImplicit &&
+                 (IsIEnumerable(builder.CollectionType) ||
+                  IsIEnumerableT(builder.CollectionType.OriginalDefinition, IsAsync, Compilation))) ||
+                // To compat behavior, we can enumerate over System.String even if it's not IEnumerable. That will
+                // store an explicit reference conversion in the bound nodes, but that conversion won't be emitted.
+                (builder.CollectionConversion.Kind == ConversionKind.ExplicitReference && collectionExpr.Type.SpecialType == SpecialType.System_String));
+
             return new BoundForEachStatement(
                 _syntax,
                 builder.Build(this.Flags),
@@ -1253,20 +1263,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             DiagnosticBag diagnostics,
             out bool foundMultiple)
         {
-            NamedTypeSymbol implementedIEnumerable = null;
-            foundMultiple = false;
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-
-            if (type.TypeKind == TypeKind.TypeParameter)
-            {
-                var typeParameter = (TypeParameterSymbol)type;
-                GetIEnumerableOfT(typeParameter.EffectiveBaseClass(ref useSiteDiagnostics).AllInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics), isAsync, ref @implementedIEnumerable, ref foundMultiple);
-                GetIEnumerableOfT(typeParameter.AllEffectiveInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics), isAsync, ref @implementedIEnumerable, ref foundMultiple);
-            }
-            else
-            {
-                GetIEnumerableOfT(type.AllInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics), isAsync, ref @implementedIEnumerable, ref foundMultiple);
-            }
+            NamedTypeSymbol implementedIEnumerable = GetIEnumerableOfT(type, isAsync, Compilation, ref useSiteDiagnostics, out foundMultiple);
 
             // Prefer generic to non-generic, unless it is inaccessible.
             if (((object)implementedIEnumerable == null) || !this.IsAccessible(implementedIEnumerable, ref useSiteDiagnostics))
@@ -1293,7 +1291,26 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (object)implementedIEnumerable != null;
         }
 
-        private void GetIEnumerableOfT(ImmutableArray<NamedTypeSymbol> interfaces, bool isAsync, ref NamedTypeSymbol result, ref bool foundMultiple)
+        internal static NamedTypeSymbol GetIEnumerableOfT(TypeSymbol type, bool isAsync, CSharpCompilation compilation, ref HashSet<DiagnosticInfo> useSiteDiagnostics, out bool foundMultiple)
+        {
+            NamedTypeSymbol implementedIEnumerable = null;
+            foundMultiple = false;
+
+            if (type.TypeKind == TypeKind.TypeParameter)
+            {
+                var typeParameter = (TypeParameterSymbol)type;
+                GetIEnumerableOfT(typeParameter.EffectiveBaseClass(ref useSiteDiagnostics).AllInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics), isAsync, compilation, ref @implementedIEnumerable, ref foundMultiple);
+                GetIEnumerableOfT(typeParameter.AllEffectiveInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics), isAsync, compilation, ref @implementedIEnumerable, ref foundMultiple);
+            }
+            else
+            {
+                GetIEnumerableOfT(type.AllInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics), isAsync, compilation, ref @implementedIEnumerable, ref foundMultiple);
+            }
+
+            return implementedIEnumerable;
+        }
+
+        private static void GetIEnumerableOfT(ImmutableArray<NamedTypeSymbol> interfaces, bool isAsync, CSharpCompilation compilation, ref NamedTypeSymbol result, ref bool foundMultiple)
         {
             if (foundMultiple)
             {
@@ -1301,7 +1318,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             foreach (NamedTypeSymbol @interface in interfaces)
             {
-                if (IsIEnumerableT(@interface.OriginalDefinition, isAsync))
+                if (IsIEnumerableT(@interface.OriginalDefinition, isAsync, compilation))
                 {
                     if ((object)result == null ||
                         TypeSymbol.Equals(@interface, result, TypeCompareKind.IgnoreTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes))
@@ -1317,11 +1334,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private bool IsIEnumerableT(TypeSymbol type, bool isAsync)
+        internal static bool IsIEnumerableT(TypeSymbol type, bool isAsync, CSharpCompilation compilation)
         {
             if (isAsync)
             {
-                return type.Equals(Compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IAsyncEnumerable_T));
+                return type.Equals(compilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IAsyncEnumerable_T));
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5377,20 +5377,112 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override void VisitForEachExpression(BoundForEachStatement node)
         {
-            var expr = node.Expression;
-            // Need to remove any implicit conversions from this expression and call ApplyConversion
-            // ourselves. https://github.com/dotnet/roslyn/issues/35151
-            VisitRvalue(expr);
+            if (node.Expression.Kind != BoundKind.Conversion)
+            {
+                // If we're in this scenario, there was a binding error, and we should suppress any further warnings.
+                Debug.Assert(node.HasErrors);
+                VisitRvalue(node.Expression);
+                return;
+            }
+
+            var (expr, conversion) = RemoveConversion(node.Expression, includeExplicitConversions: false);
+
+            // There are 7 ways that a foreach can be created:
+            //    1. The collection type is an array type. For this, initial binding will generate an implicit reference conversion to
+            //       IEnumerable, and we do not need to do any reinferring of enumerators here.
+            //    2. The collection type is dynamic. For this we do the same as 1.
+            //    3. The collection type implements the GetEnumerator pattern. For this, there is an identity conversion. Because
+            //       this identity conversion uses nested types from initial binding, we cannot trust them and must instead use
+            //       the type of the expression returned from VisitResult to reinfer the enumerator information.
+            //    4. The collection type implements IEnumerable<T>. Only a few cases can hit this without being caught by number 3,
+            //       such as a type with a private implementation of IEnumerable<T>, or a type parameter constrained to that type.
+            //       In these cases, there will be an implicit conversion to IEnumerable<T>, but this will use types from
+            //       initial binding. For this scenario, we need to look through the list of implemented interfaces on the type and
+            //       find the version of IEnumerable<T> that it has after nullable analysis, as type substitution could have changed
+            //       nested nullability of type paramters. See ForEach_22 for a concrete example of this.
+            //    5. The collection type implements IEnumerable (non-generic). Because this version isn't generic, we don't need to
+            //       do any reinference, and the existing conversion can stand as is.
+            //    6. The target framework's System.String doesn't implement IEnumerable. This is a compat case: System.String normally
+            //       does implement IEnumerable, but there are certain target frameworks where this isn't the case. The compiler will
+            //       still emit code for foreach in these scenarios.
+            //    7. Some binding error occurred, and some other error has already been reported. Usually this doesn't have any kind
+            //       of conversion on top, but if there was an explicit conversion in code then we could get past the initial check
+            //       for a BoundConversion node.
+
+            var resultTypeWithState = VisitRvalueWithState(expr);
+            SetAnalyzedNullability(expr, _visitResult);
+            TypeWithAnnotations targetTypeWithAnnotation;
+
+            if (conversion.IsIdentity ||
+                (conversion.Kind == ConversionKind.ExplicitReference && resultTypeWithState.Type.SpecialType == SpecialType.System_String))
+            {
+                // This is case 3 or 6.
+                targetTypeWithAnnotation = resultTypeWithState.ToTypeWithAnnotations();
+            }
+            else if (conversion.IsImplicit)
+            {
+                bool isAsync = ((CommonForEachStatementSyntax)node.Syntax).AwaitKeyword != default;
+                if (node.Expression.Type.SpecialType == SpecialType.System_Collections_IEnumerable)
+                {
+                    // If this is a conversion to IEnumerable (non-generic), nothing to do. This is cases 1, 2, and 5.
+                    targetTypeWithAnnotation = TypeWithAnnotations.Create(node.Expression.Type);
+                }
+                else if (ForEachLoopBinder.IsIEnumerableT(node.Expression.Type.OriginalDefinition, isAsync, compilation))
+                {
+                    // This is case 4. We need to look for the IEnumerable<T> that this reinferred expression implements,
+                    // so that we pick up any nested type substitutions that could have occurred.
+                    HashSet<DiagnosticInfo> ignoredUseSiteDiagnostics = null;
+                    targetTypeWithAnnotation = TypeWithAnnotations.Create(ForEachLoopBinder.GetIEnumerableOfT(resultTypeWithState.Type, isAsync, compilation, ref ignoredUseSiteDiagnostics, out bool foundMultiple));
+                    Debug.Assert(!foundMultiple);
+                    Debug.Assert(!(targetTypeWithAnnotation.Type is null));
+                }
+                else
+                {
+                    // This is case 7. There was not a successful binding, as a successful binding will _always_ generate one of the
+                    // above conversions. Just return, as we want to suppress further errors.
+                    return;
+                }
+            }
+            else
+            {
+                // This is also case 7.
+                return;
+            }
+
+            var convertedResult = ApplyConversion(
+                node.Expression,
+                expr,
+                conversion,
+                targetTypeWithAnnotation,
+                resultTypeWithState,
+                checkConversion: true,
+                fromExplicitCast: false,
+                useLegacyWarnings: false,
+                AssignmentKind.Assignment);
+
             bool reportedDiagnostic = CheckPossibleNullReceiver(expr);
+
+            SetResultType(node.Expression, convertedResult);
+            TrackInferredTypesThroughConversions(node.Expression, expr, _visitResult);
+
+            if (resultTypeWithState.Type.IsArray() ||
+                (conversion.Kind == ConversionKind.ExplicitReference &&
+                 resultTypeWithState.Type.SpecialType == SpecialType.System_String))
+            {
+                // If we're iterating over an array type, VisitForEachIterationVariables will need the array type to calculate
+                // the reinferred element type of the foreach, even though we use the IEnumerator pattern for arrays.
+                // If we're iterating over a string that was explicitly converted, then it doesn't implement IEnumerable and
+                // VisitForEachIterationVariables will need to explicitly set the type of the iteration variables to char.
+                SetResultType(expression: null, resultTypeWithState);
+            }
 
             if (reportedDiagnostic || node.EnumeratorInfoOpt == null)
             {
                 return;
             }
 
-            // Reinfer enumerator type based on the return type of visiting expr
-            // https://github.com/dotnet/roslyn/issues/35151
-            var enumeratorReturnType = node.EnumeratorInfoOpt.GetEnumeratorMethod.ReturnTypeWithAnnotations.ToTypeWithState();
+            var getEnumeratorMethod = (MethodSymbol)AsMemberOfType(convertedResult.Type, node.EnumeratorInfoOpt.GetEnumeratorMethod);
+            var enumeratorReturnType = getEnumeratorMethod.ReturnTypeWithAnnotations.ToTypeWithState();
             if (enumeratorReturnType.State == NullableFlowState.MaybeNull)
             {
                 ReportSafetyDiagnostic(ErrorCode.WRN_NullReferenceReceiver, expr.Syntax.GetLocation());
@@ -5399,9 +5491,42 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitForEachIterationVariables(BoundForEachStatement node)
         {
-            // declare and assign all iteration variables
-            TypeWithAnnotations sourceType = node.EnumeratorInfoOpt?.ElementTypeWithAnnotations ?? default;
-            TypeWithState sourceState = sourceType.ToTypeWithState();
+            TypeWithAnnotations sourceType;
+            TypeWithState sourceState;
+            if (node.EnumeratorInfoOpt == null)
+            {
+                sourceType = default;
+                sourceState = sourceType.ToTypeWithState();
+            }
+            else
+            {
+                var inferredCollectionType = ResultType.Type;
+
+                if (inferredCollectionType is ArrayTypeSymbol arrayType)
+                {
+                    // Even though arrays use the IEnumerator pattern, we use the array element type as the foreach target type, so
+                    // directly get our source type from there instead of doing method reinference.
+                    sourceType = arrayType.ElementTypeWithAnnotations;
+                }
+                else if (inferredCollectionType.SpecialType == SpecialType.System_String)
+                {
+                    // There are frameworks where System.String does not implement IEnumerable, but we still lower it to a for loop
+                    // using the indexer over the individual characters anyway. So the type must be not annotated char.
+                    sourceType = TypeWithAnnotations.Create(node.EnumeratorInfoOpt.ElementType, NullableAnnotation.NotAnnotated);
+                }
+                else
+                {
+                    // Reinfer the return type of the node.Expression.GetEnumerator().Current property, so that if
+                    // the collection changed nested generic types we pick up those changes. ResultType should have been
+                    // set by VisitForEachExpression, called just before this.
+                    Debug.Assert(ResultType.Type.Equals(node.EnumeratorInfoOpt.CollectionType, TypeCompareKind.AllNullableIgnoreOptions));
+                    var getEnumeratorMethod = (MethodSymbol)AsMemberOfType(inferredCollectionType, node.EnumeratorInfoOpt.GetEnumeratorMethod);
+                    var currentProperty = (MethodSymbol)AsMemberOfType(getEnumeratorMethod.ReturnType, node.EnumeratorInfoOpt.CurrentPropertyGetter);
+                    sourceType = currentProperty.ReturnTypeWithAnnotations;
+                }
+
+                sourceState = sourceType.ToTypeWithState();
+            }
 
 #pragma warning disable IDE0055 // Fix formatting
             var variableLocation = node.Syntax switch
@@ -5412,6 +5537,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 };
 #pragma warning restore IDE0055 // Fix formatting
 
+            // declare and assign all iteration variables
             foreach (var iterationVariable in node.IterationVariables)
             {
                 var state = NullableFlowState.NotNull;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -464,14 +464,13 @@ class C
     static List<T> L<T>(T t) => null!;
 }", options: WithNonNullTypesTrue());
 
-            // Missing warning on foreach (we should re-infer the enumerator and Current)
-            // https://github.com/dotnet/roslyn/issues/33257
-
             comp.VerifyDiagnostics(
                 // (7,9): warning CS8602: Dereference of a possibly null reference.
-                //         L(o)[0].ToString(); // Should get a warning
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "L(o)[0]").WithLocation(7, 9)
-                );
+                //         L(o)[0].ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "L(o)[0]").WithLocation(7, 9),
+                // (10,13): warning CS8602: Dereference of a possibly null reference.
+                //             x.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(10, 13));
         }
 
         [Fact, WorkItem(29964, "https://github.com/dotnet/roslyn/issues/29964")]
@@ -51135,10 +51134,7 @@ class C
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(IEnumerable<object>)default").WithLocation(10, 27),
                 // (10,27): warning CS8602: Dereference of a possibly null reference.
                 //         foreach (var y in (IEnumerable<object>)default) // 2
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable<object>)default").WithLocation(10, 27),
-                // (13,27): warning CS8602: Dereference of a possibly null reference.
-                //         foreach (var z in default(IEnumerable)) // 3
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "default(IEnumerable)").WithLocation(13, 27));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(IEnumerable<object>)default").WithLocation(10, 27));
         }
 
         [WorkItem(23493, "https://github.com/dotnet/roslyn/issues/23493")]
@@ -51461,6 +51457,7 @@ class Program
         }
 
         [Fact]
+        [WorkItem(35151, "https://github.com/dotnet/roslyn/issues/35151")]
         public void ForEach_19()
         {
             var source =
@@ -51504,11 +51501,360 @@ class Enumerable<T> where T : IEnumerator?
 }";
 
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/35151 Report diagnostics on 2 and 3
             comp.VerifyDiagnostics(
                 // (12,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         e = null; // 1
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(12, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(12, 13),
+                // (14,27): warning CS8602: Dereference of a possibly null reference.
+                //         foreach (var i in enumerable2) // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "enumerable2").WithLocation(14, 27),
+                // (22,27): warning CS8602: Dereference of a possibly null reference.
+                //         foreach (var i in enumerable1) // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "enumerable1").WithLocation(22, 27));
+        }
+
+        [Fact]
+        [WorkItem(35151, "https://github.com/dotnet/roslyn/issues/35151")]
+        public void ForEach_20()
+        {
+            var source =
+@"
+using System.Collections.Generic;
+class C
+{
+    void M1(string e)
+    {
+        var enumerable1 = Create(e);
+        foreach (var s in enumerable1)
+        {
+            s.ToString();
+        }
+
+        e = null; // 1
+        var enumerable2 = Create(e);
+        foreach (var s in enumerable2)
+        {
+            s.ToString(); // 2
+        }
+    }
+
+    void M2(string? e)
+    {
+        var enumerable1 = Create(e);
+        foreach (var s in enumerable1)
+        {
+            s.ToString(); // 3
+        }
+
+        if (e == null) return;
+        var enumerable2 = Create(e);
+        foreach (var s in enumerable2)
+        {
+            s.ToString();
+        }
+    }
+    static Enumerable<IEnumerator<U>, U> Create<U>(U u) => throw null!;
+}
+
+class Enumerable<T, U> where T : IEnumerator<U>?
+{
+    public T GetEnumerator() => throw null!;
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (13,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         e = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(13, 13),
+                // (17,13): warning CS8602: Dereference of a possibly null reference.
+                //             s.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(17, 13),
+                // (26,13): warning CS8602: Dereference of a possibly null reference.
+                //             s.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(26, 13));
+        }
+
+        [Fact]
+        [WorkItem(35151, "https://github.com/dotnet/roslyn/issues/35151")]
+        public void ForEach_21()
+        {
+            var source =
+@"
+using System.Collections;
+using System.Collections.Generic;
+
+class C
+{
+    void M1(string e)
+    {
+        var enumerable1 = Create(e);
+        foreach (var s in enumerable1)
+        {
+            s.ToString();
+        }
+
+        e = null; // 1
+        var enumerable2 = Create(e);
+        foreach (var s in enumerable2)
+        {
+            s.ToString(); // 2
+        }
+    }
+
+    void M2(string? e)
+    {
+        var enumerable1 = Create(e);
+        foreach (var s in enumerable1)
+        {
+            s.ToString(); // 3
+        }
+
+        if (e == null) return;
+        var enumerable2 = Create(e);
+        foreach (var s in enumerable2)
+        {
+            s.ToString();
+        }
+    }
+    static Enumerable<T> Create<T>(T t) => throw null!;
+}
+
+class Enumerable<T> : IEnumerable<T>
+{
+    public IEnumerator<T> GetEnumerator() => throw null!;
+    IEnumerator IEnumerable.GetEnumerator() => throw null!;
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (15,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         e = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(15, 13),
+                // (19,13): warning CS8602: Dereference of a possibly null reference.
+                //             s.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(19, 13),
+                // (28,13): warning CS8602: Dereference of a possibly null reference.
+                //             s.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(28, 13));
+        }
+
+        [Fact]
+        [WorkItem(35151, "https://github.com/dotnet/roslyn/issues/35151")]
+        public void ForEach_22()
+        {
+            var source =
+@"
+using System.Collections;
+using System.Collections.Generic;
+
+class C
+{
+    void M1(string e)
+    {
+        var enumerable1 = Create(e);
+        foreach (var s in enumerable1)
+        {
+            s.ToString();
+        }
+
+        e = null; // 1
+        var enumerable2 = Create(e);
+        foreach (var s in enumerable2)
+        {
+            s.ToString(); // 2
+        }
+    }
+
+    void M2(string? e)
+    {
+        var enumerable1 = Create(e);
+        foreach (var s in enumerable1)
+        {
+            s.ToString(); // 3
+        }
+
+        if (e == null) return;
+        var enumerable2 = Create(e);
+        foreach (var s in enumerable2)
+        {
+            s.ToString();
+        }
+    }
+    static Enumerable<T> Create<T>(T t) => throw null!;
+}
+
+class Enumerable<T> : IEnumerable<T>
+{
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw null!;
+    IEnumerator IEnumerable.GetEnumerator() => throw null!;
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (15,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         e = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(15, 13),
+                // (19,13): warning CS8602: Dereference of a possibly null reference.
+                //             s.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(19, 13),
+                // (28,13): warning CS8602: Dereference of a possibly null reference.
+                //             s.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(28, 13));
+        }
+
+        [Fact]
+        [WorkItem(33257, "https://github.com/dotnet/roslyn/issues/33257")]
+        [WorkItem(35151, "https://github.com/dotnet/roslyn/issues/35151")]
+        public void ForEach_23()
+        {
+            var source = @"
+class C
+{
+    void M(string? s)
+    {
+        var l1 = new[] { s };
+        foreach (var x in l1)
+        {
+            x.ToString(); // 1
+        }
+
+        if (s == null) return;
+        var l2 = new[] { s };
+        foreach (var x in l2)
+        {
+            x.ToString();
+        }
+    }
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (9,13): warning CS8602: Dereference of a possibly null reference.
+                //             x.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x").WithLocation(9, 13));
+        }
+
+        [Fact]
+        public void ForEach_StringNotIEnumerable()
+        {
+            // In some frameworks, System.String doesn't implement IEnumerable, but for compat reasons the compiler
+            // will still allow foreach'ing over these strings.
+
+            var systemSource = @"
+namespace System
+{
+    public class Object { }
+    public struct Void { }
+    public class ValueType { }
+    public struct Boolean { }
+    public struct Int32 { }
+    public struct Char
+    {
+        public string ToString() => throw null!;
+    }
+
+    public class String
+    {
+        public int Length { get; }
+
+        [System.Runtime.CompilerServices.IndexerName(""Chars"")]
+        public char this[int i] => throw null!;
+    }
+
+    public interface IDisposable
+    {
+        void Dispose();
+    }
+
+    public abstract class Attribute
+    {
+        protected Attribute() { }
+    }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    using System;
+
+    public sealed class IndexerNameAttribute: Attribute
+    {
+        public IndexerNameAttribute(String indexerName)
+        {}
+    }
+}
+
+namespace System.Reflection {
+
+    using System;
+
+    public sealed class DefaultMemberAttribute : Attribute
+    {
+        public DefaultMemberAttribute(String memberName) 
+        {}
+    }
+}
+
+namespace System.Collections
+{
+    public interface IEnumerable
+    {
+        IEnumerator GetEnumerator();
+    }
+
+    public interface IEnumerator
+    {
+        object Current { get; }
+        bool MoveNext();
+    }
+}";
+
+            var source = @"
+class C
+{
+    void M(string s, string? s2)
+    {
+        foreach (var c in s)
+        {
+            c.ToString();
+        }
+
+        s = null; // 1
+        foreach (var c in s) // 2
+        {
+            c.ToString();
+        }
+
+        foreach (var c in s2) // 3
+        {
+            c.ToString();
+        }
+
+        foreach (var c in (string)null) // 4
+        {
+        }
+    }
+}";
+
+            var comp = CreateEmptyCompilation(new[] { source, systemSource }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (11,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         s = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(11, 13),
+                // (12,27): warning CS8602: Dereference of a possibly null reference.
+                //         foreach (var c in s) // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s").WithLocation(12, 27),
+                // (17,27): warning CS8602: Dereference of a possibly null reference.
+                //         foreach (var c in s2) // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(17, 27),
+                // (22,27): error CS0186: Use of null is not valid in this context
+                //         foreach (var c in (string)null) // 4
+                Diagnostic(ErrorCode.ERR_NullNotValid, "(string)null").WithLocation(22, 27),
+                // (22,27): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         foreach (var c in (string)null) // 4
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "(string)null").WithLocation(22, 27),
+                // (22,27): warning CS8602: Dereference of a possibly null reference.
+                //         foreach (var c in (string)null) // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(string)null").WithLocation(22, 27));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -359,6 +359,7 @@ public class C
         }
 
         [Fact]
+        [WorkItem(35034, "https://github.com/dotnet/roslyn/issues/35034")]
         public void MethodDeclarationReceiver()
         {
             var source = @"


### PR DESCRIPTION
This makes 2 changes:
1. Reinfer the GetEnumerator method based on nullable analysis of the
foreach expression type.
2. Use that information to update the collection element type based on
that same analysis.

Fixes https://github.com/dotnet/roslyn/issues/33257.
Fixes https://github.com/dotnet/roslyn/issues/35151.
@dotnet/roslyn-compiler for review.