### PR TITLE
Fix violations of RS1024 in Microsoft.CodeAnalysis.Workspaces

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
                 var symbolsWithName = symbols.SelectAsArray(s => new SymbolAndProjectId(s, project.Id));
 
-                if (startingCompilation != null && startingAssembly != null && compilation.Assembly != startingAssembly)
+                if (startingCompilation != null && startingAssembly != null && !Equals(compilation.Assembly, startingAssembly))
                 {
                     // Return symbols from skeleton assembly in this case so that symbols have 
                     // the same language as startingCompilation.

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
@@ -571,7 +571,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
                         // Resolve forwarded type and verify that the types from different assembly are indeed equivalent.
                         var forwardedType = referencedAssembly.ResolveForwardedType(fullyQualifiedTypeName);
-                        if (forwardedType == expectedForwardedType)
+                        if (Equals(forwardedType, expectedForwardedType))
                         {
                             verifiedKeys.Add(kvp.Key);
                             verifiedCount++;

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
             BasicBlockAnalysisData AnalyzeLocalFunction(IMethodSymbol localFunction)
             {
                 var localFunctionOperation = rootOperation.Descendants()
-                    .FirstOrDefault(o => (o as ILocalFunctionOperation)?.Symbol == localFunction);
+                    .FirstOrDefault(o => Equals((o as ILocalFunctionOperation)?.Symbol, localFunction));
 
                 // Can likely be null for broken code.
                 if (localFunctionOperation != null)

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageResult.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageResult.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
             {
                 // 'write' operation is 'null' for the initial write of the parameter,
                 // which may be from the caller's argument or parameter initializer.
-                if (kvp.Key.write == null && kvp.Key.symbol == parameter)
+                if (kvp.Key.write == null && Equals(kvp.Key.symbol, parameter))
                 {
                     return kvp.Value;
                 }
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
             int count = 0;
             foreach (var kvp in SymbolWritesMap)
             {
-                if (kvp.Key.symbol == symbol)
+                if (Equals(kvp.Key.symbol, symbol))
                 {
                     count++;
                 }

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                                 if (conflictAnnotation.RenameDeclarationLocationReferences[symbolIndex].IsOverriddenFromMetadata)
                                 {
                                     var overridingSymbol = await SymbolFinder.FindSymbolAtPositionAsync(solution.GetDocument(newLocation.SourceTree), newLocation.SourceSpan.Start, cancellationToken: _cancellationToken).ConfigureAwait(false);
-                                    if (overridingSymbol != null && renamedSymbolInNewSolution != overridingSymbol)
+                                    if (overridingSymbol != null && !Equals(renamedSymbolInNewSolution, overridingSymbol))
                                     {
                                         if (!overridingSymbol.IsOverride)
                                         {

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/DeclarationConflictHelpers.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/DeclarationConflictHelpers.cs
@@ -58,8 +58,8 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                     {
                         var conflictingMethod = conflictingSymbol as IMethodSymbol;
                         var renamedMethod = renamedMember as IMethodSymbol;
-                        if (!(conflictingMethod.PartialDefinitionPart != null && conflictingMethod.PartialDefinitionPart == renamedMethod) &&
-                            !(conflictingMethod.PartialImplementationPart != null && conflictingMethod.PartialImplementationPart == renamedMethod))
+                        if (!(conflictingMethod.PartialDefinitionPart != null && Equals(conflictingMethod.PartialDefinitionPart, renamedMethod)) &&
+                            !(conflictingMethod.PartialImplementationPart != null && Equals(conflictingMethod.PartialImplementationPart, renamedMethod)))
                         {
                             builder.AddRange(conflictingSymbol.Locations);
                         }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -61,12 +61,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             if (method.PartialDefinitionPart != null)
             {
-                Debug.Assert(method.PartialImplementationPart == null && method.PartialDefinitionPart != method);
+                Debug.Assert(method.PartialImplementationPart == null && !Equals(method.PartialDefinitionPart, method));
                 return ImmutableArray.Create(method, method.PartialDefinitionPart);
             }
             else if (method.PartialImplementationPart != null)
             {
-                Debug.Assert(method.PartialImplementationPart != method);
+                Debug.Assert(!Equals(method.PartialImplementationPart, method));
                 return ImmutableArray.Create(method.PartialImplementationPart, method);
             }
             else

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 (t, m) =>
                 {
                     var implementation = classOrStructType.FindImplementationForInterfaceMember(m);
-                    return implementation != null && implementation.ContainingType == classOrStructType;
+                    return implementation != null && Equals(implementation.ContainingType, classOrStructType);
                 },
                 GetMembers,
                 allowReimplementation: true,
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 (t, m) =>
                 {
                     var implementation = classOrStructType.FindImplementationForInterfaceMember(m);
-                    return implementation != null && implementation.ContainingType == classOrStructType;
+                    return implementation != null && Equals(implementation.ContainingType, classOrStructType);
                 },
                 interfaceMemberGetter,
                 allowReimplementation: true,

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamespaceSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamespaceSymbolExtensions.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             {
                 // Assume that any namespace in our own assembly is accessible to us.  This saves a
                 // lot of cpu time checking namespaces.
-                if (constituent.ContainingAssembly == assembly)
+                if (Equals(constituent.ContainingAssembly, assembly))
                 {
                     return true;
                 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -714,7 +714,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             hideModuleNameAttribute = hideModuleNameAttribute ?? compilation.HideModuleNameAttribute();
             foreach (var attribute in attributes)
             {
-                if (attribute.AttributeClass == hideModuleNameAttribute)
+                if (Equals(attribute.AttributeClass, hideModuleNameAttribute))
                 {
                     return true;
                 }
@@ -734,7 +734,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             foreach (var attribute in attributes)
             {
-                if (attribute.AttributeConstructor == constructor &&
+                if (Equals(attribute.AttributeConstructor, constructor) &&
                     attribute.ConstructorArguments.Length == 1 &&
                     attribute.ConstructorArguments.First().Value is int)
                 {
@@ -794,7 +794,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 {
                     foreach (var constructor in attributeConstructors)
                     {
-                        if (attribute.AttributeConstructor == constructor)
+                        if (Equals(attribute.AttributeConstructor, constructor))
                         {
                             var actualFlags = 0;
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.SubstituteTypesVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.SubstituteTypesVisitor.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             public override ITypeSymbol VisitNamedType(INamedTypeSymbol symbol)
             {
                 var mapped = VisitType(symbol);
-                if (mapped != symbol)
+                if (!Equals(mapped, symbol))
                 {
                     return mapped;
                 }
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     : symbol.ContainingType.Accept(this);
 
                 // If our containing type changed, then find us again in the new containing type.
-                if (updatedContainingType != symbol.ContainingType)
+                if (!Equals(updatedContainingType, symbol.ContainingType))
                 {
                     symbol = updatedContainingType.GetTypeMembers(symbol.Name, symbol.Arity).First(m => m.TypeKind == symbol.TypeKind);
                 }
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             public override ITypeSymbol VisitArrayType(IArrayTypeSymbol symbol)
             {
                 var mapped = VisitType(symbol);
-                if (mapped != symbol)
+                if (!Equals(mapped, symbol))
                 {
                     return mapped;
                 }
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             public override ITypeSymbol VisitPointerType(IPointerTypeSymbol symbol)
             {
                 var mapped = VisitType(symbol);
-                if (mapped != symbol)
+                if (!Equals(mapped, symbol))
                 {
                     return mapped;
                 }

--- a/src/Workspaces/Core/Portable/Shared/Utilities/EditorBrowsableHelpers.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/EditorBrowsableHelpers.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             }
 
             var candidateConstructors = editorBrowsableAttributeType.Constructors
-                                                                    .Where(c => c.Parameters.Length == 1 && c.Parameters[0].Type == editorBrowsableStateType);
+                                                                    .Where(c => c.Parameters.Length == 1 && Equals(c.Parameters[0].Type, editorBrowsableStateType));
 
             // Ensure the constructor adheres to the expected EditorBrowsable pattern
             candidateConstructors = candidateConstructors.Where(c => (!c.IsVararg &&
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
             var candidateConstructors = typeLibAttributeType.Constructors
                                                             .Where(c => c.Parameters.Length == 1 &&
-                                                                        (c.Parameters[0].Type == typeLibFlagsType || c.Parameters[0].Type == shortType));
+                                                                        (Equals(c.Parameters[0].Type, typeLibFlagsType) || Equals(c.Parameters[0].Type, shortType)));
 
             candidateConstructors = candidateConstructors.Where(c => (!c.IsVararg &&
                                                                       !c.Parameters[0].IsRefOrOut() &&

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -894,7 +894,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 // A private class with no nested or sibling classes is effectively sealed.
                 if (namedType.DeclaredAccessibility == Accessibility.Private &&
                     namedType.ContainingType != null &&
-                    !namedType.ContainingType.GetTypeMembers().Any(nestedType => nestedType.TypeKind == TypeKind.Class && namedType != nestedType))
+                    !namedType.ContainingType.GetTypeMembers().Any(nestedType => nestedType.TypeKind == TypeKind.Class && !Equals(namedType, nestedType)))
                 {
                     return true;
                 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -400,7 +400,7 @@ namespace Microsoft.CodeAnalysis
                 if (this.TryGetCompilation(state.Id, out var compilation))
                 {
                     // if the symbol is the compilation's assembly symbol, we are done
-                    if (compilation.Assembly == assemblySymbol)
+                    if (Equals(compilation.Assembly, assemblySymbol))
                     {
                         return state;
                     }


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.