### PR TITLE
Support TimeTravelTraceInterop in function resolver.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -88,8 +88,8 @@
     <MicrosoftVisualStudioCompositionVersion>15.5.23</MicrosoftVisualStudioCompositionVersion>
     <MicrosoftVisualStudioCoreUtilityVersion>16.0.467</MicrosoftVisualStudioCoreUtilityVersion>
     <MicrosoftVisualStudioDebuggerUIInterfacesVersion>15.0.27309-vsucorediag</MicrosoftVisualStudioDebuggerUIInterfacesVersion>
-    <MicrosoftVisualStudioDebuggerEngineimplementationVersion>15.7.2082401</MicrosoftVisualStudioDebuggerEngineimplementationVersion>
-    <MicrosoftVisualStudioDebuggerMetadataimplementationVersion>15.7.2082401</MicrosoftVisualStudioDebuggerMetadataimplementationVersion>
+    <MicrosoftVisualStudioDebuggerEngineimplementationVersion>16.0.2032702 </MicrosoftVisualStudioDebuggerEngineimplementationVersion>
+    <MicrosoftVisualStudioDebuggerMetadataimplementationVersion>16.0.2032702 </MicrosoftVisualStudioDebuggerMetadataimplementationVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>1.1.4322</MicrosoftVisualStudioDesignerInterfacesVersion>
     <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>16.0.28226-alpha</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>
     <MicrosoftVisualStudioSDKEmbedInteropTypesVersion>15.0.27</MicrosoftVisualStudioSDKEmbedInteropTypesVersion>
@@ -180,6 +180,7 @@
     <SQLitePCLRawbundle_greenVersion>1.1.2</SQLitePCLRawbundle_greenVersion>
     <UIAComWrapperVersion>1.1.0.14</UIAComWrapperVersion>
     <MicrosoftVSSDKBuildToolsVersion>15.8.68-develop-g109a00ff</MicrosoftVSSDKBuildToolsVersion>
+    <MicrosoftVSSDKVSDConfigToolVersion>16.0.2032702</MicrosoftVSSDKVSDConfigToolVersion>
     <VSLangProjVersion>7.0.3301</VSLangProjVersion>
     <VSLangProj140Version>14.0.25030</VSLangProj140Version>
     <VSLangProj2Version>7.0.5001</VSLangProj2Version>
@@ -272,6 +273,7 @@
     <PrivateVisualStudioPackage Include="VSLangProj80" />
     <PrivateVisualStudioPackage Include="VSLangProj140" />
     <PrivateVisualStudioPackage Include="VsWebsite.Interop" />
+    <PrivateVisualStudioPackage Include="Microsoft.VSSDK.Debugger.VSDConfigTool" />
   </ItemGroup>
   <PropertyGroup>
     <UsingToolPdbConverter>true</UsingToolPdbConverter>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -273,7 +273,6 @@
     <PrivateVisualStudioPackage Include="VSLangProj80" />
     <PrivateVisualStudioPackage Include="VSLangProj140" />
     <PrivateVisualStudioPackage Include="VsWebsite.Interop" />
-    <PrivateVisualStudioPackage Include="Microsoft.VSSDK.Debugger.VSDConfigTool" />
   </ItemGroup>
   <PropertyGroup>
     <UsingToolPdbConverter>true</UsingToolPdbConverter>

--- a/eng/targets/Vsdconfig.targets
+++ b/eng/targets/Vsdconfig.targets
@@ -1,20 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="GenerateVsdconfig"
-          AfterTargets="CoreCompile"
-          BeforeTargets="AfterCompile"
-          Inputs="@(VsdConfigXml);$(IntermediateOutputPath)\$(AssemblyName).dll"
-          Outputs="$(OutDir)\$(AssemblyName).vsdconfig"
-          Condition="'$(BuildingProject)' == 'true' AND '@(VsdConfigXml)' != '' AND '$(IsWpfTempProject)' != 'true'">
-    <PropertyGroup>
-      <_VsdConfigTool>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\$(MicrosoftVSSDKBuildToolsVersion)\tools\VSSDK\bin\vsdconfigtool.exe</_VsdConfigTool>
-    </PropertyGroup>
-
-    <Exec Command="&quot;$(_VsdConfigTool)&quot; @(VsdConfigXml -> '&quot;%(RelativeDir)%(FileName)%(Extension)&quot;', ' ') &quot;$(IntermediateOutputPath)\$(AssemblyName).dll&quot; &quot;$(OutDir)\$(AssemblyName).vsdconfig&quot;" />
-  </Target>
-
-  <Target Name="VsdConfigOutputGroup" Outputs="@(VsdConfigOutputGroupOutput)">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VSSDK.Debugger.VSDConfigTool" Version="$(MicrosoftVSSDKVSDConfigToolVersion)"
+      Condition="'$(IsWpfTempProject)' != 'true'">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <Target Name="VsdConfigOutputGroup" Outputs="@(VsdConfigOutputGroupOutput)"
+    Condition="'@(VsdConfigXmlFiles)'!=''"
+    DependsOnTargets="AddVsdbgConfigFileToOutputGroup">
     <ItemGroup>
       <VsdConfigOutputGroupOutput Include="$(OutDir)\$(AssemblyName).vsdconfig" />
     </ItemGroup>

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Microsoft.CodeAnalysis.CSharp.ExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Microsoft.CodeAnalysis.CSharp.ExpressionCompiler.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\..\Core\Source\ExpressionCompiler\Microsoft.CodeAnalysis.ExpressionCompiler.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <VsdConfigXml Include="CSharpExpressionCompiler.vsdconfigxml" />
+    <VsdConfigXmlFiles Include="CSharpExpressionCompiler.vsdconfigxml" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ExpressionCompiler.UnitTests" />

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpResultProvider.projitems
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpResultProvider.projitems
@@ -18,8 +18,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)CSharpResultProvider.cs" />
   </ItemGroup>
   <ItemGroup>
