### PR TITLE
Use 'Nullable' for Csc Task property

### DIFF
--- a/docs/features/nullable-reference-types.md
+++ b/docs/features/nullable-reference-types.md
@@ -8,9 +8,11 @@ Project level nullable context can be set by using "nullable" command line switc
 -nullable[+|-]                        Specify nullable context option enable|disable.
 -nullable:{enable|disable|safeonly|warnings|safeonlywarnings}   Specify nullable context option enable|disable|safeonly|warnings|safeonlywarnings.
 
-Through msbuild the context could be set by supplying an argument for a "NullableContextOptions" parameter of Csc build task.
+Through msbuild the context could be set by supplying an argument for a "Nullable" parameter of Csc build task.
 Accepted values are "enable", "disable", "safeonly", "warnings", "safeonlywarnings", or null (for the default nullable context according to the compiler).
-The Microsoft.CSharp.Core.targets passes value of msbuild property named "NullableContextOptions" for that parameter.
+The Microsoft.CSharp.Core.targets passes value of msbuild property named "Nullable" for that parameter.
+
+Note that in previous preview releases of C# 8.0 this "Nullable" property was successively named "NullableReferenceTypes" then "NullableContextOptions".
 
 ## Annotations
 In source, nullable reference types are annotated with `?`.

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -149,10 +149,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return (string)_store[nameof(WarningsNotAsErrors)]; }
         }
 
-        public string NullableContextOptions
+        public string Nullable
         {
-            set { _store[nameof(NullableContextOptions)] = value; }
-            get { return (string)_store[nameof(NullableContextOptions)]; }
+            set { _store[nameof(Nullable)] = value; }
+            get { return (string)_store[nameof(Nullable)]; }
         }
 
         #endregion
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             commandLine.AppendWhenTrue("/errorendlocation", _store, nameof(ErrorEndLocation));
             commandLine.AppendSwitchIfNotNull("/preferreduilang:", PreferredUILang);
             commandLine.AppendPlusOrMinusSwitch("/highentropyva", _store, nameof(HighEntropyVA));
-            commandLine.AppendSwitchIfNotNull("/nullable:", NullableContextOptions);
+            commandLine.AppendSwitchIfNotNull("/nullable:", Nullable);
             commandLine.AppendWhenTrue("/nosdkpath", _store, nameof(DisableSdkPath));
 
             // If not design time build and the globalSessionGuid property was set then add a -globalsessionguid:<guid>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -97,7 +97,7 @@
          NoLogo="$(NoLogo)"
          NoStandardLib="$(NoCompilerStandardLib)"
          NoWin32Manifest="$(NoWin32Manifest)"
-         NullableContextOptions="$(NullableContextOptions)"
+         Nullable="$(Nullable)"
          Optimize="$(Optimize)"
          Deterministic="$(Deterministic)"
          PublicSign="$(PublicSign)"

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         {
             var csc = new Csc();
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            csc.NullableContextOptions = "enable";
+            csc.Nullable = "enable";
             Assert.Equal("/nullable:enable /out:test.exe test.cs", csc.GenerateResponseFileContents());
         }
 
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         {
             var csc = new Csc();
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            csc.NullableContextOptions = "disable";
+            csc.Nullable = "disable";
             Assert.Equal("/nullable:disable /out:test.exe test.cs", csc.GenerateResponseFileContents());
         }
 
@@ -356,7 +356,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         {
             var csc = new Csc();
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            csc.NullableContextOptions = "safeonly";
+            csc.Nullable = "safeonly";
             Assert.Equal("/nullable:safeonly /out:test.exe test.cs", csc.GenerateResponseFileContents());
         }
 
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         {
             var csc = new Csc();
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            csc.NullableContextOptions = "warnings";
+            csc.Nullable = "warnings";
             Assert.Equal("/nullable:warnings /out:test.exe test.cs", csc.GenerateResponseFileContents());
         }
 
@@ -374,7 +374,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         {
             var csc = new Csc();
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            csc.NullableContextOptions = "safeonlywarnings";
+            csc.Nullable = "safeonlywarnings";
             Assert.Equal("/nullable:safeonlywarnings /out:test.exe test.cs", csc.GenerateResponseFileContents());
         }
 
@@ -383,7 +383,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         {
             var csc = new Csc();
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            csc.NullableContextOptions = null;
+            csc.Nullable = null;
             Assert.Equal("/out:test.exe test.cs", csc.GenerateResponseFileContents());
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/35432 based on LDM decision earlier this week.

Note: I left the compilation option and enum named `NullableContextOptions`.