### PR TITLE
GetTypeInfo on suppressed expressions should return the type from the underlying expression

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -876,7 +876,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            return GetTypeInfoWorker(expression, cancellationToken);
+            var info = GetTypeInfoWorker(expression, cancellationToken);
+
+            // If the expression is suppressed, we always use the converted information. To get the information of the original expression,
+            // the user should be passing in the underlying expression.
+            if (expression.Kind() == SyntaxKind.SuppressNullableWarningExpression)
+            {
+                info = new CSharpTypeInfo(info.ConvertedType, info.ConvertedType, info.ConvertedNullability, info.ConvertedNullability, info.ImplicitConversion);
+            }
+
+            return info;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/32661. Added a note to https://github.com/dotnet/roslyn/issues/35046 that this behavior needs to be documented.

@dotnet/roslyn-compiler @gafter for review.