### PR TITLE
Fix violations of RS1024 in Roslyn.Test.Utilities

### DIFF
--- a/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -430,7 +430,7 @@ namespace Microsoft.CodeAnalysis
             {
                 // Ensure we are not invoked for merged namespace symbol, but instead for constituent namespace scoped to the source assembly.
                 var ns = (INamespaceSymbol)context.Symbol;
-                if (ns.ContainingAssembly != context.Compilation.Assembly || ns.ConstituentNamespaces.Length > 1)
+                if (!Equals(ns.ContainingAssembly, context.Compilation.Assembly) || ns.ConstituentNamespaces.Length > 1)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(Rule, ns.Locations[0]));
                 }

--- a/src/Test/Utilities/Portable/Diagnostics/CouldHaveMoreSpecificTypeAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/CouldHaveMoreSpecificTypeAnalyzer.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 bool success = true;
                 foreach (INamedTypeSymbol testType in types)
                 {
-                    if (type != testType)
+                    if (!Equals(type, testType))
                     {
                         if (!DerivesFrom(testType, type))
                         {

--- a/src/Test/Utilities/Portable/Diagnostics/FieldCouldBeReadOnlyAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/FieldCouldBeReadOnlyAnalyzer.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
                 IFieldSymbol targetField = fieldReference.Field;
 
-                if (staticConstructorType != null && targetField.IsStatic && targetField.ContainingType == staticConstructorType)
+                if (staticConstructorType != null && targetField.IsStatic && Equals(targetField.ContainingType, staticConstructorType))
                 {
                     return;
                 }

--- a/src/Test/Utilities/Portable/Diagnostics/OperationTestAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/OperationTestAnalyzer.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                             {
                                 ISimpleAssignmentOperation setupAssignment = (ISimpleAssignmentOperation)((IExpressionStatementOperation)setup).Operation;
                                 if (setupAssignment.Target.Kind == OperationKind.LocalReference &&
-                                    ((ILocalReferenceOperation)setupAssignment.Target).Local == testVariable &&
+                                    Equals(((ILocalReferenceOperation)setupAssignment.Target).Local, testVariable) &&
                                     setupAssignment.Value.ConstantValue.HasValue &&
                                     setupAssignment.Value.Type.SpecialType == SpecialType.System_Int32)
                                 {
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                 ISimpleAssignmentOperation advanceAssignment = (ISimpleAssignmentOperation)advanceExpression;
 
                 if (advanceAssignment.Target.Kind == OperationKind.LocalReference &&
-                    ((ILocalReferenceOperation)advanceAssignment.Target).Local == testVariable &&
+                    Equals(((ILocalReferenceOperation)advanceAssignment.Target).Local, testVariable) &&
                     advanceAssignment.Value.Kind == OperationKind.Binary &&
                     advanceAssignment.Value.Type.SpecialType == SpecialType.System_Int32)
                 {
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                     IBinaryOperation advanceOperation = (IBinaryOperation)advanceAssignment.Value;
                     if (advanceOperation.OperatorMethod == null &&
                         advanceOperation.LeftOperand.Kind == OperationKind.LocalReference &&
-                        ((ILocalReferenceOperation)advanceOperation.LeftOperand).Local == testVariable &&
+                        Equals(((ILocalReferenceOperation)advanceOperation.LeftOperand).Local, testVariable) &&
                         advanceOperation.RightOperand.ConstantValue.HasValue &&
                         advanceOperation.RightOperand.Type.SpecialType == SpecialType.System_Int32)
                     {
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                 ICompoundAssignmentOperation advanceAssignment = (ICompoundAssignmentOperation)advanceExpression;
 
                 if (advanceAssignment.Target.Kind == OperationKind.LocalReference &&
-                    ((ILocalReferenceOperation)advanceAssignment.Target).Local == testVariable &&
+                    Equals(((ILocalReferenceOperation)advanceAssignment.Target).Local, testVariable) &&
                     advanceAssignment.Value.ConstantValue.HasValue &&
                     advanceAssignment.Value.Type.SpecialType == SpecialType.System_Int32)
                 {
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                 IIncrementOrDecrementOperation advanceAssignment = (IIncrementOrDecrementOperation)advanceExpression;
 
                 if (advanceAssignment.Target.Kind == OperationKind.LocalReference &&
-                    ((ILocalReferenceOperation)advanceAssignment.Target).Local == testVariable)
+                    Equals(((ILocalReferenceOperation)advanceAssignment.Target).Local, testVariable))
                 {
                     // Advance binary operation is known to involve a reference to the local used in the test and a constant.
                     advanceIncrementOpt = new Optional<object>(1);


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.