### PR TITLE
Use AssemblyInformationalVersionAttribute value for logo and version

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="consoleOutput"></param>
         public override void PrintLogo(TextWriter consoleOutput)
         {
-            consoleOutput.WriteLine(ErrorFacts.GetMessage(MessageID.IDS_LogoLine1, Culture), GetToolName(), GetAssemblyFileVersion());
+            consoleOutput.WriteLine(ErrorFacts.GetMessage(MessageID.IDS_LogoLine1, Culture), GetToolName(), GetCompilerVersion());
             consoleOutput.WriteLine(ErrorFacts.GetMessage(MessageID.IDS_LogoLine2, Culture));
             consoleOutput.WriteLine();
         }

--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 {
                     if (errorText.Equals("version", StringComparison.Ordinal))
                     {
-                        string version = CommonCompiler.GetCompilerVersion(typeof(CSharpCompiler));
+                        string version = CommonCompiler.GetProductVersion(typeof(CSharpCompiler));
                         eod = this.AddError(eod, triviaOffset, triviaWidth, ErrorCode.ERR_CompilerAndLanguageVersion, version,
                             this.Options.SpecifiedLanguageVersion.ToDisplayString());
                     }

--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -320,8 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 {
                     if (errorText.Equals("version", StringComparison.Ordinal))
                     {
-                        Assembly assembly = typeof(CSharpCompiler).GetTypeInfo().Assembly;
-                        string version = CommonCompiler.GetAssemblyFileVersion(assembly);
+                        string version = CommonCompiler.GetCompilerVersion(typeof(CSharpCompiler));
                         eod = this.AddError(eod, triviaOffset, triviaWidth, ErrorCode.ERR_CompilerAndLanguageVersion, version,
                             this.Options.SpecifiedLanguageVersion.ToDisplayString());
                     }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -40,8 +40,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             Path.GetDirectoryName(typeof(CommandLineTests).GetTypeInfo().Assembly.Location),
             Path.Combine("dependency", "csc.exe"));
 
-        private static readonly string s_compilerVersion = typeof(CommandLineTests).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
-        private static readonly string s_compilerCommitHash = typeof(CommandLineTests).Assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash;
+        private static readonly string s_compilerVersionWithoutHash =
+            typeof(CommandLineTests).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0];
+        private static readonly string s_compilerCommitHash =
+            typeof(CommandLineTests).Assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash;
         private static readonly string s_compilerShortCommitHash = CommonCompiler.ExtractShortCommitHash(s_compilerCommitHash);
 
         private class TestCommandLineParser : CSharpCommandLineParser
@@ -6265,27 +6267,25 @@ class C
             int exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
 
-            var patched = Regex.Replace(outWriter.ToString().Trim(), "version \\d+\\.\\d+\\.\\d+(\\.\\d+)?", "version A.B.C.D");
+            var patched = Regex.Replace(outWriter.ToString().Trim(), "version \\d+\\.\\d+\\.\\d+(-[\\w\\d]+)?", "version A.B.C-d");
             patched = ReplaceCommitHash(patched);
             Assert.Equal(@"
-Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)
+Microsoft (R) Visual C# Compiler version A.B.C-d (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.".Trim(),
                 patched);
