### PR TITLE
Use .NET Standard API for named pipes on Unix

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -73,11 +73,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             TimeSpan? keepAlive = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (BuildServerConnection.IsPipePathTooLong(pipeName, tempPath))
-            {
-                return CommonCompiler.Failed;
-            }
-
             keepAlive = keepAlive ?? GetKeepAliveTimeout();
             listener = listener ?? new EmptyDiagnosticListener();
             clientConnectionHost = clientConnectionHost ?? CreateClientConnectionHost(pipeName);

--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
@@ -16,9 +16,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 {
     internal sealed class NamedPipeClientConnectionHost : IClientConnectionHost
     {
-        // Size of the buffers to use: 64K
-        private const int PipeBufferSize = 0x10000;
-
         private readonly ICompilerServerHost _compilerServerHost;
         private readonly string _pipeName;
         private int _loggingIdentifier;
@@ -48,15 +45,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             // (out of handles?), or the pipe was disconnected before we 
             // starting listening.
             CompilerServerLogger.Log("Constructing pipe '{0}'.", _pipeName);
-            var pipeOptions = PipeOptions.Asynchronous | PipeOptions.WriteThrough;
-            var pipeStream = NamedPipeUtil.CreateServer(
-                _pipeName,
-                PipeDirection.InOut,
-                NamedPipeServerStream.MaxAllowedServerInstances,
-                PipeTransmissionMode.Byte,
-                pipeOptions,
-                PipeBufferSize,
-                PipeBufferSize);
+            var pipeStream = NamedPipeUtil.CreateServer(_pipeName);
             CompilerServerLogger.Log("Successfully constructed pipe '{0}'.", _pipeName);
 
             CompilerServerLogger.Log("Waiting for new connection");

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerApiTest.cs
@@ -376,7 +376,7 @@ class Hello
         [Fact]
         public async Task ShutdownRequestDirect()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var serverProcessId = await ServerUtil.SendShutdown(serverData.PipeName);
                 Assert.Equal(Process.GetCurrentProcess().Id, serverProcessId);
@@ -395,7 +395,7 @@ class Hello
 
             using (var startedMre = new ManualResetEvent(initialState: false))
             using (var finishedMre = new ManualResetEvent(initialState: false))
-            using (var serverData = ServerUtil.CreateServer(compilerServerHost: host))
+            using (var serverData = await ServerUtil.CreateServer(compilerServerHost: host))
             {
                 // Create a compilation that is guaranteed to complete after the shutdown is seen. 
                 host.RunCompilation = (request, cancellationToken) =>
@@ -432,7 +432,7 @@ class Hello
 
             using (var startedMre = new ManualResetEvent(initialState: false))
             using (var finishedMre = new ManualResetEvent(initialState: false))
-            using (var serverData = ServerUtil.CreateServer(compilerServerHost: host))
+            using (var serverData = await ServerUtil.CreateServer(compilerServerHost: host))
             {
                 // Create a compilation that is guaranteed to complete after the shutdown is seen. 
                 host.RunCompilation = (request, cancellationToken) =>
@@ -468,7 +468,7 @@ class Hello
         {
             var host = new TestableCompilerServerHost();
 
-            using (var serverData = ServerUtil.CreateServer(compilerServerHost: host))
+            using (var serverData = await ServerUtil.CreateServer(compilerServerHost: host))
             using (var mre = new ManualResetEvent(initialState: false))
             {
                 const int requestCount = 5;
@@ -520,7 +520,7 @@ class Hello
         [Fact]
         public async Task IncorrectProtocolReturnsMismatchedVersionResponse()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var buildResponse = await ServerUtil.Send(serverData.PipeName, new BuildRequest(1, RequestLanguage.CSharpCompile, "abc", new List<BuildRequest.Argument> { }));
                 Assert.Equal(BuildResponse.ResponseType.MismatchedVersion, buildResponse.Type);
@@ -530,7 +530,7 @@ class Hello
         [Fact]
         public async Task IncorrectServerHashReturnsIncorrectHashResponse()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var buildResponse = await ServerUtil.Send(serverData.PipeName, new BuildRequest(BuildProtocolConstants.ProtocolVersion, RequestLanguage.CSharpCompile, "abc", new List<BuildRequest.Argument> { }));
                 Assert.Equal(BuildResponse.ResponseType.IncorrectHash, buildResponse.Type);
@@ -561,14 +561,14 @@ class Hello
         }
 
         [Theory]
-        [InlineData(@"name with space.T.basename", "name with space", true, "basename")]
-        [InlineData(@"ha_ha.T.basename", @"ha""ha", true, "basename")]
-        [InlineData(@"jared.T.ha_ha", @"jared", true, @"ha""ha")]
-        [InlineData(@"jared.F.ha_ha", @"jared", false, @"ha""ha")]
-        [InlineData(@"jared.F.ha_ha", @"jared", false, @"ha\ha")]
-        public void GetPipeNameCore(string expectedName, string userName, bool isAdmin, string basePipeName)
+        [InlineData(@"OLqrNgkgZRf14qL91MdaUn8coiKckUIZCIEkpy0Lt18", "name with space", true, "basename")]
+        [InlineData(@"8VDiJptv892LtWpeN86z76_YI0Yg0BV6j0SOv8CjQVA", @"ha""ha", true, "basename")]
+        [InlineData(@"wKSU9psJMbkw+5+TFKLEf94aeslpEb3dDRpAw+9j4nw", @"jared", true, @"ha""ha")]
+        [InlineData(@"0BDP4_GPWYQh9J_BknwhS9uAZAF_64PK4_VnNsddGZE", @"jared", false, @"ha""ha")]
+        [InlineData(@"XroHfrjD1FTk7PcXcif2hZdmlVH_L0Pg+RUX01d_uQc", @"jared", false, @"ha\ha")]
+        public void GetPipeNameCore(string expectedName, string userName, bool isAdmin, string compilerExeDir)
         {
-            Assert.Equal(expectedName, BuildServerConnection.GetPipeNameCore(userName, isAdmin, basePipeName));
+            Assert.Equal(expectedName, BuildServerConnection.GetPipeName(userName, isAdmin, compilerExeDir));
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -256,16 +256,16 @@ End Module")
                 new[] { new KeyValuePair<string, string>("TMPDIR", newTempDir.Path) },
                 async () =>
             {
-                using (var serverData = ServerUtil.CreateServer())
+                using (var serverData = await ServerUtil.CreateServer())
                 {
                     var result = RunCommandLineCompiler(
                         CSharpCompilerClientExecutable,
                         $"/shared:{serverData.PipeName} /nologo hello.cs",
                         _tempDirectory,
                         s_helloWorldSrcCs,
-                        shouldRunOnServer: false);
+                        shouldRunOnServer: true);
                     VerifyResultAndOutput(result, _tempDirectory, "Hello, world.");
-                    await serverData.Verify(connections: 0, completed: 0).ConfigureAwait(true);
+                    await serverData.Verify(connections: 1, completed: 1).ConfigureAwait(true);
                 }
             });
         }
@@ -274,7 +274,7 @@ End Module")
         public async Task FallbackToCsc()
         {
             // Verify csc will fall back to command line when server fails to process
-            using (var serverData = ServerUtil.CreateServerFailsConnection())
+            using (var serverData = await ServerUtil.CreateServerFailsConnection())
             {
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} /nologo hello.cs", _tempDirectory, s_helloWorldSrcCs, shouldRunOnServer: false);
                 VerifyResultAndOutput(result, _tempDirectory, "Hello, world.");
@@ -287,7 +287,7 @@ End Module")
         public async Task CscFallBackOutputNoUtf8()
         {
             // Verify csc will fall back to command line when server fails to process
-            using (var serverData = ServerUtil.CreateServerFailsConnection())
+            using (var serverData = await ServerUtil.CreateServerFailsConnection())
             {
                 var files = new Dictionary<string, string> { { "hello.cs", "♕" } };
 
@@ -303,7 +303,7 @@ End Module")
         {
             var srcFile = _tempDirectory.CreateFile("test.cs").WriteAllText("♕").Path;
 
-            using (var serverData = ServerUtil.CreateServerFailsConnection())
+            using (var serverData = await ServerUtil.CreateServerFailsConnection())
             {
                 var result = RunCommandLineCompiler(
                     CSharpCompilerClientExecutable,
@@ -324,7 +324,7 @@ End Module")
         {
             var srcFile = _tempDirectory.CreateFile("test.vb").WriteAllText("♕").Path;
 
-            using (var serverData = ServerUtil.CreateServerFailsConnection())
+            using (var serverData = await ServerUtil.CreateServerFailsConnection())
             {
                 var result = RunCommandLineCompiler(
                     BasicCompilerClientExecutable,
@@ -347,7 +347,7 @@ End Module")
         {
             var srcFile = _tempDirectory.CreateFile("test.vb").WriteAllText("♕").Path;
 
-            using (var serverData = ServerUtil.CreateServerFailsConnection())
+            using (var serverData = await ServerUtil.CreateServerFailsConnection())
             {
                 var result = RunCommandLineCompiler(
                     BasicCompilerClientExecutable,
@@ -368,7 +368,7 @@ End Module")
         [Fact]
         public async Task FallbackToVbc()
         {
-            using (var serverData = ServerUtil.CreateServerFailsConnection())
+            using (var serverData = await ServerUtil.CreateServerFailsConnection())
             {
                 var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.PipeName} /nologo /vbruntime* hello.vb", _tempDirectory, s_helloWorldSrcVb, shouldRunOnServer: false);
                 VerifyResultAndOutput(result, _tempDirectory, "Hello from VB");
@@ -380,7 +380,7 @@ End Module")
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task HelloWorldCS()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} /nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
                 VerifyResultAndOutput(result, _tempDirectory, "Hello, world.");
@@ -392,7 +392,7 @@ End Module")
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task HelloWorldCSDashShared()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"-shared:{serverData.PipeName} /nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
                 VerifyResultAndOutput(result, _tempDirectory, "Hello, world.");
@@ -421,7 +421,7 @@ End Module")
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task Platformx86MscorlibCsc()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var files = new Dictionary<string, string> { { "c.cs", "class C {}" } };
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable,
@@ -437,7 +437,7 @@ End Module")
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task Platformx86MscorlibVbc()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var files = new Dictionary<string, string> { { "c.vb", "Class C\nEnd Class" } };
                 var result = RunCommandLineCompiler(BasicCompilerClientExecutable,
@@ -453,7 +453,7 @@ End Module")
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task ExtraMSCorLibCS()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable,
                                                     $"/shared:{serverData.PipeName} /nologo /r:mscorlib.dll hello.cs",
@@ -468,7 +468,7 @@ End Module")
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task HelloWorldVB()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(BasicCompilerClientExecutable,
                                                     $"/shared:{serverData.PipeName} /nologo /vbruntime* hello.vb",
@@ -483,7 +483,7 @@ End Module")
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task ExtraMSCorLibVB()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(BasicCompilerClientExecutable,
                     $"/shared:{serverData.PipeName} /nologo /r:mscorlib.dll /vbruntime* hello.vb",
@@ -498,7 +498,7 @@ End Module")
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task CompileErrorsCS()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 Dictionary<string, string> files =
                                        new Dictionary<string, string> {
@@ -525,7 +525,7 @@ class Hello
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task CompileErrorsVB()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 Dictionary<string, string> files =
                                        new Dictionary<string, string> {
@@ -554,7 +554,7 @@ End Class"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task MissingFileErrorCS()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} missingfile.cs", _tempDirectory);
 
@@ -571,7 +571,7 @@ End Class"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task MissingReferenceErrorCS()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} /r:missing.dll hello.cs", _tempDirectory, s_helloWorldSrcCs);
 
@@ -589,7 +589,7 @@ End Class"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task InvalidMetadataFileErrorCS()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 Dictionary<string, string> files =
                                        new Dictionary<string, string> {
@@ -612,7 +612,7 @@ End Class"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task MissingFileErrorVB()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.PipeName} /vbruntime* missingfile.vb", _tempDirectory);
 
@@ -629,7 +629,7 @@ End Class"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task MissingReferenceErrorVB()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 Dictionary<string, string> files =
                                        new Dictionary<string, string> {
@@ -658,7 +658,7 @@ End Module"}};
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task InvalidMetadataFileErrorVB()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 Dictionary<string, string> files =
                                        new Dictionary<string, string> {
@@ -701,7 +701,7 @@ Public Class Library
 End Class
 "}};
 
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             using (var tmpFile = GetResultFile(rootDirectory, "lib.dll"))
             {
                 var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"src1.vb /shared:{serverData.PipeName} /nologo /t:library /out:lib.dll", rootDirectory, files);
@@ -803,7 +803,7 @@ End Module
         {
             TempDirectory rootDirectory = _tempDirectory.CreateDirectory("ReferenceCachingCS");
 
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             using (var tmpFile = GetResultFile(rootDirectory, "lib.dll"))
             {
                 // Create DLL "lib.dll"
@@ -969,7 +969,7 @@ End Module";
         [Trait(Traits.Environment, Traits.Environments.VSProductInstall)]
         public async Task MultipleSimultaneousCompiles()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 // Run this many compiles simultaneously in different directories.
                 const int numberOfCompiles = 20;
@@ -1010,7 +1010,7 @@ public class Library
     { return ""library1""; }
 }"}};
 
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable,
                                                     $"src1.cs /shared:{serverData.PipeName} /nologo /t:library /out:" + Path.Combine(libDirectory.Path, "lib.dll"),
@@ -1060,7 +1060,7 @@ Public Class Library
 End Class
 "}};
 
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(BasicCompilerClientExecutable,
                                                     $"src1.vb /shared:{serverData.PipeName} /vbruntime* /nologo /t:library /out:" + Path.Combine(libDirectory.Path, "lib.dll"),
@@ -1099,7 +1099,7 @@ End Module
         {
             var srcFile = _tempDirectory.CreateFile("test.cs").WriteAllText("♕").Path;
 
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(
                     CSharpCompilerClientExecutable,
@@ -1122,7 +1122,7 @@ End Module
             var srcFile = _tempDirectory.CreateFile("test.vb").WriteAllText(@"♕").Path;
             var tempOut = _tempDirectory.CreateFile("output.txt");
 
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(
                     BasicCompilerClientExecutable,
@@ -1148,7 +1148,7 @@ End Module
         {
             var srcFile = _tempDirectory.CreateFile("test.cs").WriteAllText("♕").Path;
 
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(
                     CSharpCompilerClientExecutable,
@@ -1170,7 +1170,7 @@ End Module
         {
             var srcFile = _tempDirectory.CreateFile("test.vb").WriteAllText(@"♕").Path;
 
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(
                     BasicCompilerClientExecutable,
@@ -1210,7 +1210,7 @@ End Module
 }
 "}};
 
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable,
                                                     $"ref_mscorlib2.cs /shared:{serverData.PipeName} /nologo /nostdlib /noconfig /t:library /r:mscorlib20.dll",
@@ -1249,7 +1249,7 @@ class Program
         [Fact]
         public async Task Utf8OutputInRspFileCsc()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var srcFile = _tempDirectory.CreateFile("test.cs").WriteAllText("♕").Path;
                 var rspFile = _tempDirectory.CreateFile("temp.rsp").WriteAllText(
@@ -1272,7 +1272,7 @@ class Program
         [Fact]
         public async Task Utf8OutputInRspFileVbc()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var srcFile = _tempDirectory.CreateFile("test.cs").WriteAllText("♕").Path;
                 var rspFile = _tempDirectory.CreateFile("temp.rsp").WriteAllText(
@@ -1337,7 +1337,7 @@ class Program
         [WorkItem(1024619, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1024619")]
         public async Task Bug1024619_01()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var srcFile = _tempDirectory.CreateFile("test.cs").WriteAllText("").Path;
 
@@ -1370,7 +1370,7 @@ class Program
         [WorkItem(1024619, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1024619")]
         public async Task Bug1024619_02()
         {
-            using (var serverData = ServerUtil.CreateServer())
+            using (var serverData = await ServerUtil.CreateServer())
             {
                 var srcFile = _tempDirectory.CreateFile("test.vb").WriteAllText("").Path;
 
@@ -1426,7 +1426,7 @@ class Program
             {
                 throw new FileNotFoundException();
             });
-            using (var serverData = ServerUtil.CreateServer(compilerServerHost: host))
+            using (var serverData = await ServerUtil.CreateServer(compilerServerHost: host))
             {
                 var request = new BuildRequest(1, RequestLanguage.CSharpCompile, string.Empty, new BuildRequest.Argument[0]);
                 var compileTask = ServerUtil.Send(serverData.PipeName, request);

--- a/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                     return false;
                 }
 
-                var serverData = ServerUtil.CreateServer(pipeName);
+                var serverData = ServerUtil.CreateServer(pipeName).GetAwaiter().GetResult();
                 _serverDataList.Add(serverData);
                 return true;
             }
@@ -406,22 +406,22 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         public class MiscTest
         {
             [Fact]
-            public void GetBasePipeNameSlashes()
+            public void GetPipeNameForPathOptSlashes()
             {
                 var path = string.Format(@"q:{0}the{0}path", Path.DirectorySeparatorChar);
-                var name = BuildServerConnection.GetBasePipeName(path);
-                Assert.Equal(name, BuildServerConnection.GetBasePipeName(path));
-                Assert.Equal(name, BuildServerConnection.GetBasePipeName(path + Path.DirectorySeparatorChar));
-                Assert.Equal(name, BuildServerConnection.GetBasePipeName(path + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar));
+                var name = BuildServerConnection.GetPipeNameForPathOpt(path);
+                Assert.Equal(name, BuildServerConnection.GetPipeNameForPathOpt(path));
+                Assert.Equal(name, BuildServerConnection.GetPipeNameForPathOpt(path + Path.DirectorySeparatorChar));
+                Assert.Equal(name, BuildServerConnection.GetPipeNameForPathOpt(path + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar));
             }
 
             [Fact]
-            public void GetBasePipeNameLength()
+            public void GetPipeNameForPathOptLength()
             {
                 var path = string.Format(@"q:{0}the{0}path", Path.DirectorySeparatorChar);
-                var name = BuildServerConnection.GetBasePipeName(path);
+                var name = BuildServerConnection.GetPipeNameForPathOpt(path);
                 // We only have ~50 total bytes to work with on mac, so the base path must be small
-                Assert.InRange(name.Length, 10, 30);
+                Assert.Equal(43, name.Length);
             }
         }
     }

--- a/src/Compilers/Server/VBCSCompilerTests/DesktopBuildServerControllerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/DesktopBuildServerControllerTests.cs
@@ -1,14 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Roslyn.Test.Utilities;
-using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
@@ -44,33 +37,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             {
                 Assert.Equal(ServerDispatcher.DefaultServerKeepAlive, _controller.GetKeepAliveTimeout());
             }
-        }
-
-        [ConditionalFact(typeof(UnixLikeOnly))]
-        public void RunServerWithLongTempPath()
-        {
-            var pipeName = Guid.NewGuid().ToString("N");
-            // Make a really long path. This should work on Windows, which doesn't rely on temp path,
-            // but not on Unix, which has a max path length
-            var tempPath = new string('a', 100);
-
-            // This test fails by spinning forever. If the path is not seen as invalid, the server
-            // starts up and will never return.
-            Assert.Equal(CommonCompiler.Failed, DesktopBuildServerController.RunServer(pipeName, tempPath: tempPath));
-        }
-
-        [ConditionalFact(typeof(UnixLikeOnly))]
-        public void RunServerWithLongTempPathInstance()
-        {
-            var pipeName = Guid.NewGuid().ToString("N");
-            // Make a really long path. This should work on Windows, which doesn't rely on temp path,
-            // but not on Unix, which has a max path length
-            var tempPath = new string('a', 100);
-            BuildServerController buildServerController = new DesktopBuildServerController(new NameValueCollection());
-
-            // This test fails by spinning forever. If the path is not seen as invalid, the server
-            // starts up and will never return.
-            Assert.Equal(CommonCompiler.Failed, DesktopBuildServerController.RunServer(pipeName, tempPath: tempPath));
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompilerTests/EndToEndDeterminismTest.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/EndToEndDeterminismTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             try
             {
                 string finalFlags = null;
-                using (var serverData = ServerUtil.CreateServer())
+                using (var serverData = await ServerUtil.CreateServer())
                 {
                     finalFlags = $"{ _flags } /shared:{ serverData.PipeName } /pathmap:{tempDir.Path}=/ /out:{ outFile } { srcFile }";
                     var result = CompilerServerUnitTests.RunCommandLineCompiler(

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 tempDir: tempDir);
         }
 
-        internal static ServerData CreateServer(
+        internal static async Task<ServerData> CreateServer(
             string pipeName = null,
             ICompilerServerHost compilerServerHost = null,
             bool failingServer = false,
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var serverListenSource = new TaskCompletionSource<bool>();
             var cts = new CancellationTokenSource();
             var mutexName = BuildServerConnection.GetServerMutexName(pipeName);
-            var thread = new Thread(_ =>
+            var task = Task.Run(() =>
             {
                 var listener = new TestableDiagnosticListener();
                 listener.Listening += (sender, e) => { serverListenSource.TrySetResult(true); };
@@ -122,13 +122,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 }
             });
 
-            thread.Start();
-
             // The contract of this function is that it will return once the server has started.  Spin here until
             // we can verify the server has started or simply failed to start.
-            while (BuildServerConnection.WasServerMutexOpen(mutexName) != true && thread.IsAlive)
+            while (BuildServerConnection.WasServerMutexOpen(mutexName) != true && !task.IsCompleted)
             {
-                Thread.Yield();
+                await Task.Yield();
+            }
+
+            if (task.IsFaulted)
+            {
+                throw task.Exception;
             }
 
             return new ServerData(cts, pipeName, serverStatsSource.Task, serverListenSource.Task);
@@ -137,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         /// <summary>
         /// Create a compiler server that fails all connections.
         /// </summary>
-        internal static ServerData CreateServerFailsConnection(string pipeName = null)
+        internal static Task<ServerData> CreateServerFailsConnection(string pipeName = null)
         {
             return CreateServer(pipeName, failingServer: true);
         }

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Specialized;
 using System.IO;
 using System.IO.Pipes;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -39,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             [Fact]
             public async Task Standard()
             {
-                using (var serverData = ServerUtil.CreateServer())
+                using (var serverData = await ServerUtil.CreateServer())
                 {
                     // Make sure the server is listening for this particular test. 
                     await serverData.ListenTask;
@@ -62,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 Assert.Equal(CommonCompiler.Succeeded, exitCode);
             }
 
-            [ConditionalFact(typeof(WindowsOrLinuxOnly))]
+            [Fact]
             [WorkItem(34880, "https://github.com/dotnet/roslyn/issues/34880")]
             public async Task NoServerConnection()
             {
@@ -77,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                     var thread = new Thread(() =>
                     {
                         using (var mutex = new Mutex(initiallyOwned: true, name: mutexName, createdNew: out created))
-                        using (var stream = new NamedPipeServerStream(pipeName))
+                        using (var stream = NamedPipeUtil.CreateServer(pipeName))
                         {
                             readyMre.Set();
 
@@ -112,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             /// the client can error out.
             /// </summary>
             /// <returns></returns>
-            [ConditionalFact(typeof(WindowsOrLinuxOnly))]
+            [Fact]
             [WorkItem(34880, "https://github.com/dotnet/roslyn/issues/34880")]
             public async Task ServerShutdownsDuringProcessing()
             {
@@ -126,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
                     var thread = new Thread(() =>
                     {
-                        using (var stream = new NamedPipeServerStream(pipeName))
+                        using (var stream = NamedPipeUtil.CreateServer(pipeName))
                         {
                             var mutex = new Mutex(initiallyOwned: true, name: mutexName, createdNew: out created);
                             readyMre.Set();
@@ -157,6 +158,21 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                     Assert.Equal(CommonCompiler.Succeeded, exitCode);
                     Assert.True(connected);
                     Assert.True(created);
+                }
+            }
+
+            [Fact]
+            public async Task RunServerWithLongTempPath()
+            {
+                string pipeName = BuildServerConnection.GetPipeNameForPathOpt(Guid.NewGuid().ToString());
+                string tempPath = new string('a', 100);
+                using (var serverData = await ServerUtil.CreateServer(pipeName, tempPath: tempPath))
+                {
+                    // Make sure the server is listening for this particular test.
+                    await serverData.ListenTask;
+                    var exitCode = await RunShutdownAsync(serverData.PipeName, waitForProcess: false).ConfigureAwait(false);
+                    Assert.Equal(CommonCompiler.Succeeded, exitCode);
+                    await serverData.Verify(connections: 1, completed: 1);
                 }
             }
         }

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -65,11 +65,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// <summary>
         /// Determines if the compiler server is supported in this environment.
         /// </summary>
-        internal static bool IsCompilerServerSupported(string tempPath)
-        {
-            var pipeName = GetPipeNameForPathOpt("");
-            return pipeName != null && !IsPipePathTooLong(pipeName, tempPath);
-        }
+        internal static bool IsCompilerServerSupported(string tempPath) => GetPipeNameForPathOpt("") is object;
 
         public static Task<BuildResponse> RunServerCompilation(
             RequestLanguage language,
@@ -310,14 +306,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             NamedPipeClientStream pipeStream;
             try
             {
-                // If the pipe path would be too long, there cannot be a server at the other end.
-                // We're not using a saved temp path here because pipes are created with
-                // Path.GetTempPath() in corefx NamedPipeClientStream and we want to replicate that behavior.
-                if (IsPipePathTooLong(pipeName, Path.GetTempPath()))
-                {
-                    return null;
-                }
-
                 // Machine-local named pipes are named "\\.\pipe\<pipename>".
                 // We use the SHA1 of the directory the compiler exes live in as the pipe name.
                 // The NamedPipeClientStream class handles the "\\.\pipe\" part for us.
@@ -462,8 +450,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// </returns>
         internal static string GetPipeNameForPathOpt(string compilerExeDirectory)
         {
-            var basePipeName = GetBasePipeName(compilerExeDirectory);
-
             // Prefix with username and elevation
             bool isAdmin = false;
             if (PlatformInformation.IsWindows)
@@ -479,65 +465,27 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 return null;
             }
 
-            return GetPipeNameCore(userName, isAdmin, basePipeName);
+            return GetPipeName(userName, isAdmin, compilerExeDirectory);
         }
 
-        internal static string GetPipeNameCore(string userName, bool isAdmin, string basePipeName)
-        {
-            var pipeName = $"{userName}.{(isAdmin ? 'T' : 'F')}.{basePipeName}";
-
-            // The pipe name is passed between processes as a command line argument as a 
-            // quoted value. Unfortunately we can't use ProcessStartInfo.ArgumentList as 
-            // we still target net472 (API only available on CoreClr + netstandard). To 
-            // make the problem approachable we remove the troublesome characters.
-            //
-            // This does mean if two users on the same machine are building simultaneously
-            // and the user names differ only be a " or / and a _ then there will be a 
-            // conflict. That seems rather obscure though.
-            return pipeName
-                .Replace('"', '_')
-                .Replace('\\', '_');
-        }
-
-        /// <summary>
-        /// Check if our constructed path is too long. On some Unix machines the pipe is a
-        /// real file in the temp directory, and there is a limit on how long the path can
-        /// be. This will never be true on Windows.
-        /// </summary>
-        internal static bool IsPipePathTooLong(string pipeName, string tempPath)
-        {
-            if (PlatformInformation.IsUnix)
-            {
-                // This is the maximum path length of Unix Domain Sockets on a number of systems.
-                // Since CoreFX implements named pipes using Unix Domain Sockets, if we exceed this
-                // length than the pipe will fail.
-                // This number is considered the smallest known max length according to
-                // http://man7.org/linux/man-pages/man7/unix.7.html
-                const int MaxPipePathLength = 92;
-                const int PrefixLength = 11; // "CoreFxPipe_".Length
-                return (tempPath.Length + PrefixLength + pipeName.Length) > MaxPipePathLength;
-            }
-            return false;
-        }
-
-        internal static string GetBasePipeName(string compilerExeDirectory)
+        internal static string GetPipeName(
+            string userName,
+            bool isAdmin,
+            string compilerExeDirectory)
         {
             // Normalize away trailing slashes.  File APIs include / exclude this with no 
             // discernable pattern.  Easiest to normalize it here vs. auditing every caller
             // of this method.
             compilerExeDirectory = compilerExeDirectory.TrimEnd(Path.DirectorySeparatorChar);
 
-            string basePipeName;
+            var pipeNameInput = $"{userName}.{isAdmin}.{compilerExeDirectory}";
             using (var sha = SHA256.Create())
             {
-                var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(compilerExeDirectory));
-                basePipeName = Convert.ToBase64String(bytes)
-                    .Substring(0, 10) // We only have ~50 total characters on Mac, so strip this down
+                var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(pipeNameInput));
+                return Convert.ToBase64String(bytes)
                     .Replace("/", "_")
                     .Replace("=", string.Empty);
             }
-
-            return basePipeName;
         }
 
         internal static bool WasServerMutexOpen(string mutexName)


### PR DESCRIPTION
Use new pipe API for compiler server on Unix

The default behavior for the NamedPipeServerStream API is to take a pipe
name and then construct a named pipe in the background using that name.
In Windows this involves creating a file in a special namespace in the
file system. On Unix, named pipes are implemented using Unix Domain
Sockets, which are actual files, and the CoreFX behavior is to create
them in the temporary directory. Unfortunately, Unix Domain Sockets also
often have a max path length limitation and the temporary directory
could be arbitrarily long, meaning that any attempt to create a named
pipe may fail on Unix.

To remedy this, CoreFX introduced an API which allows you to pass a full
path instead of just a pipe name. If a fully-qualifed path is passed,
the new behavior is used. We can use this functionality to improve
reliability of pipe name creation by using the "/tmp" directory on Unix,
which by the POSIX specification is always required to be a valid
temporary directory, and by using a fixed-length pipe name that is lower
than any known Unix Domain Socket path length restriction.