### PR TITLE
[EnumeratorCancellation] combines tokens

### DIFF
--- a/docs/features/async-streams.md
+++ b/docs/features/async-streams.md
@@ -3,7 +3,7 @@ async-streams (C# 8.0)
 
 Async-streams are asynchronous variants of enumerables, where getting the next element may involve an asynchronous operation. They are types that implement `IAsyncEnumerable<T>`.
 
-```C#
+```csharp
 // Those interfaces will ship as part of .NET Core 3
 namespace System.Collections.Generic
 {
@@ -40,7 +40,7 @@ An async-iterator method is a method that:
 3. uses both `await` syntax (`await` expression, `await foreach` or `await using` statements) and `yield` statements (`yield return`, `yield break`).
 
 For example:
-```C#
+```csharp
 async IAsyncEnumerable<int> GetValuesFromServer()
 {
     while (true)
@@ -86,7 +86,7 @@ thereby allowing consumers of async-streams to control cancellation.
 A producer of async-streams can make use of the cancellation token by writing an
 `IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken)` async-iterator method in a custom type.
 
-```C#
+```csharp
 E e = ((C)(x)).GetAsyncEnumerator(default);
 try
 {
@@ -117,7 +117,8 @@ But it contains additional state:
 - a promise of a value-or-end,
 - a current yielded value of type `T`,
 - an `int` capturing the id of the thread that created it,
-- a `bool` flag indicating "dispose mode".
+- a `bool` flag indicating "dispose mode",
+- a `CancellationTokenSource` for combining tokens (in enumerables).
 
 The central method of the state machine is `MoveNext()`. It gets run by `MoveNextAsync()`, or as a background continuation initiated from these from an `await` in the method.
 
@@ -133,8 +134,8 @@ Compared to the state machine for a regular async method, the `MoveNext()` for a
 - to support handling a `yield return` statement, which saves the current value and fulfills the promise with result `true`,
 - to support handling a `yield break` statement, which sets the dispose mode on and jumps to the enclosing `finally` or exit,
 - to dispatch execution to `finally` blocks (when disposing),
-- to exit the method, which fulfills the promise with result `false`,
-- to catch exceptions, which set the exception into the promise.
+- to exit the method, which disposes the `CancellationTokenSource` (if any) and fulfills the promise with result `false`,
+- to catch exceptions, which disposes the `CancellationTokenSource` (if any) and sets the exception into the promise.
 (The handling of an `await` is unchanged)
 
 This is reflected in the implementation, which extends the lowering machinery for async methods to:
@@ -143,7 +144,7 @@ This is reflected in the implementation, which extends the lowering machinery fo
 3. produce additional state and logic for the promise itself (see `AsyncIteratorRewriter`, which produces various other members: `MoveNextAsync`, `Current`, `DisposeAsync`,
 and some members supporting the resettable `ValueTask` behavior, namely `GetResult`, `SetStatus`, `OnCompleted`).
 
-```C#
+```csharp
 ValueTask<bool> MoveNextAsync()
 {
     if (state == StateMachineStates.FinishedStateMachine)
@@ -162,13 +163,13 @@ ValueTask<bool> MoveNextAsync()
 }
 ```
 
-```C#
+```csharp
 T Current => current;
 ```
 
 The kick-off method and the initialization of the state machine for an async-iterator method follows those for regular iterator methods.
 In particular, the synthesized `GetAsyncEnumerator()` method is like `GetEnumerator()` except that it sets the initial state to to StateMachineStates.NotStartedStateMachine (-1):
-```C#
+```csharp
 IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken token)
 {
     {StateMachineType} result;
@@ -182,13 +183,30 @@ IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken token)
     {
         result = new {StateMachineType}(InitialState);
     }
-    /* copy each parameter proxy, or copy the token parameter if it's not default for any parameter marked with [EnumeratorCancellation] attribute */
+    /* copy each parameter proxy, or in the case of the parameter marked with [EnumeratorCancellation] combine it with `GetAsyncEnumerator`'s `token` parameter */
+}
+```
+
+For the parameter with `[EnumeratorCancellation]`, `GetAsyncEnumerator` initializes it by combining the two available tokens:
+```csharp
+if (this.parameterProxy.Equals(default))
+{
+    result.parameter = token;
+}
+else if (token.Equals(this.parameterProxy) || token.Equals(default))
+{
+    result.parameter = this.parameterProxy;
+}
+else
+{
+    result.combinedTokens = CancellationTokenSource.CreateLinkedTokenSource(this.parameterProxy, token);
+    result.parameter = combinedTokens.Token;
 }
 ```
 For a discussion of the threadID check, see https://github.com/dotnet/corefx/issues/3481
 
 Similarly, the kick-off method is much like those of regular iterator methods:
-```C#
+```csharp
 {
     {StateMachineType} result = new {StateMachineType}(StateMachineStates.FinishedStateMachine); // -2
     /* save parameters into parameter proxies */
@@ -227,7 +245,7 @@ Looking at disposal from the perspective of a given `finally` block, the code in
 - in dispose mode, following a nested `finally`.
 
 A `yield return` is lowered as:
-```C#
+```csharp
 _current = expression;
 _state = <next_state>;
 goto <exprReturnTruelabel>; // which does _valueOrEndPromise.SetResult(true); return;
@@ -239,12 +257,12 @@ if (disposeMode) /* jump to enclosing finally or exit */
 ```
 
 A `yield break` is lowered as:
-```C#
+```csharp
 disposeMode = true;
 /* jump to enclosing finally or exit */
 ```
 
-```C#
+```csharp
 ValueTask IAsyncDisposable.DisposeAsync()
 {
     if (state >= StateMachineStates.NotStartedStateMachine /* -1 */)
@@ -266,7 +284,7 @@ ValueTask IAsyncDisposable.DisposeAsync()
 ##### Regular versus extracted finally
 
 When the `finally` clause contains no `await` expressions, a `try/finally` is lowered as:
-```C#
+```csharp
 try
 {
     ...
@@ -280,7 +298,7 @@ if (disposeMode) /* jump to enclosing finally or exit */
 ```
 
 When a `finally` contains `await` expressions, it is extracted before async rewriting (by AsyncExceptionHandlerRewriter). In those cases, we get:
-```C#
+```csharp
 try
 {
     ...
@@ -325,7 +343,7 @@ The result of invoking `DisposeAsync` from states -1 or N is unspecified. This c
  ^                                   |  |                          |
  |         done and disposed         |  |      yield return        |
  +-----------------------------------+  +-----------------------> -N
- |                                   |                             |
+ |        or exception thrown        |                             |
  |                                   |                             |
  |                             yield |                             |
  |                             break |           DisposeAsync      |

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5901,6 +5901,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_UndecoratedCancellationTokenParameter_Title" xml:space="preserve">
     <value>Async-iterator member has one or more parameters of type 'CancellationToken' but none of them is decorated with the 'EnumeratorCancellation' attribute, so the cancellation token parameter from the generated 'IAsyncEnumerable&lt;>.GetAsyncEnumerator' will be unconsumed</value>
   </data>
+  <data name="ERR_MultipleEnumeratorCancellationAttributes" xml:space="preserve">
+    <value>The EnumeratorCancellationAttribute cannot be used on multiple parameters</value>
+  </data>
   <data name="ERR_OverrideRefConstraintNotSatisfied" xml:space="preserve">
     <value>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5902,7 +5902,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Async-iterator member has one or more parameters of type 'CancellationToken' but none of them is decorated with the 'EnumeratorCancellation' attribute, so the cancellation token parameter from the generated 'IAsyncEnumerable&lt;>.GetAsyncEnumerator' will be unconsumed</value>
   </data>
   <data name="ERR_MultipleEnumeratorCancellationAttributes" xml:space="preserve">
-    <value>The EnumeratorCancellationAttribute cannot be used on multiple parameters</value>
+    <value>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</value>
   </data>
   <data name="ERR_OverrideRefConstraintNotSatisfied" xml:space="preserve">
     <value>Method '{0}' specifies a 'class' constraint for type parameter '{1}', but corresponding type parameter '{2}' of overridden or explicitly implemented method '{3}' is not a reference type.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1601,6 +1601,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AttributeNotOnEventAccessor = 8423,
         WRN_UnconsumedEnumeratorCancellationAttributeUsage = 8424,
         WRN_UndecoratedCancellationTokenParameter = 8425,
+        ERR_MultipleEnumeratorCancellationAttributes = 8426,
         // available range
 
         #region diagnostics introduced for recursive patterns

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorInfo.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorInfo.cs
@@ -12,6 +12,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         // This `ManualResetValueTaskSourceCore<bool>` struct implements the `IValueTaskSource` logic
         internal FieldSymbol PromiseOfValueOrEndField { get; }
 
+        // This `CancellationTokenSource` field helps combine two cancellation tokens
+        internal FieldSymbol CombinedTokensField { get; }
+
         // Stores the current/yielded value
         internal FieldSymbol CurrentField { get; }
 
@@ -24,10 +27,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         // Method to fulfill the promise with an exception: `void ManualResetValueTaskSourceCore<T>.SetException(Exception error)`
         internal MethodSymbol SetExceptionMethod { get; }
 
-        public AsyncIteratorInfo(FieldSymbol promiseOfValueOrEndField, FieldSymbol currentField, FieldSymbol disposeModeField,
+        public AsyncIteratorInfo(FieldSymbol promiseOfValueOrEndField, FieldSymbol combinedTokensField, FieldSymbol currentField, FieldSymbol disposeModeField,
             MethodSymbol setResultMethod, MethodSymbol setExceptionMethod)
         {
             PromiseOfValueOrEndField = promiseOfValueOrEndField;
+            CombinedTokensField = combinedTokensField;
             CurrentField = currentField;
             DisposeModeField = disposeModeField;
             SetResultMethod = setResultMethod;

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncIteratorMethodToStateMachineRewriter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeGen;
@@ -66,6 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // ... _exprReturnLabel: ...
             // ... this.state = FinishedState; ...
 
+            // if (this.combinedTokens != null) this.combinedTokens.Dispose(); // for enumerables only
             // this.promiseOfValueOrEnd.SetResult(false);
             // return;
             // _exprReturnLabelTrue:
@@ -74,13 +76,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             // ... _exitLabel: ...
             // ... return; ...
 
-            return F.Block(
+            var builder = ArrayBuilder<BoundStatement>.GetInstance();
+
+            // if (this.combinedTokens != null) this.combinedTokens.Dispose(); // for enumerables only
+            AddDisposeCombinedTokensIfNeeded(builder);
+
+            builder.AddRange(
                 // this.promiseOfValueOrEnd.SetResult(false);
                 generateSetResultOnPromise(false),
                 F.Return(),
                 F.Label(_exprReturnLabelTrue),
                 // this.promiseOfValueOrEnd.SetResult(true);
                 generateSetResultOnPromise(true));
+
+            return F.Block(builder.ToImmutableAndFree());
 
             BoundExpressionStatement generateSetResultOnPromise(bool result)
             {
@@ -91,13 +100,32 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        private void AddDisposeCombinedTokensIfNeeded(ArrayBuilder<BoundStatement> builder)
+        {
+            // if (this.combinedTokens != null) this.combinedTokens.Dispose(); // for enumerables only
+            if (_asyncIteratorInfo.CombinedTokensField is object)
+            {
+                var combinedTokens = F.Field(F.This(), _asyncIteratorInfo.CombinedTokensField);
+                builder.Add(
+                    F.If(F.ObjectNotEqual(combinedTokens, F.Null(combinedTokens.Type)),
+                        thenClause: F.ExpressionStatement(F.Call(combinedTokens, F.WellKnownMethod(WellKnownMember.System_Threading_CancellationTokenSource__Dispose)))));
+            }
+        }
+
         protected override BoundStatement GenerateSetExceptionCall(LocalSymbol exceptionLocal)
         {
+            var builder = ArrayBuilder<BoundStatement>.GetInstance();
+
+            // if (this.combinedTokens != null) this.combinedTokens.Dispose(); // for enumerables only
+            AddDisposeCombinedTokensIfNeeded(builder);
+
             // _promiseOfValueOrEnd.SetException(ex);
-            return F.ExpressionStatement(F.Call(
+            builder.Add(F.ExpressionStatement(F.Call(
                 F.InstanceField(_asyncIteratorInfo.PromiseOfValueOrEndField),
                 _asyncIteratorInfo.SetExceptionMethod,
-                F.Local(exceptionLocal)));
+                F.Local(exceptionLocal))));
+
+            return F.Block(builder.ToImmutableAndFree());
         }
 
         private BoundStatement GenerateJumpToCurrentFinallyOrExit()

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // catch (Exception ex)
             // {
             //     _state = finishedState;
-            //     builder.SetException(ex);  OR   _promiseOfValueOrEnd.SetException(ex); /* for async-iterator method */
+            //     builder.SetException(ex);  OR  if (this.combinedTokens != null) this.combinedTokens.Dispose(); _promiseOfValueOrEnd.SetException(ex); /* for async-iterator method */
             //     return;
             // }
 
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundStatement assignFinishedState =
                 F.ExpressionStatement(F.AssignmentExpression(F.Field(F.This(), stateField), F.Literal(StateMachineStates.FinishedStateMachine)));
 
-            // builder.SetException(ex);  OR  _promiseOfValueOrEnd.SetException(ex);
+            // builder.SetException(ex);  OR  if (this.combinedTokens != null) this.combinedTokens.Dispose(); _promiseOfValueOrEnd.SetException(ex);
             BoundStatement callSetException = GenerateSetExceptionCall(exceptionLocal);
 
             return new BoundCatchBlock(
@@ -234,6 +234,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected virtual BoundStatement GenerateSetExceptionCall(LocalSymbol exceptionLocal)
         {
+            Debug.Assert(!CurrentMethod.IsIterator); // an override handles async-iterators
+
             // builder.SetException(ex);
             return F.ExpressionStatement(
                 F.Call(

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncIteratorRewriter.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             private FieldSymbol _promiseOfValueOrEndField; // this struct implements the IValueTaskSource logic
             private FieldSymbol _currentField; // stores the current/yielded value
             private FieldSymbol _disposeModeField; // whether the state machine is in dispose mode (ie. skipping all logic except that in `catch` and `finally`, yielding no new elements)
+            private FieldSymbol _combinedTokensField; // CancellationTokenSource for combining tokens
 
             // true if the iterator implements IAsyncEnumerable<T>,
             // false if it implements IAsyncEnumerator<T>
@@ -46,7 +47,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (_isEnumerable)
                 {
                     EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerable_T__GetAsyncEnumerator, bag);
+                    EnsureWellKnownMember(WellKnownMember.System_Threading_CancellationToken__Equals, bag);
+                    EnsureWellKnownMember(WellKnownMember.System_Threading_CancellationTokenSource__CreateLinkedTokenSource, bag);
+                    EnsureWellKnownMember(WellKnownMember.System_Threading_CancellationTokenSource__Token, bag);
+                    EnsureWellKnownMember(WellKnownMember.System_Threading_CancellationTokenSource__Dispose, bag);
                 }
+
                 EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerator_T__MoveNextAsync, bag);
                 EnsureWellKnownMember(WellKnownMember.System_Collections_Generic_IAsyncEnumerator_T__get_Current, bag);
 
@@ -124,6 +130,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // Add a field: bool disposeMode
                 _disposeModeField = F.StateMachineField(boolType, GeneratedNames.MakeDisposeModeFieldName());
+
+                if (_isEnumerable)
+                {
+                    // Add a field: CancellationTokenSource combinedTokens
+                    _combinedTokensField = F.StateMachineField(
+                        F.WellKnownType(WellKnownType.System_Threading_CancellationTokenSource),
+                        GeneratedNames.MakeAsyncIteratorCombinedTokensFieldName());
+                }
             }
 
             protected override void GenerateConstructor()
@@ -174,6 +188,56 @@ namespace Microsoft.CodeAnalysis.CSharp
                     F.Assignment(
                         F.Local(stateMachineLocal),
                         F.New(stateMachineType.Constructor.AsMember(frameType), F.Literal(initialState))));
+            }
+
+            protected override BoundStatement InitializeParameterField(MethodSymbol getEnumeratorMethod, ParameterSymbol parameter, BoundExpression resultParameter, BoundExpression parameterProxy)
+            {
+                BoundStatement result;
+                if (parameter is SourceComplexParameterSymbol { HasEnumeratorCancellationAttribute: true })
+                {
+                    // For the parameter with [EnumeratorCancellation]
+                    // if (this.parameterProxy.Equals(default))
+                    // {
+                    //     result.parameter = token;
+                    // }
+                    // else if (token.Equals(this.parameterProxy) || token.Equals(default))
+                    // {
+                    //     result.parameter = this.parameterProxy;
+                    // }
+                    // else
+                    // {
+                    //     result.combinedTokens = CancellationTokenSource.CreateLinkedTokenSource(this.parameterProxy, token);
+                    //     result.parameter = combinedTokens.Token;
+                    // }
+
+                    BoundParameter tokenParameter = F.Parameter(getEnumeratorMethod.Parameters[0]);
+                    BoundFieldAccess combinedTokens = F.Field(F.This(), _combinedTokensField);
+                    result = F.If(
+                        // if (this.parameterProxy.Equals(default))
+                        F.Call(parameterProxy, WellKnownMember.System_Threading_CancellationToken__Equals, F.Default(parameterProxy.Type)),
+                        // result.parameter = token;
+                        thenClause: F.Assignment(resultParameter, tokenParameter),
+                        elseClauseOpt: F.If(
+                            // else if (token.Equals(this.parameterProxy) || token.Equals(default))
+                            F.LogicalOr(
+                                F.Call(tokenParameter, WellKnownMember.System_Threading_CancellationToken__Equals, parameterProxy),
+                                F.Call(tokenParameter, WellKnownMember.System_Threading_CancellationToken__Equals, F.Default(tokenParameter.Type))),
+                            // result.parameter = this.parameterProxy;
+                            thenClause: F.Assignment(resultParameter, parameterProxy),
+                            elseClauseOpt: F.Block(
+                                // result.combinedTokens = CancellationTokenSource.CreateLinkedTokenSource(this.parameterProxy, token);
+                                F.Assignment(combinedTokens, F.StaticCall(WellKnownMember.System_Threading_CancellationTokenSource__CreateLinkedTokenSource, parameterProxy, tokenParameter)),
+                                // result.parameter = result.combinedTokens.Token;
+                                F.Assignment(resultParameter, F.Property(combinedTokens, WellKnownMember.System_Threading_CancellationTokenSource__Token)))));
+                }
+                else
+                {
+                    // For parameters that don't have [EnumeratorCancellation], initialize their parameter fields
+                    // result.parameter = this.parameterProxy;
+                    result = F.Assignment(resultParameter, parameterProxy);
+                }
+
+                return result;
             }
 
             protected override BoundStatement GenerateStateMachineCreation(LocalSymbol stateMachineVariable, NamedTypeSymbol frameType)
@@ -590,7 +654,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     method: method,
                     methodOrdinal: _methodOrdinal,
                     asyncMethodBuilderMemberCollection: _asyncMethodBuilderMemberCollection,
-                    asyncIteratorInfo: new AsyncIteratorInfo(_promiseOfValueOrEndField, _currentField, _disposeModeField, setResultMethod, setExceptionMethod),
+                    asyncIteratorInfo: new AsyncIteratorInfo(_promiseOfValueOrEndField, _combinedTokensField, _currentField, _disposeModeField, setResultMethod, setExceptionMethod),
                     F: F,
                     state: stateField,
                     builder: _builderField,

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -375,10 +375,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //        result = new {StateMachineType}({initialState});
             //    }
             //
-            //    // Initialize each parameter fields
-            //    result.parameter = this.parameterProxy;
-            //      OR
-            //    if (token.Equals(default)) { result.parameter = this.parameterProxy; } else { result.parameter = token; } // for async-enumerable parameters marked with [EnumeratorCancellation]
+            //    result.parameter = this.parameterProxy; // OR more complex initialization for async-iterator parameter marked with [EnumeratorCancellation]
 
             // The implementation doesn't depend on the method body of the iterator method.
             // Only on its parameters and staticness.
@@ -455,29 +452,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CapturedSymbolReplacement proxy;
                 if (copyDest.TryGetValue(parameter, out proxy))
                 {
-                    // result.parameter = this.parameterProxy;
-                    BoundExpression left = proxy.Replacement(F.Syntax, stateMachineType => F.Local(resultVariable));
-                    BoundStatement copy = F.Assignment(
-                            left,
-                            copySrc[parameter].Replacement(F.Syntax, stateMachineType => F.This()));
-
-                    if (this.method.IsAsync && parameter is SourceComplexParameterSymbol { HasEnumeratorCancellationAttribute: true })
-                    {
-                        ParameterSymbol tokenParameter = getEnumeratorMethod.Parameters[0];
-                        // For any async-enumerable parameter marked with [EnumeratorCancellation] attribute, conditionally copy GetAsyncEnumerator's cancellation token parameter instead
-                        // if (token.Equals(default))
-                        //     result.parameter = this.parameterProxy;
-                        // else
-                        //     result.parameter = token;
-
-                        copy = F.If(
-                            // if (token.Equals(default))
-                            F.Call(F.Parameter(tokenParameter), WellKnownMember.System_Threading_CancellationToken__Equals, F.Default(tokenParameter.Type)),
-                            // result.parameter = this.parameterProxy;
-                            copy,
-                            // result.parameter = token;
-                            F.Assignment(left, F.Parameter(tokenParameter)));
-                    }
+                    // result.parameter
+                    BoundExpression resultParameter = proxy.Replacement(F.Syntax, stateMachineType => F.Local(resultVariable));
+                    // this.parameterProxy
+                    BoundExpression parameterProxy = copySrc[parameter].Replacement(F.Syntax, stateMachineType => F.This());
+                    BoundStatement copy = InitializeParameterField(getEnumeratorMethod, parameter, resultParameter, parameterProxy);
 
                     bodyBuilder.Add(copy);
                 }
@@ -486,6 +465,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             bodyBuilder.Add(F.Return(F.Local(resultVariable)));
             F.CloseMethod(F.Block(ImmutableArray.Create(resultVariable), bodyBuilder.ToImmutableAndFree()));
             return getEnumerator;
+        }
+
+        protected virtual BoundStatement InitializeParameterField(MethodSymbol getEnumeratorMethod, ParameterSymbol parameter, BoundExpression resultParameter, BoundExpression parameterProxy)
+        {
+            Debug.Assert(!method.IsIterator || !method.IsAsync); // an override handles async-iterators
+
+            // result.parameter = this.parameterProxy;
+            return F.Assignment(resultParameter, parameterProxy);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -184,16 +184,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var location = this.Locations[0];
             if (IsAsync)
             {
-                // Warn for CancellationToken parameters in async-iterators with no parameter decorated with [EnumeratorCancellation]
                 var cancellationTokenType = DeclaringCompilation.GetWellKnownType(WellKnownType.System_Threading_CancellationToken);
                 var iAsyncEnumerableType = DeclaringCompilation.GetWellKnownType(WellKnownType.System_Collections_Generic_IAsyncEnumerable_T);
+                var enumeratorCancellationCount = Parameters.Count(p => p is SourceComplexParameterSymbol { HasEnumeratorCancellationAttribute: true });
                 if (ReturnType.OriginalDefinition.Equals(iAsyncEnumerableType) &&
-                    (Bodies.blockBody != null || Bodies.arrowBody != null) &&
-                    ParameterTypesWithAnnotations.Any(p => p.Type.Equals(cancellationTokenType)) &&
-                    !Parameters.Any(p => p is SourceComplexParameterSymbol { HasEnumeratorCancellationAttribute: true }))
+                    (Bodies.blockBody != null || Bodies.arrowBody != null))
                 {
-                    // There could be more than one parameter that could be decorated with [EnumeratorCancellation] so we warn on the method instead
-                    diagnostics.Add(ErrorCode.WRN_UndecoratedCancellationTokenParameter, location, this);
+                    if (ParameterTypesWithAnnotations.Any(p => p.Type.Equals(cancellationTokenType)) &&
+                        enumeratorCancellationCount == 0)
+                    {
+                        // Warn for CancellationToken parameters in async-iterators with no parameter decorated with [EnumeratorCancellation]
+                        // There could be more than one parameter that could be decorated with [EnumeratorCancellation] so we warn on the method instead
+                        diagnostics.Add(ErrorCode.WRN_UndecoratedCancellationTokenParameter, location, this);
+                    }
+
+                    if (enumeratorCancellationCount > 1)
+                    {
+                        // The [EnumeratorCancellation] attribute can only be used on one parameter
+                        diagnostics.Add(ErrorCode.ERR_MultipleEnumeratorCancellationAttributes, location);
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -190,8 +190,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (ReturnType.OriginalDefinition.Equals(iAsyncEnumerableType) &&
                     (Bodies.blockBody != null || Bodies.arrowBody != null))
                 {
-                    if (ParameterTypesWithAnnotations.Any(p => p.Type.Equals(cancellationTokenType)) &&
-                        enumeratorCancellationCount == 0)
+                    if (enumeratorCancellationCount == 0 &&
+                        ParameterTypesWithAnnotations.Any(p => p.Type.Equals(cancellationTokenType)))
                     {
                         // Warn for CancellationToken parameters in async-iterators with no parameter decorated with [EnumeratorCancellation]
                         // There could be more than one parameter that could be decorated with [EnumeratorCancellation] so we warn on the method instead

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs
@@ -39,7 +39,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         DynamicCallSiteContainerType = 'o',
         DynamicCallSiteField = 'p',
         AsyncIteratorPromiseOfValueOrEndBackingField = 'v',
-        DisposeModeField = 'w', // last
+        DisposeModeField = 'w',
+        CombinedTokensField = 'x', // last
 
         // Deprecated - emitted by Dev12, but not by Roslyn.
         // Don't reuse the values because the debugger might encounter them when consuming old binaries.

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
@@ -436,6 +436,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return "<>v__promiseOfValueOrEnd";
         }
 
+        internal static string MakeAsyncIteratorCombinedTokensFieldName()
+        {
+            Debug.Assert((char)GeneratedNameKind.CombinedTokensField == 'x');
+            return "<>x__combinedTokens";
+        }
+
         internal static string MakeIteratorCurrentFieldName()
         {
             Debug.Assert((char)GeneratedNameKind.IteratorCurrentBackingField == '2');

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">Omezení new() nejde používat s omezením unmanaged.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">Die new()-Einschränkung kann nicht mit der unmanaged-Einschränkung verwendet werden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">La restricción "new()" no se puede utilizar con la restricción "unmanaged"</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">La contrainte 'new()' ne peut pas être utilisée avec la contrainte 'unmanaged'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">Non è possibile usare il vincolo 'new()' con il vincolo 'unmanaged'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">new()' 制約は 'unmanaged' 制約と一緒には使用できません</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">new()' 제약 조건은 'unmanaged' 제약 조건과 함께 사용할 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">Ograniczenie „new()” nie może być używane z ograniczeniem „unmanaged”</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">A restrição 'new()' não pode ser usada com a restrição 'unmanaged'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">Ограничение "new()" невозможно использовать вместе с ограничением "unmanaged"</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">'new()' kısıtlaması, 'unmanaged' kısıtlamasıyla kullanılamaz</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -283,8 +283,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -282,6 +282,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">"new()" 约束不能与 "unmanaged" 约束一起使用</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -257,6 +257,11 @@
         <target state="new">Multiple analyzer config files cannot be in the same directory ('{0}').</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
+        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
+        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">
         <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
         <target state="translated">new()' 條件約束不能和 'unmanaged' 條件約束一起使用</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MultipleEnumeratorCancellationAttributes">
-        <source>The EnumeratorCancellationAttribute cannot be used on multiple parameters</source>
-        <target state="new">The EnumeratorCancellationAttribute cannot be used on multiple parameters</target>
+        <source>The attribute [EnumeratorCancellation] cannot be used on multiple parameters</source>
+        <target state="new">The attribute [EnumeratorCancellation] cannot be used on multiple parameters</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_NewBoundWithUnmanaged">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -114,7 +113,7 @@ class C
 
         private static void VerifyMissingType(string source, WellKnownType type, params DiagnosticDescription[] expected)
         {
-            var lib = CreateCompilationWithTasksExtensions(AsyncStreamsTypes);
+            var lib = CreateCompilationWithTasksExtensions(new[] { AsyncStreamsTypes });
             var lib_ref = lib.EmitToImageReference();
             var comp = CreateCompilationWithTasksExtensions(source, references: new[] { lib_ref });
             comp.MakeTypeMissing(type);
@@ -860,6 +859,74 @@ namespace System
                 //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Threading.Tasks.ValueTask", ".ctor").WithLocation(5, 64)
                 );
+        }
+
+        [Fact]
+        public void MissingTypeAndMembers_CancellationToken()
+        {
+            VerifyMissingMember(_enumerable, WellKnownMember.System_Threading_CancellationToken__Equals,
+                // (5,64): error CS0656: Missing compiler required member 'System.Threading.CancellationToken.Equals'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Threading.CancellationToken", "Equals").WithLocation(5, 64)
+                );
+
+            VerifyMissingMember(_enumerator, WellKnownMember.System_Threading_CancellationToken__Equals);
+
+            VerifyMissingType(_enumerable, WellKnownType.System_Threading_CancellationToken,
+                // (5,64): error CS0656: Missing compiler required member 'System.Collections.Generic.IAsyncEnumerable`1.GetAsyncEnumerator'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Collections.Generic.IAsyncEnumerable`1", "GetAsyncEnumerator").WithLocation(5, 64),
+                // (5,64): error CS0656: Missing compiler required member 'System.Threading.CancellationToken.Equals'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Threading.CancellationToken", "Equals").WithLocation(5, 64),
+                // (5,64): error CS0656: Missing compiler required member 'System.Threading.CancellationTokenSource.CreateLinkedTokenSource'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Threading.CancellationTokenSource", "CreateLinkedTokenSource").WithLocation(5, 64),
+                // (5,64): error CS0656: Missing compiler required member 'System.Threading.CancellationTokenSource.Token'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Threading.CancellationTokenSource", "Token").WithLocation(5, 64)
+                );
+
+            VerifyMissingType(_enumerator, WellKnownType.System_Threading_CancellationToken);
+        }
+
+        [Fact]
+        public void MissingTypeAndMembers_CancellationTokenSource()
+        {
+            VerifyMissingMember(_enumerable, WellKnownMember.System_Threading_CancellationTokenSource__CreateLinkedTokenSource,
+                // (5,64): error CS0656: Missing compiler required member 'System.Threading.CancellationTokenSource.CreateLinkedTokenSource'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Threading.CancellationTokenSource", "CreateLinkedTokenSource").WithLocation(5, 64)
+                );
+
+            VerifyMissingMember(_enumerable, WellKnownMember.System_Threading_CancellationTokenSource__Token,
+                // (5,64): error CS0656: Missing compiler required member 'System.Threading.CancellationTokenSource.Token'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Threading.CancellationTokenSource", "Token").WithLocation(5, 64)
+                );
+
+            VerifyMissingMember(_enumerable, WellKnownMember.System_Threading_CancellationTokenSource__Dispose,
+                // (5,64): error CS0656: Missing compiler required member 'System.Threading.CancellationTokenSource.Dispose'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Threading.CancellationTokenSource", "Dispose").WithLocation(5, 64)
+                );
+
+            VerifyMissingType(_enumerable, WellKnownType.System_Threading_CancellationTokenSource,
+                // (5,64): error CS0656: Missing compiler required member 'System.Threading.CancellationTokenSource.CreateLinkedTokenSource'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Threading.CancellationTokenSource", "CreateLinkedTokenSource").WithLocation(5, 64),
+                // (5,64): error CS0656: Missing compiler required member 'System.Threading.CancellationTokenSource.Token'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Threading.CancellationTokenSource", "Token").WithLocation(5, 64),
+                // (5,64): error CS0656: Missing compiler required member 'System.Threading.CancellationTokenSource.Dispose'
+                //     async System.Collections.Generic.IAsyncEnumerable<int> M() { await Task.CompletedTask; yield return 3; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.CompletedTask; yield return 3; }").WithArguments("System.Threading.CancellationTokenSource", "Dispose").WithLocation(5, 64)
+                );
+
+            VerifyMissingMember(_enumerator, WellKnownMember.System_Threading_CancellationTokenSource__CreateLinkedTokenSource);
+            VerifyMissingMember(_enumerator, WellKnownMember.System_Threading_CancellationTokenSource__Token);
+            VerifyMissingMember(_enumerator, WellKnownMember.System_Threading_CancellationTokenSource__Dispose);
+            VerifyMissingType(_enumerator, WellKnownType.System_Threading_CancellationTokenSource);
         }
 
         [Fact]
@@ -2055,7 +2122,7 @@ class C
                 {
                     verifier.VerifyIL("C.<M>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
 @"{
-  // Code size      298 (0x12a)
+  // Code size      338 (0x152)
   .maxstack  3
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter V_1,
@@ -2084,7 +2151,7 @@ class C
     IL_002f:  ldarg.0
     IL_0030:  ldfld      ""bool C.<M>d__0.<>w__disposeMode""
     IL_0035:  brfalse.s  IL_003c
-    IL_0037:  leave      IL_0106
+    IL_0037:  leave      IL_011a
     IL_003c:  ldarg.0
     IL_003d:  ldc.i4.m1
     IL_003e:  dup
@@ -2121,7 +2188,7 @@ class C
     IL_007f:  ldloca.s   V_2
     IL_0081:  call       ""void System.Runtime.CompilerServices.AsyncIteratorMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<M>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<M>d__0)""
     IL_0086:  nop
-    IL_0087:  leave      IL_0129
+    IL_0087:  leave      IL_0151
     // async: resume
     IL_008c:  ldarg.0
     IL_008d:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<M>d__0.<>u__1""
@@ -2150,7 +2217,7 @@ class C
     IL_00c5:  dup
     IL_00c6:  stloc.0
     IL_00c7:  stfld      ""int C.<M>d__0.<>1__state""
-    IL_00cc:  leave.s    IL_011c
+    IL_00cc:  leave.s    IL_0144
     // sequence point: <hidden>
     IL_00ce:  ldarg.0
     IL_00cf:  ldc.i4.m1
@@ -2160,12 +2227,12 @@ class C
     IL_00d7:  ldarg.0
     IL_00d8:  ldfld      ""bool C.<M>d__0.<>w__disposeMode""
     IL_00dd:  brfalse.s  IL_00e1
-    IL_00df:  leave.s    IL_0106
+    IL_00df:  leave.s    IL_011a
     // sequence point: Write("" 4 "");
     IL_00e1:  ldstr      "" 4 ""
     IL_00e6:  call       ""void System.Console.Write(string)""
     IL_00eb:  nop
-    IL_00ec:  leave.s    IL_0106
+    IL_00ec:  leave.s    IL_011a
   }
   catch System.Exception
   {
@@ -2175,36 +2242,50 @@ class C
     IL_00f0:  ldc.i4.s   -2
     IL_00f2:  stfld      ""int C.<M>d__0.<>1__state""
     IL_00f7:  ldarg.0
-    IL_00f8:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-    IL_00fd:  ldloc.3
-    IL_00fe:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetException(System.Exception)""
-    IL_0103:  nop
-    IL_0104:  leave.s    IL_0129
+    IL_00f8:  ldfld      ""System.Threading.CancellationTokenSource C.<M>d__0.<>x__combinedTokens""
+    IL_00fd:  brfalse.s  IL_010b
+    IL_00ff:  ldarg.0
+    IL_0100:  ldfld      ""System.Threading.CancellationTokenSource C.<M>d__0.<>x__combinedTokens""
+    IL_0105:  callvirt   ""void System.Threading.CancellationTokenSource.Dispose()""
+    IL_010a:  nop
+    IL_010b:  ldarg.0
+    IL_010c:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+    IL_0111:  ldloc.3
+    IL_0112:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetException(System.Exception)""
+    IL_0117:  nop
+    IL_0118:  leave.s    IL_0151
   }
   // sequence point: }
-  IL_0106:  ldarg.0
-  IL_0107:  ldc.i4.s   -2
-  IL_0109:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_011a:  ldarg.0
+  IL_011b:  ldc.i4.s   -2
+  IL_011d:  stfld      ""int C.<M>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_010e:  ldarg.0
-  IL_010f:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-  IL_0114:  ldc.i4.0
-  IL_0115:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
-  IL_011a:  nop
-  IL_011b:  ret
-  IL_011c:  ldarg.0
-  IL_011d:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-  IL_0122:  ldc.i4.1
-  IL_0123:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
-  IL_0128:  nop
-  IL_0129:  ret
+  IL_0122:  ldarg.0
+  IL_0123:  ldfld      ""System.Threading.CancellationTokenSource C.<M>d__0.<>x__combinedTokens""
+  IL_0128:  brfalse.s  IL_0136
+  IL_012a:  ldarg.0
+  IL_012b:  ldfld      ""System.Threading.CancellationTokenSource C.<M>d__0.<>x__combinedTokens""
+  IL_0130:  callvirt   ""void System.Threading.CancellationTokenSource.Dispose()""
+  IL_0135:  nop
+  IL_0136:  ldarg.0
+  IL_0137:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+  IL_013c:  ldc.i4.0
+  IL_013d:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
+  IL_0142:  nop
+  IL_0143:  ret
+  IL_0144:  ldarg.0
+  IL_0145:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+  IL_014a:  ldc.i4.1
+  IL_014b:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
+  IL_0150:  nop
+  IL_0151:  ret
 }", sequencePoints: "C+<M>d__0.MoveNext", source: source);
                 }
                 else
                 {
                     verifier.VerifyIL("C.<M>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      278 (0x116)
+  // Code size      316 (0x13c)
   .maxstack  3
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter V_1,
@@ -2229,7 +2310,7 @@ class C
     IL_0024:  ldarg.0
     IL_0025:  ldfld      ""bool C.<M>d__0.<>w__disposeMode""
     IL_002a:  brfalse.s  IL_0031
-    IL_002c:  leave      IL_00f4
+    IL_002c:  leave      IL_0107
     IL_0031:  ldarg.0
     IL_0032:  ldc.i4.m1
     IL_0033:  dup
@@ -2262,7 +2343,7 @@ class C
     IL_0070:  ldloca.s   V_1
     IL_0072:  ldloca.s   V_2
     IL_0074:  call       ""void System.Runtime.CompilerServices.AsyncIteratorMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<M>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<M>d__0)""
-    IL_0079:  leave      IL_0115
+    IL_0079:  leave      IL_013b
     // async: resume
     IL_007e:  ldarg.0
     IL_007f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<M>d__0.<>u__1""
@@ -2289,7 +2370,7 @@ class C
     IL_00b5:  dup
     IL_00b6:  stloc.0
     IL_00b7:  stfld      ""int C.<M>d__0.<>1__state""
-    IL_00bc:  leave.s    IL_0109
+    IL_00bc:  leave.s    IL_012f
     // sequence point: <hidden>
     IL_00be:  ldarg.0
     IL_00bf:  ldc.i4.m1
@@ -2299,11 +2380,11 @@ class C
     IL_00c7:  ldarg.0
     IL_00c8:  ldfld      ""bool C.<M>d__0.<>w__disposeMode""
     IL_00cd:  brfalse.s  IL_00d1
-    IL_00cf:  leave.s    IL_00f4
+    IL_00cf:  leave.s    IL_0107
     // sequence point: Write("" 4 "");
     IL_00d1:  ldstr      "" 4 ""
     IL_00d6:  call       ""void System.Console.Write(string)""
-    IL_00db:  leave.s    IL_00f4
+    IL_00db:  leave.s    IL_0107
   }
   catch System.Exception
   {
@@ -2313,26 +2394,38 @@ class C
     IL_00df:  ldc.i4.s   -2
     IL_00e1:  stfld      ""int C.<M>d__0.<>1__state""
     IL_00e6:  ldarg.0
-    IL_00e7:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-    IL_00ec:  ldloc.3
-    IL_00ed:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetException(System.Exception)""
-    IL_00f2:  leave.s    IL_0115
+    IL_00e7:  ldfld      ""System.Threading.CancellationTokenSource C.<M>d__0.<>x__combinedTokens""
+    IL_00ec:  brfalse.s  IL_00f9
+    IL_00ee:  ldarg.0
+    IL_00ef:  ldfld      ""System.Threading.CancellationTokenSource C.<M>d__0.<>x__combinedTokens""
+    IL_00f4:  callvirt   ""void System.Threading.CancellationTokenSource.Dispose()""
+    IL_00f9:  ldarg.0
+    IL_00fa:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+    IL_00ff:  ldloc.3
+    IL_0100:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetException(System.Exception)""
+    IL_0105:  leave.s    IL_013b
   }
   // sequence point: }
-  IL_00f4:  ldarg.0
-  IL_00f5:  ldc.i4.s   -2
-  IL_00f7:  stfld      ""int C.<M>d__0.<>1__state""
+  IL_0107:  ldarg.0
+  IL_0108:  ldc.i4.s   -2
+  IL_010a:  stfld      ""int C.<M>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_00fc:  ldarg.0
-  IL_00fd:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-  IL_0102:  ldc.i4.0
-  IL_0103:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
-  IL_0108:  ret
-  IL_0109:  ldarg.0
-  IL_010a:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
-  IL_010f:  ldc.i4.1
-  IL_0110:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
-  IL_0115:  ret
+  IL_010f:  ldarg.0
+  IL_0110:  ldfld      ""System.Threading.CancellationTokenSource C.<M>d__0.<>x__combinedTokens""
+  IL_0115:  brfalse.s  IL_0122
+  IL_0117:  ldarg.0
+  IL_0118:  ldfld      ""System.Threading.CancellationTokenSource C.<M>d__0.<>x__combinedTokens""
+  IL_011d:  callvirt   ""void System.Threading.CancellationTokenSource.Dispose()""
+  IL_0122:  ldarg.0
+  IL_0123:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+  IL_0128:  ldc.i4.0
+  IL_0129:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
+  IL_012e:  ret
+  IL_012f:  ldarg.0
+  IL_0130:  ldflda     ""System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool> C.<M>d__0.<>v__promiseOfValueOrEnd""
+  IL_0135:  ldc.i4.1
+  IL_0136:  call       ""void System.Threading.Tasks.Sources.ManualResetValueTaskSourceCore<bool>.SetResult(bool)""
+  IL_013b:  ret
 }", sequencePoints: "C+<M>d__0.MoveNext", source: source);
                 }
             }
@@ -5027,7 +5120,7 @@ class C
     {
         using CancellationTokenSource source = new CancellationTokenSource();
         CancellationToken token = source.Token;
-        var enumerable = Iter(42, token);
+        var enumerable = Iter(42, token, token);
         await using var enumerator = enumerable.GetAsyncEnumerator(); // no token passed
 
         if (!await enumerator.MoveNextAsync()) throw null;
@@ -5046,8 +5139,9 @@ class C
             Write(""Cancelled"");
         }
     }
-    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [EnumeratorCancellation] CancellationToken token)
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [EnumeratorCancellation] CancellationToken token, CancellationToken origToken)
     {
+        if (!token.Equals(origToken)) throw null; // no need for a combined token 
         yield return value++;
         await Task.Yield();
         yield return value++;
@@ -5061,6 +5155,55 @@ class C
             CompileAndVerify(comp, expectedOutput: "42 43 Cancelled");
 
             // IL for GetAsyncEnumerator is verified by AsyncIteratorWithAwaitCompletedAndYield already
+        }
+
+        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        public void CancellationTokenParameter_SameTokenPassedInGetAsyncEnumerator()
+        {
+            string source = @"
+using static System.Console;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+class C
+{
+    static async Task Main()
+    {
+        using CancellationTokenSource source = new CancellationTokenSource();
+        CancellationToken token = source.Token;
+        var enumerable = Iter(42, token, origToken: token);
+        await using var enumerator = enumerable.GetAsyncEnumerator(token); // same token passed
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 42
+
+        if (!await enumerator.MoveNextAsync()) throw null;
+        System.Console.Write($""{enumerator.Current} ""); // 43
+
+        source.Cancel();
+        try
+        {
+            await enumerator.MoveNextAsync();
+        }
+        catch (System.OperationCanceledException)
+        {
+            Write(""Cancelled"");
+        }
+    }
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [EnumeratorCancellation] CancellationToken token, CancellationToken origToken)
+    {
+        if (!token.Equals(origToken)) throw null; // no need for a combined token 
+        yield return value++;
+        await Task.Yield();
+        yield return value++;
+        token.ThrowIfCancellationRequested();
+        Write(""SKIPPED"");
+        yield return value++;
+    }
+}";
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, EnumeratorCancellationAttributeType }, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "42 43 Cancelled");
         }
 
         [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
@@ -5125,7 +5268,7 @@ class C
     {
         using CancellationTokenSource source = new CancellationTokenSource();
         CancellationToken token = source.Token;
-        var enumerable = Iter(42, default);
+        var enumerable = Iter(42, default, token);
         await using var enumerator = enumerable.GetAsyncEnumerator(token); // some token passed
 
         if (!await enumerator.MoveNextAsync()) throw null;
@@ -5144,8 +5287,9 @@ class C
             Write(""Cancelled"");
         }
     }
