### PR TITLE
Deadlock during shutdown of interactive window

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Interactive/InteractiveEvaluator.cs
+++ b/src/EditorFeatures/Core.Wpf/Interactive/InteractiveEvaluator.cs
@@ -11,7 +11,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using System.Windows;
 using Microsoft.CodeAnalysis.Editor.Implementation.Interactive;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
@@ -147,8 +146,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
                 _currentWindow = value;
                 _workspace.Window = value;
 
-                _interactiveHost.SetOutput(_currentWindow.OutputWriter);
-                _interactiveHost.SetErrorOutput(_currentWindow.ErrorOutputWriter);
+                Task.Run(() => _interactiveHost.SetOutputs(_currentWindow.OutputWriter, _currentWindow.ErrorOutputWriter));
 
                 _currentWindow.SubmissionBufferAdded += SubmissionBufferAdded;
                 _interactiveCommands = _commandsFactory.CreateInteractiveCommands(_currentWindow, CommandPrefix, _commands);
@@ -460,8 +458,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             var window = GetCurrentWindowOrThrow();
             var resetOptions = ResetOptions;
 
-            _interactiveHost.SetOutput(window.OutputWriter);
-            _interactiveHost.SetErrorOutput(window.ErrorOutputWriter);
+            _interactiveHost.SetOutputs(window.OutputWriter, window.ErrorOutputWriter);
 
             return ResetAsyncWorker(GetHostOptions(initialize: true, resetOptions.Is64Bit));
         }

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                 this.Service = service;
                 _processExitHandlerStatus = ProcessExitHandlerStatus.Uninitialized;
 
-                var _cancellationTokenSource = new CancellationTokenSource();
+                _cancellationTokenSource = new CancellationTokenSource();
                 var cancellationToken = _cancellationTokenSource.Token;
                 ReadOutputAsync(error: false, cancellationToken).Start();
                 ReadOutputAsync(error: true, cancellationToken).Start();

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                         return null;
                     }
 
-                    WriteOutput(isError: false, string.Format(InteractiveHostResources.Attempt_to_connect_to_process_Sharp_0_failed_retrying, newProcessId));
+                    WriteOutputInBackground(isError: false, string.Format(InteractiveHostResources.Attempt_to_connect_to_process_Sharp_0_failed_retrying, newProcessId));
                     cancellationToken.ThrowIfCancellationRequested();
                 }
 
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             {
                 string errorString = process.StandardError.ReadToEnd();
 
-                WriteOutput(
+                WriteOutputInBackground(
                     isError: true,
                     string.Format(InteractiveHostResources.Failed_to_launch_0_process_exit_code_colon_1_with_output_colon, hostPath, process.ExitCode),
                     errorString);
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
             if (exitCode.HasValue)
             {
-                WriteOutput(isError: true, string.Format(InteractiveHostResources.Hosting_process_exited_with_exit_code_0, exitCode.Value));
+                WriteOutputInBackground(isError: true, string.Format(InteractiveHostResources.Hosting_process_exited_with_exit_code_0, exitCode.Value));
             }
         }
 
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                     }
                 }
 
-                WriteOutput(isError: true, InteractiveHostResources.Unable_to_create_hosting_process);
+                WriteOutputInBackground(isError: true, InteractiveHostResources.Unable_to_create_hosting_process);
             }
             catch (OperationCanceledException)
             {

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
@@ -387,7 +387,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             const int TimeoutInMs = 100;
             var tokenSource = new CancellationTokenSource();
             var cancellationToken = tokenSource.Token;
-            var task = new Task(() => action(writer), cancellationToken);
+            var task = Task.Run(() => action(writer), cancellationToken);
             while (true)
             {
                 if (_isDisposing)

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -95,8 +95,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
             _synchronizedOutput = new SynchronizedStringWriter();
             _synchronizedErrorOutput = new SynchronizedStringWriter();
             ClearOutput();
-            _host.SetOutput(_synchronizedOutput);
-            _host.SetErrorOutput(_synchronizedErrorOutput);
+            _host.SetOutputs(_synchronizedOutput, _synchronizedErrorOutput);
         }
 
         private static ImmutableArray<string> SplitLines(string text)


### PR DESCRIPTION
Fix: https://github.com/dotnet/roslyn/issues/35292

There are two processes:
1. Closing the interactive window is performed in `UIOnly`. Closing interactive window triggers:
- `closeEventDelegate` from `VsInteractiveWindowProvider`
- `InteractiveEvaluator.Dispose()`
- `InteractiveHost.Dispose()`
- `InteractiveHost.SetOutput`
- Here we come to lock `_outputGuard` for `_output.Flush()`. However, `_outputGuard` is locked by thread 2.

2. `ctor` of `InteractiveHost.RemoteService` was called
- It triggers `new Thread(() => ReadOutput(error: false));` on a new **thread**
- `ReadOutput` ends with `localHost.OnOutputReceived(error, buffer, count);`
- OnOutputReceived locks  `_outputGuard` and tries to make _output.Write
- It calls a writer from the interactive window which refers to `InteractiveWindow.Write`.
- This one requires `UIOnly` which was locked by thread 1.


