### PR TITLE
Update analyzers to follow recommended patterns

### DIFF
--- a/eng/config/rulesets/NonShipping.ruleset
+++ b/eng/config/rulesets/NonShipping.ruleset
@@ -35,6 +35,9 @@
     <!-- Configure generated code analysis - suppress for non-shipping/test projects -->
     <Rule Id="RS1025" Action="None" />
 
+    <!-- Enable concurrent execution - suppress for non-shipping/test projects -->
+    <Rule Id="RS1026" Action="None" />
+
     <!-- Do not use generic CodeAction.Create to create CodeAction - not useful for tests -->
     <Rule Id="RS0005" Action="None" />
   </Rules>

--- a/eng/config/rulesets/NonShipping.ruleset
+++ b/eng/config/rulesets/NonShipping.ruleset
@@ -32,6 +32,9 @@
     <!-- DiagnosticId must be unique across analyzers - suppress for non-shipping/test projects -->
     <Rule Id="RS1019" Action="None" />
 
+    <!-- Configure generated code analysis - suppress for non-shipping/test projects -->
+    <Rule Id="RS1025" Action="None" />
+
     <!-- Do not use generic CodeAction.Create to create CodeAction - not useful for tests -->
     <Rule Id="RS0005" Action="None" />
   </Rules>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public sealed override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
             context.RegisterCompilationStartAction(c =>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.cs
@@ -35,6 +35,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public sealed override void Initialize(AnalysisContext context)
         {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
             context.RegisterCompilationStartAction(c =>
             {
                 var analyzer = new CompilationAnalyzer(c.Compilation);

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingDiagnosticAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingDiagnosticAnalyzer.cs
@@ -27,7 +27,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             => true;
 
         public override void Initialize(AnalysisContext context)
-            => context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+            context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
+        }
 
         private void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
         {

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingDiagnosticAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingDiagnosticAnalyzer.cs
@@ -26,7 +26,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
         public bool OpenFileOnly(Workspace workspace)
             => true;
 
+#pragma warning disable RS1026 // Enable concurrent execution
         public override void Initialize(AnalysisContext context)
+#pragma warning restore RS1026 // Enable concurrent execution
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/DocumentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/DocumentDiagnosticAnalyzer.cs
@@ -20,7 +20,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// it is not allowed one to implement both DocumentDiagnosticAnalzyer and DiagnosticAnalyzer
         /// </summary>
+#pragma warning disable RS1025 // Configure generated code analysis
         public sealed override void Initialize(AnalysisContext context)
+#pragma warning restore RS1025 // Configure generated code analysis
         {
         }
 

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/DocumentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/DocumentDiagnosticAnalyzer.cs
@@ -20,9 +20,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// it is not allowed one to implement both DocumentDiagnosticAnalzyer and DiagnosticAnalyzer
         /// </summary>
+#pragma warning disable RS1026 // Enable concurrent execution
 #pragma warning disable RS1025 // Configure generated code analysis
         public sealed override void Initialize(AnalysisContext context)
 #pragma warning restore RS1025 // Configure generated code analysis
+#pragma warning restore RS1026 // Enable concurrent execution
         {
         }
 

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/ProjectDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/ProjectDiagnosticAnalyzer.cs
@@ -18,7 +18,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// it is not allowed one to implement both ProjectDiagnosticAnalzyer and DiagnosticAnalyzer
         /// </summary>
+#pragma warning disable RS1025 // Configure generated code analysis
         public sealed override void Initialize(AnalysisContext context)
+#pragma warning restore RS1025 // Configure generated code analysis
         {
         }
 

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/ProjectDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/ProjectDiagnosticAnalyzer.cs
@@ -18,9 +18,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// it is not allowed one to implement both ProjectDiagnosticAnalzyer and DiagnosticAnalyzer
         /// </summary>
+#pragma warning disable RS1026 // Enable concurrent execution
 #pragma warning disable RS1025 // Configure generated code analysis
         public sealed override void Initialize(AnalysisContext context)
 #pragma warning restore RS1025 // Configure generated code analysis
+#pragma warning restore RS1026 // Enable concurrent execution
         {
         }
 

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.AddImport
         public override void Initialize(AnalysisContext context)
         {
             context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
             context.RegisterSyntaxNodeAction(AnalyzeNode, this.SyntaxKindsOfInterest.ToArray());
         }

--- a/src/Features/Core/Portable/EmbeddedLanguages/AbstractEmbeddedLanguageDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/AbstractEmbeddedLanguageDiagnosticAnalyzer.cs
@@ -53,6 +53,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
             foreach (var analyzer in _analyzers)

--- a/src/Features/Core/Portable/EmbeddedLanguages/AbstractEmbeddedLanguageDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/AbstractEmbeddedLanguageDiagnosticAnalyzer.cs
@@ -53,6 +53,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages
 
         public override void Initialize(AnalysisContext context)
         {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
             foreach (var analyzer in _analyzers)
             {
                 analyzer.Initialize(context);

--- a/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
@@ -73,6 +73,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
         public override void Initialize(AnalysisContext context)
         {
             context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
             context.RegisterSemanticModelAction(this.AnalyzeSemanticModel);
         }

--- a/src/Features/Core/Portable/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
@@ -65,6 +65,7 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
         public override void Initialize(AnalysisContext context)
         {
             context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
             context.RegisterCompilationStartAction(startContext =>
             {


### PR DESCRIPTION
* Fix violations of RS1025 (Configure generated code analysis)
* Fix violations of RS1026 (Enable concurrent execution)

This is a prerequisite to updating our diagnostic analyzer package in #35439.