-    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [EnumeratorCancellation] CancellationToken token1)
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [EnumeratorCancellation] CancellationToken token1, CancellationToken origToken)
     {
+        if (!token1.Equals(origToken)) throw null;
         yield return value++;
         await Task.Yield();
         yield return value++;
@@ -5160,11 +5304,11 @@ class C
                 comp.VerifyDiagnostics();
                 var verifier = CompileAndVerify(comp, expectedOutput: "42 43 Cancelled");
 
-                // field for token1 gets overridden with value from GetAsyncEnumerator's token parameter
+                // GetAsyncEnumerator's token parameter is used directly, since the argument token is default
                 verifier.VerifyIL("C.<Iter>d__1.System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)", @"
 {
-  // Code size      103 (0x67)
-  .maxstack  2
+  // Code size      189 (0xbd)
+  .maxstack  3
   .locals init (C.<Iter>d__1 V_0,
                 System.Threading.CancellationToken V_1)
   IL_0000:  ldarg.0
@@ -5191,22 +5335,50 @@ class C
   IL_0033:  ldarg.0
   IL_0034:  ldfld      ""int C.<Iter>d__1.<>3__value""
   IL_0039:  stfld      ""int C.<Iter>d__1.value""
-  IL_003e:  ldarga.s   V_1
-  IL_0040:  ldloca.s   V_1
-  IL_0042:  initobj    ""System.Threading.CancellationToken""
-  IL_0048:  ldloc.1
-  IL_0049:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
-  IL_004e:  brfalse.s  IL_005e
-  IL_0050:  ldloc.0
-  IL_0051:  ldarg.0
-  IL_0052:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token1""
-  IL_0057:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
-  IL_005c:  br.s       IL_0065
-  IL_005e:  ldloc.0
-  IL_005f:  ldarg.1
-  IL_0060:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
-  IL_0065:  ldloc.0
-  IL_0066:  ret
+  IL_003e:  ldarg.0
+  IL_003f:  ldflda     ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token1""
+  IL_0044:  ldloca.s   V_1
+  IL_0046:  initobj    ""System.Threading.CancellationToken""
+  IL_004c:  ldloc.1
+  IL_004d:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
+  IL_0052:  brfalse.s  IL_005d
+  IL_0054:  ldloc.0
+  IL_0055:  ldarg.1
+  IL_0056:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
+  IL_005b:  br.s       IL_00af
+  IL_005d:  ldarga.s   V_1
+  IL_005f:  ldarg.0
+  IL_0060:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token1""
+  IL_0065:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
+  IL_006a:  brtrue.s   IL_007e
+  IL_006c:  ldarga.s   V_1
+  IL_006e:  ldloca.s   V_1
+  IL_0070:  initobj    ""System.Threading.CancellationToken""
+  IL_0076:  ldloc.1
+  IL_0077:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
+  IL_007c:  brfalse.s  IL_008c
+  IL_007e:  ldloc.0
+  IL_007f:  ldarg.0
+  IL_0080:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token1""
+  IL_0085:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
+  IL_008a:  br.s       IL_00af
+  IL_008c:  ldarg.0
+  IL_008d:  ldarg.0
+  IL_008e:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token1""
+  IL_0093:  ldarg.1
+  IL_0094:  call       ""System.Threading.CancellationTokenSource System.Threading.CancellationTokenSource.CreateLinkedTokenSource(System.Threading.CancellationToken, System.Threading.CancellationToken)""
+  IL_0099:  stfld      ""System.Threading.CancellationTokenSource C.<Iter>d__1.<>x__combinedTokens""
+  IL_009e:  ldloc.0
+  IL_009f:  ldarg.0
+  IL_00a0:  ldfld      ""System.Threading.CancellationTokenSource C.<Iter>d__1.<>x__combinedTokens""
+  IL_00a5:  callvirt   ""System.Threading.CancellationToken System.Threading.CancellationTokenSource.Token.get""
+  IL_00aa:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
+  IL_00af:  ldloc.0
+  IL_00b0:  ldarg.0
+  IL_00b1:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__origToken""
+  IL_00b6:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.origToken""
+  IL_00bb:  ldloc.0
+  IL_00bc:  ret
 }
 ");
             }
@@ -5257,59 +5429,10 @@ class C
 }";
             foreach (var options in new[] { TestOptions.DebugExe, TestOptions.ReleaseExe })
             {
+                // field for token1 gets overridden with value from GetAsyncEnumerator's token parameter
                 var comp = CreateCompilationWithAsyncIterator(new[] { source, EnumeratorCancellationAttributeType }, options: options);
                 comp.VerifyDiagnostics();
-                var verifier = CompileAndVerify(comp, expectedOutput: "42 43 Cancelled");
-
-                // field for token1 gets overridden with value from GetAsyncEnumerator's token parameter
-                verifier.VerifyIL("C.<Iter>d__1.System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)", @"
-{
-  // Code size      103 (0x67)
-  .maxstack  2
-  .locals init (C.<Iter>d__1 V_0,
-                System.Threading.CancellationToken V_1)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<Iter>d__1.<>1__state""
-  IL_0006:  ldc.i4.s   -2
-  IL_0008:  bne.un.s   IL_002a
-  IL_000a:  ldarg.0
-  IL_000b:  ldfld      ""int C.<Iter>d__1.<>l__initialThreadId""
-  IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
-  IL_0015:  bne.un.s   IL_002a
-  IL_0017:  ldarg.0
-  IL_0018:  ldc.i4.s   -3
-  IL_001a:  stfld      ""int C.<Iter>d__1.<>1__state""
-  IL_001f:  ldarg.0
-  IL_0020:  stloc.0
-  IL_0021:  ldarg.0
-  IL_0022:  ldc.i4.0
-  IL_0023:  stfld      ""bool C.<Iter>d__1.<>w__disposeMode""
-  IL_0028:  br.s       IL_0032
-  IL_002a:  ldc.i4.s   -3
-  IL_002c:  newobj     ""C.<Iter>d__1..ctor(int)""
-  IL_0031:  stloc.0
-  IL_0032:  ldloc.0
-  IL_0033:  ldarg.0
-  IL_0034:  ldfld      ""int C.<Iter>d__1.<>3__value""
-  IL_0039:  stfld      ""int C.<Iter>d__1.value""
-  IL_003e:  ldarga.s   V_1
-  IL_0040:  ldloca.s   V_1
-  IL_0042:  initobj    ""System.Threading.CancellationToken""
-  IL_0048:  ldloc.1
-  IL_0049:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
-  IL_004e:  brfalse.s  IL_005e
-  IL_0050:  ldloc.0
-  IL_0051:  ldarg.0
-  IL_0052:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token1""
-  IL_0057:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
-  IL_005c:  br.s       IL_0065
-  IL_005e:  ldloc.0
-  IL_005f:  ldarg.1
-  IL_0060:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
-  IL_0065:  ldloc.0
-  IL_0066:  ret
-}
-");
+                CompileAndVerify(comp, expectedOutput: "42 43 Cancelled");
             }
         }
 