-            // Privately queued builds have 3-part version numbers instead of 4.  Since we're throwing away the version number,
-            // making the last part optional will fix this.
 
             CleanupAllGeneratedFiles(file.Path);
         }
 
         [Theory,
-            InlineData("Microsoft (R) Visual C# Compiler version A.B.C.D (<developer build>)",
-                "Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)"),
-            InlineData("Microsoft (R) Visual C# Compiler version A.B.C.D (ABCDEF01)",
-                "Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)"),
-            InlineData("Microsoft (R) Visual C# Compiler version A.B.C.D (abcdef90)",
-                "Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)"),
-            InlineData("Microsoft (R) Visual C# Compiler version A.B.C.D (12345678)",
-                "Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)")]
+            InlineData("Microsoft (R) Visual C# Compiler version A.B.C-d (<developer build>)",
+                "Microsoft (R) Visual C# Compiler version A.B.C-d (HASH)"),
+            InlineData("Microsoft (R) Visual C# Compiler version A.B.C-d (ABCDEF01)",
+                "Microsoft (R) Visual C# Compiler version A.B.C-d (HASH)"),
+            InlineData("Microsoft (R) Visual C# Compiler version A.B.C-d (abcdef90)",
+                "Microsoft (R) Visual C# Compiler version A.B.C-d (HASH)"),
+            InlineData("Microsoft (R) Visual C# Compiler version A.B.C-d (12345678)",
+                "Microsoft (R) Visual C# Compiler version A.B.C-d (HASH)")]
         public void TestReplaceCommitHash(string orig, string expected)
         {
             Assert.Equal(expected, ReplaceCommitHash(orig));
@@ -8082,7 +8082,7 @@ class Program3
 
             var output = ProcessUtilities.RunAndGetOutput(s_CSharpCompilerExecutable, $"/target:library /debug:portable {libSrc.Path}", startFolder: dir.ToString());
             AssertEx.AssertEqualToleratingWhitespaceDifferences($@"
-Microsoft (R) Visual C# Compiler version {s_compilerVersion} ({s_compilerShortCommitHash })
+Microsoft (R) Visual C# Compiler version {s_compilerVersionWithoutHash} ({s_compilerShortCommitHash })
 Copyright (C) Microsoft Corporation. All rights reserved.", output);
 
             // reading original content from the memory map:
@@ -10242,7 +10242,7 @@ class Runner
         public void Version()
         {
             var folderName = Temp.CreateDirectory().ToString();
-            var expected = $"{FileVersionInfo.GetVersionInfo(typeof(CSharpCompiler).Assembly.Location).FileVersion} ({s_compilerShortCommitHash})";
+            var expected = $"{s_compilerVersionWithoutHash} ({s_compilerShortCommitHash})";
             var argss = new[]
             {
                 "/version",

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -40,11 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             Path.GetDirectoryName(typeof(CommandLineTests).GetTypeInfo().Assembly.Location),
             Path.Combine("dependency", "csc.exe"));
 
-        private static readonly string s_compilerVersionWithoutHash =
-            typeof(CommandLineTests).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0];
-        private static readonly string s_compilerCommitHash =
-            typeof(CommandLineTests).Assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash;
-        private static readonly string s_compilerShortCommitHash = CommonCompiler.ExtractShortCommitHash(s_compilerCommitHash);
+        private static readonly string s_compilerVersionWithoutHash = CommonCompiler.GetInformationalVersionWithoutHash(typeof(CommandLineTests));
+        private static readonly string s_compilerShortCommitHash = CommonCompiler.GetShortCommitHash(typeof(CommandLineTests));
 
         private class TestCommandLineParser : CSharpCommandLineParser
         {

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -40,7 +40,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             Path.GetDirectoryName(typeof(CommandLineTests).GetTypeInfo().Assembly.Location),
             Path.Combine("dependency", "csc.exe"));
 
-        private static readonly string s_compilerVersion = typeof(CommandLineTests).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+        private static readonly string s_compilerVersion = typeof(CommandLineTests).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+        private static readonly string s_compilerCommitHash = typeof(CommandLineTests).Assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash;
+        private static readonly string s_compilerShortCommitHash = CommonCompiler.ExtractShortCommitHash(s_compilerCommitHash);
 
         private class TestCommandLineParser : CSharpCommandLineParser
         {
@@ -6263,15 +6265,49 @@ class C
             int exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
 
-            var patched = Regex.Replace(outWriter.ToString().Trim(), "version \\d+\\.\\d+\\.\\d+(\\.\\d+)?-[\\w\\d.-]+", "version A.B.C.D-E");
+            var patched = Regex.Replace(outWriter.ToString().Trim(), "version \\d+\\.\\d+\\.\\d+(\\.\\d+)?", "version A.B.C.D");
+            patched = ReplaceCommitHash(patched);
             Assert.Equal(@"
-Microsoft (R) Visual C# Compiler version A.B.C.D-E
+Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.".Trim(),
                 patched);
             // Privately queued builds have 3-part version numbers instead of 4.  Since we're throwing away the version number,
-            // making the D part optional will fix this.
+            // making the last part optional will fix this.
 
             CleanupAllGeneratedFiles(file.Path);
+        }
+
+        [Theory,
+            InlineData("Microsoft (R) Visual C# Compiler version A.B.C.D (<developer build>)",
+                "Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)"),
+            InlineData("Microsoft (R) Visual C# Compiler version A.B.C.D (ABCDEF01)",
+                "Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)"),
+            InlineData("Microsoft (R) Visual C# Compiler version A.B.C.D (abcdef90)",
+                "Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)"),
+            InlineData("Microsoft (R) Visual C# Compiler version A.B.C.D (12345678)",
+                "Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)")]
+        public void TestReplaceCommitHash(string orig, string expected)
+        {
+            Assert.Equal(expected, ReplaceCommitHash(orig));
+        }
+
+        private static string ReplaceCommitHash(string s)
+        {
+            // open paren, followed by either <developer build> or 8 hex, followed by close paren
+            return Regex.Replace(s, "(\\((<developer build>|[a-fA-F0-9]{8})\\))", "(HASH)");
+        }
+
+        [Fact]
+        public void ExtractShortCommitHash()
+        {
+            Assert.Null(CommonCompiler.ExtractShortCommitHash(null));
+            Assert.Equal("", CommonCompiler.ExtractShortCommitHash(""));
+            Assert.Equal("<", CommonCompiler.ExtractShortCommitHash("<"));
+            Assert.Equal("<developer build>", CommonCompiler.ExtractShortCommitHash("<developer build>"));
+            Assert.Equal("1", CommonCompiler.ExtractShortCommitHash("1"));
+            Assert.Equal("1234567", CommonCompiler.ExtractShortCommitHash("1234567"));
+            Assert.Equal("12345678", CommonCompiler.ExtractShortCommitHash("12345678"));
+            Assert.Equal("12345678", CommonCompiler.ExtractShortCommitHash("123456789"));
         }
 
         private void CheckOutputFileName(string source1, string source2, string inputName1, string inputName2, string[] commandLineArguments, string expectedOutputName)
@@ -8046,7 +8082,7 @@ class Program3
 
             var output = ProcessUtilities.RunAndGetOutput(s_CSharpCompilerExecutable, $"/target:library /debug:portable {libSrc.Path}", startFolder: dir.ToString());
             AssertEx.AssertEqualToleratingWhitespaceDifferences($@"
-Microsoft (R) Visual C# Compiler version {s_compilerVersion}
+Microsoft (R) Visual C# Compiler version {s_compilerVersion} ({s_compilerShortCommitHash })
 Copyright (C) Microsoft Corporation. All rights reserved.", output);
 
             // reading original content from the memory map:
@@ -10206,6 +10242,7 @@ class Runner
         public void Version()
         {
             var folderName = Temp.CreateDirectory().ToString();
+            var expected = $"{FileVersionInfo.GetVersionInfo(typeof(CSharpCompiler).Assembly.Location).FileVersion} ({s_compilerShortCommitHash})";
             var argss = new[]
             {
                 "/version",
@@ -10217,7 +10254,7 @@ class Runner
             foreach (var args in argss)
             {
                 var output = ProcessUtilities.RunAndGetOutput(s_CSharpCompilerExecutable, args, startFolder: folderName);
-                Assert.Equal(s_compilerVersion, output.Trim());
+                Assert.Equal(expected, output.Trim());
             }
         }
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -40,8 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             Path.GetDirectoryName(typeof(CommandLineTests).GetTypeInfo().Assembly.Location),
             Path.Combine("dependency", "csc.exe"));
 
-        private static readonly string s_compilerVersionWithoutHash = CommonCompiler.GetInformationalVersionWithoutHash(typeof(CommandLineTests));
-        private static readonly string s_compilerShortCommitHash = CommonCompiler.GetShortCommitHash(typeof(CommandLineTests));
+        private static readonly string s_compilerVersion = CommonCompiler.GetProductVersion(typeof(CommandLineTests));
 
         private class TestCommandLineParser : CSharpCommandLineParser
         {
@@ -8079,7 +8078,7 @@ class Program3
 
             var output = ProcessUtilities.RunAndGetOutput(s_CSharpCompilerExecutable, $"/target:library /debug:portable {libSrc.Path}", startFolder: dir.ToString());
             AssertEx.AssertEqualToleratingWhitespaceDifferences($@"
-Microsoft (R) Visual C# Compiler version {s_compilerVersionWithoutHash} ({s_compilerShortCommitHash })
+Microsoft (R) Visual C# Compiler version {s_compilerVersion}
 Copyright (C) Microsoft Corporation. All rights reserved.", output);
 
             // reading original content from the memory map:
@@ -10239,7 +10238,6 @@ class Runner
         public void Version()
         {
             var folderName = Temp.CreateDirectory().ToString();
-            var expected = $"{s_compilerVersionWithoutHash} ({s_compilerShortCommitHash})";
             var argss = new[]
             {
                 "/version",
@@ -10251,7 +10249,7 @@ class Runner
             foreach (var args in argss)
             {
                 var output = ProcessUtilities.RunAndGetOutput(s_CSharpCompilerExecutable, args, startFolder: folderName);
-                Assert.Equal(expected, output.Trim());
+                Assert.Equal(s_compilerVersion, output.Trim());
             }
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -3047,7 +3047,7 @@ class A { }
                 // (1,8): error CS1029: #error: 'version'
                 // #error version
                 Diagnostic(ErrorCode.ERR_ErrorDirective, "version").WithArguments("version").WithLocation(1, 8),
-                // (1,8): error CS8304: Compiler version: '3.2.0-dev'. Language version: 4.
+                // (1,8): error CS8304: Compiler version: '42.42.42.42424 (<developer build>)'. Language version: 4.
                 // #error version
                 Diagnostic(ErrorCode.ERR_CompilerAndLanguageVersion, "version").WithArguments(GetExpectedVersion(), "4").WithLocation(1, 8)
                 );
@@ -4517,7 +4517,9 @@ class safeonly
         private static string GetExpectedVersion()
         {
             Assembly assembly = typeof(CSharpCompiler).GetTypeInfo().Assembly;
-            return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            string fileVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+            string hash = CommonCompiler.ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>().Hash);
+            return $"{fileVersion} ({hash})";
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -4516,9 +4516,7 @@ class safeonly
 
         private static string GetExpectedVersion()
         {
-            string fileVersion = CommonCompiler.GetInformationalVersionWithoutHash(typeof(CSharpCompiler));
-            string hash = CommonCompiler.GetShortCommitHash(typeof(CSharpCompiler));
-            return $"{fileVersion} ({hash})";
+            return CommonCompiler.GetProductVersion(typeof(CSharpCompiler));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -4517,7 +4517,7 @@ class safeonly
         private static string GetExpectedVersion()
         {
             Assembly assembly = typeof(CSharpCompiler).GetTypeInfo().Assembly;
-            string fileVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+            string fileVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0];
             string hash = CommonCompiler.ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>().Hash);
             return $"{fileVersion} ({hash})";
         }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -4516,9 +4516,8 @@ class safeonly
 
         private static string GetExpectedVersion()
         {
-            Assembly assembly = typeof(CSharpCompiler).GetTypeInfo().Assembly;
-            string fileVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0];
-            string hash = CommonCompiler.ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>().Hash);
+            string fileVersion = CommonCompiler.GetInformationalVersionWithoutHash(typeof(CSharpCompiler));
+            string hash = CommonCompiler.GetShortCommitHash(typeof(CSharpCompiler));
             return $"{fileVersion} ({hash})";
         }
     }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -3047,7 +3047,7 @@ class A { }
                 // (1,8): error CS1029: #error: 'version'
                 // #error version
                 Diagnostic(ErrorCode.ERR_ErrorDirective, "version").WithArguments("version").WithLocation(1, 8),
-                // (1,8): error CS8304: Compiler version: '42.42.42.42424 (<developer build>)'. Language version: 4.
+                // (1,8): error CS8304: Compiler version: '3.2.0-dev'. Language version: 4.
                 // #error version
                 Diagnostic(ErrorCode.ERR_CompilerAndLanguageVersion, "version").WithArguments(GetExpectedVersion(), "4").WithLocation(1, 8)
                 );
@@ -4517,9 +4517,7 @@ class safeonly
         private static string GetExpectedVersion()
         {
             Assembly assembly = typeof(CSharpCompiler).GetTypeInfo().Assembly;
-            string fileVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
-            string hash = CommonCompiler.ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>().Hash);
-            return $"{fileVersion} ({hash})";
+            return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
         }
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis
 
         internal static string GetAssemblyFileVersion(Assembly assembly)
         {
-            string assemblyVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
+            string assemblyVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion.Split('+')[0];
             string hash = ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash);
             return $"{assemblyVersion} ({hash})";
         }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -142,20 +142,8 @@ namespace Microsoft.CodeAnalysis
 
         internal static string GetAssemblyFileVersion(Assembly assembly)
         {
-            string assemblyVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
-            string hash = ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash);
-            return $"{assemblyVersion} ({hash})";
-        }
-
-        internal static string ExtractShortCommitHash(string hash)
-        {
-            // leave "<developer build>" alone, but truncate SHA to 8 characters
-            if (hash != null && hash.Length >= 8 && hash[0] != '<')
-            {
-                return hash.Substring(0, 8);
-            }
-
-            return hash;
+            // Something like 3.1.0-beta2-19209-07+b02e2c50a2f2aeabb5b4e5d850c65ad8686848e3
+            return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -136,10 +136,10 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal string GetCompilerVersion()
         {
-            return GetCompilerVersion(Type);
+            return GetProductVersion(Type);
         }
 
-        internal static string GetCompilerVersion(Type type)
+        internal static string GetProductVersion(Type type)
         {
             string assemblyVersion = GetInformationalVersionWithoutHash(type);
             string hash = GetShortCommitHash(type);
@@ -157,14 +157,14 @@ namespace Microsoft.CodeAnalysis
             return hash;
         }
 
-        internal static string GetInformationalVersionWithoutHash(Type type)
+        private static string GetInformationalVersionWithoutHash(Type type)
         {
             // The attribute stores a SemVer2-formatted string: `A.B.C(-...)?(+...)?`
             // We remove the section after the + (if any is present)
             return type.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion.Split('+')[0];
         }
 
-        internal static string GetShortCommitHash(Type type)
+        private static string GetShortCommitHash(Type type)
         {
             var hash = type.Assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash;
             return ExtractShortCommitHash(hash);

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -142,8 +142,20 @@ namespace Microsoft.CodeAnalysis
 
         internal static string GetAssemblyFileVersion(Assembly assembly)
         {
-            // Something like 3.1.0-beta2-19209-07+b02e2c50a2f2aeabb5b4e5d850c65ad8686848e3
-            return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            string assemblyVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
+            string hash = ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash);
+            return $"{assemblyVersion} ({hash})";
+        }
+
+        internal static string ExtractShortCommitHash(string hash)
+        {
+            // leave "<developer build>" alone, but truncate SHA to 8 characters
+            if (hash != null && hash.Length >= 8 && hash[0] != '<')
+            {
+                return hash.Substring(0, 8);
+            }
+
+            return hash;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="consoleOutput"></param>
         public virtual void PrintVersion(TextWriter consoleOutput)
         {
-            consoleOutput.WriteLine(GetAssemblyFileVersion());
+            consoleOutput.WriteLine(GetCompilerVersion());
         }
 
         protected abstract bool TryGetCompilerDiagnosticCode(string diagnosticId, out uint code);
@@ -132,18 +132,17 @@ namespace Microsoft.CodeAnalysis
         internal abstract Type Type { get; }
 
         /// <summary>
-        /// The assembly file version of this compiler, used in logo and /version output.
+        /// The version of this compiler with commit hash, used in logo and /version output.
         /// </summary>
-        internal virtual string GetAssemblyFileVersion()
+        internal string GetCompilerVersion()
         {
-            Assembly assembly = Type.GetTypeInfo().Assembly;
-            return GetAssemblyFileVersion(assembly);
+            return GetCompilerVersion(Type);
         }
 
-        internal static string GetAssemblyFileVersion(Assembly assembly)
+        internal static string GetCompilerVersion(Type type)
         {
-            string assemblyVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion.Split('+')[0];
-            string hash = ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash);
+            string assemblyVersion = GetInformationalVersionWithoutHash(type);
+            string hash = GetShortCommitHash(type);
             return $"{assemblyVersion} ({hash})";
         }
 
@@ -156,6 +155,19 @@ namespace Microsoft.CodeAnalysis
             }
 
             return hash;
