### PR TITLE
Clean up YAML

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -3,12 +3,8 @@ trigger:
 - master
 - master-vs-deps
 - release/*
-- dev16.0
-- dev16.0-vs-deps
-- dev16.1-preview2
-- dev16.1-preview2-vs-deps
-- dev16.1-preview3
-- dev16.1-preview3-vs-deps
+- features/*
+- demos/*
 
 # Branches that trigger builds on PR
 pr:
@@ -17,10 +13,6 @@ pr:
 - release/*
 - features/*
 - demos/*
-- dev16.0
-- dev16.0-vs-deps
-- dev16.1-preview2
-- dev16.1-preview2-vs-deps
 
 jobs:
 - job: VS_Integration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,12 +5,6 @@ trigger:
 - release/*
 - features/*
 - demos/*
-- dev16.0
-- dev16.0-vs-deps
-- dev16.1-preview2
-- dev16.1-preview2-vs-deps
-- dev16.1-preview3
-- dev16.1-preview3-vs-deps
 
 # Branches that trigger builds on PR
 pr:
@@ -19,10 +13,6 @@ pr:
 - release/*
 - features/*
 - demos/*
-- dev16.0
-- dev16.0-vs-deps
-- dev16.1-preview2
-- dev16.1-preview2-vs-deps
 
 jobs:
 - job: Windows_Desktop_Unit_Tests


### PR DESCRIPTION
Going forward our release branches will all be under release/*. This
adds a glob for release/* so future release branches will just work. It
also removes all the old branches to which this change will not flow.