### PR TITLE
Fix violations of RS1024 in Microsoft.CodeAnalysis.EditorFeatures

### DIFF
--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
                         ? symbolToNavigateTo
                         : symbolToNavigateTo.ContainingType;
 
-                    if (containingTypeSymbol == candidateTypeSymbol)
+                    if (Equals(containingTypeSymbol, candidateTypeSymbol))
                     {
                         // We are navigating from the same type, so don't allow third parties to perform the navigation.
                         // This ensures that if we navigate to a class from within that class, we'll stay in the same file


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.