### PR TITLE
Optimize codegen for pattern index access

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -79,12 +79,10 @@ class C
 2");
             verifier.VerifyIL("C.Main", @"
 {
-  // Code size      135 (0x87)
+  // Code size       90 (0x5a)
   .maxstack  3
   .locals init (S V_0, //s
-                int V_1,
-                int V_2,
-                System.Index V_3)
+                int V_1)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""S""
   IL_0008:  ldloca.s   V_0
@@ -93,52 +91,34 @@ class C
   IL_0010:  ldloca.s   V_0
   IL_0012:  dup
   IL_0013:  call       ""int S.Length.get""
-  IL_0018:  stloc.1
-  IL_0019:  ldc.i4.1
-  IL_001a:  ldc.i4.1
-  IL_001b:  newobj     ""System.Index..ctor(int, bool)""
-  IL_0020:  stloc.3
-  IL_0021:  ldloca.s   V_3
-  IL_0023:  ldloc.1
-  IL_0024:  call       ""int System.Index.GetOffset(int)""
-  IL_0029:  stloc.2
-  IL_002a:  ldloc.2
-  IL_002b:  call       ""int S.this[int].get""
-  IL_0030:  call       ""void System.Console.WriteLine(int)""
-  IL_0035:  ldloca.s   V_0
-  IL_0037:  dup
-  IL_0038:  call       ""int S.Length.get""
-  IL_003d:  stloc.2
-  IL_003e:  ldc.i4.1
-  IL_003f:  ldc.i4.1
-  IL_0040:  newobj     ""System.Index..ctor(int, bool)""
-  IL_0045:  stloc.3
-  IL_0046:  ldloca.s   V_3
-  IL_0048:  ldloc.2
-  IL_0049:  call       ""int System.Index.GetOffset(int)""
-  IL_004e:  stloc.1
-  IL_004f:  ldloc.1
-  IL_0050:  ldc.i4.2
-  IL_0051:  call       ""void S.this[int].set""
-  IL_0056:  ldloca.s   V_0
-  IL_0058:  dup
-  IL_0059:  call       ""int S.Length.get""
-  IL_005e:  stloc.1
-  IL_005f:  ldc.i4.1
-  IL_0060:  ldc.i4.1
-  IL_0061:  newobj     ""System.Index..ctor(int, bool)""
-  IL_0066:  stloc.3
-  IL_0067:  ldloca.s   V_3
-  IL_0069:  ldloc.1
-  IL_006a:  call       ""int System.Index.GetOffset(int)""
-  IL_006f:  stloc.2
-  IL_0070:  ldloc.2
-  IL_0071:  call       ""int S.this[int].get""
-  IL_0076:  call       ""void System.Console.WriteLine(int)""
-  IL_007b:  ldloc.0
-  IL_007c:  ldfld      ""int S.F""
-  IL_0081:  call       ""void System.Console.WriteLine(int)""
-  IL_0086:  ret
+  IL_0018:  ldc.i4.1
+  IL_0019:  sub
+  IL_001a:  stloc.1
+  IL_001b:  ldloc.1
+  IL_001c:  call       ""int S.this[int].get""
+  IL_0021:  call       ""void System.Console.WriteLine(int)""
+  IL_0026:  ldloca.s   V_0
+  IL_0028:  dup
+  IL_0029:  call       ""int S.Length.get""
+  IL_002e:  ldc.i4.1
+  IL_002f:  sub
+  IL_0030:  stloc.1
+  IL_0031:  ldloc.1
+  IL_0032:  ldc.i4.2
+  IL_0033:  call       ""void S.this[int].set""
+  IL_0038:  ldloca.s   V_0
+  IL_003a:  dup
+  IL_003b:  call       ""int S.Length.get""
+  IL_0040:  ldc.i4.1
+  IL_0041:  sub
+  IL_0042:  stloc.1
+  IL_0043:  ldloc.1
+  IL_0044:  call       ""int S.this[int].get""
+  IL_0049:  call       ""void System.Console.WriteLine(int)""
+  IL_004e:  ldloc.0
+  IL_004f:  ldfld      ""int S.F""
+  IL_0054:  call       ""void System.Console.WriteLine(int)""
+  IL_0059:  ret
 }");
         }
 
