### PR TITLE
Fix buttons for high contrast on PullMembersUpWarningDialog

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/WarningDialog/PullMemberUpWarningDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/WarningDialog/PullMemberUpWarningDialog.xaml
@@ -64,7 +64,7 @@
             HorizontalAlignment="Right"
             VerticalAlignment="Top"
             Margin="0,18,3,0">
-            <vs:DialogButton
+            <Button
                 x:Uid="FinishButton"
                 Click="FinishButton_Click"
                 IsDefault="True"
@@ -73,7 +73,7 @@
                 Content="{Binding ElementName=dialog, Path=Finish}"
                 MinWidth= "{StaticResource ResourceKey=ButtonWidth}"
                 MinHeight="{StaticResource ResourceKey=ButtonHeight}"/>
-            <vs:DialogButton
+            <Button
                 x:Uid="BackButton"
                 IsCancel="True"
                 Padding= "{StaticResource ResourceKey=ButtonPadding}"


### PR DESCRIPTION
Use Button instead of vs:Button on warning dialog for PMU

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/794008 and https://devdiv.visualstudio.com/_workitems/edit/794027 