### PR TITLE
made error navigation and de-duplication a bit better with mapped span…

### DIFF
--- a/src/EditorFeatures/TestUtilities/Diagnostics/TestDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/TestDiagnosticAnalyzerService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics.Log;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
 using Roslyn.Utilities;
 
@@ -27,8 +28,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             string language,
             ImmutableArray<DiagnosticAnalyzer> analyzers,
             AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource = null,
-            Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null)
-            : this(CreateHostAnalyzerManager(language, analyzers, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, onAnalyzerException)
+            Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = null,
+            IAsynchronousOperationListener listener = null)
+            : this(CreateHostAnalyzerManager(language, analyzers, hostDiagnosticUpdateSource), hostDiagnosticUpdateSource, onAnalyzerException, listener: listener)
         {
         }
 
@@ -53,8 +55,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             HostAnalyzerManager hostAnalyzerManager,
             AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource,
             Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException,
-            IDiagnosticUpdateSourceRegistrationService registrationService = null)
-            : base(hostAnalyzerManager, hostDiagnosticUpdateSource, registrationService ?? new MockDiagnosticUpdateSourceRegistrationService())
+            IDiagnosticUpdateSourceRegistrationService registrationService = null,
+            IAsynchronousOperationListener listener = null)
+            : base(hostAnalyzerManager, hostDiagnosticUpdateSource, registrationService ?? new MockDiagnosticUpdateSourceRegistrationService(), listener)
         {
             _hostAnalyzerReferenceMap = hostAnalyzerManager.CreateAnalyzerReferencesMap(projectOpt: null);
             _onAnalyzerException = onAnalyzerException;

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableControlEventProcessorProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableControlEventProcessorProvider.cs
@@ -42,10 +42,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     return;
                 }
 
-                // we always mark it as handled if entry is ours
-                e.Handled = true;
-
-                roslynSnapshot.TryNavigateTo(index, e.IsPreview);
+                // don't be too strict on navigation on our item. if we can't handle the item,
+                // let default handler to handle it at least.
+                // we might fail to navigate if we don't see the document in our solution anymore.
+                // that can happen if error is staled build error or user used #line pragma in C#
+                // to point to some random file in error or more.
+                e.Handled = roslynSnapshot.TryNavigateTo(index, e.IsPreview);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -532,7 +532,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
                 return false;
 
-                bool IsDocumentLevelDiagnostic(DiagnosticData diagnoaticData)
+                static bool IsDocumentLevelDiagnostic(DiagnosticData diagnoaticData)
                 {
                     if (diagnoaticData.DocumentId != null)
                     {
@@ -558,7 +558,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     // unfortunately, there is no 100% correct way to do this.
                     // so we will use a heuristic that will most likely work for most of common cases.
                     return !string.IsNullOrEmpty(diagnoaticData.DataLocation.OriginalFilePath) &&
-                            (diagnoaticData.DataLocation.OriginalStartLine > 0 || 
+                            (diagnoaticData.DataLocation.OriginalStartLine > 0 ||
                              diagnoaticData.DataLocation.OriginalStartColumn > 0);
                 }
             }

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -135,10 +135,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
             var line = error.iLine;
             var column = error.iCol;
-            /* TODO: make work again
-            if (hostDocument is ContainedDocument containedDocument)
+
+            // something we should move to document service one day. but until then, we keep the old way.
+            // build basically output error location on surface buffer and we map it back to
+            // subject buffer for contained document. so that contained document can map
+            // it back to surface buffer when navigate. whole problem comes in due to the mapped span.
+            // unlike live error, build outputs mapped span and we save it as original span (since we
+            // have no idea whether it is mapped or not). for contained document case, we do know it is
+            // mapped span, so we calculate original span and put that in original span.
+            var containedDocument = ContainedDocument.TryGetContainedDocument(documentId);
+            if (containedDocument != null)
             {
-                var span = new VsTextSpan
+                var span = new TextSpan
                 {
                     iStartLine = line,
                     iStartIndex = column,
@@ -146,15 +154,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     iEndIndex = column,
                 };
 
-                var spans = new VsTextSpan[1];
-                Marshal.ThrowExceptionForHR(containedDocument.ContainedLanguage.BufferCoordinator.MapPrimaryToSecondarySpan(
+                var spans = new TextSpan[1];
+                Marshal.ThrowExceptionForHR(containedDocument.BufferCoordinator.MapPrimaryToSecondarySpan(
                     span,
                     spans));
 
                 line = spans[0].iStartLine;
                 column = spans[0].iStartIndex;
             }
-            */
 
             return GetDiagnosticData(error, documentId, line, column);
         }

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -1,7 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
-Imports System.Reflection
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -1,8 +1,8 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Reflection
 Imports System.Threading
-Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
@@ -313,6 +313,56 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 source.OnSolutionBuild(Me, Shell.UIContextChangedEventArgs.From(False))
                 Await waiter.CreateExpeditedWaitTask()
+            End Using
+        End Function
+
+        <Fact>
+        Public Async Function TestCompilerDiagnosticWithoutDocumentId() As Task
+            Using workspace = TestWorkspace.CreateCSharp(String.Empty)
+                Dim listenerProvider = workspace.ExportProvider.GetExportedValue(Of IAsynchronousOperationListenerProvider)()
+                Dim waiter = TryCast(listenerProvider.GetListener(FeatureAttribute.ErrorList), AsynchronousOperationListener)
+
+                Dim project = workspace.CurrentSolution.Projects.First()
+
+                Dim analyzer = New CompilationAnalyzer()
+                Dim compiler = DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp)
+
+                Dim diagnosticWaiter = TryCast(listenerProvider.GetListener(FeatureAttribute.DiagnosticService), AsynchronousOperationListener)
+
+                Dim service = New Microsoft.CodeAnalysis.Diagnostics.TestDiagnosticAnalyzerService(
+                    LanguageNames.CSharp,
+                    New DiagnosticAnalyzer() {compiler, analyzer}.ToImmutableArray(),
+                    listener:=diagnosticWaiter)
+
+                Dim registation = service.CreateIncrementalAnalyzer(workspace)
+
+                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, New MockDiagnosticUpdateSourceRegistrationService(), waiter)
+
+                Dim diagnostic = New DiagnosticData(
+                    "CS1002",
+                    "Test",
+                    "Test Message",
+                    "Test Message Format",
+                    DiagnosticSeverity.Error,
+                    True,
+                    0,
+                    workspace,
+                    project.Id,
+                    New DiagnosticDataLocation(documentId:=Nothing, sourceSpan:=Nothing, "Test.txt", 4, 4))
+
+                AddHandler service.DiagnosticsUpdated, Sub(o, args)
+                                                           Assert.Single(args.Diagnostics)
+                                                           Assert.Equal(args.Diagnostics(0).Id, diagnostic.Id)
+                                                       End Sub
+
+                source.AddNewErrors(project.Id, diagnostic)
+                Await waiter.CreateExpeditedWaitTask()
+
+                source.OnSolutionBuild(Me, Shell.UIContextChangedEventArgs.From(False))
+                Await waiter.CreateExpeditedWaitTask()
+
+                Dim diagnosticServiceWaiter = TryCast(listenerProvider.GetListener(FeatureAttribute.DiagnosticService), AsynchronousOperationListener)
+                Await diagnosticServiceWaiter.CreateExpeditedWaitTask()
             End Using
         End Function
 


### PR DESCRIPTION
… error such as

// A.cs having
// #line 2 RandomeFile.txt
//       ErrorHere
// #line default

previously, we didn't do the de-dup correctly and navigate correctly.

now, it at least do that better. but there is still question wehther current behavior is what we want or not.

...

handle this situation better - https://github.com/dotnet/roslyn/issues/35448

and root issue - https://github.com/dotnet/roslyn/issues/34950