@@ -5371,12 +5494,11 @@ class C
     static async Task Main()
     {
         using CancellationTokenSource source1 = new CancellationTokenSource();
-        source1.Cancel();
         CancellationToken token1 = source1.Token;
-        var enumerable = Iter(default, 42);
-
         using CancellationTokenSource source2 = new CancellationTokenSource();
         CancellationToken token2 = source2.Token;
+        var enumerable = Iter(token1, token2, token1, 42);
+
         await using var enumerator = enumerable.GetAsyncEnumerator(token2); // some other token passed
 
         if (!await enumerator.MoveNextAsync()) throw null;
@@ -5385,7 +5507,7 @@ class C
         if (!await enumerator.MoveNextAsync()) throw null;
         System.Console.Write($""{enumerator.Current} ""); // 43
 
-        source2.Cancel();
+        SOURCETOCANCEL.Cancel();
         try
         {
             await enumerator.MoveNextAsync();
@@ -5395,71 +5517,27 @@ class C
             Write(""Cancelled"");
         }
     }
-    static async System.Collections.Generic.IAsyncEnumerable<int> Iter([EnumeratorCancellation] CancellationToken token1, int value) // note: token is in first position
+
+    static async System.Collections.Generic.IAsyncEnumerable<int> Iter(CancellationToken token1, CancellationToken token2, [EnumeratorCancellation] CancellationToken token3, int value) // note: token is in first position
     {
+        if (token3.Equals(token1) || token3.Equals(token2)) throw null;
         yield return value++;
         await Task.Yield();
         yield return value++;
-        token1.ThrowIfCancellationRequested();
+        token3.ThrowIfCancellationRequested();
         Write(""SKIPPED"");
         yield return value++;
     }
 }";