@@ -166,14 +146,11 @@ class C
 9");
             verifier.VerifyIL("C.Main", @"
 {
-  // Code size      188 (0xbc)
+  // Code size      120 (0x78)
   .maxstack  4
   .locals init (System.Span<int> V_0, //s
                 int V_1,
-                int V_2,
-                System.Index V_3,
-                int V_4,
-                int V_5)
+                int V_2)
   IL_0000:  ldc.i4.4
   IL_0001:  newarr     ""int""
   IL_0006:  dup
@@ -184,71 +161,47 @@ class C
   IL_0017:  ldloca.s   V_0
   IL_0019:  dup
   IL_001a:  call       ""int System.Span<int>.Length.get""
-  IL_001f:  stloc.1
-  IL_0020:  ldc.i4.2
-  IL_0021:  ldc.i4.1
-  IL_0022:  newobj     ""System.Index..ctor(int, bool)""
-  IL_0027:  stloc.3
-  IL_0028:  ldloca.s   V_3
-  IL_002a:  ldloc.1
-  IL_002b:  call       ""int System.Index.GetOffset(int)""
-  IL_0030:  stloc.2
-  IL_0031:  ldloc.2
-  IL_0032:  call       ""ref int System.Span<int>.this[int].get""
-  IL_0037:  ldind.i4
-  IL_0038:  call       ""void System.Console.WriteLine(int)""
-  IL_003d:  ldloca.s   V_0
+  IL_001f:  ldc.i4.2
+  IL_0020:  sub
+  IL_0021:  stloc.1
+  IL_0022:  ldloc.1
+  IL_0023:  call       ""ref int System.Span<int>.this[int].get""
+  IL_0028:  ldind.i4
+  IL_0029:  call       ""void System.Console.WriteLine(int)""
+  IL_002e:  ldloca.s   V_0
+  IL_0030:  dup
+  IL_0031:  call       ""int System.Span<int>.Length.get""
+  IL_0036:  ldc.i4.2
+  IL_0037:  sub
+  IL_0038:  stloc.1
+  IL_0039:  ldloc.1
+  IL_003a:  call       ""ref int System.Span<int>.this[int].get""
   IL_003f:  dup
-  IL_0040:  call       ""int System.Span<int>.Length.get""
-  IL_0045:  stloc.2
-  IL_0046:  ldc.i4.2
-  IL_0047:  ldc.i4.1
-  IL_0048:  newobj     ""System.Index..ctor(int, bool)""
-  IL_004d:  stloc.3
-  IL_004e:  ldloca.s   V_3
-  IL_0050:  ldloc.2
-  IL_0051:  call       ""int System.Index.GetOffset(int)""
-  IL_0056:  stloc.1
-  IL_0057:  ldloc.1
-  IL_0058:  call       ""ref int System.Span<int>.this[int].get""
-  IL_005d:  dup
-  IL_005e:  ldind.i4
-  IL_005f:  call       ""void System.Console.WriteLine(int)""
-  IL_0064:  ldloca.s   V_0
-  IL_0066:  dup
-  IL_0067:  call       ""int System.Span<int>.Length.get""
-  IL_006c:  stloc.s    V_4
-  IL_006e:  ldc.i4.2
-  IL_006f:  ldc.i4.1
-  IL_0070:  newobj     ""System.Index..ctor(int, bool)""
-  IL_0075:  stloc.3
-  IL_0076:  ldloca.s   V_3
-  IL_0078:  ldloc.s    V_4
-  IL_007a:  call       ""int System.Index.GetOffset(int)""
-  IL_007f:  stloc.s    V_5
-  IL_0081:  ldloc.s    V_5
-  IL_0083:  call       ""ref int System.Span<int>.this[int].get""
-  IL_0088:  ldc.i4.s   9
-  IL_008a:  stind.i4
-  IL_008b:  ldloca.s   V_0
-  IL_008d:  dup
-  IL_008e:  call       ""int System.Span<int>.Length.get""
-  IL_0093:  stloc.s    V_5
-  IL_0095:  ldc.i4.2
-  IL_0096:  ldc.i4.1
-  IL_0097:  newobj     ""System.Index..ctor(int, bool)""
-  IL_009c:  stloc.3
-  IL_009d:  ldloca.s   V_3
-  IL_009f:  ldloc.s    V_5
-  IL_00a1:  call       ""int System.Index.GetOffset(int)""
-  IL_00a6:  stloc.s    V_4
-  IL_00a8:  ldloc.s    V_4
-  IL_00aa:  call       ""ref int System.Span<int>.this[int].get""
-  IL_00af:  ldind.i4
-  IL_00b0:  call       ""void System.Console.WriteLine(int)""
-  IL_00b5:  ldind.i4
-  IL_00b6:  call       ""void System.Console.WriteLine(int)""
-  IL_00bb:  ret
+  IL_0040:  ldind.i4
+  IL_0041:  call       ""void System.Console.WriteLine(int)""
+  IL_0046:  ldloca.s   V_0
+  IL_0048:  dup
+  IL_0049:  call       ""int System.Span<int>.Length.get""
+  IL_004e:  ldc.i4.2
+  IL_004f:  sub
+  IL_0050:  stloc.2
+  IL_0051:  ldloc.2
+  IL_0052:  call       ""ref int System.Span<int>.this[int].get""
+  IL_0057:  ldc.i4.s   9
+  IL_0059:  stind.i4
+  IL_005a:  ldloca.s   V_0
+  IL_005c:  dup
+  IL_005d:  call       ""int System.Span<int>.Length.get""
+  IL_0062:  ldc.i4.2
+  IL_0063:  sub
+  IL_0064:  stloc.2
+  IL_0065:  ldloc.2
+  IL_0066:  call       ""ref int System.Span<int>.this[int].get""
+  IL_006b:  ldind.i4
+  IL_006c:  call       ""void System.Console.WriteLine(int)""
+  IL_0071:  ldind.i4
+  IL_0072:  call       ""void System.Console.WriteLine(int)""
+  IL_0077:  ret
 }");
         }
 
