### PR TITLE
Refactor ApplyConversion into VisitConversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 conversion: conversion.UserDefinedFromConversion,
                 isCast: false,
                 conversionGroup,
-                wasCompilerGenerated: true,
+                wasCompilerGenerated: false,
                 destination: conversion.BestUserDefinedConversionAnalysis.FromType,
                 diagnostics: diagnostics);
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2572,8 +2572,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 resultType = node.Type.SetUnknownNullabilityForReferenceTypes();
                 resultState = NullableFlowState.NotNull;
-                Debug.Assert(node.Consequence == consequence);
-                Debug.Assert(node.Alternative == alternative);
+
+                var resultTypeWithState = TypeWithState.Create(resultType, resultState);
+
+                if (consequence != node.Consequence)
+                {
+                    TrackAnalyzedNullabilityThroughConversionGroup(resultTypeWithState, (BoundConversion)node.Consequence, consequence);
+                }
+
+                if (alternative != node.Alternative)
+                {
+                    TrackAnalyzedNullabilityThroughConversionGroup(resultTypeWithState, (BoundConversion)node.Alternative, alternative);
+                }
             }
             else
             {
@@ -4203,7 +4213,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 case ConversionKind.MethodGroup:
                     {
-                        var receiverOpt = ((BoundMethodGroup)convertedNode)?.ReceiverOpt;
+                        var receiverOpt = ((BoundMethodGroup)conversionOperand)?.ReceiverOpt;
                         // https://github.com/dotnet/roslyn/issues/33637: Should update method based on inferred receiver type.
                         var method = conversion.Method;
                         if (TryGetMethodGroupReceiverNullability(receiverOpt, out TypeWithState receiverType))

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4502,6 +4502,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!IsConditionalState);
             Debug.Assert(conversionOperand != null);
             Debug.Assert(targetTypeWithNullability.HasType);
+            Debug.Assert(diagnosticLocation != null);
             Debug.Assert((object)target != null || assignmentKind != AssignmentKind.Argument);
             Debug.Assert(conversion.Kind == ConversionKind.ExplicitUserDefined || conversion.Kind == ConversionKind.ImplicitUserDefined);
 
@@ -4550,6 +4551,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // conversion "from" type -> method parameter type
             NullableFlowState operandState = operandType.State;
+            Location operandLocation = conversionOperand.Syntax.GetLocation();
             _ = ClassifyAndVisitConversion(
                 conversionOperand,
                 parameterType,
@@ -4559,7 +4561,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 target: parameter,
                 reportWarnings: reportRemainingWarnings,
                 fromExplicitCast: false,
-                diagnosticLocation: null);
+                diagnosticLocation: operandLocation);
 
             // method parameter type -> method return type
             var methodReturnType = methodOpt.ReturnTypeWithAnnotations;
@@ -4587,7 +4589,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 target,
                 reportWarnings: reportRemainingWarnings,
                 fromExplicitCast: false,
-                null);
+                diagnosticLocation: operandLocation);
 
             // conversion "to" type -> final type
             // We should only pass fromExplicitCast here. Given the following example:
