### PR TITLE
Fix typo in OptProf test name

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -6,7 +6,7 @@
         {
           "container": "ManagedLangs",
           "testCases": [
-            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+            "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs"
           ]
         },
         {
@@ -60,7 +60,7 @@
         {
           "container": "ManagedLangs",
           "testCases": [
-            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+            "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs"
           ]
         },
         {
@@ -91,7 +91,7 @@
         {
           "container": "ManagedLangs",
           "testCases": [
-            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+            "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs"
           ]
         },
         {
@@ -140,7 +140,7 @@
         {
           "container": "ManagedLangs",
           "testCases": [
-            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+            "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs"
           ]
         },
         {


### PR DESCRIPTION
Fix typo in the test class name, this is why the new test wasn't picked up

https://devdiv.visualstudio.com/DevDiv/_git/VS?path=%2Fsrc%2FTests%2FManagedLangs%2FOptProfTests.cs&version=GBmaster&line=15&lineStyle=plain&lineEnd=16&lineStartColumn=1&lineEndColumn=1

@tmat 
@vatsalyaagrawal @jinujoe This is a infrastructure only change