@@ -276,93 +229,87 @@ f
 g");
             verifier.VerifyIL(@"C.Main", @"
 {
-  // Code size      193 (0xc1)
+  // Code size      177 (0xb1)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //s
                 System.Index V_1, //index
                 int V_2,
                 int V_3,
-                System.Index V_4,
-                System.ReadOnlySpan<char> V_5,
-                System.Range V_6,
-                int V_7)
+                System.ReadOnlySpan<char> V_4,
+                System.Range V_5,
+                int V_6,
+                System.Index V_7)
   IL_0000:  ldstr      ""abcdefg""
   IL_0005:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(string)""
   IL_000a:  stloc.0
   IL_000b:  ldloca.s   V_0
   IL_000d:  dup
   IL_000e:  call       ""int System.ReadOnlySpan<char>.Length.get""
-  IL_0013:  stloc.2
-  IL_0014:  ldc.i4.2
-  IL_0015:  ldc.i4.1
-  IL_0016:  newobj     ""System.Index..ctor(int, bool)""
-  IL_001b:  stloc.s    V_4
-  IL_001d:  ldloca.s   V_4
-  IL_001f:  ldloc.2
-  IL_0020:  call       ""int System.Index.GetOffset(int)""
-  IL_0025:  stloc.3
-  IL_0026:  ldloc.3
-  IL_0027:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
-  IL_002c:  ldind.u2
-  IL_002d:  call       ""void System.Console.WriteLine(char)""
-  IL_0032:  ldloca.s   V_1
-  IL_0034:  ldc.i4.1
-  IL_0035:  ldc.i4.1
-  IL_0036:  call       ""System.Index..ctor(int, bool)""
-  IL_003b:  ldloca.s   V_0
-  IL_003d:  dup
-  IL_003e:  call       ""int System.ReadOnlySpan<char>.Length.get""
-  IL_0043:  stloc.3
-  IL_0044:  ldloca.s   V_1
-  IL_0046:  ldloc.3
-  IL_0047:  call       ""int System.Index.GetOffset(int)""
-  IL_004c:  stloc.2
-  IL_004d:  ldloc.2
-  IL_004e:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
-  IL_0053:  ldind.u2
-  IL_0054:  call       ""void System.Console.WriteLine(char)""
-  IL_0059:  ldloc.0
-  IL_005a:  stloc.s    V_5
-  IL_005c:  ldloca.s   V_5
-  IL_005e:  call       ""int System.ReadOnlySpan<char>.Length.get""
-  IL_0063:  stloc.2
-  IL_0064:  ldc.i4.2
-  IL_0065:  ldc.i4.1
-  IL_0066:  newobj     ""System.Index..ctor(int, bool)""
-  IL_006b:  call       ""System.Range System.Range.StartAt(System.Index)""
-  IL_0070:  stloc.s    V_6
-  IL_0072:  ldloca.s   V_6
-  IL_0074:  call       ""System.Index System.Range.Start.get""
-  IL_0079:  stloc.s    V_4
-  IL_007b:  ldloca.s   V_4
-  IL_007d:  ldloc.2
-  IL_007e:  call       ""int System.Index.GetOffset(int)""
-  IL_0083:  stloc.3
-  IL_0084:  ldloca.s   V_6
-  IL_0086:  call       ""System.Index System.Range.End.get""
-  IL_008b:  stloc.s    V_4
-  IL_008d:  ldloca.s   V_4
-  IL_008f:  ldloc.2
-  IL_0090:  call       ""int System.Index.GetOffset(int)""
-  IL_0095:  stloc.s    V_7
-  IL_0097:  ldloca.s   V_5
-  IL_0099:  ldloc.3
-  IL_009a:  ldloc.s    V_7
-  IL_009c:  ldloc.3
-  IL_009d:  sub
-  IL_009e:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.Slice(int, int)""
-  IL_00a3:  stloc.0
-  IL_00a4:  ldloca.s   V_0
-  IL_00a6:  ldc.i4.0
-  IL_00a7:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
-  IL_00ac:  ldind.u2
-  IL_00ad:  call       ""void System.Console.WriteLine(char)""
-  IL_00b2:  ldloca.s   V_0
-  IL_00b4:  ldc.i4.1
-  IL_00b5:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
-  IL_00ba:  ldind.u2
-  IL_00bb:  call       ""void System.Console.WriteLine(char)""
-  IL_00c0:  ret
+  IL_0013:  ldc.i4.2
+  IL_0014:  sub
+  IL_0015:  stloc.2
+  IL_0016:  ldloc.2
+  IL_0017:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+  IL_001c:  ldind.u2
+  IL_001d:  call       ""void System.Console.WriteLine(char)""
+  IL_0022:  ldloca.s   V_1
+  IL_0024:  ldc.i4.1
+  IL_0025:  ldc.i4.1
+  IL_0026:  call       ""System.Index..ctor(int, bool)""
+  IL_002b:  ldloca.s   V_0
+  IL_002d:  dup
+  IL_002e:  call       ""int System.ReadOnlySpan<char>.Length.get""
+  IL_0033:  stloc.2
+  IL_0034:  ldloca.s   V_1
+  IL_0036:  ldloc.2
+  IL_0037:  call       ""int System.Index.GetOffset(int)""
+  IL_003c:  stloc.3
+  IL_003d:  ldloc.3
+  IL_003e:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+  IL_0043:  ldind.u2
+  IL_0044:  call       ""void System.Console.WriteLine(char)""
+  IL_0049:  ldloc.0
+  IL_004a:  stloc.s    V_4
+  IL_004c:  ldloca.s   V_4
+  IL_004e:  call       ""int System.ReadOnlySpan<char>.Length.get""
+  IL_0053:  stloc.3
+  IL_0054:  ldc.i4.2
+  IL_0055:  ldc.i4.1
+  IL_0056:  newobj     ""System.Index..ctor(int, bool)""
+  IL_005b:  call       ""System.Range System.Range.StartAt(System.Index)""
+  IL_0060:  stloc.s    V_5
+  IL_0062:  ldloca.s   V_5
+  IL_0064:  call       ""System.Index System.Range.Start.get""
+  IL_0069:  stloc.s    V_7
+  IL_006b:  ldloca.s   V_7
+  IL_006d:  ldloc.3
+  IL_006e:  call       ""int System.Index.GetOffset(int)""
+  IL_0073:  stloc.2
+  IL_0074:  ldloca.s   V_5
+  IL_0076:  call       ""System.Index System.Range.End.get""
+  IL_007b:  stloc.s    V_7
+  IL_007d:  ldloca.s   V_7
+  IL_007f:  ldloc.3
+  IL_0080:  call       ""int System.Index.GetOffset(int)""
+  IL_0085:  stloc.s    V_6
+  IL_0087:  ldloca.s   V_4
+  IL_0089:  ldloc.2
+  IL_008a:  ldloc.s    V_6
+  IL_008c:  ldloc.2
+  IL_008d:  sub
+  IL_008e:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.Slice(int, int)""
+  IL_0093:  stloc.0
+  IL_0094:  ldloca.s   V_0
+  IL_0096:  ldc.i4.0
+  IL_0097:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+  IL_009c:  ldind.u2
+  IL_009d:  call       ""void System.Console.WriteLine(char)""
+  IL_00a2:  ldloca.s   V_0
+  IL_00a4:  ldc.i4.1
+  IL_00a5:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+  IL_00aa:  ldind.u2
+  IL_00ab:  call       ""void System.Console.WriteLine(char)""
+  IL_00b0:  ret
 }");
         }
 
