### PR TITLE
Fix violations of RS1024 in Microsoft.CodeAnalysis.UnitTests

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageTargetSymbolResolverTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageTargetSymbolResolverTests.cs
@@ -1327,7 +1327,7 @@ End Class
                     }
 
                     var symbol = symbols.SingleOrDefault();
-                    Assert.True(expectedSymbol == symbol,
+                    Assert.True(Equals(expectedSymbol, symbol),
                         string.Format("Failed to resolve FxCop fully-qualified name '{0}' to symbol '{1}': got '{2}'",
                             fxCopName, expectedSymbol, symbol));
                 }


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.