### PR TITLE
Use more robust initialization for TypeWithAnnotations.Builder

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -248,6 +248,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         type = type.WithTypeAndModifiers(
                             CustomModifierUtils.CopyTypeCustomModifiers(overriddenPropertyType.Type, type.Type, this.ContainingAssembly),
                             overriddenPropertyType.CustomModifiers);
+
+                        // Although we only do this in error scenarios, it is undesirable to mutate the symbol by setting its type twice.
+                        // Tracked by https://github.com/dotnet/roslyn/issues/35381
                         _lazyType.InterlockedReset();
                         _lazyType.InterlockedInitialize(type);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                         // Although we only do this in error scenarios, it is undesirable to mutate the symbol by setting its type twice.
                         // Tracked by https://github.com/dotnet/roslyn/issues/35381
-                        _lazyType.InterlockedReset();
+                        _lazyType.InterlockedDangerousReset();
                         _lazyType.InterlockedInitialize(type);
                     }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -248,7 +248,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         type = type.WithTypeAndModifiers(
                             CustomModifierUtils.CopyTypeCustomModifiers(overriddenPropertyType.Type, type.Type, this.ContainingAssembly),
                             overriddenPropertyType.CustomModifiers);
-                        _lazyType = default;
+                        _lazyType.InterlockedReset();
                         _lazyType.InterlockedInitialize(type);
                     }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.PooledObjects;
+using System.ComponentModel;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -66,7 +67,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             /// which currently sets the property's type twice in error scenarios.
             /// We should be able to remove this method by fixing https://github.com/dotnet/roslyn/issues/35381
             /// </summary>
-            internal void InterlockedReset()
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            internal void InterlockedDangerousReset()
             {
                 Interlocked.Exchange(ref _nullableAnnotation, 0);
                 Interlocked.Exchange(ref _defaultType, null);


### PR DESCRIPTION
FYI @jaredpar @agocke @stephentoub 

May fix https://github.com/dotnet/roslyn/issues/35290 