### PR TITLE
VS 2017 -> VS 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Discussion about the transition of language design to the new repos is at https:
 
 ### Download C# and Visual Basic
 
-Want to start developing in C# and Visual Basic? Download [Visual Studio 2017](https://www.visualstudio.com/downloads/), which has the latest features built-in. There are 
-also [prebuilt Azure VM images](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/category/compute?search=visual%20studio%202017) available with 
-Visual Studio 2017 already installed.
+Want to start developing in C# and Visual Basic? Download [Visual Studio 2019](https://www.visualstudio.com/downloads/), which has the latest features built-in. There are 
+also [prebuilt Azure VM images](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/category/compute?search=visual%20studio%202019) available with 
+Visual Studio 2019 already installed.
 
 To install the latest release without Visual Studio, run one of the following [nuget](https://dist.nuget.org/index.html) command lines:
 


### PR DESCRIPTION
readme has vs 2017 instead of 2019
