### PR TITLE
DynamicFileInfo.cs: fix typo in the constructor

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/SourceFiles/DynamicFileInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SourceFiles/DynamicFileInfo.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Host
         public DynamicFileInfo(string filePath, SourceCodeKind sourceCodeKind, TextLoader textLoader, IDocumentServiceProvider documentServiceProvider)
         {
             FilePath = filePath;
-            SourceCodeKind = SourceCodeKind;
+            SourceCodeKind = sourceCodeKind;
             TextLoader = textLoader;
             DocumentServiceProvider = documentServiceProvider;
         }


### PR DESCRIPTION
One of the issues found in #34725