### PR TITLE
Fix violations of RS1024 in Microsoft.CodeAnalysis.VisualBasic.Features

### DIFF
--- a/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
+++ b/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
@@ -569,7 +569,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
                         convertedType = If(Await SymbolFinder.FindSourceDefinitionAsync(convertedType, document.Project.Solution).ConfigureAwait(False), convertedType)
                     End If
 
-                    If convertedType Is symbol.ContainingType Then
+                    If Equals(convertedType, symbol.ContainingType) Then
                         convertedType = semanticModel.GetSymbolInfo(u.Operand).Symbol
                         If convertedType IsNot Nothing Then
                             results.Add(convertedType)
@@ -588,7 +588,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
                             nodeType = If(Await SymbolFinder.FindSourceDefinitionAsync(nodeType, document.Project.Solution).ConfigureAwait(False), nodeType)
                         End If
 
-                        If nodeType Is symbol.ContainingType Then
+                        If Equals(nodeType, symbol.ContainingType) Then
                             results.Add(semanticModel.GetDeclaredSymbol(cast.Identifier.Parent))
                         End If
                     End If

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
@@ -118,7 +118,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
 
             Dim existingSymbols = existingSymbolAndProjectIds.SelectAsArray(Function(t) t.Symbol)
             If existingSymbols.Any(Function(existingSymbol) existingSymbol IsNot Nothing _
-                                                   AndAlso existingSymbol.ContainingNamespace Is targetType.ContainingNamespace) Then
+                                                   AndAlso Equals(existingSymbol.ContainingNamespace, targetType.ContainingNamespace)) Then
                 ' There already exists a delegate that matches the event handler name
                 Return Nothing
             End If

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.ReferenceRewriter.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.ReferenceRewriter.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.InlineTemporary
                 End If
 
                 Dim symbolInfo = _semanticModel.GetSymbolInfo(node)
-                Return symbolInfo.Symbol Is _localSymbol
+                Return Equals(symbolInfo.Symbol, _localSymbol)
             End Function
 
             Public Overrides Function VisitIdentifierName(node As IdentifierNameSyntax) As SyntaxNode

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.InlineTemporary
                 Dim solution = document.Project.Solution
                 Dim findReferencesResult = Await SymbolFinder.FindReferencesAsync(local, solution, cancellationToken).ConfigureAwait(False)
 
-                Dim locations = findReferencesResult.Single(Function(r) r.Definition Is local).Locations
+                Dim locations = findReferencesResult.Single(Function(r) Equals(r.Definition, local)).Locations
                 If Not locations.Any(Function(loc) semanticModel.SyntaxTree.OverlapsHiddenPosition(loc.Location.SourceSpan, cancellationToken)) Then
                     Return locations
                 End If
@@ -154,7 +154,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.InlineTemporary
             ' Collect the identifier names for each reference.
             Dim local = semanticModel.GetDeclaredSymbol(modifiedIdentifier, cancellationToken)
             Dim symbolRefs = Await SymbolFinder.FindReferencesAsync(local, updatedDocument.Project.Solution, cancellationToken).ConfigureAwait(False)
-            Dim references = symbolRefs.Single(Function(r) r.Definition Is local).Locations
+            Dim references = symbolRefs.Single(Function(r) Equals(r.Definition, local)).Locations
             Dim syntaxRoot = Await updatedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False)
 
             ' Collect the target statement for each reference.

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
@@ -74,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 Function(s) s.MatchesKind(SymbolKind.Field, SymbolKind.Local, SymbolKind.Parameter, SymbolKind.Property) AndAlso
                     s.IsEditorBrowsable(hideAdvancedMembers, context.SemanticModel.Compilation))
 
-            Dim otherInstances = otherSymbols.WhereAsArray(Function(s) enumType Is GetTypeFromSymbol(s))
+            Dim otherInstances = otherSymbols.WhereAsArray(Function(s) Equals(enumType, GetTypeFromSymbol(s)))
 
             Return Task.FromResult(otherInstances.Concat(enumType))
         End Function
@@ -102,7 +102,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
         Protected Overrides Function GetDisplayAndSuffixAndInsertionText(symbol As ISymbol, context As SyntaxContext) As (displayText As String, suffix As String, insertionText As String)
             If symbol.ContainingType IsNot Nothing AndAlso symbol.ContainingType.TypeKind = TypeKind.Enum Then
-                If _cachedDisplayAndInsertionTextContainingType IsNot symbol.ContainingType OrElse _cachedDisplayAndInsertionTextContext IsNot context Then
+                If Not Equals(_cachedDisplayAndInsertionTextContainingType, symbol.ContainingType) OrElse _cachedDisplayAndInsertionTextContext IsNot context Then
                     Dim displayFormat = SymbolDisplayFormat.MinimallyQualifiedFormat.WithMemberOptions(SymbolDisplayMemberOptions.IncludeContainingType).WithLocalOptions(SymbolDisplayLocalOptions.None)
                     Dim displayService = context.GetLanguageService(Of ISymbolDisplayService)()
                     _cachedDisplayAndInsertionTextContainingTypeText = displayService.ToMinimalDisplayString(context.SemanticModel, context.Position, symbol.ContainingType, displayFormat)

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/MeKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/MeKeywordRecommender.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
 
                 Dim priority = MatchPriority.Default
                 Dim enclosingType = context.SemanticModel.GetEnclosingNamedType(context.Position, cancellationToken)
