### PR TITLE
Fix violations of RS1024 in Microsoft.CodeAnalysis.CSharp

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var arrayType = symbol;
-            while (arrayType != null && arrayType != underlyingType)
+            while (arrayType != null && !Equals(arrayType, underlyingType))
             {
                 if (!this.isFirstSymbolVisited)
                 {


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.