### PR TITLE
Fix having the wrong syntax trees after adding an .editorconfig 

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1141,7 +1141,7 @@ namespace Microsoft.CodeAnalysis
         {
             return AddDocumentsToMultipleProjects(documentInfos,
                 (documentInfo, project) => project.CreateDocument(documentInfo, project.ParseOptions),
-                (project, documents) => (project.AddDocuments(documents), new CompilationTranslationAction.AddDocumentsAction(documents)));
+                (oldProject, documents) => (oldProject.AddDocuments(documents), new CompilationTranslationAction.AddDocumentsAction(documents)));
         }
 
         /// <summary>
@@ -1225,7 +1225,11 @@ namespace Microsoft.CodeAnalysis
             // attached to them, so we'll just replace all syntax trees in that case.
             return AddDocumentsToMultipleProjects(documentInfos,
                 (documentInfo, project) => new AnalyzerConfigDocumentState(documentInfo, _solutionServices),
-                (projectState, documents) => (projectState.AddAnalyzerConfigDocuments(documents), new CompilationTranslationAction.ReplaceAllSyntaxTreesAction(projectState)));
+                (oldProject, documents) =>
+                {
+                    var newProject = oldProject.AddAnalyzerConfigDocuments(documents);
+                    return (newProject, new CompilationTranslationAction.ReplaceAllSyntaxTreesAction(newProject));
+                });
         }
 
         public SolutionState RemoveAnalyzerConfigDocument(DocumentId documentId)


### PR DESCRIPTION
Adding an .editorconfig requires us to update the compilation with new syntax trees that contain the per-tree diagnostic options for the compiler. When I created the CompilationTranslationAction, I accidentally passed the old ProjectState instead of the new ProjectState which meant we'd remove and re-add all the old trees instead of the new trees.



### Customer scenario

Customer tries to turn on our new .editorconfig support. After adding a new .editorconfig, Visual Studio might crash.

### Bugs this fixes

Bug not filed; discovered during other feature work.

### Workarounds, if any

It's limited to new code, so you can turn off the new support, but that kinda defeats the point.

### Risk

Low, and is restricted to new codepaths that are under the feature flag.

### Performance impact

None.

### Is this a regression from a previous update?

No, new feature code.

### Root cause analysis

A typo in a function, and we didn't (yet) have the tests in place. There are now tests.

### How was the bug found?

Feature validation testing.