@@ -390,16 +337,16 @@ class C
 6");
             verifier.VerifyIL("C.Main", @"
 {
-  // Code size      205 (0xcd)
+  // Code size      189 (0xbd)
   .maxstack  4
   .locals init (System.Span<int> V_0, //s
                 System.Index V_1, //index
                 int V_2,
                 int V_3,
-                System.Index V_4,
-                System.Span<int> V_5,
-                System.Range V_6,
-                int V_7)
+                System.Span<int> V_4,
+                System.Range V_5,
+                int V_6,
+                System.Index V_7)
   IL_0000:  ldc.i4.4
   IL_0001:  newarr     ""int""
   IL_0006:  dup
@@ -410,77 +357,71 @@ class C
   IL_0017:  ldloca.s   V_0
   IL_0019:  dup
   IL_001a:  call       ""int System.Span<int>.Length.get""
-  IL_001f:  stloc.2
-  IL_0020:  ldc.i4.2
-  IL_0021:  ldc.i4.1
-  IL_0022:  newobj     ""System.Index..ctor(int, bool)""
-  IL_0027:  stloc.s    V_4
-  IL_0029:  ldloca.s   V_4
-  IL_002b:  ldloc.2
-  IL_002c:  call       ""int System.Index.GetOffset(int)""
-  IL_0031:  stloc.3
-  IL_0032:  ldloc.3
-  IL_0033:  call       ""ref int System.Span<int>.this[int].get""
-  IL_0038:  ldind.i4
-  IL_0039:  call       ""void System.Console.WriteLine(int)""
-  IL_003e:  ldloca.s   V_1
-  IL_0040:  ldc.i4.1
-  IL_0041:  ldc.i4.1
-  IL_0042:  call       ""System.Index..ctor(int, bool)""
-  IL_0047:  ldloca.s   V_0
-  IL_0049:  dup
-  IL_004a:  call       ""int System.Span<int>.Length.get""
-  IL_004f:  stloc.3
-  IL_0050:  ldloca.s   V_1
-  IL_0052:  ldloc.3
-  IL_0053:  call       ""int System.Index.GetOffset(int)""
-  IL_0058:  stloc.2
-  IL_0059:  ldloc.2
-  IL_005a:  call       ""ref int System.Span<int>.this[int].get""
-  IL_005f:  ldind.i4
-  IL_0060:  call       ""void System.Console.WriteLine(int)""
-  IL_0065:  ldloc.0
-  IL_0066:  stloc.s    V_5
-  IL_0068:  ldloca.s   V_5
-  IL_006a:  call       ""int System.Span<int>.Length.get""
-  IL_006f:  stloc.2
-  IL_0070:  ldc.i4.2
-  IL_0071:  ldc.i4.1
-  IL_0072:  newobj     ""System.Index..ctor(int, bool)""
-  IL_0077:  call       ""System.Range System.Range.StartAt(System.Index)""
-  IL_007c:  stloc.s    V_6
-  IL_007e:  ldloca.s   V_6
-  IL_0080:  call       ""System.Index System.Range.Start.get""
-  IL_0085:  stloc.s    V_4
-  IL_0087:  ldloca.s   V_4
-  IL_0089:  ldloc.2
-  IL_008a:  call       ""int System.Index.GetOffset(int)""
-  IL_008f:  stloc.3
-  IL_0090:  ldloca.s   V_6
-  IL_0092:  call       ""System.Index System.Range.End.get""
-  IL_0097:  stloc.s    V_4
-  IL_0099:  ldloca.s   V_4
-  IL_009b:  ldloc.2
-  IL_009c:  call       ""int System.Index.GetOffset(int)""
-  IL_00a1:  stloc.s    V_7
-  IL_00a3:  ldloca.s   V_5
-  IL_00a5:  ldloc.3
-  IL_00a6:  ldloc.s    V_7
-  IL_00a8:  ldloc.3
-  IL_00a9:  sub
-  IL_00aa:  call       ""System.Span<int> System.Span<int>.Slice(int, int)""
-  IL_00af:  stloc.0
-  IL_00b0:  ldloca.s   V_0
-  IL_00b2:  ldc.i4.0
-  IL_00b3:  call       ""ref int System.Span<int>.this[int].get""
-  IL_00b8:  ldind.i4
-  IL_00b9:  call       ""void System.Console.WriteLine(int)""
-  IL_00be:  ldloca.s   V_0
-  IL_00c0:  ldc.i4.1
-  IL_00c1:  call       ""ref int System.Span<int>.this[int].get""
-  IL_00c6:  ldind.i4
-  IL_00c7:  call       ""void System.Console.WriteLine(int)""
-  IL_00cc:  ret
+  IL_001f:  ldc.i4.2
+  IL_0020:  sub
+  IL_0021:  stloc.2
+  IL_0022:  ldloc.2
+  IL_0023:  call       ""ref int System.Span<int>.this[int].get""
+  IL_0028:  ldind.i4
+  IL_0029:  call       ""void System.Console.WriteLine(int)""
+  IL_002e:  ldloca.s   V_1
+  IL_0030:  ldc.i4.1
+  IL_0031:  ldc.i4.1
+  IL_0032:  call       ""System.Index..ctor(int, bool)""
+  IL_0037:  ldloca.s   V_0
+  IL_0039:  dup
+  IL_003a:  call       ""int System.Span<int>.Length.get""
+  IL_003f:  stloc.2
+  IL_0040:  ldloca.s   V_1
+  IL_0042:  ldloc.2
+  IL_0043:  call       ""int System.Index.GetOffset(int)""
+  IL_0048:  stloc.3
+  IL_0049:  ldloc.3
+  IL_004a:  call       ""ref int System.Span<int>.this[int].get""
+  IL_004f:  ldind.i4
+  IL_0050:  call       ""void System.Console.WriteLine(int)""
+  IL_0055:  ldloc.0
+  IL_0056:  stloc.s    V_4
+  IL_0058:  ldloca.s   V_4
+  IL_005a:  call       ""int System.Span<int>.Length.get""
+  IL_005f:  stloc.3
+  IL_0060:  ldc.i4.2
+  IL_0061:  ldc.i4.1
+  IL_0062:  newobj     ""System.Index..ctor(int, bool)""
+  IL_0067:  call       ""System.Range System.Range.StartAt(System.Index)""
+  IL_006c:  stloc.s    V_5
+  IL_006e:  ldloca.s   V_5
+  IL_0070:  call       ""System.Index System.Range.Start.get""
+  IL_0075:  stloc.s    V_7
+  IL_0077:  ldloca.s   V_7
+  IL_0079:  ldloc.3
+  IL_007a:  call       ""int System.Index.GetOffset(int)""
+  IL_007f:  stloc.2
+  IL_0080:  ldloca.s   V_5
+  IL_0082:  call       ""System.Index System.Range.End.get""
+  IL_0087:  stloc.s    V_7
+  IL_0089:  ldloca.s   V_7
+  IL_008b:  ldloc.3
+  IL_008c:  call       ""int System.Index.GetOffset(int)""
+  IL_0091:  stloc.s    V_6
+  IL_0093:  ldloca.s   V_4
+  IL_0095:  ldloc.2
+  IL_0096:  ldloc.s    V_6
+  IL_0098:  ldloc.2
+  IL_0099:  sub
+  IL_009a:  call       ""System.Span<int> System.Span<int>.Slice(int, int)""
+  IL_009f:  stloc.0
+  IL_00a0:  ldloca.s   V_0
+  IL_00a2:  ldc.i4.0
+  IL_00a3:  call       ""ref int System.Span<int>.this[int].get""
+  IL_00a8:  ldind.i4
+  IL_00a9:  call       ""void System.Console.WriteLine(int)""
+  IL_00ae:  ldloca.s   V_0
+  IL_00b0:  ldc.i4.1
+  IL_00b1:  call       ""ref int System.Span<int>.this[int].get""
+  IL_00b6:  ldind.i4
+  IL_00b7:  call       ""void System.Console.WriteLine(int)""
+  IL_00bc:  ret
 }");
         }
 
