### PR TITLE
Fix violations of RS1024 in Microsoft.CodeAnalysis.VisualBasic

### DIFF
--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
@@ -95,7 +95,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 If Not format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.ExpandNullable) Then
-                    If ITypeSymbolHelpers.IsNullableType(symbol) AndAlso symbol IsNot symbol.OriginalDefinition Then
+                    If ITypeSymbolHelpers.IsNullableType(symbol) AndAlso Not Equals(symbol, symbol.OriginalDefinition) Then
                         symbol.TypeArguments(0).Accept(Me.NotFirstVisitor())
                         AddPunctuation(SyntaxKind.QuestionToken)
                         Return


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.