### PR TITLE
Fix violations of RS1024 in Microsoft.CodeAnalysis.EditorFeatures.UnitTests

### DIFF
--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
@@ -492,7 +492,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var attributeType = (INamedTypeSymbol)GetTypeSymbol(attributeClass)(context.SemanticModel);
                 var taggedNode = context.GetDestinationNode();
                 ISymbol attributeTarget = context.SemanticModel.GetDeclaredSymbol(taggedNode);
-                var attribute = attributeTarget.GetAttributes().Single(attr => attr.AttributeClass == attributeType);
+                var attribute = attributeTarget.GetAttributes().Single(attr => Equals(attr.AttributeClass, attributeType));
                 var declarationNode = taggedNode.FirstAncestorOrSelf<T>();
                 var newNode = CodeGenerator.RemoveAttribute(declarationNode, context.Document.Project.Solution.Workspace, attribute)
                                            .WithAdditionalAnnotations(Formatter.Annotation);


### PR DESCRIPTION
(Compare symbols correctly)

📝 The changes here were applied by a refactoring which I believe correctly translates the comparison operators. However, reviewers should pay particular attention to cases where reference equality was intentionally used for correctness or performance.

This is a prerequisite to updating our diagnostic analyzer package in #35439.