@@ -531,43 +472,36 @@ class C
 6");
             verifier.VerifyIL("C.Main", @"
 {
-  // Code size       82 (0x52)
+  // Code size       67 (0x43)
   .maxstack  3
   .locals init (System.Index V_0, //index
                 int V_1,
-                int V_2,
-                System.Index V_3)
+                int V_2)
   IL_0000:  ldsfld     ""System.Collections.Generic.List<int> C.list""
   IL_0005:  dup
   IL_0006:  callvirt   ""int System.Collections.Generic.List<int>.Count.get""
-  IL_000b:  stloc.1
-  IL_000c:  ldc.i4.2
-  IL_000d:  ldc.i4.1
-  IL_000e:  newobj     ""System.Index..ctor(int, bool)""
-  IL_0013:  stloc.3
-  IL_0014:  ldloca.s   V_3
-  IL_0016:  ldloc.1
-  IL_0017:  call       ""int System.Index.GetOffset(int)""
-  IL_001c:  stloc.2
-  IL_001d:  ldloc.2
-  IL_001e:  callvirt   ""int System.Collections.Generic.List<int>.this[int].get""
-  IL_0023:  call       ""void System.Console.WriteLine(int)""
-  IL_0028:  ldloca.s   V_0
-  IL_002a:  ldc.i4.1
-  IL_002b:  ldc.i4.1
-  IL_002c:  call       ""System.Index..ctor(int, bool)""
-  IL_0031:  ldsfld     ""System.Collections.Generic.List<int> C.list""
-  IL_0036:  dup
-  IL_0037:  callvirt   ""int System.Collections.Generic.List<int>.Count.get""
-  IL_003c:  stloc.2
-  IL_003d:  ldloca.s   V_0
-  IL_003f:  ldloc.2
-  IL_0040:  call       ""int System.Index.GetOffset(int)""
-  IL_0045:  stloc.1
-  IL_0046:  ldloc.1
-  IL_0047:  callvirt   ""int System.Collections.Generic.List<int>.this[int].get""
-  IL_004c:  call       ""void System.Console.WriteLine(int)""
-  IL_0051:  ret
+  IL_000b:  ldc.i4.2
+  IL_000c:  sub
+  IL_000d:  stloc.1
+  IL_000e:  ldloc.1
+  IL_000f:  callvirt   ""int System.Collections.Generic.List<int>.this[int].get""
+  IL_0014:  call       ""void System.Console.WriteLine(int)""
+  IL_0019:  ldloca.s   V_0
+  IL_001b:  ldc.i4.1
+  IL_001c:  ldc.i4.1
+  IL_001d:  call       ""System.Index..ctor(int, bool)""
+  IL_0022:  ldsfld     ""System.Collections.Generic.List<int> C.list""
+  IL_0027:  dup
+  IL_0028:  callvirt   ""int System.Collections.Generic.List<int>.Count.get""
+  IL_002d:  stloc.1
+  IL_002e:  ldloca.s   V_0
+  IL_0030:  ldloc.1
+  IL_0031:  call       ""int System.Index.GetOffset(int)""
+  IL_0036:  stloc.2
+  IL_0037:  ldloc.2
+  IL_0038:  callvirt   ""int System.Collections.Generic.List<int>.this[int].get""
+  IL_003d:  call       ""void System.Console.WriteLine(int)""
+  IL_0042:  ret
 }");
         }
 
