### PR TITLE
Avoid caching VS completion item

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -48,8 +48,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         private static readonly EditorOptionKey<bool> NonBlockingCompletionEditorOption = new EditorOptionKey<bool>(NonBlockingCompletion);
 
-        private static readonly ConditionalWeakTable<RoslynCompletionItem, VSCompletionItem> s_roslynItemToVsItem =
-            new ConditionalWeakTable<RoslynCompletionItem, VSCompletionItem>();
+        // Use CWT to cache data needed to create VSCompletionItem, so the table would be cleared when Roslyn completion item cache is cleared.
+        private static readonly ConditionalWeakTable<RoslynCompletionItem, VSCompletionItemData> s_roslynItemToVsItemData =
+            new ConditionalWeakTable<RoslynCompletionItem, VSCompletionItemData>();
 
         // Cache all the VS completion filters which essentially make them singletons.
         // Because all items that should be filtered using the same filter button must 
@@ -315,13 +316,50 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             }
         }
 
+        /// <summary>
+        /// We'd like to cache VS Completion item dircetly to avoid allocation completely. However it holds references
+        /// to transient objects, which would cause memory leak (among other potential issues) if cached. 
+        /// So as a compromise,  we cache data that can be calculated from Roslyn completion item to avoid repeated 
+        /// calculation cost for cached Roslyn completion items.
+        /// </summary>
+        private class VSCompletionItemData
+        {
+            public VSCompletionItemData(string displayText, ImageElement icon, ImmutableArray<AsyncCompletionData.CompletionFilter> filters, ImmutableArray<ImageElement> attributeIcons, string insertionText)
+            {
+                DisplayText = displayText;
+                Icon = icon;
+                Filters = filters;
+                AttributeIcons = attributeIcons;
+                InsertionText = insertionText;
+            }
+
+            public string DisplayText { get; }
+
+            public ImageElement Icon { get; }
+
+            public ImmutableArray<AsyncCompletionData.CompletionFilter> Filters { get; }
+
+            public ImmutableArray<ImageElement> AttributeIcons { get; }
+
+            public string InsertionText { get; }
+        }
+
         private VSCompletionItem Convert(
             Document document,
             RoslynCompletionItem roslynItem)
         {
-            if (roslynItem.IsCached && s_roslynItemToVsItem.TryGetValue(roslynItem, out var vsItem))
+            if (roslynItem.IsCached && s_roslynItemToVsItemData.TryGetValue(roslynItem, out var itemData))
             {
-                return vsItem;
+                return new VSCompletionItem(
+                    displayText: itemData.DisplayText,
+                    source: this,
+                    icon: itemData.Icon,
+                    filters: itemData.Filters,
+                    suffix: roslynItem.InlineDescription, // InlineDescription will be right-aligned in the selection popup
+                    insertText: itemData.InsertionText,
+                    sortText: roslynItem.SortText,
+                    filterText: roslynItem.FilterText,
+                    attributeIcons: itemData.AttributeIcons);
             }
 
             var imageId = roslynItem.Tags.GetFirstGlyph().GetImageId();
@@ -351,11 +389,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             item.Properties.AddProperty(RoslynItem, roslynItem);
 
-            // It doesn't make sense to cache VS item for those Roslyn items created from scratch for each session,
+            // It doesn't make sense to cache VS item data for those Roslyn items created from scratch for each session,
             // since CWT uses object identity for comparison.
             if (roslynItem.IsCached)
             {
-                s_roslynItemToVsItem.Add(roslynItem, item);
+                var data = new VSCompletionItemData(item.DisplayText, item.Icon, item.Filters, item.AttributeIcons, item.InsertText);
+                s_roslynItemToVsItemData.Add(roslynItem, data);
             }
 
             return item;


### PR DESCRIPTION
Due to several reasons:

1. VS item holds a reference to CompletionSource, which holds a references to ITextView. We don't want to keep it alive. Also we have no control on how CompletionSource is used by Editor, so there might be problems too.

2. VS item has a property bag, which might contains anything.

I misunderstood how CWT work earlier, it turns out the CWT based cache is holding VS items alive indefinitely (released only when Roslyn item cache is cleared)

We need to talk to editor team to figure out the best solution, meanwhile, this change caches the data required to creating VS item instead. This way, we will pay the cost of creating a new VS completion item every time, but still avoid the cost of calculating those data based on cached Roslyn completion item.

I will update the PR with profiling data later. But so far, the perf of this change passed my eye test, no noticeable perf issue found.

@CyrusNajmabadi @jasonmalinowski @dpoeschl Please review.

@jinujoseph @vatsalyaagrawal I think this fix is a must-have for 16.1.

---


**Customer and scenario info**

**Who is impacted by this bug?**
Users who turned on import completion

**What is the customer scenario and impact of the bug?**
Memory leak. There might be other issues caused by this when user use import completion we haven't found, since the VS item cached contains a old completion source.

**What is the workaround?**
Don't turn on Import Completion

**How was the bug found?**
dogfooding

**If this fix is for a regression - what had regressed, when was the regression introduced, and why was the regression originally missed?**

No, this feature is added in 16.1