### PR TITLE
Fix lambda lowering for cast to generic ReadOnlySpan<T>

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -648,12 +648,17 @@
     <Field Name="ConversionGroupOpt" Type="ConversionGroup" Null="allow"/>
   </Node>
 
-  <!-- A special node for emitting the implicit conversion from an array (of T) to System.ReadOnlySpan<T> -->
+  <!--
+       A special node for emitting the implicit conversion from an array (of T) to System.ReadOnlySpan<T>.
+       Although the conversion has an explicitly declared conversion operator, we want to retain it as something
+       other than a method call after lowering so it can be recognized as a special case and possibly
+       optimized during code generation.
+       -->
   <Node Name="BoundReadOnlySpanFromArray" Base="BoundExpression">
-    <!-- The type is required an instance of the well-known type System.ReadOnlySpan<T> -->
+    <!-- The type is required to be an instance of the well-known type System.ReadOnlySpan<T> -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="Operand" Type="BoundExpression"/>
-    <Field Name="Method" Type="MethodSymbol"/>
+    <Field Name="ConversionMethod" Type="MethodSymbol"/>
   </Node>
 
   <!--

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -646,7 +646,15 @@
          Conversion is represented by a single BoundConversion.
          -->
     <Field Name="ConversionGroupOpt" Type="ConversionGroup" Null="allow"/>
-</Node>
+  </Node>
+
+  <!-- A special node for emitting the implicit conversion from an array (of T) to System.ReadOnlySpan<T> -->
+  <Node Name="BoundReadOnlySpanFromArray" Base="BoundExpression">
+    <!-- The type is required an instance of the well-known type System.ReadOnlySpan<T> -->
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <Field Name="Operand" Type="BoundExpression"/>
+    <Field Name="Method" Type="MethodSymbol"/>
+  </Node>
 
   <!--
   <Node Name="BoundRefValueOperator" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -25,12 +25,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             var operand = conversion.Operand;
 
-            if (conversion.ConversionKind.IsUserDefinedConversion())
-            {
-                EmitSpecialUserDefinedConversion(conversion, used, operand);
-                return;
-            }
-
             if (!used && !conversion.ConversionHasSideEffects())
             {
                 EmitExpression(operand, false); // just do expr side effects
@@ -43,9 +37,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             EmitPopIfUnused(used);
         }
 
