### PR TITLE
Fix mismatched use of MEF 1 and 2

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Tags/DefaultImageMonikerService.cs
+++ b/src/EditorFeatures/Core.Wpf/Tags/DefaultImageMonikerService.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Composition;
 using Microsoft.CodeAnalysis.Editor.Wpf;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace Microsoft.CodeAnalysis.Editor.Tags
 {
-    [ExportImageMonikerService(Name = Name), Shared]
+    [ExportImageMonikerService(Name = Name)]
     internal class DefaultImageMonikerService : IImageMonikerService
     {
         public const string Name = nameof(DefaultImageMonikerService);


### PR DESCRIPTION
This is a prerequisite to updating our diagnostic analyzer package in #35439.