### PR TITLE
Remove some restrictions for base access expression.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1904,6 +1904,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                     if (!this.ContainingType.IsDerivedFrom(baseType, TypeCompareKind.ConsiderEverything, ref useSiteDiagnostics) &&
+                        !(this.ContainingType.IsInterface && baseType.IsObjectType()) &&
                         !this.ContainingType.ImplementsInterface(baseType, ref useSiteDiagnostics))
                     {
                         Error(diagnostics, ErrorCode.ERR_NotBaseOrImplementedInterface, node.TypeClause.BaseType, baseType, this.ContainingType);
@@ -5921,7 +5922,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 bool leftIsBaseReference = boundLeft.Kind == BoundKind.BaseReference;
                 if (leftIsBaseReference)
                 {
-                    options |= (LookupOptions.UseBaseReferenceAccessibility | LookupOptions.NoObjectMembersOnInterfaces);
+                    options |= LookupOptions.UseBaseReferenceAccessibility;
                 }
 
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
@@ -7187,7 +7188,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(analyzedArguments != null);
 
             LookupResult lookupResult = LookupResult.GetInstance();
-            LookupOptions lookupOptions = expr.Kind == BoundKind.BaseReference ? (LookupOptions.UseBaseReferenceAccessibility | LookupOptions.NoObjectMembersOnInterfaces) : LookupOptions.Default;
+            LookupOptions lookupOptions = expr.Kind == BoundKind.BaseReference ? LookupOptions.UseBaseReferenceAccessibility : LookupOptions.Default;
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
             this.LookupMembersWithFallback(lookupResult, expr.Type, WellKnownMemberNames.Indexer, arity: 0, useSiteDiagnostics: ref useSiteDiagnostics, options: lookupOptions);
             diagnostics.Add(node, useSiteDiagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -963,7 +963,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             LookupMembersInInterfaceOnly(current, type, name, arity, basesBeingResolved, options, originalBinder, type, diagnose, ref useSiteDiagnostics);
 
-            if (!originalBinder.InCrefButNotParameterOrReturnType && (options & LookupOptions.NoObjectMembersOnInterfaces) == 0)
+            if (!originalBinder.InCrefButNotParameterOrReturnType)
             {
                 var tmp = LookupResult.GetInstance();
                 // NB: we assume use-site-errors on System.Object, if any, have been reported earlier.

--- a/src/Compilers/CSharp/Portable/Binder/LookupOptions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LookupOptions.cs
@@ -96,11 +96,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Do not consider symbols that are method type parameters.
         /// </summary>
         MustNotBeMethodTypeParameter = 1 << 14,
-
-        /// <summary>
-        /// Do not consider System.Object members when looking for members in an interface.
-        /// </summary>
-        NoObjectMembersOnInterfaces = 1 << 15,
     }
 
     internal static class LookupOptionExtensions


### PR DESCRIPTION
- Allow ```base(object)``` in interfaces
- System.Object members should be available of off ```base(<some interface type>)```.