+        }
+
+        internal static string GetInformationalVersionWithoutHash(Type type)
+        {
+            // The attribute stores a SemVer2-formatted string: `A.B.C(-...)?(+...)?`
+            // We remove the section after the + (if any is present)
+            return type.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion.Split('+')[0];
+        }
+
+        internal static string GetShortCommitHash(Type type)
+        {
+            var hash = type.Assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash;
+            return ExtractShortCommitHash(hash);
         }
 
         /// <summary>
@@ -575,7 +587,7 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                logger = new StreamErrorLogger(errorLog, GetToolName(), GetAssemblyFileVersion(), GetAssemblyVersion(), Culture);
+                logger = new StreamErrorLogger(errorLog, GetToolName(), GetCompilerVersion(), GetAssemblyVersion(), Culture);
             }
 
             ReportDiagnostics(diagnostics.ToReadOnlyAndFree(), consoleOutput, errorLoggerOpt: logger);

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -206,7 +206,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="consoleOutput"></param>
         Public Overrides Sub PrintLogo(consoleOutput As TextWriter)
-            consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_LogoLine1, Culture), GetToolName(), GetAssemblyFileVersion())
+            consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_LogoLine1, Culture), GetToolName(), GetCompilerVersion())
             consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_LogoLine2, Culture))
             consoleOutput.WriteLine()
         End Sub

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -36,7 +36,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
             Path.GetDirectoryName(GetType(CommandLineTests).Assembly.Location),
             Path.Combine("dependency", "vbc.exe"))
         Private Shared ReadOnly s_defaultSdkDirectory As String = RuntimeEnvironment.GetRuntimeDirectory()
-        Private Shared ReadOnly s_compilerVersion As String = GetType(CommandLineTests).Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute)().InformationalVersion
+        Private Shared ReadOnly s_compilerVersion As String = FileVersionInfo.GetVersionInfo(GetType(CommandLineTests).Assembly.Location).FileVersion
+        Private Shared ReadOnly s_compilerShortCommitHash As String =
+            CommonCompiler.ExtractShortCommitHash(GetType(CommandLineTests).Assembly.GetCustomAttribute(Of CommitHashAttribute).Hash)
 
         Private Shared Function DefaultParse(args As IEnumerable(Of String), baseDirectory As String, Optional sdkDirectory As String = Nothing, Optional additionalReferenceDirectories As String = Nothing) As VisualBasicCommandLineArguments
             sdkDirectory = If(sdkDirectory, s_defaultSdkDirectory)
@@ -512,9 +514,10 @@ End Class
             Dim exitCode = cmd.Run(output, Nothing)
 
             Assert.Equal(0, exitCode)
