### PR TITLE
Use more robust initialization for TypeWithAnnotations.Builder (#35373)

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -248,7 +248,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         type = type.WithTypeAndModifiers(
                             CustomModifierUtils.CopyTypeCustomModifiers(overriddenPropertyType.Type, type.Type, this.ContainingAssembly),
                             overriddenPropertyType.CustomModifiers);
-                        _lazyType = default;
+
+                        // Although we only do this in error scenarios, it is undesirable to mutate the symbol by setting its type twice.
+                        // Tracked by https://github.com/dotnet/roslyn/issues/35381
+                        _lazyType.InterlockedDangerousReset();
                         _lazyType.InterlockedInitialize(type);
                     }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Roslyn.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -24,25 +25,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal struct Builder
         {
             private TypeSymbol _defaultType;
-            private NullableAnnotation _nullableAnnotation;
+            private int _nullableAnnotation;
             private Extensions _extensions;
 
             /// <summary>
             /// The underlying type, unless overridden by _extensions.
             /// </summary>
-            internal TypeSymbol DefaultType => _defaultType;
+            internal TypeSymbol DefaultType => Volatile.Read(ref _defaultType);
 
             /// <summary>
             /// True if the fields of the builder are unset.
             /// </summary>
-            internal bool IsDefault => _defaultType is null && _nullableAnnotation == 0 && (_extensions == null || _extensions == Extensions.Default);
+            internal bool IsDefault => Volatile.Read(ref _extensions) == null;
 
             /// <summary>
             /// Set the fields of the builder.
             /// </summary>
             /// <remarks>
             /// This method guarantees: fields will be set once; exactly one caller is
-            /// returned true; and IsNull will return true until all fields are initialized.
+            /// returned true; and IsDefault will return true until all fields are initialized.
             /// This method does not guarantee that all fields will be set by the same
             /// caller. Instead, the expectation is that all callers will attempt to initialize
             /// the builder with equivalent TypeWithAnnotations instances where
@@ -50,13 +51,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             /// </remarks>
             internal bool InterlockedInitialize(TypeWithAnnotations type)
             {
-                if ((object)_defaultType != null)
+                if (!IsDefault)
                 {
                     return false;
                 }
-                _nullableAnnotation = type.NullableAnnotation;
-                Interlocked.CompareExchange(ref _extensions, type._extensions, null);
-                return (object)Interlocked.CompareExchange(ref _defaultType, type.DefaultType, null) == null;
+
+                Interlocked.CompareExchange(ref _nullableAnnotation, (int)type.NullableAnnotation, 0);
+                Interlocked.CompareExchange(ref _defaultType, type.DefaultType, null);
+
+                // Because _extensions always gets a non-null value when the struct is initialized, we use it
+                // as a flag to signal that the initialization is complete. This means _extensions should be
+                // initialized last.
+                bool wasFirst = Interlocked.CompareExchange(ref _extensions, type._extensions ?? Extensions.Default, null) is null;
+
+                Debug.Assert(_extensions == (type._extensions ?? Extensions.Default));
+                Debug.Assert(_nullableAnnotation == (int)type.NullableAnnotation);
+                Debug.Assert(_defaultType.Equals(type.DefaultType));
+                return wasFirst;
+            }
+
+            /// <summary>
+            /// We should not be adding any new usages of this method. The only one is currently in SourcePropertySymbol,
+            /// which currently sets the property's type twice in error scenarios.
+            /// We should be able to remove this method by fixing https://github.com/dotnet/roslyn/issues/35381
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            internal void InterlockedDangerousReset()
+            {
+                Interlocked.Exchange(ref _nullableAnnotation, 0);
+                Interlocked.Exchange(ref _defaultType, null);
+                Interlocked.Exchange(ref _extensions, null);
             }
 
             /// <summary>
@@ -66,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return IsDefault ?
                     default :
-                    new TypeWithAnnotations(_defaultType, _nullableAnnotation, _extensions);
+                    new TypeWithAnnotations(Volatile.Read(ref _defaultType), (NullableAnnotation)Volatile.Read(ref _nullableAnnotation), Volatile.Read(ref _extensions));
             }
 
             internal string GetDebuggerDisplay() => ToType().GetDebuggerDisplay();
@@ -757,7 +781,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         private abstract class Extensions
         {
-            internal static readonly Extensions Default = new NonLazyType(ImmutableArray<CustomModifier>.Empty);
+            internal static readonly Extensions Default = new NonLazyType(customModifiers: ImmutableArray<CustomModifier>.Empty);
 
             internal static Extensions Create(ImmutableArray<CustomModifier> customModifiers)
             {


### PR DESCRIPTION
(cherry picked from commit c421f1249d1c2ba94e7703037ec49b4341f3b9f4)