### PR TITLE
Fix violations of CA2237 (Mark ISerializable types with serializable)

### DIFF
--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmException.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmException.cs
@@ -14,6 +14,7 @@ namespace Microsoft.VisualStudio.Debugger
     // Summary:
     //     Base exception class for all exceptions within this API.
     [DebuggerDisplay("\\{DkmException Code={Code,h}\\}")]
+    [Serializable]
     public class DkmException : ApplicationException
     {
         private readonly DkmExceptionCode _code;

--- a/src/Test/Utilities/Portable/Compilation/Exceptions.cs
+++ b/src/Test/Utilities/Portable/Compilation/Exceptions.cs
@@ -2,13 +2,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis;
 using static Roslyn.Test.Utilities.ExceptionHelper;
 
 namespace Roslyn.Test.Utilities
 {
+    [Serializable]
     public class EmitException : Exception
     {
+        [field: NonSerialized]
         public IEnumerable<Diagnostic> Diagnostics { get; }
 
         public EmitException(IEnumerable<Diagnostic> diagnostics, string directory)
@@ -16,8 +19,14 @@ namespace Roslyn.Test.Utilities
         {
             this.Diagnostics = diagnostics;
         }
+
+        protected EmitException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            throw new NotImplementedException();
+        }
     }
 
+    [Serializable]
     public class ExecutionException : Exception
     {
         public ExecutionException(string expectedOutput, string actualOutput, string exePath)
@@ -25,5 +34,10 @@ namespace Roslyn.Test.Utilities
 
         public ExecutionException(Exception innerException, string exePath)
             : base(GetMessageFromException(innerException, exePath), innerException) { }
+
+        protected ExecutionException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Test/Utilities/Portable/Diagnostics/ThrowingDiagnosticAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/ThrowingDiagnosticAnalyzer.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -17,8 +18,18 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 {
     public class ThrowingDiagnosticAnalyzer<TLanguageKindEnum> : TestDiagnosticAnalyzer<TLanguageKindEnum> where TLanguageKindEnum : struct
     {
+        [Serializable]
         public class DeliberateException : Exception
         {
+            public DeliberateException()
+            {
+            }
+
+            protected DeliberateException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+            {
+                throw new NotImplementedException();
+            }
+
             public override string Message
             {
                 get { return "If this goes unhandled, our diagnostics engine is susceptible to malicious analyzers"; }


### PR DESCRIPTION
This is a prerequisite to updating our diagnostic analyzer package in #35439.