-    <VsdConfigXml Include="$(MSBuildThisFileDirectory)CSharpResultProvider.vsdconfigxml">
+    <VsdConfigXmlFiles Include="$(MSBuildThisFileDirectory)CSharpResultProvider.vsdconfigxml">
       <SubType>Designer</SubType>
-    </VsdConfigXml>
+    </VsdConfigXmlFiles>
   </ItemGroup>
 </Project>

--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/CSharp/FunctionResolver.vsdconfigxml
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/CSharp/FunctionResolver.vsdconfigxml
@@ -15,6 +15,7 @@
       <Implements>
         <InterfaceGroup Priority="Normal">
           <Filter>
+            <BaseDebugMonitorId RequiredValue="DkmBaseDebugMonitorId.TimeTravelTraceInterop"/>
             <BaseDebugMonitorId RequiredValue="DkmBaseDebugMonitorId.InProcessManagedNativeInterop"/>
             <BaseDebugMonitorId RequiredValue="DkmBaseDebugMonitorId.ClrVirtualMachine"/>
           </Filter>

--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/Microsoft.CodeAnalysis.FunctionResolver.csproj
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/Microsoft.CodeAnalysis.FunctionResolver.csproj
@@ -34,8 +34,8 @@
     <Compile Include="..\ExpressionCompiler\DkmExceptionUtilities.cs">
       <Link>ExpressionCompiler\DkmExceptionUtilities.cs</Link>
     </Compile>
-    <VsdConfigXml Include="CSharp\FunctionResolver.vsdconfigxml" />
-    <VsdConfigXml Include="VisualBasic\FunctionResolver.vsdconfigxml" />
+    <VsdConfigXmlFiles Include="CSharp\FunctionResolver.vsdconfigxml" />
+    <VsdConfigXmlFiles Include="VisualBasic\FunctionResolver.vsdconfigxml" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExpressionEvaluator.FunctionResolver.UnitTests" />

--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/VisualBasic/FunctionResolver.vsdconfigxml
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/VisualBasic/FunctionResolver.vsdconfigxml
@@ -16,6 +16,7 @@
         <InterfaceGroup Priority="Normal">
           <Filter>
             <LanguageId RequiredValue="DkmLanguageId.VB"/>
+            <BaseDebugMonitorId RequiredValue="DkmBaseDebugMonitorId.TimeTravelTraceInterop"/>
             <BaseDebugMonitorId RequiredValue="DkmBaseDebugMonitorId.InProcessManagedNativeInterop"/>
             <BaseDebugMonitorId RequiredValue="DkmBaseDebugMonitorId.ClrVirtualMachine"/>
           </Filter>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Microsoft.CodeAnalysis.VisualBasic.ExpressionCompiler.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Microsoft.CodeAnalysis.VisualBasic.ExpressionCompiler.vbproj
@@ -13,9 +13,9 @@
     <ProjectReference Include="..\..\..\Core\Source\ExpressionCompiler\Microsoft.CodeAnalysis.ExpressionCompiler.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <VsdConfigXml Include="BasicExpressionCompiler.vsdconfigxml">
+    <VsdConfigXmlFiles Include="BasicExpressionCompiler.vsdconfigxml">
       <SubType>Designer</SubType>
-    </VsdConfigXml>
+    </VsdConfigXmlFiles>
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ExpressionCompiler.UnitTests" />

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/BasicResultProvider.projitems
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/BasicResultProvider.projitems
@@ -18,9 +18,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)VisualBasicResultProvider.vb" />
   </ItemGroup>
   <ItemGroup>
-    <VsdConfigXml Include="$(MSBuildThisFileDirectory)VisualBasicResultProvider.vsdconfigxml">
+    <VsdConfigXmlFiles Include="$(MSBuildThisFileDirectory)VisualBasicResultProvider.vsdconfigxml">
       <SubType>Designer</SubType>
-    </VsdConfigXml>
+    </VsdConfigXmlFiles>
   </ItemGroup>
   <ItemGroup>
     <Import Include="IdentifierComparison=Microsoft.CodeAnalysis.CaseInsensitiveComparison" />

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -278,7 +278,7 @@
     </VSCTCompile>
   </ItemGroup>
   <ItemGroup>
-    <VsdConfigXml Include="ManagedEditAndContinueService.vsdconfigxml" />
+    <VsdConfigXmlFiles Include="ManagedEditAndContinueService.vsdconfigxml" />
   </ItemGroup>
   <Import Project="$(RepositoryEngineeringDir)targets\Vsdconfig.targets" />
 </Project>


### PR DESCRIPTION
- The function resolver isn't loaded when the base monitor is
TimeTravelTraceInterop, which needs it to resolve function for function
breakpoint.
- To add TimeTravelTraceInterop to the right vsdconfigxml file, I also
need to update some package so that it can be built.

#35317