### PR TITLE
Fix violations of RS1024 in Microsoft.VisualStudio.LanguageServices

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialogViewModel.cs
@@ -483,7 +483,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                         }
 
                         if (_changeSignatureDialogViewModel._thisParameter != null &&
-                            ParameterSymbol == _changeSignatureDialogViewModel._thisParameter.ParameterSymbol)
+                            Equals(ParameterSymbol, _changeSignatureDialogViewModel._thisParameter.ParameterSymbol))
                         {
                             return @this ?? string.Empty;
                         }

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphNodeIdCreation.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphNodeIdCreation.cs
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
         private static async Task<GraphNodeId> GetPartialForNamedTypeAsync(INamedTypeSymbol namedType, GraphNodeIdName nodeName, Solution solution, CancellationToken cancellationToken, bool isInGenericArguments = false)
         {
             // If this is a simple type, then we don't have much to do
-            if (namedType.ContainingType == null && namedType.ConstructedFrom == namedType && namedType.Arity == 0)
+            if (namedType.ContainingType == null && Equals(namedType.ConstructedFrom, namedType) && namedType.Arity == 0)
             {
                 return GraphNodeId.GetPartial(nodeName, namedType.Name);
             }
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                 // because a symbol is not marked as "constructed" when a type is constructed using its own type parameters.
                 // To distinguish this case, we use "isInGenericArguments" flag which we pass either to populate arguments recursively or to populate "ParentType".
 
-                bool hasGenericArguments = (namedType.ConstructedFrom != namedType || isInGenericArguments) && namedType.TypeArguments != null && namedType.TypeArguments.Any();
+                bool hasGenericArguments = (!Equals(namedType.ConstructedFrom, namedType) || isInGenericArguments) && namedType.TypeArguments != null && namedType.TypeArguments.Any();
 
                 if (hasGenericArguments)
                 {
@@ -375,7 +375,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             }
 
             var underlyingType = ChaseToUnderlyingType(typeSymbol);
-            if (typeSymbol == underlyingType)
+            if (Equals(typeSymbol, underlyingType))
             {
                 // when symbol is for dynamic type
                 return null;


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.