-        private void EmitSpecialUserDefinedConversion(BoundConversion conversion, bool used, BoundExpression operand)
+        private void EmitReadOnlySpanFromArrayExpression(BoundReadOnlySpanFromArray expression, bool used)
         {
-            var typeTo = (NamedTypeSymbol)conversion.Type;
+            BoundExpression operand = expression.Operand;
+            var typeTo = (NamedTypeSymbol)expression.Type;
 
             Debug.Assert((operand.Type.IsArray()) &&
                          this._module.Compilation.IsReadOnlySpanType(typeTo),
@@ -60,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 {
                     // consumes 1 argument (array) and produces one result (span)
                     _builder.EmitOpCode(ILOpCode.Call, stackAdjustment: 0);
-                    EmitSymbolToken(conversion.SymbolOpt, conversion.Syntax, optArgList: null);
+                    EmitSymbolToken(expression.Method, expression.Syntax, optArgList: null);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 {
                     // consumes 1 argument (array) and produces one result (span)
                     _builder.EmitOpCode(ILOpCode.Call, stackAdjustment: 0);
-                    EmitSymbolToken(expression.Method, expression.Syntax, optArgList: null);
+                    EmitSymbolToken(expression.ConversionMethod, expression.Syntax, optArgList: null);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -111,6 +111,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     EmitConvertedStackAllocExpression((BoundConvertedStackAllocExpression)expression, used);
                     break;
 
+                case BoundKind.ReadOnlySpanFromArray:
+                    EmitReadOnlySpanFromArrayExpression((BoundReadOnlySpanFromArray)expression, used);
+                    break;
+
                 case BoundKind.Conversion:
                     EmitConversionExpression((BoundConversion)expression, used);
                     break;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2902,6 +2902,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitReadOnlySpanFromArray(BoundReadOnlySpanFromArray node)
+        {
+            VisitRvalue(node.Operand);
+            return null;
+        }
+
         /// <summary>
         /// This visitor represents just the assignment part of the null coalescing assignment
         /// operator.

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -2429,29 +2429,29 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundReadOnlySpanFromArray : BoundExpression
     {
-        public BoundReadOnlySpanFromArray(SyntaxNode syntax, BoundExpression operand, MethodSymbol method, TypeSymbol type, bool hasErrors = false)
+        public BoundReadOnlySpanFromArray(SyntaxNode syntax, BoundExpression operand, MethodSymbol conversionMethod, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.ReadOnlySpanFromArray, syntax, type, hasErrors || operand.HasErrors())
         {
 
             Debug.Assert((object)operand != null, "Field 'operand' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
-            Debug.Assert((object)method != null, "Field 'method' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert((object)conversionMethod != null, "Field 'conversionMethod' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert((object)type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
             this.Operand = operand;
-            this.Method = method;
+            this.ConversionMethod = conversionMethod;
         }
 
 
         public BoundExpression Operand { get; }
 
-        public MethodSymbol Method { get; }
+        public MethodSymbol ConversionMethod { get; }
         public override BoundNode Accept(BoundTreeVisitor visitor) => visitor.VisitReadOnlySpanFromArray(this);
 
-        public BoundReadOnlySpanFromArray Update(BoundExpression operand, MethodSymbol method, TypeSymbol type)
+        public BoundReadOnlySpanFromArray Update(BoundExpression operand, MethodSymbol conversionMethod, TypeSymbol type)
         {
-            if (operand != this.Operand || method != this.Method || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
+            if (operand != this.Operand || conversionMethod != this.ConversionMethod || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundReadOnlySpanFromArray(this.Syntax, operand, method, type, this.HasErrors);
+                var result = new BoundReadOnlySpanFromArray(this.Syntax, operand, conversionMethod, type, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -2460,7 +2460,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override BoundExpression ShallowClone()
         {
-            var result = new BoundReadOnlySpanFromArray(this.Syntax, this.Operand, this.Method, this.Type, this.HasErrors);
+            var result = new BoundReadOnlySpanFromArray(this.Syntax, this.Operand, this.ConversionMethod, this.Type, this.HasErrors);
             result.CopyAttributes(this);
             return result;
         }
@@ -9523,7 +9523,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(operand, node.Method, type);
+            return node.Update(operand, node.ConversionMethod, type);
         }
         public override BoundNode VisitArgList(BoundArgList node)
         {
@@ -10990,12 +10990,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(operand, node.Method, infoAndType.Type);
+                updatedNode = node.Update(operand, node.ConversionMethod, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(operand, node.Method, node.Type);
+                updatedNode = node.Update(operand, node.ConversionMethod, node.Type);
             }
             return updatedNode;
         }
@@ -12534,7 +12534,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override TreeDumperNode VisitReadOnlySpanFromArray(BoundReadOnlySpanFromArray node, object arg) => new TreeDumperNode("readOnlySpanFromArray", null, new TreeDumperNode[]
         {
             new TreeDumperNode("operand", null, new TreeDumperNode[] { Visit(node.Operand, null) }),
-            new TreeDumperNode("method", node.Method, null),
+            new TreeDumperNode("conversionMethod", node.ConversionMethod, null),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null)
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -1292,6 +1292,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitConversion(BoundConversion conversion)
         {
+            // a conversion with a method should have been rewritten, e.g. to an invocation
+            Debug.Assert(_inExpressionLambda || conversion.Conversion.MethodSymbol is null);
+
             Debug.Assert(conversion.ConversionKind != ConversionKind.MethodGroup);
             if (conversion.ConversionKind == ConversionKind.AnonymousFunction)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -1025,7 +1025,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            // do not rewrite user defined conversion in expression trees or
+            // do not rewrite user defined conversion in expression trees
             if (_inExpressionLambda)
             {
                 return BoundConversion.Synthesized(syntax, rewrittenOperand, conversion, false, explicitCastInCode: true, conversionGroupOpt: null, default(ConstantValue), rewrittenType);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -1025,16 +1025,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            // do not rewrite user defined conversion 
-            // - in expression trees or 
-            // - special situations when converting from array to ReadOnlySpan, which has special support in codegen
-            bool doNotLowerToCall = _inExpressionLambda ||
-                                    (rewrittenOperand.Type.IsArray()) && _compilation.IsReadOnlySpanType(rewrittenType);
+            // do not rewrite user defined conversion in expression trees or
+            if (_inExpressionLambda)
+            {
+                return BoundConversion.Synthesized(syntax, rewrittenOperand, conversion, false, explicitCastInCode: true, conversionGroupOpt: null, default(ConstantValue), rewrittenType);
+            }
 
-            BoundExpression result =
-                doNotLowerToCall
-                ? BoundConversion.Synthesized(syntax, rewrittenOperand, conversion, false, explicitCastInCode: true, conversionGroupOpt: null, default(ConstantValue), rewrittenType)
-                : (BoundExpression)BoundCall.Synthesized(syntax, null, conversion.Method, rewrittenOperand);
+            if ((rewrittenOperand.Type.IsArray()) && _compilation.IsReadOnlySpanType(rewrittenType))
+            {
+                return new BoundReadOnlySpanFromArray(syntax, rewrittenOperand, conversion.Method, rewrittenType) { WasCompilerGenerated = true };
+            }
+
+            BoundExpression result = BoundCall.Synthesized(syntax, null, conversion.Method, rewrittenOperand);
             Debug.Assert(TypeSymbol.Equals(result.Type, rewrittenType, TypeCompareKind.ConsiderEverything2));
             return result;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -628,6 +628,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return node.Update(member, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, receiverType, node.BinderOpt, type);
         }
 
+        public override BoundNode VisitReadOnlySpanFromArray(BoundReadOnlySpanFromArray node)
+        {
+            BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
+            MethodSymbol method = VisitMethodSymbol(node.Method);
+            TypeSymbol type = this.VisitType(node.Type);
+            return node.Update(operand, method, type);
+        }
+
         private static bool BaseReferenceInReceiverWasRewritten(BoundExpression originalReceiver, BoundExpression rewrittenReceiver)
         {
             return originalReceiver != null && originalReceiver.Kind == BoundKind.BaseReference &&

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -631,7 +631,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override BoundNode VisitReadOnlySpanFromArray(BoundReadOnlySpanFromArray node)
         {
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
-            MethodSymbol method = VisitMethodSymbol(node.Method);
+            MethodSymbol method = VisitMethodSymbol(node.ConversionMethod);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(operand, method, type);
         }


### PR DESCRIPTION
Fixes #31685

The problem to be solved is to generate good code for
``` c#
ReadOnlySpan<byte> s = new byte[] { 1, 2, 3 };
```

There is an implicit conversion operator declared in `ReadOnlySpan<T>` that converts from `T[]` to `ReadOnlySpan<T>`.  However, in the particular case above we would like to elide creation of the array and create a read-only span that wraps the underlying data in the assembly.  There are primitives for doing this.

This was previously done in the compiler by eliding the lowering of the conversion to a bound call.  Lowering would instead preserve the user-defined conversion in the tree.  Then, in emit we would recognize that particular conversion and either perform the optimization if possible, or simply produce a call to the conversion method.  However, that had an unfortunate side-effect (bug), which this PR addresses.

Normally, the lowering phase would translate an invocation of a user-defined conversion operator into a `BoundCall`.  Subsequent phases of the compiler that need to rewrite symbols (such as lambda lowering and iterator rewriting, when the enclosing method is generic) would inherit the proper handling of rewriting symbols from the bound tree rewriter that is generated from `BoundNodes.xml`.  Unfortunately, the symbol appearing inside the conversion is not rewritten by that generated code, and there is no simple way to make it do so.  The bug report #31685 describes symptoms of this underlying issue.

There are a number of approaches one could take to address this issue:
1. Attempt to rehabilitate the original approach by extending the generated rewriter to handle conversions that may contain symbols.  That would require extending a few internal APIs and the bound tree rewriter.
2. Have the emit phase recognize a call to this particular conversion operator, and perform the optimization on that basis.
3. Add a new `BoundNode` that represents this particular optimizable pattern (which we would lower to), and let the generated bound node rewriter handle the contained symbol in subsequent phases where needed.

The approach here takes the third approach.  We back out the implementation of the optimization and add a new implementation based on a newly added bound node.