@@ -4662,8 +4664,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Location diagnosticLocation)
         {
             Debug.Assert((object)target != null || assignmentKind != AssignmentKind.Argument);
+            Debug.Assert(diagnosticLocation != null);
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-            diagnosticLocation ??= node.Syntax.GetLocation();
             var conversion = _conversions.ClassifyStandardConversion(null, operandType.Type, targetType.Type, ref useSiteDiagnostics);
             if (reportWarnings && !conversion.Exists)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -498,7 +498,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 conversions.Add(conversion);
                 var armType = VisitRvalueWithState(expression);
                 resultTypes.Add(armType);
-                TrackInferredTypesThroughConversions(arm.Value, expression, _visitResult);
                 Join(ref endState, ref this.State);
 
                 // Build placeholders for inference in order to preserve annotations.
@@ -516,7 +515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < numSwitchArms; i++)
             {
                 var expression = expressions[i];
-                resultTypes[i] = ApplyConversion(expression, expression, conversions[i], inferredTypeWithAnnotations, resultTypes[i], checkConversion: true,
+                resultTypes[i] = VisitConversion(conversionOpt: null, expression, conversions[i], inferredTypeWithAnnotations, resultTypes[i], checkConversion: true,
                     fromExplicitCast: false, useLegacyWarnings: false, AssignmentKind.Assignment, reportRemainingWarnings: true, reportTopLevelWarnings: false);
             }
 
@@ -527,8 +526,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < numSwitchArms; i++)
             {
                 var nodeForSyntax = expressions[i];
+                var conversionOpt = node.SwitchArms[i].Value switch { BoundConversion c when c != nodeForSyntax => c, _ => null };
                 // Report top-level warnings
-                _ = ApplyConversion(nodeForSyntax, operandOpt: nodeForSyntax, conversions[i], targetTypeWithNullability: inferredTypeWithAnnotations, operandType: resultTypes[i],
+                _ = VisitConversion(conversionOpt, convertedNode: nodeForSyntax, conversions[i], targetTypeWithNullability: inferredTypeWithAnnotations, operandType: resultTypes[i],
                     checkConversion: true, fromExplicitCast: false, useLegacyWarnings: false, AssignmentKind.Assignment, reportRemainingWarnings: false, reportTopLevelWarnings: true);
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -528,7 +528,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var nodeForSyntax = expressions[i];
                 var conversionOpt = node.SwitchArms[i].Value switch { BoundConversion c when c != nodeForSyntax => c, _ => null };
                 // Report top-level warnings
-                _ = VisitConversion(conversionOpt, convertedNode: nodeForSyntax, conversions[i], targetTypeWithNullability: inferredTypeWithAnnotations, operandType: resultTypes[i],
+                _ = VisitConversion(conversionOpt, conversionOperand: nodeForSyntax, conversions[i], targetTypeWithNullability: inferredTypeWithAnnotations, operandType: resultTypes[i],
                     checkConversion: true, fromExplicitCast: false, useLegacyWarnings: false, AssignmentKind.Assignment, reportRemainingWarnings: false, reportTopLevelWarnings: true);
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -5544,7 +5544,7 @@ class MyAttribute : System.Attribute
 }
 
 [MyAttribute(null)] //1
-class C { } 
+class C { }
 
 [MyAttribute(null, null)] // 2, 3
 class D { }
@@ -5580,8 +5580,8 @@ class MyAttribute : System.Attribute
     public MyAttribute(string s, string s2 = null) { } //1
 }
 
-[MyAttribute(""str"")] 
-class C { } 
+[MyAttribute(""str"")]
+class C { }
 
 [MyAttribute(""str"", null)] // 2
 class D { }
@@ -6194,7 +6194,7 @@ class MyAttribute : System.Attribute
     new string[] { null }, // 2
     PropertyArray = null, // 3
     PropertyNullableArray = new string[] { null } // 4
-)] 
+)]
 class C { }
 ";
             var comp = CreateCompilation(source);
@@ -10681,7 +10681,7 @@ class B : A
             var compilation = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue());
             compilation.VerifyDiagnostics(
                 // (8,23): error CS8627: A nullable type parameter must be known to be a value type or non-nullable reference type. Consider adding a 'class', 'struct', or type constraint.
-                //     public void M2<T>(T? x) 
+                //     public void M2<T>(T? x)
                 Diagnostic(ErrorCode.ERR_NullableUnconstrainedTypeParameter, "T?").WithLocation(8, 23),
                 // (27,26): error CS0115: 'B.M2<T>(T?)': no suitable method found to override
                 //     public override void M2<T>(T? x)
@@ -11726,10 +11726,10 @@ class B2 : A2
 
             compilation.VerifyDiagnostics(
                 // (27,39): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
-                //     public override string[] P1 {get; set;} 
+                //     public override string[] P1 {get; set;}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride, "set").WithArguments("value").WithLocation(27, 39),
                 // (28,35): warning CS8609: Nullability of reference types in return type doesn't match overridden member.
-                //     public override string[]? P2 {get; set;} 
+                //     public override string[]? P2 {get; set;}
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride, "get").WithLocation(28, 35),
                 // (33,9): warning CS8610: Nullability of reference types in type of parameter 'value' doesn't match overridden member.
                 //         set {}
@@ -13770,10 +13770,10 @@ class B : IA
 
             compilation.VerifyDiagnostics(
                 // (20,13): error CS0539: 'B.M2<T>(T?[])' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     void IA.M2<T>(T?[] x)  
+                //     void IA.M2<T>(T?[] x)
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M2").WithArguments("B.M2<T>(T?[])").WithLocation(20, 13),
                 // (24,13): error CS0539: 'B.M3<T>(T?[]?)' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     void IA.M3<T>(T?[]? x)  
+                //     void IA.M3<T>(T?[]? x)
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M3").WithArguments("B.M3<T>(T?[]?)").WithLocation(24, 13),
                 // (16,13): warning CS8617: Nullability of reference types in type of parameter 'x' doesn't match implemented member 'void IA.M1(string[] x)'.
                 //     void IA.M1(string?[] x)
@@ -13785,10 +13785,10 @@ class B : IA
                 // class B : IA
                 Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "IA").WithArguments("B", "IA.M2<T>(T[])").WithLocation(14, 11),
                 // (20,24): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                //     void IA.M2<T>(T?[] x)  
+                //     void IA.M2<T>(T?[] x)
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "x").WithArguments("System.Nullable<T>", "T", "T").WithLocation(20, 24),
                 // (24,25): error CS0453: The type 'T' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Nullable<T>'