+            // cancelling either the token given as argument or the one given to GetAsyncEnumerator results in cancelling the combined token3
             foreach (var options in new[] { TestOptions.DebugExe, TestOptions.ReleaseExe })
             {
-                var comp = CreateCompilationWithAsyncIterator(new[] { source, EnumeratorCancellationAttributeType }, options: options);
-                comp.VerifyDiagnostics();
-                var verifier = CompileAndVerify(comp, expectedOutput: "42 43 Cancelled");
-
-                // field for token1 gets overridden with value from GetAsyncEnumerator's token parameter
-                verifier.VerifyIL("C.<Iter>d__1.System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)", @"
-{
-  // Code size      103 (0x67)
-  .maxstack  2
-  .locals init (C.<Iter>d__1 V_0,
-                System.Threading.CancellationToken V_1)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<Iter>d__1.<>1__state""
-  IL_0006:  ldc.i4.s   -2
-  IL_0008:  bne.un.s   IL_002a
-  IL_000a:  ldarg.0
-  IL_000b:  ldfld      ""int C.<Iter>d__1.<>l__initialThreadId""
-  IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
-  IL_0015:  bne.un.s   IL_002a
-  IL_0017:  ldarg.0
-  IL_0018:  ldc.i4.s   -3
-  IL_001a:  stfld      ""int C.<Iter>d__1.<>1__state""
-  IL_001f:  ldarg.0
-  IL_0020:  stloc.0
-  IL_0021:  ldarg.0
-  IL_0022:  ldc.i4.0
-  IL_0023:  stfld      ""bool C.<Iter>d__1.<>w__disposeMode""
-  IL_0028:  br.s       IL_0032
-  IL_002a:  ldc.i4.s   -3
-  IL_002c:  newobj     ""C.<Iter>d__1..ctor(int)""
-  IL_0031:  stloc.0
-  IL_0032:  ldarga.s   V_1
-  IL_0034:  ldloca.s   V_1
-  IL_0036:  initobj    ""System.Threading.CancellationToken""
-  IL_003c:  ldloc.1
-  IL_003d:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
-  IL_0042:  brfalse.s  IL_0052
-  IL_0044:  ldloc.0
-  IL_0045:  ldarg.0
-  IL_0046:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token1""
-  IL_004b:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
-  IL_0050:  br.s       IL_0059
-  IL_0052:  ldloc.0
-  IL_0053:  ldarg.1
-  IL_0054:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
-  IL_0059:  ldloc.0
-  IL_005a:  ldarg.0
-  IL_005b:  ldfld      ""int C.<Iter>d__1.<>3__value""
-  IL_0060:  stfld      ""int C.<Iter>d__1.value""
-  IL_0065:  ldloc.0
-  IL_0066:  ret
-}
-");
+                foreach (var sourceToCancel in new[] { "source1", "source2" })
+                {
+                    var comp = CreateCompilationWithAsyncIterator(new[] { source.Replace("SOURCETOCANCEL", sourceToCancel), EnumeratorCancellationAttributeType }, options: options);
+                    comp.VerifyDiagnostics();
+                    CompileAndVerify(comp, expectedOutput: "42 43 Cancelled");
+                }
             }
         }
 
