### PR TITLE
Localize "General" groupbox header in the Formatting>General option page

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
@@ -268,6 +268,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to General.
+        /// </summary>
+        internal static string General {
+            get {
+                return ResourceManager.GetString("General", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Generate Event Subscription.
         /// </summary>
         internal static string Generate_Event_Subscription {

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -593,4 +593,8 @@
     <value>'using' preferences:</value>
     <comment>'using' is a C# keyword and should not be localized</comment>
   </data>
+  <data name="General" xml:space="preserve">
+    <value>General</value>
+    <comment>Title of the control group on the General Formatting options page</comment>
+  </data>
 </root>

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingGeneralOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingGeneralOptionPageStrings.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
+{
+    internal static class FormattingGeneralOptionPageStrings
+    {
+        public static string General => CSharpVSResources.General;
+    }
+}

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
@@ -7,10 +7,11 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:options="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Options;assembly=Microsoft.VisualStudio.LanguageServices.Implementation"
+    xmlns:local="clr-namespace:Microsoft.VisualStudio.LanguageServices.CSharp.Options"
     mc:Ignorable="d" d:DesignHeight="279" d:DesignWidth="514">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel>
-            <GroupBox x:Uid="GroupBox_1" Header="General">
+            <GroupBox x:Uid="GroupBox_1" Header="{x:Static local:FormattingGeneralOptionPageStrings.General}">
                 <StackPanel>
                     <CheckBox x:Name="FormatWhenTypingCheckBox" x:Uid="FormatWhenTypingCheckBox" />
                     <StackPanel Margin="15, 0, 0, 0" IsEnabled="{Binding ElementName=FormatWhenTypingCheckBox, Path=IsChecked}">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">Obecné</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Nastavení formátování dokumentu (experiment)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">Generovat odběr událostí</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Einstellungen zur Dokumentformatierung (experimentell)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">Ereignisabonnement generieren</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">Allgemein</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Configuración de “Dar formato al documento” (experimento)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">Generar suscripción de eventos</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">General</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">Général</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Paramètres de mise en forme du document (essai)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">Générer un abonnement à des événements</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Impostazioni formattazione documento (sperimentale)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">Genera sottoscrizione di eventi</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">Generale</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">全般</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">ドキュメントのフォーマットの設定 (実験)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">イベント サブスクリプションの生成</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">문서 서식 설정(실험)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">이벤트 구독 생성</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">일반</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">Ogólne</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Ustawienia dokumentu formatu (eksperyment)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">Generuj subskrypcję zdarzenia</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">Geral</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Formatar Configurações do Documento (Experimento)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">Gerar Assinatura de Evento</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Параметры форматирования документа (эксперимент) </target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">Создать подписку на события</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">Общее</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">Genel</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Belge Biçimlendirme Ayarları (Deneme)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">Olay Aboneliği Oluştur</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">设定文档设置的格式(试验)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">生成事件订阅</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">常规</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="General">
         <source>General</source>
-        <target state="new">General</target>
+        <target state="translated">一般</target>
         <note>Title of the control group on the General Formatting options page</note>
       </trans-unit>
       <trans-unit id="Generate_Event_Subscription">

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">格式化文件設定 (實驗)</target>
         <note />
       </trans-unit>
+      <trans-unit id="General">
+        <source>General</source>
+        <target state="new">General</target>
+        <note>Title of the control group on the General Formatting options page</note>
+      </trans-unit>
       <trans-unit id="Generate_Event_Subscription">
         <source>Generate Event Subscription</source>
         <target state="translated">產生事件訂閱</target>


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/859456

Reusing the loc'd strings from VSPackage.resx in the same project, done manually.