### PR TITLE
 Use expected syntax for intentional reference equality test

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
@@ -607,7 +607,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End Sub
 
             Public Function Compare(x As ISymbol, y As ISymbol) As Integer Implements IComparer(Of ISymbol).Compare
-                If x Is y Then
+                If ReferenceEquals(x, y) Then
                     Return 0
                 End If
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
@@ -231,7 +231,7 @@ End Class
             Dim symbol1 = model1.GetSymbolInfo(statement.Label).Symbol
             Dim symbol2 = model2.GetSymbolInfo(statement.Label).Symbol
 
-            Assert.Equal(False, symbol1 Is symbol2)
+            Assert.NotSame(symbol1, symbol2)
             Assert.Equal(symbol1, symbol2)
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelGetDeclaredSymbolAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelGetDeclaredSymbolAPITests.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
             Dim symbol1 = model1.GetDeclaredSymbol(vardecl)
             Dim symbol2 = model2.GetDeclaredSymbol(vardecl)
 
-            Assert.Equal(False, symbol1 Is symbol2)
+            Assert.NotSame(symbol1, symbol2)
             Assert.Equal(symbol1, symbol2)
         End Sub
 
@@ -142,7 +142,7 @@ End Namespace
             Dim symbol1 = model1.GetDeclaredSymbol(vardecl)
             Dim symbol2 = model2.GetDeclaredSymbol(vardecl)
 
-            Assert.Equal(False, symbol1 Is symbol2)
+            Assert.NotSame(symbol1, symbol2)
             Assert.Equal(symbol1, symbol2)
         End Sub
 
@@ -175,7 +175,7 @@ End Namespace
             Dim vardecl2 = tree2.GetCompilationUnitRoot().DescendantNodes().OfType(Of ModifiedIdentifierSyntax)().First()
             Dim symbol2 = model2.GetDeclaredSymbol(vardecl2)
 
-            Assert.Equal(False, symbol1 Is symbol2)
+            Assert.NotSame(symbol1, symbol2)
             Assert.NotEqual(symbol1, symbol2)
         End Sub
 
@@ -209,7 +209,7 @@ End Namespace
             Dim vardecl2 = tree2.GetCompilationUnitRoot().DescendantNodes().OfType(Of ModifiedIdentifierSyntax)().First()
             Dim symbol2 = model2.GetDeclaredSymbol(vardecl2)
 
-            Assert.Equal(False, symbol1 Is symbol2)
+            Assert.NotSame(symbol1, symbol2)
             Assert.NotEqual(symbol1, symbol2)
         End Sub
 

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -1028,7 +1028,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             {
                 if (x is null || y is null)
                 {
-                    return x == y;
+                    return (object)x == y;
                 }
 
                 return x.OriginalDefinition.Equals(y.OriginalDefinition);

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                     {
                         // With the current implementation of the C# binder, this is impossible, but it's probably not wise to
                         // depend on an implementation detail of another layer.
-                        return originalExpressionType != newExpressionType;
+                        return (object)originalExpressionType != newExpressionType;
                     }
 
                     var originalConversion = this.OriginalSemanticModel.ClassifyConversion(originalOtherPartOfConditional, originalExpressionType);
@@ -687,7 +687,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
             if (originalConvertedType == null || newConvertedType == null)
             {
-                return originalConvertedType != newConvertedType;
+                return (object)originalConvertedType != newConvertedType;
             }
 
             var originalConversion = this.OriginalSemanticModel.ClassifyConversion(originalIsOrAsExpression.Left, originalConvertedType, isExplicitInSource: true);

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SignatureComparer.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SignatureComparer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         public bool HaveSameSignature(ISymbol symbol1, ISymbol symbol2, bool caseSensitive)
         {
             // NOTE - we're deliberately using reference equality here for speed.
-            if (symbol1 == symbol2)
+            if ((object)symbol1 == symbol2)
             {
                 return true;
             }
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         public bool HaveSameSignatureAndConstraintsAndReturnTypeAndAccessors(ISymbol symbol1, ISymbol symbol2, bool caseSensitive)
         {
             // NOTE - we're deliberately using reference equality here for speed.
-            if (symbol1 == symbol2)
+            if ((object)symbol1 == symbol2)
             {
                 return true;
             }


### PR DESCRIPTION
This is a prerequisite to updating our diagnostic analyzer package in #35439.

The new `ISymbol` comparison analyzer (RS1024) has exclusions in it for the most common patterns used in C# compiler code for intentionally comparing symbols using reference equality. The cast-to-object pattern was established primarily because the C# compiler code almost always operates on concrete symbol types, and these types have an overridden `operator==`. This change updates the outlying cases, typically cases where the cast-to-object was unnecessary due to the use of interfaces as operands, to follow the patterns used elsewhere in the code.

In addition to the C# cases, there is one outlier case in VB code. The VB compiler code does not have a pattern for intentional reference comparison of `ISymbol`, so the analyzer allows the use of `Is` and `IsNot` for *concrete* symbol types (classes that implement `ISymbol`). This does not impact user scenarios because concrete symbol types are only allowed inside the compiler itself. All of the VB compiler code uses concrete types to interfaces for performance, so this was the only case that couldn't be automatically handled by the analyzer.