@@ -5589,123 +5667,29 @@ class C
                 );
         }
 
-        [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        [Fact]
+        [WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]
+        [WorkItem(35159, "https://github.com/dotnet/roslyn/issues/35159")]
         public void CancellationTokenParameter_TwoParameterHaveAttribute()
         {
             string source = @"
-using static System.Console;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 class C
 {
-    static async Task Main()
-    {
-        using CancellationTokenSource source = new CancellationTokenSource();
-        CancellationToken token = source.Token;
-        var enumerable = Iter(42, default, default);
-        await using var enumerator = enumerable.GetAsyncEnumerator(token); // some token passed
-
-        if (!await enumerator.MoveNextAsync()) throw null;
-        System.Console.Write($""{enumerator.Current} ""); // 42
-
-        if (!await enumerator.MoveNextAsync()) throw null;
-        System.Console.Write($""{enumerator.Current} ""); // 43
-
-        source.Cancel();
-        try
-        {
-            await enumerator.MoveNextAsync();
-        }
-        catch (System.OperationCanceledException)
-        {
-            Write(""Cancelled"");
-        }
-    }
     static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [EnumeratorCancellation] CancellationToken token1, [EnumeratorCancellation] CancellationToken token2)
     {
         yield return value++;
         await Task.Yield();
-        yield return value++;
-        if (token1.IsCancellationRequested) Write(""token1 cancelled "");
-        if (token2.IsCancellationRequested) Write(""token2 cancelled "");
-        token2.ThrowIfCancellationRequested();
-        Write(""SKIPPED"");
-        yield return value++;
     }
 }";
-            // Should we produce a warning here (attribute specified on two parameters)?
-            // Tracked by https://github.com/dotnet/roslyn/issues/35159
-            foreach (var options in new[] { TestOptions.DebugExe, TestOptions.ReleaseExe })
-            {
-                var comp = CreateCompilationWithAsyncIterator(new[] { source, EnumeratorCancellationAttributeType }, options: options);
-                comp.VerifyDiagnostics();
-                var verifier = CompileAndVerify(comp, expectedOutput: "42 43 token1 cancelled token2 cancelled Cancelled");
-
-                // fields for token1 and token2 get overridden with value from token parameter
-                verifier.VerifyIL("C.<Iter>d__1.System.Collections.Generic.IAsyncEnumerable<int>.GetAsyncEnumerator(System.Threading.CancellationToken)", @"
-{
-  // Code size      142 (0x8e)
-  .maxstack  2
-  .locals init (C.<Iter>d__1 V_0,
-                System.Threading.CancellationToken V_1)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int C.<Iter>d__1.<>1__state""
-  IL_0006:  ldc.i4.s   -2
-  IL_0008:  bne.un.s   IL_002a
-  IL_000a:  ldarg.0
-  IL_000b:  ldfld      ""int C.<Iter>d__1.<>l__initialThreadId""
-  IL_0010:  call       ""int System.Environment.CurrentManagedThreadId.get""
-  IL_0015:  bne.un.s   IL_002a
-  IL_0017:  ldarg.0
-  IL_0018:  ldc.i4.s   -3
-  IL_001a:  stfld      ""int C.<Iter>d__1.<>1__state""
-  IL_001f:  ldarg.0
-  IL_0020:  stloc.0
-  IL_0021:  ldarg.0
-  IL_0022:  ldc.i4.0
-  IL_0023:  stfld      ""bool C.<Iter>d__1.<>w__disposeMode""
-  IL_0028:  br.s       IL_0032
-  IL_002a:  ldc.i4.s   -3
-  IL_002c:  newobj     ""C.<Iter>d__1..ctor(int)""
-  IL_0031:  stloc.0
-  IL_0032:  ldloc.0
-  IL_0033:  ldarg.0
-  IL_0034:  ldfld      ""int C.<Iter>d__1.<>3__value""
-  IL_0039:  stfld      ""int C.<Iter>d__1.value""
-  IL_003e:  ldarga.s   V_1
-  IL_0040:  ldloca.s   V_1
-  IL_0042:  initobj    ""System.Threading.CancellationToken""
-  IL_0048:  ldloc.1
-  IL_0049:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
-  IL_004e:  brfalse.s  IL_005e
-  IL_0050:  ldloc.0
-  IL_0051:  ldarg.0
-  IL_0052:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token1""
-  IL_0057:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
-  IL_005c:  br.s       IL_0065
-  IL_005e:  ldloc.0
-  IL_005f:  ldarg.1
-  IL_0060:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token1""
-  IL_0065:  ldarga.s   V_1
-  IL_0067:  ldloca.s   V_1
-  IL_0069:  initobj    ""System.Threading.CancellationToken""
-  IL_006f:  ldloc.1
-  IL_0070:  call       ""bool System.Threading.CancellationToken.Equals(System.Threading.CancellationToken)""
-  IL_0075:  brfalse.s  IL_0085
-  IL_0077:  ldloc.0
-  IL_0078:  ldarg.0
-  IL_0079:  ldfld      ""System.Threading.CancellationToken C.<Iter>d__1.<>3__token2""
-  IL_007e:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token2""
-  IL_0083:  br.s       IL_008c
-  IL_0085:  ldloc.0
-  IL_0086:  ldarg.1
-  IL_0087:  stfld      ""System.Threading.CancellationToken C.<Iter>d__1.token2""
-  IL_008c:  ldloc.0
-  IL_008d:  ret
-}
-");
-            }
+            var comp = CreateCompilationWithAsyncIterator(new[] { source, EnumeratorCancellationAttributeType });
+            comp.VerifyDiagnostics(
+                // (7,67): error CS8426: The EnumeratorCancellationAttribute cannot be used on multiple parameters
+                //     static async System.Collections.Generic.IAsyncEnumerable<int> Iter(int value, [EnumeratorCancellation] CancellationToken token1, [EnumeratorCancellation] CancellationToken token2)
+                Diagnostic(ErrorCode.ERR_MultipleEnumeratorCancellationAttributes, "Iter").WithLocation(7, 67)
+                );
         }
 
         [Fact, WorkItem(34407, "https://github.com/dotnet/roslyn/issues/34407")]

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -492,6 +492,9 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_SwitchExpressionException__ctorObject,
 
         System_Threading_CancellationToken__Equals,
+        System_Threading_CancellationTokenSource__CreateLinkedTokenSource,
+        System_Threading_CancellationTokenSource__Token,
+        System_Threading_CancellationTokenSource__Dispose,
 
         Count
 

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3396,6 +3396,29 @@ namespace Microsoft.CodeAnalysis
                     1,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean, // Return Type
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_CancellationToken - WellKnownType.ExtSentinel), // Argument: CancellationToken
+
+                // System_Threading_CancellationTokenSource__CreateLinkedTokenSource
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_CancellationTokenSource - WellKnownType.ExtSentinel), // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_CancellationTokenSource - WellKnownType.ExtSentinel), // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_CancellationToken - WellKnownType.ExtSentinel), // Argument: CancellationToken
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_CancellationToken - WellKnownType.ExtSentinel), // Argument: CancellationToken
+
+                // System_Threading_CancellationTokenSource__Token
+                (byte)MemberFlags.Property,                                                                                 // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_CancellationTokenSource - WellKnownType.ExtSentinel), // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_CancellationToken - WellKnownType.ExtSentinel), // Return Type
+
+                // System_Threading_CancellationTokenSource__Dispose
+                (byte)MemberFlags.Method,                                                                                   // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Threading_CancellationTokenSource - WellKnownType.ExtSentinel), // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3823,6 +3846,9 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Runtime_CompilerServices_SwitchExpressionException__ctor
                 ".ctor",                                    // System_Runtime_CompilerServices_SwitchExpressionException__ctorObject
                 "Equals",                                   // System_Threading_CancellationToken__Equals