@@ -732,11 +666,9 @@ class C
 6");
             verifier.VerifyIL("C.Main", @"
 {
-  // Code size       53 (0x35)
+  // Code size       38 (0x26)
   .maxstack  3
-  .locals init (int V_0,
-                int V_1,
-                System.Index V_2)
+  .locals init (int V_0)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  dup
   IL_0006:  ldc.i4.0
@@ -744,19 +676,13 @@ class C
   IL_000c:  call       ""void System.Console.WriteLine(int)""
   IL_0011:  dup
   IL_0012:  callvirt   ""int C." + propertyName + @".get""
-  IL_0017:  stloc.0
-  IL_0018:  ldc.i4.1
-  IL_0019:  ldc.i4.1
-  IL_001a:  newobj     ""System.Index..ctor(int, bool)""
-  IL_001f:  stloc.2
-  IL_0020:  ldloca.s   V_2
-  IL_0022:  ldloc.0
-  IL_0023:  call       ""int System.Index.GetOffset(int)""
-  IL_0028:  stloc.1
-  IL_0029:  ldloc.1
-  IL_002a:  callvirt   ""int C.this[int].get""
-  IL_002f:  call       ""void System.Console.WriteLine(int)""
-  IL_0034:  ret
+  IL_0017:  ldc.i4.1
+  IL_0018:  sub
+  IL_0019:  stloc.0
+  IL_001a:  ldloc.0
+  IL_001b:  callvirt   ""int C.this[int].get""
+  IL_0020:  call       ""void System.Console.WriteLine(int)""
+  IL_0025:  ret
 }");
         }
 
