### PR TITLE
Pull Members Up: A couple of fixes to pull to base class as abstract

### DIFF
--- a/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -2172,7 +2172,7 @@ abstract class B
 
 class D : B
 {
-    int X => 7;
+    override int X => 7;
 }";
             await TestWithPullMemberDialogAsync(testText, expected, selection: new[] { ("X", true) }, index: 1);
         }
@@ -2248,7 +2248,7 @@ namespace PushUpTest
 
     public class TestClass : BaseClass
     {
-        public event EventHandler Event1
+        public override event EventHandler Event1
         {
             add
             {

--- a/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -1732,7 +1732,7 @@ namespace PushUpTest
 
     public class TestClass : Base
     {
-        public void TestMeth[||]od()
+        public override void TestMeth[||]od()
         {
             System.Console.WriteLine(""Hello World"");
         }
@@ -1767,7 +1767,6 @@ namespace PushUpTest
 
     public abstract class TestClass : Base
     {
-        public abstract void TestMethod();
     }
 }";
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("TestMethod", true) }, index: 0);

--- a/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
@@ -272,9 +272,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
                     else
                     {
                         var declarationSyntax = originalMemberEditor.Generator.GetDeclaration(syntax);
-                        var generator = SyntaxGenerator.GetGenerator(solution.GetDocument(syntax.SyntaxTree));
-                        var newDeclarationSyntax = generator.WithModifiers(declarationSyntax, DeclarationModifiers.Override);
-                        originalMemberEditor.ReplaceNode(declarationSyntax, newDeclarationSyntax);
+                        originalMemberEditor.ReplaceNode<object>(declarationSyntax, (node, generator, _) => generator.WithModifiers(node, DeclarationModifiers.Override), null);
                     }
                 }
             }

--- a/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
                     else
                     {
                         var declarationSyntax = originalMemberEditor.Generator.GetDeclaration(syntax);
-                        originalMemberEditor.ReplaceNode<object>(declarationSyntax, (node, generator, _) => generator.WithModifiers(node, DeclarationModifiers.Override), null);
+                        originalMemberEditor.ReplaceNode(declarationSyntax, (node, generator) => generator.WithModifiers(node, DeclarationModifiers.Override));
                     }
                 }
             }

--- a/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
@@ -254,19 +254,27 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
             var newDestination = codeGenerationService.AddMembers(destinationSyntaxNode, pullUpMembersSymbols, options: options);
 
             // Remove some original members since we are pulling members into class.
-            // Note: If user chooses to make the member abstract, then the original member won't be touched,
-            // It will just pull a abstract declaration up to destination.
+            // Note: If the user chooses to make the member abstract, then the original member will be changed to an override,
+            // and it will pull an abstract declaration up to the destination.
             // But if the member is abstract itself, it will still be removed.
             foreach (var analysisResult in result.MemberAnalysisResults)
             {
-                if (!analysisResult.MakeMemberDeclarationAbstract)
+                foreach (var syntax in symbolToDeclarations[analysisResult.Member])
                 {
-                    foreach (var syntax in symbolToDeclarations[analysisResult.Member])
+                    var originalMemberEditor = await solutionEditor.GetDocumentEditorAsync(
+                        solution.GetDocumentId(syntax.SyntaxTree),
+                        cancellationToken).ConfigureAwait(false);
+
+                    if (!analysisResult.MakeMemberDeclarationAbstract || analysisResult.Member.IsAbstract)
                     {
-                        var originalMemberEditor = await solutionEditor.GetDocumentEditorAsync(
-                            solution.GetDocumentId(syntax.SyntaxTree),
-                            cancellationToken).ConfigureAwait(false);
                         originalMemberEditor.RemoveNode(originalMemberEditor.Generator.GetDeclaration(syntax));
+                    }
+                    else
+                    {
+                        var declarationSyntax = originalMemberEditor.Generator.GetDeclaration(syntax);
+                        var generator = SyntaxGenerator.GetGenerator(solution.GetDocument(syntax.SyntaxTree));
+                        var newDeclarationSyntax = generator.WithModifiers(declarationSyntax, DeclarationModifiers.Override);
+                        originalMemberEditor.ReplaceNode(declarationSyntax, newDeclarationSyntax);
                     }
                 }
             }


### PR DESCRIPTION
See #34235

Make methods overrides when pulling to base class with the make abstract option.

Remove abstract methods when pulling to base class with the make abstract option.