-            Dim patched As String = Regex.Replace(output.ToString().Trim(), "version \d+\.\d+\.\d+(\.\d+)?-[\w\d.-]+", "version A.B.C.D-E")
+            Dim patched As String = Regex.Replace(output.ToString().Trim(), "version \d+\.\d+\.\d+(\.\d+)?", "version A.B.C.D")
+            patched = ReplaceCommitHash(patched)
             Assert.Equal(<text>
-Microsoft (R) Visual Basic Compiler version A.B.C.D-E
+Microsoft (R) Visual Basic Compiler version A.B.C.D (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.
 </text>.Value.Replace(vbLf, vbCrLf).Trim,
                 patched)
@@ -523,6 +526,23 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
             CleanupAllGeneratedFiles(src)
         End Sub
+
+        <Theory,
+            InlineData("Microsoft (R) Visual Basic Compiler version A.B.C.D (<developer build>)",
+                       "Microsoft (R) Visual Basic Compiler version A.B.C.D (HASH)"),
+            InlineData("Microsoft (R) Visual Basic Compiler version A.B.C.D (ABCDEF01)",
+                       "Microsoft (R) Visual Basic Compiler version A.B.C.D (HASH)"),
+            InlineData("Microsoft (R) Visual Basic Compiler version A.B.C.D (abcdef90)",
+                       "Microsoft (R) Visual Basic Compiler version A.B.C.D (HASH)"),
+            InlineData("Microsoft (R) Visual Basic Compiler version A.B.C.D (12345678)",
+                       "Microsoft (R) Visual Basic Compiler version A.B.C.D (HASH)")>
+        Public Sub TestReplaceCommitHash(orig As String, expected As String)
+            Assert.Equal(expected, ReplaceCommitHash(orig))
+        End Sub
+
+        Private Shared Function ReplaceCommitHash(s As String) As String
+            Return Regex.Replace(s, "(\((<developer build>|[a-fA-F0-9]{8})\))", "(HASH)")
+        End Function
 
         <Fact>
         Public Sub VbcNologo_2a()
@@ -537,9 +557,10 @@ End Class
             Dim exitCode = cmd.Run(output, Nothing)
 
             Assert.Equal(0, exitCode)
-            Dim patched As String = Regex.Replace(output.ToString().Trim(), "version \d+\.\d+\.\d+(\.\d+)?-[\w\d.-]+", "version A.B.C.D-E")
+            Dim patched As String = Regex.Replace(output.ToString().Trim(), "version \d+\.\d+\.\d+(\.\d+)?", "version A.B.C.D")
+            patched = ReplaceCommitHash(patched)
             Assert.Equal(<text>
-Microsoft (R) Visual Basic Compiler version A.B.C.D-E
+Microsoft (R) Visual Basic Compiler version A.B.C.D (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.
 </text>.Value.Replace(vbLf, vbCrLf).Trim,
                 patched)
@@ -5679,7 +5700,7 @@ End Module
                 </compilation>
 
             Dim result =
-                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION
+                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 PATH(5) : warning BC42024: Unused local variable: 'x'.
@@ -5709,7 +5730,7 @@ PATH(11) : warning BC42105: Function 'goo' doesn't return a value on all code pa
             Dim vbc As New MockVisualBasicCompiler(Nothing, dir.Path, {fileName, "/preferreduilang:en"})
             vbc.Run(output, Nothing)
 
-            Dim expected = ReplacePathAndVersion(result, file).Trim()
+            Dim expected = ReplacePathAndVersionAndHash(result, file).Trim()
             Dim actual = output.ToString().Trim()
             Assert.Equal(expected, actual)
 
@@ -5744,7 +5765,7 @@ End Module
                 </compilation>
 
             Dim result =
-                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION
+                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 PATH(9) : error BC36640: Instance of restricted type 'ArgIterator' cannot be used in a lambda expression.
@@ -5762,7 +5783,7 @@ PATH(9) : error BC36640: Instance of restricted type 'ArgIterator' cannot be use
             Dim vbc As New MockVisualBasicCompiler(Nothing, dir.Path, {fileName, "/preferreduilang:en", "-imports:System"})
             vbc.Run(output, Nothing)
 
-            Assert.Equal(ReplacePathAndVersion(result, file), output.ToString())
+            Assert.Equal(ReplacePathAndVersionAndHash(result, file), output.ToString())
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -5777,7 +5798,7 @@ PATH(9) : error BC36640: Instance of restricted type 'ArgIterator' cannot be use
                          "  End Sub" + vbCrLf +
                          "End Module" + vbCrLf
 
-            Dim result = <file name="output">Microsoft (R) Visual Basic Compiler version VERSION
+            Dim result = <file name="output">Microsoft (R) Visual Basic Compiler version VERSION (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 PATH(3) : error BC30201: Expression expected.
@@ -5799,7 +5820,7 @@ PATH(3) : error BC30004: Character constant must contain exactly one character.
             Dim vbc As New MockVisualBasicCompiler(Nothing, dir.Path, {fileName, "/preferreduilang:en"})
             vbc.Run(output, Nothing)
 
-            Dim expected = ReplacePathAndVersion(result, file).Trim()
+            Dim expected = ReplacePathAndVersionAndHash(result, file).Trim()
             Dim actual = output.ToString().Trim()
             Assert.Equal(expected, actual)
 
@@ -5827,7 +5848,7 @@ End Module
                 </compilation>
 
             Dim result =
-                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION
+                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 PATH(5) : error BC36593: Expression of type 'Integer()' is not queryable. Make sure you are not missing an assembly reference and/or namespace import for the LINQ provider.
@@ -5849,7 +5870,7 @@ PATH(5) : error BC36593: Expression of type 'Integer()' is not queryable. Make s
             Dim vbc As New MockVisualBasicCompiler(Nothing, dir.Path, {fileName, "/preferreduilang:en"})
             vbc.Run(output, Nothing)
 
-            Assert.Equal(ReplacePathAndVersion(result, file), output.ToString())
+            Assert.Equal(ReplacePathAndVersionAndHash(result, file), output.ToString())
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -5873,7 +5894,7 @@ Module _
                 </compilation>
 
             Dim result =
-                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION
+                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 PATH(3) : error BC30625: 'Module' statement must end with a matching 'End Module'.
@@ -5893,7 +5914,7 @@ Module _
             Dim vbc As New MockVisualBasicCompiler(Nothing, dir.Path, {fileName, "/preferreduilang:en"})
             vbc.Run(output, Nothing)
 
-            Assert.Equal(ReplacePathAndVersion(result, file), output.ToString())
+            Assert.Equal(ReplacePathAndVersionAndHash(result, file), output.ToString())
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -5923,7 +5944,7 @@ End Module
                 </compilation>
 
             Dim result =
-                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION
+                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 PATH(7) : error BC37220: Name 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeEventHandler' exceeds the maximum length allowed in metadata.
@@ -5941,7 +5962,7 @@ PATH(7) : error BC37220: Name 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
             Dim vbc As New MockVisualBasicCompiler(Nothing, dir.Path, {fileName, "/preferreduilang:en"})
             vbc.Run(output, Nothing)
 
-            Assert.Equal(ReplacePathAndVersion(result, file), output.ToString())
+            Assert.Equal(ReplacePathAndVersionAndHash(result, file), output.ToString())
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -5965,7 +5986,7 @@ End Class]]>
                 </compilation>
 
             Dim result =
-                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION
+                    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 PATH(4) : error BC30625: 'Module' statement must end with a matching 'End Module'.
@@ -5987,7 +6008,7 @@ End Class
             Dim vbc As New MockVisualBasicCompiler(Nothing, dir.Path, {fileName, "/preferreduilang:en"})
             vbc.Run(output, Nothing)
 
-            Assert.Equal(ReplacePathAndVersion(result, file), output.ToString())
+            Assert.Equal(ReplacePathAndVersionAndHash(result, file), output.ToString())
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
@@ -6011,7 +6032,7 @@ End Module
                 </compilation>
 
             Dim result =
-    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION
+    <file name="output">Microsoft (R) Visual Basic Compiler version VERSION (HASH)
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 PATH(6) : error BC30203: Identifier expected.
@@ -6029,13 +6050,13 @@ PATH(6) : error BC30203: Identifier expected.
             Dim vbc As New MockVisualBasicCompiler(Nothing, dir.Path, {fileName, "/preferreduilang:en"})
             vbc.Run(output, Nothing)
 
-            Assert.Equal(ReplacePathAndVersion(result, file), output.ToString())
+            Assert.Equal(ReplacePathAndVersionAndHash(result, file), output.ToString())
 
             CleanupAllGeneratedFiles(file.Path)
         End Sub
 
-        Private Shared Function ReplacePathAndVersion(result As XElement, file As TempFile) As String
-            Return result.Value.Replace("PATH", file.Path).Replace("VERSION", s_compilerVersion).Replace(vbLf, vbCrLf)
+        Private Shared Function ReplacePathAndVersionAndHash(result As XElement, file As TempFile) As String
+            Return result.Value.Replace("PATH", file.Path).Replace("VERSION", s_compilerVersion).Replace("HASH", s_compilerShortCommitHash).Replace(vbLf, vbCrLf)
         End Function
 
         <WorkItem(545247, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545247")>
@@ -8893,6 +8914,7 @@ End Class
         <Fact()>
         Public Sub Version()
             Dim folderName = Temp.CreateDirectory().ToString()
+            Dim expected As String = $"{s_compilerVersion} ({s_compilerShortCommitHash})"
 
             Dim argss = {
                 "/version",
@@ -8902,7 +8924,7 @@ End Class
 
             For Each args In argss
                 Dim output = ProcessUtilities.RunAndGetOutput(s_basicCompilerExecutable, args, startFolder:=folderName)
-                Assert.Equal(s_compilerVersion, output.Trim())
+                Assert.Equal(expected, output.Trim())
             Next
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -36,8 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
             Path.GetDirectoryName(GetType(CommandLineTests).Assembly.Location),
             Path.Combine("dependency", "vbc.exe"))
         Private Shared ReadOnly s_defaultSdkDirectory As String = RuntimeEnvironment.GetRuntimeDirectory()
-        Private Shared ReadOnly s_compilerVersionWithoutHash As String = CommonCompiler.GetInformationalVersionWithoutHash(GetType(CommandLineTests))
-        Private Shared ReadOnly s_compilerShortCommitHash As String = CommonCompiler.GetShortCommitHash(GetType(CommandLineTests))
+        Private Shared ReadOnly s_compilerVersion As String = CommonCompiler.GetProductVersion(GetType(CommandLineTests))
 
         Private Shared Function DefaultParse(args As IEnumerable(Of String), baseDirectory As String, Optional sdkDirectory As String = Nothing, Optional additionalReferenceDirectories As String = Nothing) As VisualBasicCommandLineArguments
             sdkDirectory = If(sdkDirectory, s_defaultSdkDirectory)
@@ -6051,7 +6050,7 @@ PATH(6) : error BC30203: Identifier expected.
         End Sub
 
         Private Shared Function ReplacePathAndVersionAndHash(result As XElement, file As TempFile) As String
-            Return result.Value.Replace("PATH", file.Path).Replace("VERSION", s_compilerVersionWithoutHash).Replace("HASH", s_compilerShortCommitHash).Replace(vbLf, vbCrLf)
+            Return result.Value.Replace("PATH", file.Path).Replace("VERSION (HASH)", s_compilerVersion).Replace(vbLf, vbCrLf)
         End Function
 
         <WorkItem(545247, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545247")>
@@ -8909,7 +8908,6 @@ End Class
         <Fact()>
         Public Sub Version()
             Dim folderName = Temp.CreateDirectory().ToString()
-            Dim expected As String = $"{s_compilerVersionWithoutHash} ({s_compilerShortCommitHash})"
 
             Dim argss = {
                 "/version",
@@ -8919,7 +8917,7 @@ End Class
 
             For Each args In argss
                 Dim output = ProcessUtilities.RunAndGetOutput(s_basicCompilerExecutable, args, startFolder:=folderName)
-                Assert.Equal(expected, output.Trim())
+                Assert.Equal(s_compilerVersion, output.Trim())
             Next
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -36,10 +36,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests
             Path.GetDirectoryName(GetType(CommandLineTests).Assembly.Location),
             Path.Combine("dependency", "vbc.exe"))
         Private Shared ReadOnly s_defaultSdkDirectory As String = RuntimeEnvironment.GetRuntimeDirectory()
-        Private Shared ReadOnly s_compilerVersionWithoutHash As String =
-            GetType(CommandLineTests).Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute).InformationalVersion.Split("+"c)(0)
-        Private Shared ReadOnly s_compilerShortCommitHash As String =
-            CommonCompiler.ExtractShortCommitHash(GetType(CommandLineTests).Assembly.GetCustomAttribute(Of CommitHashAttribute).Hash)
+        Private Shared ReadOnly s_compilerVersionWithoutHash As String = CommonCompiler.GetInformationalVersionWithoutHash(GetType(CommandLineTests))
+        Private Shared ReadOnly s_compilerShortCommitHash As String = CommonCompiler.GetShortCommitHash(GetType(CommandLineTests))
 
         Private Shared Function DefaultParse(args As IEnumerable(Of String), baseDirectory As String, Optional sdkDirectory As String = Nothing, Optional additionalReferenceDirectories As String = Nothing) As VisualBasicCommandLineArguments
             sdkDirectory = If(sdkDirectory, s_defaultSdkDirectory)

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
 
             Assert.Equal("", errorOutput);
             Assert.Equal(2, output.Length);
-            var version = typeof(CSharpReplServiceProvider).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0];
+            var version = CommonCompiler.GetInformationalVersionWithoutHash(typeof(CSharpReplServiceProvider));
             Assert.Equal(string.Format(CSharpScriptingResources.LogoLine1, version), output[0]);
             // "Type "#help" for more information."
             Assert.Equal(InteractiveHostResources.Type_Sharphelp_for_more_information, output[1]);

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -60,7 +60,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
 
             Assert.Equal("", errorOutput);
             Assert.Equal(2, output.Length);
-            Assert.Equal(string.Format(CSharpScriptingResources.LogoLine1, typeof(CSharpReplServiceProvider).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version), output[0]);
+            var version = typeof(CSharpReplServiceProvider).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0];
+            Assert.Equal(string.Format(CSharpScriptingResources.LogoLine1, version), output[0]);
             // "Type "#help" for more information."
             Assert.Equal(InteractiveHostResources.Type_Sharphelp_for_more_information, output[1]);
 

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
 
             Assert.Equal("", errorOutput);
             Assert.Equal(2, output.Length);