-                If enclosingType IsNot Nothing AndAlso context.InferredTypes.Any(Function(t) t Is enclosingType) Then
+                If enclosingType IsNot Nothing AndAlso context.InferredTypes.Any(Function(t) Equals(t, enclosingType)) Then
                     priority = SymbolMatchPriority.Keyword
                 End If
 

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.vb
@@ -101,7 +101,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Dim symbolInfo = binding.GetSpeculativeSymbolInfo(contextNode.SpanStart, typeName, SpeculativeBindingOption.BindAsTypeOrNamespace)
                 Dim currentType = TryCast(symbolInfo.Symbol, ITypeSymbol)
 
-                If currentType IsNot vbType Then
+                If Not Equals(currentType, vbType) Then
                     Return New OperationStatus(OperationStatusFlag.BestEffort,
                         String.Format(FeaturesResources.Type_parameter_0_is_hidden_by_another_type_parameter_1,
                             typeParameter.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionValidator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionValidator.vb
@@ -212,8 +212,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     Continue For
                 End If
 
-                If result.WrittenOutside().Any(Function(s) s Is local) OrElse
-result.ReadOutside().Any(Function(s) s Is local) Then
+                If result.WrittenOutside().Any(Function(s) Equals(s, local)) OrElse
+result.ReadOutside().Any(Function(s) Equals(s, local)) Then
                     Return False
                 End If
             Next

--- a/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
@@ -211,7 +211,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateConstructor
 
                 Dim typeNameToReplace = DirectCast(oldToken.Parent, TypeSyntax)
                 Dim newTypeName As TypeSyntax
-                If namedType IsNot state.TypeToGenerateIn Then
+                If Not Equals(namedType, state.TypeToGenerateIn) Then
                     While True
                         Dim parentType = TryCast(typeNameToReplace.Parent, TypeSyntax)
                         If parentType Is Nothing Then

--- a/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicAnonymousTypeDisplayService.vb
+++ b/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicAnonymousTypeDisplayService.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LanguageServices
             ' So ugly.  We remove the 'Invoke' name that was added by the symbol display service.
             Dim result = New List(Of SymbolDisplayPart)
             For Each part In parts
-                If part.Symbol Is delegateInvoke Then
+                If Equals(part.Symbol, delegateInvoke) Then
                     Continue For
                 End If
 

--- a/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
@@ -53,7 +53,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodSynchronous
                 Dim newFunctionStatement = functionStatement.WithAsClause(newAsClause)
                 newFunctionStatement = RemoveAsyncKeyword(newFunctionStatement)
                 Return node.WithSubOrFunctionStatement(newFunctionStatement)
-            ElseIf methodSymbol.ReturnType.OriginalDefinition Is knownTypes._taskType Then
+            ElseIf Equals(methodSymbol.ReturnType.OriginalDefinition, knownTypes._taskType) Then
                 ' Convert this to a 'Sub' method.
                 Dim subStatement = SyntaxFactory.SubStatement(
                     functionStatement.AttributeLists,

--- a/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.vb
@@ -84,7 +84,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
 
             ' if the symbol could be bound, replace that item in the symbol list
             If matchedMethodSymbol IsNot Nothing AndAlso matchedMethodSymbol.IsGenericMethod Then
-                memberGroup = memberGroup.SelectAsArray(Function(m) If(matchedMethodSymbol.OriginalDefinition Is m, matchedMethodSymbol, m))
+                memberGroup = memberGroup.SelectAsArray(Function(m) If(Equals(matchedMethodSymbol.OriginalDefinition, m), matchedMethodSymbol, m))
             End If
 
             Dim enclosingSymbol = semanticModel.GetEnclosingSymbol(position)

--- a/src/Features/VisualBasic/Portable/SignatureHelp/RaiseEventStatementSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/RaiseEventStatementSignatureHelpProvider.vb
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 semanticModel.LookupSymbols(raiseEventStatement.SpanStart, containingType, raiseEventStatement.Name.Identifier.ValueText))
 
             Dim symbolDisplayService = document.GetLanguageService(Of ISymbolDisplayService)()
-            Dim allowedEvents = events.WhereAsArray(Function(s) s.Kind = SymbolKind.Event AndAlso s.ContainingType Is containingType).
+            Dim allowedEvents = events.WhereAsArray(Function(s) s.Kind = SymbolKind.Event AndAlso Equals(s.ContainingType, containingType)).
                                        OfType(Of IEventSymbol)().
                                        ToImmutableArrayOrEmpty().
                                        FilterToVisibleAndBrowsableSymbolsAndNotUnsafeSymbols(document.ShouldHideAdvancedMembers(), semanticModel.Compilation).


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.