### PR TITLE
Ensure we set _isSubscribedToSolutionEvents

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/SolutionEventsBatchScopeCreator.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/SolutionEventsBatchScopeCreator.cs
@@ -111,7 +111,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             // We never unsubscribe from these, so we just throw out the cookie. We could consider unsubscribing if/when all our
             // projects are unloaded, but it seems fairly unecessary -- it'd only be useful if somebody closed one solution but then
             // opened other solutions in entirely different languages from there.
-            solution.AdviseSolutionEvents(new SolutionEventsEventSink(this), out _);
+            if (ErrorHandler.Succeeded(solution.AdviseSolutionEvents(new SolutionEventsEventSink(this), out _)))
+            {
+                _isSubscribedToSolutionEvents = true;
+            }
 
             // It's possible that we're loading after the solution has already fully loaded, so see if we missed the event 
             var shellMonitorSelection = (IVsMonitorSelection)_serviceProvider.GetService(typeof(SVsShellMonitorSelection));


### PR DESCRIPTION
If we don't set this, we'll subscribe to solution events multiple times which isn't great. Our event handler is idempotent so it'll still do the right thing, but we'll just be wasting extra time processing notifications that won't do anything.

Fixes https://github.com/dotnet/roslyn/issues/35372