### PR TITLE
Fix violations of RS1024 in Microsoft.CodeAnalysis.CSharp.Features

### DIFF
--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -662,7 +662,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
                                 convertedType = SymbolFinder.FindSourceDefinitionAsync(convertedType, document.Project.Solution, cancellationToken).WaitAndGetResult_CanCallOnBackground(cancellationToken) ?? convertedType;
                             }
 
-                            return convertedType == symbol.ContainingType;
+                            return Equals(convertedType, symbol.ContainingType);
                         })
                 .SelectAsArray(n => semanticModel.GetSymbolInfo(n, cancellationToken).Symbol);
 

--- a/src/Features/CSharp/Portable/CodeRefactorings/ConvertLocalFunctionToMethod/CSharpConvertLocalFunctionToMethodCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/ConvertLocalFunctionToMethod/CSharpConvertLocalFunctionToMethodCodeRefactoringProvider.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertLocalFunctionToM
 
                 // Using symbol to get type arguments, since it could be inferred and not present in the source
                 var symbol = semanticModel.GetSymbolInfo(node, cancellationToken).Symbol as IMethodSymbol;
-                if (symbol?.OriginalDefinition != declaredSymbol)
+                if (!Equals(symbol?.OriginalDefinition, declaredSymbol))
                 {
                     continue;
                 }

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
             if (local != null)
             {
                 var findReferencesResult = await SymbolFinder.FindReferencesAsync(local, document.Project.Solution, cancellationToken).ConfigureAwait(false);
-                var locations = findReferencesResult.Single(r => r.Definition == local).Locations;
+                var locations = findReferencesResult.Single(r => Equals(r.Definition, local)).Locations;
                 if (!locations.Any(loc => semanticModel.SyntaxTree.OverlapsHiddenPosition(loc.Location.SourceSpan, cancellationToken)))
                 {
                     return locations;
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
             // Collect the identifier names for each reference.
             var local = (ILocalSymbol)semanticModel.GetDeclaredSymbol(variableDeclarator, cancellationToken);
             var symbolRefs = await SymbolFinder.FindReferencesAsync(local, updatedDocument.Project.Solution, cancellationToken).ConfigureAwait(false);
-            var references = symbolRefs.Single(r => r.Definition == local).Locations;
+            var references = symbolRefs.Single(r => Equals(r.Definition, local)).Locations;
             var syntaxRoot = await updatedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             // Collect the topmost parenting expression for each reference.

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -199,9 +199,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 var valueTaskType = compilation.ValueTaskOfTType();
                 var lazyOfTType = compilation.LazyOfTType();
 
-                if (originalDefinition == taskOfTType ||
-                    originalDefinition == valueTaskType ||
-                    originalDefinition == lazyOfTType ||
+                if (Equals(originalDefinition, taskOfTType) ||
+                    Equals(originalDefinition, valueTaskType) ||
+                    Equals(originalDefinition, lazyOfTType) ||
                     originalDefinition.SpecialType == SpecialType.System_Nullable_T)
                 {
                     return UnwrapType(namedType.TypeArguments[0], compilation, wasPlural: wasPlural, seenTypes: seenTypes);

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ThisKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ThisKeywordRecommender.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         protected override bool ShouldPreselect(CSharpSyntaxContext context, CancellationToken cancellationToken)
         {
             var outerType = context.SemanticModel.GetEnclosingNamedType(context.Position, cancellationToken);
-            return context.InferredTypes.Any(t => t == outerType);
+            return context.InferredTypes.Any(t => Equals(t, outerType));
         }
     }
 }

--- a/src/Features/CSharp/Portable/ConvertLinq/ConvertForEachToLinqQuery/CSharpConvertForEachToLinqQueryProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertLinq/ConvertForEachToLinqQuery/CSharpConvertForEachToLinqQueryProvider.cs
@@ -277,8 +277,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertLinq.ConvertForEachToLinqQuery
 
                     var yieldStatementsCount = memberDeclarationSyntax.DescendantNodes().OfType<YieldStatementSyntax>()
                         // Exclude yield statements from nested local functions.
-                        .Where(statement => semanticModel.GetEnclosingSymbol(
-                            statement.SpanStart, cancellationToken) == memberDeclarationSymbol).Count();
+                        .Where(statement => Equals(semanticModel.GetEnclosingSymbol(
+                            statement.SpanStart, cancellationToken), memberDeclarationSymbol)).Count();
 
                     if (forEachInfo.ForEachStatement.IsParentKind(SyntaxKind.Block) &&
                         forEachInfo.ForEachStatement.Parent.Parent == memberDeclarationSyntax)

--- a/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
             {
                 SyntaxToken thisOrBaseKeyword;
                 SyntaxKind newCtorInitializerKind;
-                if (tokenKind != SyntaxKind.BaseKeyword && state.TypeToGenerateIn == namedType)
+                if (tokenKind != SyntaxKind.BaseKeyword && Equals(state.TypeToGenerateIn, namedType))
                 {
                     thisOrBaseKeyword = SyntaxFactory.Token(SyntaxKind.ThisKeyword);
                     newCtorInitializerKind = SyntaxKind.ThisConstructorInitializer;
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
 
                 var typeNameToReplace = (TypeSyntax)oldToken.Parent;
                 TypeSyntax newTypeName;
-                if (namedType != state.TypeToGenerateIn)
+                if (!Equals(namedType, state.TypeToGenerateIn))
                 {
                     while (true)
                     {

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
             // if the symbol could be bound, replace that item in the symbol list
             if (symbolInfo.Symbol is IMethodSymbol matchedMethodSymbol && matchedMethodSymbol.IsGenericMethod)
             {
-                methodGroup = methodGroup.SelectAsArray(m => matchedMethodSymbol.OriginalDefinition == m ? matchedMethodSymbol : m);
+                methodGroup = methodGroup.SelectAsArray(m => Equals(matchedMethodSymbol.OriginalDefinition, m) ? matchedMethodSymbol : m);
             }
 
             methodGroup = methodGroup.Sort(

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
 
                 var includeStatic = throughSymbol is INamedTypeSymbol ||
                     (throughExpression.IsKind(SyntaxKind.IdentifierName) &&
-                    semanticModel.LookupNamespacesAndTypes(throughExpression.SpanStart, name: throughSymbol.Name).Any(t => t.GetSymbolType() == throughType));
+                    semanticModel.LookupNamespacesAndTypes(throughExpression.SpanStart, name: throughSymbol.Name).Any(t => Equals(t.GetSymbolType(), throughType)));
 
                 Contract.ThrowIfFalse(includeInstance || includeStatic);
                 methodGroup = methodGroup.Where(m => (m.IsStatic && includeStatic) || (!m.IsStatic && includeInstance));
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         {
             foreach (var m in methodSet)
             {
-                if (m != method)
+                if (!Equals(m, method))
                 {
                     if (IsHiddenBy(method, m))
                     {


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.