-            var version = CommonCompiler.GetInformationalVersionWithoutHash(typeof(CSharpReplServiceProvider));
+            var version = CommonCompiler.GetProductVersion(typeof(CSharpReplServiceProvider));
             Assert.Equal(string.Format(CSharpScriptingResources.LogoLine1, version), output[0]);
             // "Type "#help" for more information."
             Assert.Equal(InteractiveHostResources.Type_Sharphelp_for_more_information, output[1]);

--- a/src/Scripting/CSharp/Hosting/CSharpReplServiceProvider.cs
+++ b/src/Scripting/CSharp/Hosting/CSharpReplServiceProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
         public override DiagnosticFormatter DiagnosticFormatter => CSharpDiagnosticFormatter.Instance;
 
         public override string Logo
-            => string.Format(CSharpScriptingResources.LogoLine1, GetType().GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0]);
+            => string.Format(CSharpScriptingResources.LogoLine1, CommonCompiler.GetInformationalVersionWithoutHash(typeof(CSharpReplServiceProvider)));
 
         public override Script<T> CreateScript<T>(string code, ScriptOptions options, Type globalsTypeOpt, InteractiveAssemblyLoader assemblyLoader)
             => CSharpScript.Create<T>(code, options, globalsTypeOpt, assemblyLoader);

--- a/src/Scripting/CSharp/Hosting/CSharpReplServiceProvider.cs
+++ b/src/Scripting/CSharp/Hosting/CSharpReplServiceProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
         public override DiagnosticFormatter DiagnosticFormatter => CSharpDiagnosticFormatter.Instance;
 
         public override string Logo
-            => string.Format(CSharpScriptingResources.LogoLine1, GetType().GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version);
+            => string.Format(CSharpScriptingResources.LogoLine1, GetType().GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0]);
 
         public override Script<T> CreateScript<T>(string code, ScriptOptions options, Type globalsTypeOpt, InteractiveAssemblyLoader assemblyLoader)
             => CSharpScript.Create<T>(code, options, globalsTypeOpt, assemblyLoader);

--- a/src/Scripting/CSharp/Hosting/CSharpReplServiceProvider.cs
+++ b/src/Scripting/CSharp/Hosting/CSharpReplServiceProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
         public override DiagnosticFormatter DiagnosticFormatter => CSharpDiagnosticFormatter.Instance;
 
         public override string Logo
-            => string.Format(CSharpScriptingResources.LogoLine1, CommonCompiler.GetInformationalVersionWithoutHash(typeof(CSharpReplServiceProvider)));
+            => string.Format(CSharpScriptingResources.LogoLine1, CommonCompiler.GetProductVersion(typeof(CSharpReplServiceProvider)));
 
         public override Script<T> CreateScript<T>(string code, ScriptOptions options, Type globalsTypeOpt, InteractiveAssemblyLoader assemblyLoader)
             => CSharpScript.Create<T>(code, options, globalsTypeOpt, assemblyLoader);

