### PR TITLE
Fix violations of RS1024 in Microsoft.CodeAnalysis.VisualBasic.Workspaces

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/CaseCorrection/VisualBasicCaseCorrectionService.Rewriter.vb
@@ -94,7 +94,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CaseCorrection
                         ' If this is a partial method implementation part, then case correct the method name to match the partial method definition part.
                         Dim definitionPart As IMethodSymbol = Nothing
                         Dim otherPartOfPartial = GetOtherPartOfPartialMethod(methodDeclaration, definitionPart)
-                        If otherPartOfPartial IsNot Nothing And otherPartOfPartial Is definitionPart Then
+                        If otherPartOfPartial IsNot Nothing And Equals(otherPartOfPartial, definitionPart) Then
                             Return CaseCorrectIdentifierIfNamesDiffer(token, newToken, otherPartOfPartial)
                         End If
                     Else
@@ -106,7 +106,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CaseCorrection
                             If methodDeclaration IsNot Nothing Then
                                 Dim definitionPart As IMethodSymbol = Nothing
                                 Dim otherPartOfPartial = GetOtherPartOfPartialMethod(methodDeclaration, definitionPart)
-                                If otherPartOfPartial IsNot Nothing And otherPartOfPartial Is definitionPart Then
+                                If otherPartOfPartial IsNot Nothing And Equals(otherPartOfPartial, definitionPart) Then
                                     Dim ordinal As Integer = 0
                                     For Each param As SyntaxNode In methodDeclaration.ParameterList.Parameters
                                         If param Is parameterSyntax Then

--- a/src/Workspaces/VisualBasic/Portable/Extensions/CastAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/CastAnalyzer.vb
@@ -292,7 +292,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
                         Return True
                     ElseIf expressionToCastTypeIsWideningRefOrDefault OrElse expressionToOuterTypeIsWideningRefOrDefault Then
-                        Return castType Is speculatedExpressionOuterType
+                        Return Equals(castType, speculatedExpressionOuterType)
                     End If
 
                     If expressionToCastType.IsWidening AndAlso expressionToCastType.IsLambda AndAlso

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
@@ -708,7 +708,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Dim taskOfT = Me.Compilation.TaskOfTType()
 
                         Return If(
-                            taskOfT IsNot Nothing AndAlso memberMethod.ReturnType.OriginalDefinition Is taskOfT AndAlso typeArguments.Any(),
+                            taskOfT IsNot Nothing AndAlso Equals(memberMethod.ReturnType.OriginalDefinition, taskOfT) AndAlso typeArguments.Any(),
                             CreateResult(typeArguments.First()),
                             SpecializedCollections.EmptyEnumerable(Of TypeInferenceInfo))
                     Else

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
 
             Return _context.SemanticModel _
                 .LookupSymbols(_context.Position, container:=containingType) _
-                .WhereAsArray(Function(s) s.Kind = SymbolKind.Event AndAlso s.ContainingType Is containingType)
+                .WhereAsArray(Function(s) s.Kind = SymbolKind.Event AndAlso Equals(s.ContainingType, containingType))
         End Function
 
         Private Function GetUnqualifiedSymbolsForType() As ImmutableArray(Of ISymbol)
@@ -225,7 +225,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
 
                         ' case:
                         '    MyBase.
-                        If parameter.IsMe AndAlso parameter.Type IsNot container Then
+                        If parameter.IsMe AndAlso Not Equals(parameter.Type, container) Then
                             useBaseReferenceAccessibility = True
                         End If
                 End Select
@@ -233,7 +233,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
                 ' Check for color color
                 Dim speculativeTypeBinding = _context.SemanticModel.GetSpeculativeTypeInfo(_context.Position, leftExpression, SpeculativeBindingOption.BindAsTypeOrNamespace)
                 Dim speculativeAliasBinding = _context.SemanticModel.GetSpeculativeAliasInfo(_context.Position, leftExpression, SpeculativeBindingOption.BindAsTypeOrNamespace)
-                If TypeOf leftHandSymbolInfo.Symbol IsNot INamespaceOrTypeSymbol AndAlso speculativeAliasBinding Is Nothing AndAlso firstSymbol.GetSymbolType() Is speculativeTypeBinding.Type Then
+                If TypeOf leftHandSymbolInfo.Symbol IsNot INamespaceOrTypeSymbol AndAlso speculativeAliasBinding Is Nothing AndAlso Equals(firstSymbol.GetSymbolType(), speculativeTypeBinding.Type) Then
                     excludeShared = False
                     excludeInstance = False
                 End If
@@ -461,7 +461,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
             Dim type = TryCast(symbol, ITypeSymbol)
 
             If type IsNot Nothing Then
-                If type.TypeKind = TypeKind.Class AndAlso Not type.IsSealed AndAlso type IsNot within Then
+                If type.TypeKind = TypeKind.Class AndAlso Not type.IsSealed AndAlso Not Equals(type, within) Then
                     Return True
                 End If
 
@@ -491,7 +491,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
                 Return False
             End If
 
-            If namedTypeSymbol.TypeKind = TypeKind.Class AndAlso Not namedTypeSymbol.IsSealed AndAlso namedTypeSymbol IsNot within Then
+            If namedTypeSymbol.TypeKind = TypeKind.Class AndAlso Not namedTypeSymbol.IsSealed AndAlso Not Equals(namedTypeSymbol, within) Then
                 Return True
             End If
 

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -373,7 +373,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                     If TypeOf token.Parent Is SimpleNameSyntax AndAlso token.Kind <> SyntaxKind.GlobalKeyword AndAlso token.Parent.Parent.IsKind(SyntaxKind.QualifiedName, SyntaxKind.QualifiedCrefOperatorReference) Then
                         Dim symbol = Me._speculativeModel.GetSymbolInfo(token.Parent, Me._cancellationToken).Symbol
                         If symbol IsNot Nothing AndAlso Me._renamedSymbol.Kind <> SymbolKind.Local AndAlso Me._renamedSymbol.Kind <> SymbolKind.RangeVariable AndAlso
-                            (symbol Is Me._renamedSymbol OrElse SymbolKey.GetComparer(ignoreCase:=True, ignoreAssemblyKeys:=False).Equals(symbol.GetSymbolKey(), Me._renamedSymbol.GetSymbolKey())) Then
+                            (Equals(symbol, Me._renamedSymbol) OrElse SymbolKey.GetComparer(ignoreCase:=True, ignoreAssemblyKeys:=False).Equals(symbol.GetSymbolKey(), Me._renamedSymbol.GetSymbolKey())) Then
                             Return True
                         End If
                     End If

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.Expander.vb
@@ -653,7 +653,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                             replaceNode:=False)
                     Else
                         Dim left As ExpressionSyntax
-                        If _semanticModel.GetEnclosingNamedType(originalSimpleName.SpanStart, _cancellationToken) IsNot symbol.ContainingType Then
+                        If Not Equals(_semanticModel.GetEnclosingNamedType(originalSimpleName.SpanStart, _cancellationToken), symbol.ContainingType) Then
                             left = SyntaxFactory.MyBaseExpression()
                         Else
                             left = SyntaxFactory.MeExpression()


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.