-                //     void IA.M3<T>(T?[]? x)  
+                //     void IA.M3<T>(T?[]? x)
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "x").WithArguments("System.Nullable<T>", "T", "T").WithLocation(24, 25));
         }
 
@@ -27354,7 +27354,7 @@ class C
                 //         u7[0][0,0] = null;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(27, 22),
                 // (32,46): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         object [][,]? u8 = new object [][,] {null, 
+                //         object [][,]? u8 = new object [][,] {null,
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(32, 46),
                 // (33,53): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //                                     new object[,] {{null}}};
@@ -29360,7 +29360,7 @@ struct S1
                 //         x9 = v9.p2;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "v9.p2").WithLocation(84, 14),
                 // (100,15): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                //         x10 = u10.a2.p2; // 6 
+                //         x10 = u10.a2.p2; // 6
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "u10.a2.p2").WithLocation(100, 15));
         }
 
@@ -36877,13 +36877,13 @@ class CL1
                 //         CL1 u5 = --x5;
                 Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "--x5").WithLocation(32, 18),
                 // (37,9): warning CS8601: Possible null reference assignment.
-                //         x6--; 
+                //         x6--;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x6--").WithLocation(37, 9),
                 // (43,9): error CS0165: Use of unassigned local variable 'x7'
-                //         x7--; 
+                //         x7--;
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x7").WithArguments("x7").WithLocation(43, 9),
                 // (43,9): warning CS8601: Possible null reference assignment.
-                //         x7--; 
+                //         x7--;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x7--").WithLocation(43, 9)
                 );
         }
@@ -49188,7 +49188,7 @@ class Program
 
         [Fact]
         [WorkItem(35334, "https://github.com/dotnet/roslyn/issues/35334")]
-        public void Conversions_ExplicitNullable_UserDefinedIntroducingNullablility()
+        public void Conversions_ExplicitNullable_UserDefinedIntroducingNullability()
         {
             var source =
 @"
@@ -52868,7 +52868,7 @@ namespace System.Reflection {
 
     public sealed class DefaultMemberAttribute : Attribute
     {
-        public DefaultMemberAttribute(String memberName) 
+        public DefaultMemberAttribute(String memberName)
         {}
     }
 }
@@ -61506,10 +61506,10 @@ delegate C<object?> D(C<object?> p); // 8
                 //     C<object?> I.Property => Field; // 6
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, "Property").WithArguments("C<T>", "object", "T", "object?").WithLocation(15, 18),
                 // (16,18): warning CS8631: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'C<T>'. Nullability of type argument 'object?' doesn't match constraint type 'object'.
-                //     C<object?> I.Method(C<object?> p) => Field; // 7 
+                //     C<object?> I.Method(C<object?> p) => Field; // 7
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, "Method").WithArguments("C<T>", "object", "T", "object?").WithLocation(16, 18),
                 // (16,36): warning CS8631: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'C<T>'. Nullability of type argument 'object?' doesn't match constraint type 'object'.
-                //     C<object?> I.Method(C<object?> p) => Field; // 7 
+                //     C<object?> I.Method(C<object?> p) => Field; // 7
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, "p").WithArguments("C<T>", "object", "T", "object?").WithLocation(16, 36),
                 // (19,12): warning CS8631: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'C<T>'. Nullability of type argument 'object?' doesn't match constraint type 'object'.
                 // delegate C<object?> D(C<object?> p); // 8