--- a/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
+++ b/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 
         internal override string GetAssemblyFileVersion()
         {
-            return Type.GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+            return Type.GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0]; // remove SHA, if any
         }
 
         internal override MetadataReferenceResolver GetCommandLineMetadataReferenceResolver(TouchedFileLogger loggerOpt)

--- a/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
+++ b/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 
         internal override string GetAssemblyFileVersion()
         {
-            return Type.GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+            return Type.GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
         }
 
         internal override MetadataReferenceResolver GetCommandLineMetadataReferenceResolver(TouchedFileLogger loggerOpt)

--- a/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
+++ b/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
@@ -20,11 +20,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 
         internal override Type Type => typeof(CSharpInteractiveCompiler);
 
-        internal override string GetAssemblyFileVersion()
-        {
-            return Type.GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0]; // remove SHA, if any
-        }
-
         internal override MetadataReferenceResolver GetCommandLineMetadataReferenceResolver(TouchedFileLogger loggerOpt)
         {
             return CommandLineRunner.GetMetadataReferenceResolver(Arguments, loggerOpt);
@@ -32,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 
         public override void PrintLogo(TextWriter consoleOutput)
         {
-            consoleOutput.WriteLine(CSharpScriptingResources.LogoLine1, GetAssemblyFileVersion());
+            consoleOutput.WriteLine(CSharpScriptingResources.LogoLine1, GetCompilerVersion());
             consoleOutput.WriteLine(CSharpScriptingResources.LogoLine2);
             consoleOutput.WriteLine();
         }

--- a/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
+++ b/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 
         internal override string GetAssemblyFileVersion()
         {
-            return Type.GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            return Type.GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
         }
 
         internal override MetadataReferenceResolver GetCommandLineMetadataReferenceResolver(TouchedFileLogger loggerOpt)

--- a/src/Scripting/CSharpTest.Desktop/CsiTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/CsiTests.cs
@@ -15,7 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
 {
     public class CsiTests : TestBase
     {
-        private static readonly string s_compilerVersion = typeof(Csi).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+        private static readonly string s_compilerVersionWithoutHash =
+            typeof(Csi).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0];
         private string CsiPath => typeof(Csi).GetTypeInfo().Assembly.Location;
 
         /// <summary>
@@ -52,7 +53,7 @@ Environment.Exit(0)
 ");
 
             var expected = $@"
-{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
+{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
 {CSharpScriptingResources.LogoLine2}
 
 {ScriptingResources.HelpPrompt}

--- a/src/Scripting/CSharpTest.Desktop/CsiTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/CsiTests.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
 {
     public class CsiTests : TestBase
     {
-        private static readonly string s_compilerVersionWithoutHash =
-            typeof(Csi).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0];
+        private static readonly string s_compilerVersionWithoutHash = CommonCompiler.GetInformationalVersionWithoutHash(typeof(Csi));
+        private static readonly string s_commitHash = CommonCompiler.GetShortCommitHash(typeof(Csi));
         private string CsiPath => typeof(Csi).GetTypeInfo().Assembly.Location;
 
         /// <summary>
@@ -53,7 +53,7 @@ Environment.Exit(0)
 ");
 
             var expected = $@"
-{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
+{ string.Format(CSharpScriptingResources.LogoLine1, $"{s_compilerVersionWithoutHash} ({s_commitHash})") }
 {CSharpScriptingResources.LogoLine2}
 
 {ScriptingResources.HelpPrompt}

--- a/src/Scripting/CSharpTest.Desktop/CsiTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/CsiTests.cs
@@ -15,8 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
 {
     public class CsiTests : TestBase
     {
-        private static readonly string s_compilerVersionWithoutHash = CommonCompiler.GetInformationalVersionWithoutHash(typeof(Csi));
-        private static readonly string s_commitHash = CommonCompiler.GetShortCommitHash(typeof(Csi));
+        private static readonly string s_compilerVersion = CommonCompiler.GetProductVersion(typeof(Csi));
         private string CsiPath => typeof(Csi).GetTypeInfo().Assembly.Location;
 
         /// <summary>
@@ -53,7 +52,7 @@ Environment.Exit(0)
 ");
 
             var expected = $@"
-{ string.Format(CSharpScriptingResources.LogoLine1, $"{s_compilerVersionWithoutHash} ({s_commitHash})") }
+{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
 {CSharpScriptingResources.LogoLine2}
 
 {ScriptingResources.HelpPrompt}

--- a/src/Scripting/CSharpTest.Desktop/CsiTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/CsiTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
 {
     public class CsiTests : TestBase
     {
-        private static readonly string s_compilerVersion = typeof(Csi).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+        private static readonly string s_compilerVersion = typeof(Csi).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
         private string CsiPath => typeof(Csi).GetTypeInfo().Assembly.Location;
 
         /// <summary>

--- a/src/Scripting/CSharpTest.Desktop/CsiTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/CsiTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
 {
     public class CsiTests : TestBase
     {
-        private static readonly string s_compilerVersion = typeof(Csi).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+        private static readonly string s_compilerVersion = typeof(Csi).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
         private string CsiPath => typeof(Csi).GetTypeInfo().Assembly.Location;
 
         /// <summary>

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
     public class CommandLineRunnerTests : TestBase
     {
         private static readonly string s_compilerVersion =
-            typeof(CSharpInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            typeof(CSharpInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
 
         private string LogoAndHelpPrompt => $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
 {CSharpScriptingResources.LogoLine2}

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -21,10 +21,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
 
     public class CommandLineRunnerTests : TestBase
     {
-        private static readonly string s_compilerVersionWithoutHash =
-            typeof(CSharpInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0];
+        private static readonly string s_compilerVersionWithoutHash = CommonCompiler.GetInformationalVersionWithoutHash(typeof(CSharpInteractiveCompiler));
+        private static readonly string s_commitHash = CommonCompiler.GetCommitHash(typeof(CSharpInteractiveCompiler));
 
-        private string LogoAndHelpPrompt => $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
+        private string LogoAndHelpPrompt => $@"{ string.Format(CSharpScriptingResources.LogoLine1, $"{s_compilerVersionWithoutHash} ({s_commitHash})") }
 {CSharpScriptingResources.LogoLine2}
 
 {ScriptingResources.HelpPrompt}";
@@ -176,7 +176,7 @@ $@"{ logoOutput }
         public void TestDisplayResultsWithCurrentUICulture2()
         {
             // logoOutput needs to be retrieved before the runner is started, because the runner changes the culture to de-DE. 
-            var logoOutput = $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
+            var logoOutput = $@"{ string.Format(CSharpScriptingResources.LogoLine1, $"{s_compilerVersionWithoutHash} ({s_commitHash})") }
 { CSharpScriptingResources.LogoLine2}
 
 { ScriptingResources.HelpPrompt}";
@@ -481,7 +481,7 @@ $@"""@arg1""
             Assert.Equal(0, runner.RunInteractive());
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
-$@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
+$@"{ string.Format(CSharpScriptingResources.LogoLine1, $"{s_compilerVersionWithoutHash} ({s_commitHash})") }
 {CSharpScriptingResources.LogoLine2}
 
 {CSharpScriptingResources.InteractiveHelp}
@@ -493,19 +493,19 @@ $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutH
         {
             var runner = CreateRunner(new[] { "/version" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash}", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash} ({s_commitHash})", runner.Console.Out.ToString());
 
             runner = CreateRunner(new[] { "/version", "/help" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash}", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash} ({s_commitHash})", runner.Console.Out.ToString());
 
             runner = CreateRunner(new[] { "/version", "/r:somefile" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash}", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash} ({s_commitHash})", runner.Console.Out.ToString());
 
             runner = CreateRunner(new[] { "/version", "/nologo" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash}", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash} ({s_commitHash})", runner.Console.Out.ToString());
         }
 
         [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/30303")]
@@ -932,7 +932,7 @@ Print(t.a);
             runner.RunInteractive();
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
-$@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
+$@"{ string.Format(CSharpScriptingResources.LogoLine1, $"{s_compilerVersionWithoutHash} ({s_commitHash})") }
 {CSharpScriptingResources.LogoLine2}
 {ScriptingResources.HelpPrompt}
 > var a = 1;

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
     public class CommandLineRunnerTests : TestBase
     {
         private static readonly string s_compilerVersion =
-            typeof(CSharpInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+            typeof(CSharpInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
         private string LogoAndHelpPrompt => $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
 {CSharpScriptingResources.LogoLine2}

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -21,10 +21,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
 
     public class CommandLineRunnerTests : TestBase
     {
-        private static readonly string s_compilerVersion =
-            typeof(CSharpInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+        private static readonly string s_compilerVersionWithoutHash =
+            typeof(CSharpInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('+')[0];
 
-        private string LogoAndHelpPrompt => $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
+        private string LogoAndHelpPrompt => $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
 {CSharpScriptingResources.LogoLine2}
 
 {ScriptingResources.HelpPrompt}";
@@ -142,7 +142,7 @@ Enumerable.WhereSelectArrayIterator<int, int> {{ 9, 16, 25 }}
         public void TestDisplayResultsWithCurrentUICulture1()
         {
             // logoOutput needs to be retrieved before the runner is started, because the runner changes the culture to de-DE. 
-            var logoOutput = $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
+            var logoOutput = $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
 { CSharpScriptingResources.LogoLine2}
 
 { ScriptingResources.HelpPrompt}";
@@ -176,7 +176,7 @@ $@"{ logoOutput }
         public void TestDisplayResultsWithCurrentUICulture2()
         {
             // logoOutput needs to be retrieved before the runner is started, because the runner changes the culture to de-DE. 
-            var logoOutput = $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
+            var logoOutput = $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
 { CSharpScriptingResources.LogoLine2}
 
 { ScriptingResources.HelpPrompt}";
@@ -481,7 +481,7 @@ $@"""@arg1""
             Assert.Equal(0, runner.RunInteractive());
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
-$@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
+$@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
 {CSharpScriptingResources.LogoLine2}
 
 {CSharpScriptingResources.InteractiveHelp}
@@ -493,19 +493,19 @@ $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
         {
             var runner = CreateRunner(new[] { "/version" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersion}", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash}", runner.Console.Out.ToString());
 
             runner = CreateRunner(new[] { "/version", "/help" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersion}", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash}", runner.Console.Out.ToString());
 
             runner = CreateRunner(new[] { "/version", "/r:somefile" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersion}", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash}", runner.Console.Out.ToString());
 
             runner = CreateRunner(new[] { "/version", "/nologo" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersion}", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash}", runner.Console.Out.ToString());
         }
 
         [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/30303")]
@@ -932,7 +932,7 @@ Print(t.a);
             runner.RunInteractive();
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
-$@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
+$@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
 {CSharpScriptingResources.LogoLine2}
 {ScriptingResources.HelpPrompt}
 > var a = 1;

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -21,10 +21,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
 
     public class CommandLineRunnerTests : TestBase
     {
-        private static readonly string s_compilerVersionWithoutHash = CommonCompiler.GetInformationalVersionWithoutHash(typeof(CSharpInteractiveCompiler));
-        private static readonly string s_commitHash = CommonCompiler.GetCommitHash(typeof(CSharpInteractiveCompiler));
+        private static readonly string s_compilerVersion = CommonCompiler.GetProductVersion(typeof(CSharpInteractiveCompiler));
 
-        private string LogoAndHelpPrompt => $@"{ string.Format(CSharpScriptingResources.LogoLine1, $"{s_compilerVersionWithoutHash} ({s_commitHash})") }
+        private string LogoAndHelpPrompt => $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
 {CSharpScriptingResources.LogoLine2}
 
 {ScriptingResources.HelpPrompt}";
@@ -142,7 +141,7 @@ Enumerable.WhereSelectArrayIterator<int, int> {{ 9, 16, 25 }}
         public void TestDisplayResultsWithCurrentUICulture1()
         {
             // logoOutput needs to be retrieved before the runner is started, because the runner changes the culture to de-DE. 
-            var logoOutput = $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersionWithoutHash) }
+            var logoOutput = $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
 { CSharpScriptingResources.LogoLine2}
 
 { ScriptingResources.HelpPrompt}";
@@ -176,7 +175,7 @@ $@"{ logoOutput }
         public void TestDisplayResultsWithCurrentUICulture2()
         {
             // logoOutput needs to be retrieved before the runner is started, because the runner changes the culture to de-DE. 
-            var logoOutput = $@"{ string.Format(CSharpScriptingResources.LogoLine1, $"{s_compilerVersionWithoutHash} ({s_commitHash})") }
+            var logoOutput = $@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
 { CSharpScriptingResources.LogoLine2}
 
 { ScriptingResources.HelpPrompt}";
@@ -481,7 +480,7 @@ $@"""@arg1""
             Assert.Equal(0, runner.RunInteractive());
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
-$@"{ string.Format(CSharpScriptingResources.LogoLine1, $"{s_compilerVersionWithoutHash} ({s_commitHash})") }
+$@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
 {CSharpScriptingResources.LogoLine2}
 
 {CSharpScriptingResources.InteractiveHelp}
@@ -493,19 +492,19 @@ $@"{ string.Format(CSharpScriptingResources.LogoLine1, $"{s_compilerVersionWitho
         {
             var runner = CreateRunner(new[] { "/version" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash} ({s_commitHash})", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString());
 
             runner = CreateRunner(new[] { "/version", "/help" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash} ({s_commitHash})", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString());
 
             runner = CreateRunner(new[] { "/version", "/r:somefile" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash} ({s_commitHash})", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString());
 
             runner = CreateRunner(new[] { "/version", "/nologo" });
             Assert.Equal(0, runner.RunInteractive());
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"{s_compilerVersionWithoutHash} ({s_commitHash})", runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString());
         }
 
         [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/30303")]
@@ -932,7 +931,7 @@ Print(t.a);
             runner.RunInteractive();
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
-$@"{ string.Format(CSharpScriptingResources.LogoLine1, $"{s_compilerVersionWithoutHash} ({s_commitHash})") }
+$@"{ string.Format(CSharpScriptingResources.LogoLine1, s_compilerVersion) }
 {CSharpScriptingResources.LogoLine2}
 {ScriptingResources.HelpPrompt}
 > var a = 1;

--- a/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
+++ b/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
@@ -25,13 +25,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
             End Get
         End Property
 
-        Friend Overrides Function GetAssemblyFileVersion() As String
-            Dim version = Type.GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute)().InformationalVersion
-            Return version.Split("+"c)(0) ' remove SHA, if any
-        End Function
-
         Public Overrides Sub PrintLogo(consoleOutput As TextWriter)
-            consoleOutput.WriteLine(VBScriptingResources.LogoLine1, GetAssemblyFileVersion())
+            consoleOutput.WriteLine(VBScriptingResources.LogoLine1, GetCompilerVersion())
             consoleOutput.WriteLine(VBScriptingResources.LogoLine2)
             consoleOutput.WriteLine()
         End Sub

--- a/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
+++ b/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         End Property
 
         Friend Overrides Function GetAssemblyFileVersion() As String
-            Return Type.GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute)().InformationalVersion
+            Return Type.GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyFileVersionAttribute)().Version
         End Function
 
         Public Overrides Sub PrintLogo(consoleOutput As TextWriter)

--- a/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
+++ b/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         End Property
 
         Friend Overrides Function GetAssemblyFileVersion() As String
-            Return Type.GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyFileVersionAttribute)().Version
+            Return Type.GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute)().InformationalVersion
         End Function
 
         Public Overrides Sub PrintLogo(consoleOutput As TextWriter)

--- a/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
+++ b/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
@@ -26,7 +26,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         End Property
 
         Friend Overrides Function GetAssemblyFileVersion() As String
-            Return Type.GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyFileVersionAttribute)().Version
+            Dim version = Type.GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute)().InformationalVersion
+            Return version.Split("+"c)(0) ' remove SHA, if any
         End Function
 
         Public Overrides Sub PrintLogo(consoleOutput As TextWriter)

--- a/src/Scripting/VisualBasic/Hosting/VisualBasicReplServiceProvider.vb
+++ b/src/Scripting/VisualBasic/Hosting/VisualBasicReplServiceProvider.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
 
         Public Overrides ReadOnly Property Logo As String
             Get
-                Return String.Format(VBScriptingResources.LogoLine1, Me.GetType().GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyFileVersionAttribute).Version)
+                Return String.Format(VBScriptingResources.LogoLine1, Me.GetType().GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute).InformationalVersion.Split("+"c)(0))
             End Get
         End Property
 

--- a/src/Scripting/VisualBasic/Hosting/VisualBasicReplServiceProvider.vb
+++ b/src/Scripting/VisualBasic/Hosting/VisualBasicReplServiceProvider.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
 
         Public Overrides ReadOnly Property Logo As String
             Get
-                Return String.Format(VBScriptingResources.LogoLine1, Me.GetType().GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute).InformationalVersion.Split("+"c)(0))
+                Return String.Format(VBScriptingResources.LogoLine1, CommonCompiler.GetInformationalVersionWithoutHash(GetType(VisualBasicReplServiceProvider)))
             End Get
         End Property
 

--- a/src/Scripting/VisualBasic/Hosting/VisualBasicReplServiceProvider.vb
+++ b/src/Scripting/VisualBasic/Hosting/VisualBasicReplServiceProvider.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
 
         Public Overrides ReadOnly Property Logo As String
             Get
-                Return String.Format(VBScriptingResources.LogoLine1, CommonCompiler.GetInformationalVersionWithoutHash(GetType(VisualBasicReplServiceProvider)))
+                Return String.Format(VBScriptingResources.LogoLine1, CommonCompiler.GetProductVersion(GetType(VisualBasicReplServiceProvider)))
             End Get
         End Property
 

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -193,19 +193,19 @@ s_logoAndHelpPrompt + "
         Public Sub Version()
             Dim runner = CreateRunner({"/version"})
             Assert.Equal(0, runner.RunInteractive())
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersionWithoutHash, runner.Console.Out.ToString())
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString())
 
             runner = CreateRunner({"/version", "/help"})
             Assert.Equal(0, runner.RunInteractive())
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersionWithoutHash, runner.Console.Out.ToString())
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString())
 
             runner = CreateRunner({"/version", "/r:somefile"})
             Assert.Equal(0, runner.RunInteractive())
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersionWithoutHash, runner.Console.Out.ToString())
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString())
 
             runner = CreateRunner({"/version", "/nologo"})
             Assert.Equal(0, runner.RunInteractive())
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersionWithoutHash, runner.Console.Out.ToString())
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString())
         End Sub
 
     End Class

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
         Inherits TestBase
 
         Private Shared ReadOnly s_compilerVersion As String =
-            GetType(VisualBasicInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute)().InformationalVersion
+            GetType(VisualBasicInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyFileVersionAttribute)().Version
         Private Shared ReadOnly s_logoAndHelpPrompt As String =
             String.Format(VBScriptingResources.LogoLine1, s_compilerVersion) + vbNewLine + VBScriptingResources.LogoLine2 + "
 

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -16,10 +16,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
     Public Class CommandLineRunnerTests
         Inherits TestBase
 
-        Private Shared ReadOnly s_compilerVersion As String =
-            GetType(VisualBasicInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyFileVersionAttribute)().Version
+        Private Shared ReadOnly s_compilerVersionWithoutHash As String =
+            GetType(VisualBasicInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute)().InformationalVersion.Split("+"c)(0)
         Private Shared ReadOnly s_logoAndHelpPrompt As String =
-            String.Format(VBScriptingResources.LogoLine1, s_compilerVersion) + vbNewLine + VBScriptingResources.LogoLine2 + "
+            String.Format(VBScriptingResources.LogoLine1, s_compilerVersionWithoutHash) + vbNewLine + VBScriptingResources.LogoLine2 + "
 
 " + ScriptingResources.HelpPrompt
 
@@ -192,19 +192,19 @@ s_logoAndHelpPrompt + "
         Public Sub Version()
             Dim runner = CreateRunner({"/version"})
             Assert.Equal(0, runner.RunInteractive())
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString())
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersionWithoutHash, runner.Console.Out.ToString())
 
             runner = CreateRunner({"/version", "/help"})
             Assert.Equal(0, runner.RunInteractive())
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString())
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersionWithoutHash, runner.Console.Out.ToString())
 
             runner = CreateRunner({"/version", "/r:somefile"})
             Assert.Equal(0, runner.RunInteractive())
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString())
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersionWithoutHash, runner.Console.Out.ToString())
 
             runner = CreateRunner({"/version", "/nologo"})
             Assert.Equal(0, runner.RunInteractive())
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersion, runner.Console.Out.ToString())
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(s_compilerVersionWithoutHash, runner.Console.Out.ToString())
         End Sub
 
     End Class

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
         Inherits TestBase
 
         Private Shared ReadOnly s_compilerVersion As String =
-            GetType(VisualBasicInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyFileVersionAttribute)().Version
+            GetType(VisualBasicInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute)().InformationalVersion
         Private Shared ReadOnly s_logoAndHelpPrompt As String =
             String.Format(VBScriptingResources.LogoLine1, s_compilerVersion) + vbNewLine + VBScriptingResources.LogoLine2 + "
 

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -17,7 +17,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
         Inherits TestBase
 
         Private Shared ReadOnly s_compilerVersionWithoutHash As String =
-            GetType(VisualBasicInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyInformationalVersionAttribute)().InformationalVersion.Split("+"c)(0)
+            CommonCompiler.GetInformationalVersionWithoutHash(GetType(VisualBasicInteractiveCompiler))
+
         Private Shared ReadOnly s_logoAndHelpPrompt As String =
             String.Format(VBScriptingResources.LogoLine1, s_compilerVersionWithoutHash) + vbNewLine + VBScriptingResources.LogoLine2 + "
 

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -16,11 +16,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
     Public Class CommandLineRunnerTests
         Inherits TestBase
 
-        Private Shared ReadOnly s_compilerVersionWithoutHash As String =
-            CommonCompiler.GetInformationalVersionWithoutHash(GetType(VisualBasicInteractiveCompiler))
+        Private Shared ReadOnly s_compilerVersion As String =
+            CommonCompiler.GetProductVersion(GetType(VisualBasicInteractiveCompiler))
 
         Private Shared ReadOnly s_logoAndHelpPrompt As String =
-            String.Format(VBScriptingResources.LogoLine1, s_compilerVersionWithoutHash) + vbNewLine + VBScriptingResources.LogoLine2 + "
+            String.Format(VBScriptingResources.LogoLine1, s_compilerVersion) + vbNewLine + VBScriptingResources.LogoLine2 + "
 
 " + ScriptingResources.HelpPrompt
 

--- a/src/Test/Utilities/Portable/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/DiagnosticExtensions.cs
@@ -334,7 +334,7 @@ namespace Microsoft.CodeAnalysis
             var expectedToolName = compiler.GetToolName();
             var expectedVersion = compiler.GetAssemblyVersion();
             var expectedSemanticVersion = compiler.GetAssemblyVersion().ToString(fieldCount: 3);
-            var expectedFileVersion = compiler.GetAssemblyFileVersion();
+            var expectedFileVersion = compiler.GetCompilerVersion();
             var expectedLanguage = compiler.GetCultureName();
 
             return string.Format(@"{{


### PR DESCRIPTION
As described in https://github.com/dotnet/roslyn/issues/35140, the contents of `AssemblyFileVersionAttribute` are no longer the value we should use.

~~This is a small regression as~~
- ~~the output of `csc -version` (and the logo) will now read something like `3.1.0-beta2-19209-07+b02e2c50a2f2aeabb5b4e5d850c65ad8686848e3` instead of something like `3.1.0-beta2-19209-07`,~~
- ~~the output of `#error version` will now read something like `3.1.0-beta2-19209-07+b02e2c50a2f2aeabb5b4e5d850c65ad8686848e3` instead of something like `3.1.0-beta2-19209-07 (b02e2c50a2f)`.~~

Update: after discussion with Tomas about expected format of the version stored in assembly information attribute, I restored the original behavior. We'll print something like `3.1.0-beta2-19209-07` as the version (ie. SHA removed) and we'll still print the short SHA separately. It looks something like: `3.1.0-beta2-19209-07 (b02e2c50a2f)`.

Fixes https://github.com/dotnet/roslyn/issues/35140