### PR TITLE
Fix violations of RS1024 in Microsoft.CodeAnalysis

### DIFF
--- a/src/Compilers/Core/AnalyzerDriver/DeclarationComputer.cs
+++ b/src/Compilers/Core/AnalyzerDriver/DeclarationComputer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis
             if (namespaceSymbol != null && namespaceSymbol.ConstituentNamespaces.Length > 1)
             {
                 var assemblyToScope = model.Compilation.Assembly;
-                var assemblyScopedNamespaceSymbol = namespaceSymbol.ConstituentNamespaces.FirstOrDefault(ns => ns.ContainingAssembly == assemblyToScope);
+                var assemblyScopedNamespaceSymbol = namespaceSymbol.ConstituentNamespaces.FirstOrDefault(ns => Equals(ns.ContainingAssembly, assemblyToScope));
                 if (assemblyScopedNamespaceSymbol != null)
                 {
                     Debug.Assert(assemblyScopedNamespaceSymbol.ConstituentNamespaces.Length == 1);

--- a/src/Compilers/Core/Portable/Diagnostic/MetadataLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/MetadataLocation.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis
 
         public bool Equals(MetadataLocation other)
         {
-            return other != null && other._module == _module;
+            return other != null && Equals(other._module, _module);
         }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var builder = ImmutableArray.CreateBuilder<CompilationEvent>();
             foreach (var symbol in declaredSymbols)
             {
-                Debug.Assert(symbol.ContainingAssembly == compilation.Assembly);
+                Debug.Assert(Equals(symbol.ContainingAssembly, compilation.Assembly));
                 builder.Add(new SymbolDeclaredCompilationEvent(compilation, symbol));
             }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private ImmutableDictionary<string, SuppressMessageInfo> DecodeLocalSuppressMessageAttributes(ISymbol symbol)
         {
-            var attributes = symbol.GetAttributes().Where(a => a.AttributeClass == this.SuppressMessageAttribute);
+            var attributes = symbol.GetAttributes().Where(a => Equals(a.AttributeClass, this.SuppressMessageAttribute));
             return DecodeLocalSuppressMessageAttributes(symbol, attributes);
         }
 
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             Debug.Assert(symbol is IAssemblySymbol || symbol is IModuleSymbol);
 
-            var attributes = symbol.GetAttributes().Where(a => a.AttributeClass == this.SuppressMessageAttribute);
+            var attributes = symbol.GetAttributes().Where(a => Equals(a.AttributeClass, this.SuppressMessageAttribute));
             DecodeGlobalSuppressMessageAttributes(compilation, symbol, globalSuppressions, attributes);
         }
 

--- a/src/Compilers/Core/Portable/DocumentationCommentId.cs
+++ b/src/Compilers/Core/Portable/DocumentationCommentId.cs
@@ -363,7 +363,7 @@ namespace Microsoft.CodeAnalysis
 
                 private ReferenceGenerator GetReferenceGenerator(ISymbol typeParameterContext)
                 {
-                    if (_referenceGenerator == null || _referenceGenerator.TypeParameterContext != typeParameterContext)
+                    if (_referenceGenerator == null || !Equals(_referenceGenerator.TypeParameterContext, typeParameterContext))
                     {
                         _referenceGenerator = new ReferenceGenerator(_builder, typeParameterContext);
                     }
@@ -547,7 +547,7 @@ namespace Microsoft.CodeAnalysis
 
                 if (symbol.IsGenericType)
                 {
-                    if (symbol.OriginalDefinition == symbol)
+                    if (Equals(symbol.OriginalDefinition, symbol))
                     {
                         _builder.Append("`");
                         _builder.Append(symbol.TypeParameters.Length);
@@ -635,7 +635,7 @@ namespace Microsoft.CodeAnalysis
 
                 for (var scope = _typeParameterContext; scope != null; scope = scope.ContainingSymbol)
                 {
-                    if (scope == typeParameterDeclarer)
+                    if (Equals(scope, typeParameterDeclarer))
                     {
                         return true;
                     }

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
         internal Cci.IMethodBody GetMethodBody(IMethodSymbol methodSymbol)
         {
-            Debug.Assert(methodSymbol.ContainingModule == CommonSourceModule);
+            Debug.Assert(Equals(methodSymbol.ContainingModule, CommonSourceModule));
             Debug.Assert(methodSymbol.IsDefinition);
             Debug.Assert(methodSymbol.PartialDefinitionPart == null); // Must be definition.
 
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
         public void SetMethodBody(IMethodSymbol methodSymbol, Cci.IMethodBody body)
         {
-            Debug.Assert(methodSymbol.ContainingModule == CommonSourceModule);
+            Debug.Assert(Equals(methodSymbol.ContainingModule, CommonSourceModule));
             Debug.Assert(methodSymbol.IsDefinition);
             Debug.Assert(methodSymbol.PartialDefinitionPart == null); // Must be definition.
             Debug.Assert(body == null || (object)methodSymbol == body.MethodDefinition);
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
         private bool IsSourceDefinition(IMethodSymbol method)
         {
-            return method.ContainingModule == CommonSourceModule && method.IsDefinition;
+            return Equals(method.ContainingModule, CommonSourceModule) && method.IsDefinition;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 return false;
             }
 
-            Debug.Assert(localFunction == LocalFunctions[info.ordinal]);
+            Debug.Assert(Equals(localFunction, LocalFunctions[info.ordinal]));
 
             if (_lazyLocalFunctionsGraphs == null)
             {
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             if (_lazyLocalFunctionsGraphs[info.ordinal] == null)
             {
-                Debug.Assert(localFunction == info.operation.Symbol);
+                Debug.Assert(Equals(localFunction, info.operation.Symbol));
                 ControlFlowGraph graph = ControlFlowGraphBuilder.Create(info.operation, this, info.enclosing, _captureIdDispenser);
                 Debug.Assert(graph.OriginalOperation == info.operation);
                 Interlocked.CompareExchange(ref _lazyLocalFunctionsGraphs[info.ordinal], graph, null);

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -3709,7 +3709,7 @@ oneMoreTime:
 
             IOperation tryDispose(IOperation value)
             {
-                Debug.Assert(value.Type == iDisposable);
+                Debug.Assert(Equals(value.Type, iDisposable));
 
                 var method = (IMethodSymbol)_compilation.CommonGetSpecialTypeMember(SpecialMember.System_IDisposable__Dispose);
                 if (method != null)
@@ -6126,7 +6126,7 @@ oneMoreTime:
             if (operation.Instance is IInstanceReferenceOperation instanceReference &&
                 instanceReference.ReferenceKind == InstanceReferenceKind.ImplicitReceiver &&
                 operation.Property.ContainingType.IsAnonymousType &&
-                operation.Property.ContainingType == _currentImplicitInstance.AnonymousType)
+                Equals(operation.Property.ContainingType, _currentImplicitInstance.AnonymousType))
             {
                 if (_currentImplicitInstance.AnonymousTypePropertyValues.TryGetValue(operation.Property, out IOperation captured))
                 {

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeDataComparer.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeDataComparer.cs
@@ -23,8 +23,8 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert(attr1 != null);
             Debug.Assert(attr2 != null);
 
-            return attr1.AttributeClass == attr2.AttributeClass &&
-                attr1.AttributeConstructor == attr2.AttributeConstructor &&
+            return Equals(attr1.AttributeClass, attr2.AttributeClass) &&
+                Equals(attr1.AttributeConstructor, attr2.AttributeConstructor) &&
                 attr1.HasErrors == attr2.HasErrors &&
                 attr1.IsConditionallyOmitted == attr2.IsConditionallyOmitted &&
                 attr1.CommonConstructorArguments.SequenceEqual(attr2.CommonConstructorArguments) &&


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.