@@ -61573,10 +61573,10 @@ delegate C<object?> D(C<object?> p); // 8
                 //     C<object?> I.Property => Field; // 6
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "Property").WithArguments("C<T>", "T", "object?").WithLocation(15, 18),
                 // (16,18): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'C<T>'. Nullability of type argument 'object?' doesn't match 'class' constraint.
-                //     C<object?> I.Method(C<object?> p) => Field; // 7 
+                //     C<object?> I.Method(C<object?> p) => Field; // 7
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "Method").WithArguments("C<T>", "T", "object?").WithLocation(16, 18),
                 // (16,36): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'C<T>'. Nullability of type argument 'object?' doesn't match 'class' constraint.
-                //     C<object?> I.Method(C<object?> p) => Field; // 7 
+                //     C<object?> I.Method(C<object?> p) => Field; // 7
                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "p").WithArguments("C<T>", "T", "object?").WithLocation(16, 36),
                 // (19,12): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'C<T>'. Nullability of type argument 'object?' doesn't match 'class' constraint.
                 // delegate C<object?> D(C<object?> p); // 8
@@ -94226,7 +94226,7 @@ partial class C<T> where T : I1, I2?
             var comp1 = CreateCompilation(new[] { source });
             comp1.VerifyDiagnostics(
                 // (12,15): error CS0265: Partial declarations of 'C<T>' have inconsistent constraints for type parameter 'T'
-                // partial class C<T> where T : I1?, 
+                // partial class C<T> where T : I1?,
                 Diagnostic(ErrorCode.ERR_PartialWrongConstraints, "C").WithArguments("C<T>", "T").WithLocation(12, 15)
                 );
 
@@ -94267,7 +94267,7 @@ partial class C<T> where T : I1?, I2
             var comp1 = CreateCompilation(new[] { source });
             comp1.VerifyDiagnostics(
                 // (12,15): error CS0265: Partial declarations of 'C<T>' have inconsistent constraints for type parameter 'T'
-                // partial class C<T> where T : I1, 
+                // partial class C<T> where T : I1,
                 Diagnostic(ErrorCode.ERR_PartialWrongConstraints, "C").WithArguments("C<T>", "T").WithLocation(12, 15)
                 );
 
@@ -94306,7 +94306,7 @@ partial class C<T> where T : I1?, I2
             var comp1 = CreateCompilation(new[] { source });
             comp1.VerifyDiagnostics(
                 // (12,15): error CS0265: Partial declarations of 'C<T>' have inconsistent constraints for type parameter 'T'
-                // partial class C<T> where T : I1, 
+                // partial class C<T> where T : I1,
                 Diagnostic(ErrorCode.ERR_PartialWrongConstraints, "C").WithArguments("C<T>", "T").WithLocation(12, 15)
                 );
 
@@ -94345,7 +94345,7 @@ partial class C<T> where T : I1, I2?
             var comp1 = CreateCompilation(new[] { source });
             comp1.VerifyDiagnostics(
                 // (12,15): error CS0265: Partial declarations of 'C<T>' have inconsistent constraints for type parameter 'T'
-                // partial class C<T> where T : I1, 
+                // partial class C<T> where T : I1,
                 Diagnostic(ErrorCode.ERR_PartialWrongConstraints, "C").WithArguments("C<T>", "T").WithLocation(12, 15)
                 );
 


### PR DESCRIPTION
Refactors out ApplyConversion into a more aptly named VisitConversion. Adjusts the parameters to take the node being converted, and optionally the original boundconversion. When the boundconversion is passed it, the calculated nullability is now tracked through nested levels of conversions between the top-level boundconversion and the underlying converted node. Removed TrackInferredTypesThroughConversions, as this is now being handled by VisitConversion.

This PR additionally fixes a conversion issue where user-defined conversions that added nullability were not then marking the result type of that conversion as nullable.

Fixes https://github.com/dotnet/roslyn/issues/35334
Fixes https://github.com/dotnet/roslyn/issues/34302
Fixes https://github.com/dotnet/roslyn/issues/35039

@dotnet/roslyn-compiler for review.