@@ -940,7 +866,7 @@ class C
 f");
             verifier.VerifyIL("C.Main", @"
 {
-  // Code size       77 (0x4d)
+  // Code size       62 (0x3e)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
@@ -963,19 +889,13 @@ f");
   IL_0024:  call       ""void System.Console.WriteLine(char)""
   IL_0029:  dup
   IL_002a:  callvirt   ""int string.Length.get""
-  IL_002f:  stloc.1
-  IL_0030:  ldc.i4.1
-  IL_0031:  ldc.i4.1
-  IL_0032:  newobj     ""System.Index..ctor(int, bool)""
-  IL_0037:  stloc.2
-  IL_0038:  ldloca.s   V_2
-  IL_003a:  ldloc.1
-  IL_003b:  call       ""int System.Index.GetOffset(int)""
-  IL_0040:  stloc.0
-  IL_0041:  ldloc.0
-  IL_0042:  callvirt   ""char string.this[int].get""
-  IL_0047:  call       ""void System.Console.WriteLine(char)""
-  IL_004c:  ret
+  IL_002f:  ldc.i4.1
+  IL_0030:  sub
+  IL_0031:  stloc.1
+  IL_0032:  ldloc.1
+  IL_0033:  callvirt   ""char string.this[int].get""
+  IL_0038:  call       ""void System.Console.WriteLine(char)""
+  IL_003d:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/IndexAndRangeTests.cs
@@ -312,16 +312,13 @@ class C
 }";
             var comp = CreateCompilation(src);
             comp.VerifyDiagnostics(
-                // At binding time we don't look for all the necessary members
-                // on the Index and Range types.
+                // (21,13): error CS0656: Missing compiler required member 'System.Index.GetOffset'
+                //         _ = this[^0];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "this[^0]").WithArguments("System.Index", "GetOffset").WithLocation(21, 13),
+                // (22,13): error CS0656: Missing compiler required member 'System.Index.GetOffset'
+                //         _ = this[0..];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "this[0..]").WithArguments("System.Index", "GetOffset").WithLocation(22, 13)
                 );
-            comp.VerifyEmitDiagnostics(
-                // (20,5): error CS0656: Missing compiler required member 'System.Index.GetOffset'
-                //     {
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"{
-        _ = this[^0];
-        _ = this[0..];
-    }").WithArguments("System.Index", "GetOffset").WithLocation(20, 5));
         }
 
         [Theory]


### PR DESCRIPTION
Pattern System.Index indexers currently call GetOffset on the System.Index
argument, even if the argument is hat operator. If the argument is a hat
operator, we can skip the creation of the intermediate System.Index type
and directly emit the offset calculation.