### PR TITLE
Add release/* globs to azure pipelines config

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -2,15 +2,13 @@
 trigger:
 - master
 - master-vs-deps
-- releases/*
+- release/*
 - dev16.0
 - dev16.0-vs-deps
 - dev16.1-preview2
 - dev16.1-preview2-vs-deps
 - dev16.1-preview3
 - dev16.1-preview3-vs-deps
-- dev16.1
-- dev16.1-vs-deps
 
 # Branches that trigger builds on PR
 pr:
@@ -18,13 +16,11 @@ pr:
 - master-vs-deps
 - features/*
 - demos/*
-- releases/*
+- release/*
 - dev16.0
 - dev16.0-vs-deps
 - dev16.1-preview2
 - dev16.1-preview2-vs-deps
-- dev16.1
-- dev16.1-vs-deps
 
 jobs:
 - job: VS_Integration

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -2,6 +2,7 @@
 trigger:
 - master
 - master-vs-deps
+- releases/*
 - dev16.0
 - dev16.0-vs-deps
 - dev16.1-preview2
@@ -17,6 +18,7 @@ pr:
 - master-vs-deps
 - features/*
 - demos/*
+- releases/*
 - dev16.0
 - dev16.0-vs-deps
 - dev16.1-preview2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ trigger:
 - master-vs-deps
 - features/*
 - demos/*
+- releases/*
 - dev16.0
 - dev16.0-vs-deps
 - dev16.1-preview2
@@ -19,6 +20,7 @@ pr:
 - master-vs-deps
 - features/*
 - demos/*
+- releases/*
 - dev16.0
 - dev16.0-vs-deps
 - dev16.1-preview2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,15 +4,13 @@ trigger:
 - master-vs-deps
 - features/*
 - demos/*
-- releases/*
+- release/*
 - dev16.0
 - dev16.0-vs-deps
 - dev16.1-preview2
 - dev16.1-preview2-vs-deps
 - dev16.1-preview3
 - dev16.1-preview3-vs-deps
-- dev16.1
-- dev16.1-vs-deps
 
 # Branches that trigger builds on PR
 pr:
@@ -20,13 +18,11 @@ pr:
 - master-vs-deps
 - features/*
 - demos/*
-- releases/*
+- release/*
 - dev16.0
 - dev16.0-vs-deps
 - dev16.1-preview2
 - dev16.1-preview2-vs-deps
-- dev16.1
-- dev16.1-vs-deps
 
 jobs:
 - job: Windows_Desktop_Unit_Tests

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -36,7 +36,7 @@
             "vsBranch": "rel/d16.1",
             "vsMajorVersion": 16
           },
-          "dev16.1-vs-deps": {
+          "release/dev16.1-vs-deps": {
             "nugetKind": ["Shipping", "NonShipping"],
             "version": "3.1.*",
             "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],


### PR DESCRIPTION
This should reduce config churn moving forward as we add new release branches (e.g. `dev16.2-preview2`, etc...)