+                "CreateLinkedTokenSource",                  // System_Threading_CancellationTokenSource__CreateLinkedTokenSource
+                "Token",                                    // System_Threading_CancellationTokenSource__Token
+                "Dispose",                                  // System_Threading_CancellationTokenSource__Dispose
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -297,6 +297,7 @@ namespace Microsoft.CodeAnalysis
         System_Threading_Tasks_ValueTask,
         System_Runtime_CompilerServices_AsyncIteratorMethodBuilder,
         System_Threading_CancellationToken,
+        System_Threading_CancellationTokenSource,
 
         System_InvalidOperationException,
         System_Runtime_CompilerServices_SwitchExpressionException,
@@ -594,6 +595,7 @@ namespace Microsoft.CodeAnalysis
             "System.Threading.Tasks.ValueTask",
             "System.Runtime.CompilerServices.AsyncIteratorMethodBuilder",
             "System.Threading.CancellationToken",
+            "System.Threading.CancellationTokenSource",
 
             "System.InvalidOperationException",
             "System.Runtime.CompilerServices.SwitchExpressionException"

--- a/src/Test/Utilities/Portable/Metadata/MetadataReaderUtils.cs
+++ b/src/Test/Utilities/Portable/Metadata/MetadataReaderUtils.cs
@@ -350,6 +350,17 @@ namespace Roslyn.Test.Utilities
                         TypeReference type = reader.GetTypeReference((TypeReferenceHandle)handle);
                         return getQualifiedName(type.Namespace, type.Name);
                     }
+                case HandleKind.FieldDefinition:
+                    {
+                        FieldDefinition field = reader.GetFieldDefinition((FieldDefinitionHandle)handle);
+                        var name = reader.GetString(field.Name);
+
+                        var blob = reader.GetBlobReader(field.Signature);
+                        var decoder = new SignatureDecoder<string, object>(ConstantSignatureVisualizer.Instance, reader, genericContext: null);
+                        var type = decoder.DecodeFieldSignature(ref blob);
+
+                        return $"{type} {name}";
+                    }
                 default:
                     return null;
             }


### PR DESCRIPTION
- Previously, `[EnumeratorCancellation]` would mean that a non-default token from `GetAsyncEnumerator` would be used instead of the token passed as argument to the method. With this PR, we're instead combining both tokens. So the execution of the method can be cancelled if either token is cancelled.
- Fixes https://github.com/dotnet/roslyn/issues/35159 (error for `[EnumeratorCancellation]` on multiple tokens)

Note: I haven't found a way to validate that the CancellationTokenSource is properly disposed (end of method, early disposal, exception). 

~~This PR is pending confirmation from LDM (expected Monday 4/29/2019).~~ LDM confirmed the above design today.

FYI @stephentoub 