### PR TITLE
Update PublishData.json in master

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -26,6 +26,15 @@
           "channels": [ "dev16.1", "dev16.1p2" ],
           "vsBranch": "rel/d16.1",
           "vsMajorVersion": 16
+        },          
+        "release/dev16.1-vs-deps": {
+          "nugetKind": ["Shipping", "NonShipping"],
+          "version": "3.1.*",
+          "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+          "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
+          "channels": [ "dev16.1", "dev16.1p4" ],
+          "vsBranch": "lab/d16.1stg",
+          "vsMajorVersion": 16
         },
         "dev16.1-preview3-vs-deps": {
             "nugetKind": ["Shipping", "NonShipping"],


### PR DESCRIPTION
**Copied from https://github.com/dotnet/roslyn/pull/35497 but for `master`**

Seems we are missing the entry for new release/dev16.1-vs-deps branch, which might be causing optprof run failure