### PR TITLE
Remove unnecessary parameter

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -105,7 +105,6 @@
          OutputRefAssembly="@(IntermediateRefAssembly)"
          PdbFile="$(PdbFile)"
          Platform="$(PlatformTarget)"
-         PotentialAnalyzerConfigFiles="@(PotentialEditorConfigFiles)"
          Prefer32Bit="$(Prefer32Bit)"
          PreferredUILang="$(PreferredUILang)"
          ProvideCommandLineArgs="$(ProvideCommandLineArgs)"

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -90,7 +90,6 @@
          OutputRefAssembly="@(IntermediateRefAssembly)"
          PdbFile="$(PdbFile)"
          Platform="$(PlatformTarget)"
-         PotentialAnalyzerConfigFiles="@(PotentialEditorConfigFiles)"
          Prefer32Bit="$(Prefer32Bit)"
          PreferredUILang="$(PreferredUILang)"
          ProvideCommandLineArgs="$(ProvideCommandLineArgs)"


### PR DESCRIPTION
The `CoreCompile` targets for C# and VB were both passing the set of `PotentialEditorConfigFiles` to the `PotentialAnalyzerConfigFiles` input parameter of `CscTask`/`VbcTask`. However, this parameter no longer exists. At one point in the development of the editorconfig-in-compiler feature we had a separate MSBuild task that would compute both the actual and potential .editorconfig file paths and pass them to the task. These are now computed as part of the MSBuild evaluation pass, and the potential .editorconfig files are passed to the project systems via a separate target (`GetPotentialEditorConfigFiles` in Microsoft.Common.CurrentVersion.targets).