### PR TITLE
moved error and todo list initialization to VS workspace.

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -45,6 +45,22 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public void Register(Workspace workspace)
         {
+            EnsureRegistration(workspace, initializeLazily: true);
+        }
+
+        /// <summary>
+        /// make sure solution cralwer is registered for the given workspace.
+        /// 
+        /// we need this until https://github.com/dotnet/roslyn/issues/35514 is fixed.
+        /// 
+        /// basically, solution crawler is currently not initialized until a file is opened (package is loaded)
+        /// this force solution crawler to be initialized.
+        /// 
+        /// initializeLazily should be removed once the issue above is fixed. 
+        /// </summary>
+        /// <param name="workspace"></param>
+        internal void EnsureRegistration(Workspace workspace, bool initializeLazily)
+        {
             var correlationId = LogAggregator.GetNextId();
 
             lock (_gate)
@@ -58,6 +74,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 var coordinator = new WorkCoordinator(
                     _listener,
                     GetAnalyzerProviders(workspace),
+                    initializeLazily,
                     new Registration(correlationId, workspace, _progressReporter));
 
                 _documentWorkCoordinatorMap.Add(workspace, coordinator);

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             public WorkCoordinator(
                  IAsynchronousOperationListener listener,
                  IEnumerable<Lazy<IIncrementalAnalyzerProvider, IncrementalAnalyzerProviderMetadata>> analyzerProviders,
+                 bool initializeLazily,
                  Registration registration)
             {
                 _logAggregator = new LogAggregator();
@@ -57,7 +58,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 var entireProjectWorkerBackOffTimeSpanInMS = _optionService.GetOption(InternalSolutionCrawlerOptions.EntireProjectWorkerBackOffTimeSpanInMS);
 
                 _documentAndProjectWorkerProcessor = new IncrementalAnalyzerProcessor(
-                    listener, analyzerProviders, _registration,
+                    listener, analyzerProviders, initializeLazily, _registration,
                     activeFileBackOffTimeSpanInMS, allFilesWorkerBackOffTimeSpanInMS, entireProjectWorkerBackOffTimeSpanInMS, _shutdownToken);
 
                 var semanticBackOffTimeSpanInMS = _optionService.GetOption(InternalSolutionCrawlerOptions.SemanticChangeBackOffTimeSpanInMS);

--- a/src/VisualStudio/Core/Def/IKnownUIContextService.cs
+++ b/src/VisualStudio/Core/Def/IKnownUIContextService.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.LanguageServices
+{
+    /// <summary>
+    /// This is an abstraction on top of <see cref="KnownUIContexts"/>.
+    /// 
+    /// We need this abstraction for unit test since KnownUIContext is static VS type that we can't
+    /// use or mock in unit test
+    /// </summary>
+    internal interface IKnownUIContextService
+    {
+        bool IsSolutionBuilding { get; }
+        event EventHandler<UIContextChangedEventArgs> SolutionBuilding;
+    }
+
+    [Export(typeof(IKnownUIContextService))]
+    internal class KnownUIContextService : IKnownUIContextService
+    {
+        public bool IsSolutionBuilding => KnownUIContexts.SolutionBuildingContext.IsActive;
+
+        public event EventHandler<UIContextChangedEventArgs> SolutionBuilding
+        {
+            add { KnownUIContexts.SolutionBuildingContext.UIContextChanged += value; }
+            remove { KnownUIContexts.SolutionBuildingContext.UIContextChanged -= value; }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
@@ -14,16 +15,16 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.TableManager;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
-    using Workspace = Microsoft.CodeAnalysis.Workspace;
-
     [Export(typeof(MiscellaneousFilesWorkspace))]
     internal sealed partial class MiscellaneousFilesWorkspace : Workspace, IVsRunningDocTableEvents2
     {
@@ -59,6 +60,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             IMetadataAsSourceFileService fileTrackingMetadataAsSourceService,
             SaveEventsService saveEventsService,
             VisualStudioWorkspace visualStudioWorkspace,
+            IDiagnosticService diagnosticService,
+            ITodoListProvider todoListProvider,
+            ITableManagerProvider provider,
             SVsServiceProvider serviceProvider) :
             base(visualStudioWorkspace.Services.HostServices, WorkspaceKind.MiscellaneousFiles)
         {
@@ -73,6 +77,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             _metadataReferences = ImmutableArray.CreateRange(CreateMetadataReferences());
             saveEventsService.StartSendingSaveEvents();
+
+            MiscellaneousDiagnosticListTable.Register(this, diagnosticService, provider);
+            MiscellaneousTodoListTable.Register(this, todoListProvider, provider);
         }
 
         public void RegisterLanguage(Guid languageGuid, string languageName, string scriptExtension)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspace.cs
@@ -7,13 +7,10 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser.Lists;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices
 {
-    using Workspace = Microsoft.CodeAnalysis.Workspace;
-
     /// <summary>
     /// A Workspace specific to Visual Studio.
     /// </summary>

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -126,7 +126,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 this,
                 exportProvider.GetExportedValue<IDiagnosticAnalyzerService>(),
                 exportProvider.GetExportedValue<IDiagnosticUpdateSourceRegistrationService>(),
-                exportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>());
+                exportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>(),
+                exportProvider.GetExportedValues<IKnownUIContextService>().SingleOrDefault());
         }
 
         internal ExternalErrorDiagnosticUpdateSource ExternalErrorDiagnosticUpdateSource { get; }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -11,11 +11,11 @@ using System.Threading;
 using EnvDTE;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Text;
@@ -25,6 +25,7 @@ using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.MetadataReferences;
+using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
 using Microsoft.VisualStudio.LanguageServices.Utilities;
 using Microsoft.VisualStudio.Shell;
@@ -34,7 +35,6 @@ using Microsoft.VisualStudio.Text.Projection;
 using Roslyn.Utilities;
 using VSLangProj;
 using VSLangProj140;
-using VSLangProj80;
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 using OleInterop = Microsoft.VisualStudio.OLE.Interop;
 
@@ -121,7 +121,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             FileWatchedReferenceFactory = exportProvider.GetExportedValue<FileWatchedPortableExecutableReferenceFactory>();
 
             FileWatchedReferenceFactory.ReferenceChanged += this.RefreshMetadataReferencesForFile;
+
+            ExternalErrorDiagnosticUpdateSource = new ExternalErrorDiagnosticUpdateSource(
+                this,
+                exportProvider.GetExportedValue<IDiagnosticAnalyzerService>(),
+                exportProvider.GetExportedValue<IDiagnosticUpdateSourceRegistrationService>(),
+                exportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>());
         }
+
+        internal ExternalErrorDiagnosticUpdateSource ExternalErrorDiagnosticUpdateSource { get; }
 
         public async System.Threading.Tasks.Task ConnectToOpenFileTrackerOnUIThreadAsync(IAsyncServiceProvider asyncServiceProvider)
         {

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTable.cs
@@ -7,26 +7,19 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 {
-    using Workspace = Microsoft.CodeAnalysis.Workspace;
-
     /// <summary>
     /// Base implementation of new platform table. this knows how to create various ITableDataSource and connect
     /// them to ITableManagerProvider
     /// </summary>
     internal abstract class AbstractTable
     {
-        private readonly Workspace _workspace;
-        private readonly ITableManagerProvider _provider;
-
         protected AbstractTable(Workspace workspace, ITableManagerProvider provider, string tableIdentifier)
         {
-            _workspace = workspace;
-            _provider = provider;
-
+            Workspace = workspace;
             this.TableManager = provider.GetTableManager(tableIdentifier);
         }
 
-        protected Workspace Workspace => _workspace;
+        protected Workspace Workspace { get; }
 
         protected abstract void AddTableSourceIfNecessary(Solution solution);
         protected abstract void RemoveTableSourceIfNecessary(Solution solution);
@@ -34,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
         protected void ConnectWorkspaceEvents()
         {
-            _workspace.WorkspaceChanged += OnWorkspaceChanged;
+            Workspace.WorkspaceChanged += OnWorkspaceChanged;
         }
 
         private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousDiagnosticListTable.cs
@@ -1,37 +1,26 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.TableManager;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 {
-    using Workspace = Microsoft.CodeAnalysis.Workspace;
-
-    [Export(typeof(MiscellaneousDiagnosticListTable))]
     internal class MiscellaneousDiagnosticListTable : VisualStudioBaseDiagnosticListTable
     {
         internal const string IdentifierString = nameof(MiscellaneousDiagnosticListTable);
 
         private readonly LiveTableDataSource _source;
 
-        [ImportingConstructor]
         public MiscellaneousDiagnosticListTable(MiscellaneousFilesWorkspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider) :
-            this((Workspace)workspace, diagnosticService, provider)
-        {
-            ConnectWorkspaceEvents();
-        }
-
-        /// this is for test only
-        internal MiscellaneousDiagnosticListTable(Workspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider) :
-            base(workspace, diagnosticService, provider)
+            base(workspace, provider)
         {
             _source = new LiveTableDataSource(workspace, diagnosticService, IdentifierString);
             AddInitialTableSource(workspace.CurrentSolution, _source);
+
+            ConnectWorkspaceEvents();
         }
 
         protected override void AddTableSourceIfNecessary(Solution solution)

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousDiagnosticListTable.cs
@@ -8,13 +8,18 @@ using Microsoft.VisualStudio.Shell.TableManager;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 {
-    internal class MiscellaneousDiagnosticListTable : VisualStudioBaseDiagnosticListTable
+    internal sealed class MiscellaneousDiagnosticListTable : VisualStudioBaseDiagnosticListTable
     {
         internal const string IdentifierString = nameof(MiscellaneousDiagnosticListTable);
 
         private readonly LiveTableDataSource _source;
 
-        public MiscellaneousDiagnosticListTable(MiscellaneousFilesWorkspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider) :
+        public static void Register(MiscellaneousFilesWorkspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider)
+        {
+            new MiscellaneousDiagnosticListTable(workspace, diagnosticService, provider);
+        }
+
+        private MiscellaneousDiagnosticListTable(MiscellaneousFilesWorkspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider) :
             base(workspace, provider)
         {
             _source = new LiveTableDataSource(workspace, diagnosticService, IdentifierString);

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousTodoListTable.cs
@@ -1,29 +1,19 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.ComponentModel.Composition;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.TableManager;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 {
-    [Export(typeof(MiscellaneousTodoListTable))]
     internal class MiscellaneousTodoListTable : VisualStudioBaseTodoListTable
     {
         internal const string IdentifierString = nameof(MiscellaneousTodoListTable);
 
-        [ImportingConstructor]
         public MiscellaneousTodoListTable(MiscellaneousFilesWorkspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
             base(workspace, todoListProvider, IdentifierString, provider)
         {
             ConnectWorkspaceEvents();
-        }
-
-        // only for test
-        public MiscellaneousTodoListTable(Microsoft.CodeAnalysis.Workspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
-            base(workspace, todoListProvider, IdentifierString, provider)
-        {
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousTodoListTable.cs
@@ -6,11 +6,16 @@ using Microsoft.VisualStudio.Shell.TableManager;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 {
-    internal class MiscellaneousTodoListTable : VisualStudioBaseTodoListTable
+    internal sealed class MiscellaneousTodoListTable : VisualStudioBaseTodoListTable
     {
         internal const string IdentifierString = nameof(MiscellaneousTodoListTable);
 
-        public MiscellaneousTodoListTable(MiscellaneousFilesWorkspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
+        public static void Register(MiscellaneousFilesWorkspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider)
+        {
+            new MiscellaneousTodoListTable(workspace, todoListProvider, provider);
+        }
+
+        private MiscellaneousTodoListTable(MiscellaneousFilesWorkspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
             base(workspace, todoListProvider, IdentifierString, provider)
         {
             ConnectWorkspaceEvents();

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
@@ -51,7 +51,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
             SVsServiceProvider serviceProvider,
             VisualStudioWorkspaceImpl workspace,
             IDiagnosticAnalyzerService diagnosticService,
-            ExternalErrorDiagnosticUpdateSource buildErrorDiagnosticService,
             ICodeFixService codeFixService,
             ICodeActionEditHandlerService editHandlerService,
             IVisualStudioDiagnosticListSuppressionStateService suppressionStateService,
@@ -60,7 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
         {
             _workspace = workspace;
             _diagnosticService = diagnosticService;
-            _buildErrorDiagnosticService = buildErrorDiagnosticService;
+            _buildErrorDiagnosticService = workspace.ExternalErrorDiagnosticUpdateSource;
             _codeFixService = codeFixService;
             _suppressionStateService = (VisualStudioDiagnosticListSuppressionStateService)suppressionStateService;
             _editHandlerService = editHandlerService;

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -21,8 +21,6 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 {
-    using Workspace = Microsoft.CodeAnalysis.Workspace;
-
     internal abstract partial class VisualStudioBaseDiagnosticListTable
     {
         protected class LiveTableDataSource : AbstractRoslynTableDataSource<DiagnosticData>

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             SuppressionStateColumnDefinition.ColumnName
         };
 
-        protected VisualStudioBaseDiagnosticListTable(Workspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider) :
+        protected VisualStudioBaseDiagnosticListTable(Workspace workspace, ITableManagerProvider provider) :
             base(workspace, provider, StandardTables.ErrorsTable)
         {
         }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
@@ -19,8 +19,6 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 {
-    using Workspace = Microsoft.CodeAnalysis.Workspace;
-
     internal class VisualStudioBaseTodoListTable : AbstractTable
     {
         private static readonly string[] s_columns = new string[]

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioTodoListTable.cs
@@ -1,30 +1,19 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.VisualStudio.Shell.TableManager;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 {
-    using Workspace = Microsoft.CodeAnalysis.Workspace;
-
-    [Export(typeof(VisualStudioTodoListTable))]
     internal class VisualStudioTodoListTable : VisualStudioBaseTodoListTable
     {
         internal const string IdentifierString = nameof(VisualStudioTodoListTable);
 
-        [ImportingConstructor]
-        public VisualStudioTodoListTable(VisualStudioWorkspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
-            base(workspace, todoListProvider, IdentifierString, provider)
-        {
-            ConnectWorkspaceEvents();
-        }
-
-        // only for test
         public VisualStudioTodoListTable(Workspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
             base(workspace, todoListProvider, IdentifierString, provider)
         {
+            ConnectWorkspaceEvents();
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioTodoListTable.cs
@@ -10,7 +10,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
     {
         internal const string IdentifierString = nameof(VisualStudioTodoListTable);
 
-        public VisualStudioTodoListTable(Workspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
+        public static void Register(Workspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider)
+        {
+            new VisualStudioTodoListTable(workspace, todoListProvider, provider);
+        }
+
+        // internal for testing
+        internal VisualStudioTodoListTable(Workspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
             base(workspace, todoListProvider, IdentifierString, provider)
         {
             ConnectWorkspaceEvents();

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -36,11 +36,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             VisualStudioWorkspaceImpl workspace,
             IDiagnosticAnalyzerService diagnosticService,
             IDiagnosticUpdateSourceRegistrationService registrationService,
-            IAsynchronousOperationListenerProvider listenerProvider) :
+            IAsynchronousOperationListenerProvider listenerProvider,
+            IKnownUIContextService uiContextService) :
                 this(workspace, diagnosticService, registrationService, listenerProvider.GetListener(FeatureAttribute.ErrorList))
         {
-            Debug.Assert(!KnownUIContexts.SolutionBuildingContext.IsActive);
-            KnownUIContexts.SolutionBuildingContext.UIContextChanged += OnSolutionBuild;
+            // it can be null in unit test
+            if (uiContextService != null)
+            {
+                Debug.Assert(!uiContextService.IsSolutionBuilding);
+                uiContextService.SolutionBuilding += OnSolutionBuild;
+            }
         }
 
         /// <summary>

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -20,9 +19,6 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 {
-    using Workspace = Microsoft.CodeAnalysis.Workspace;
-
-    [Export(typeof(ExternalErrorDiagnosticUpdateSource))]
     internal class ExternalErrorDiagnosticUpdateSource : IDiagnosticUpdateSource
     {
         private readonly Workspace _workspace;
@@ -36,7 +32,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         private InprogressState _stateDoNotAccessDirectly = null;
         private ImmutableArray<DiagnosticData> _lastBuiltResult = ImmutableArray<DiagnosticData>.Empty;
 
-        [ImportingConstructor]
         public ExternalErrorDiagnosticUpdateSource(
             VisualStudioWorkspaceImpl workspace,
             IDiagnosticAnalyzerService diagnosticService,

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
@@ -16,24 +16,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
     [Export(typeof(HostDiagnosticUpdateSource))]
     internal sealed class HostDiagnosticUpdateSource : AbstractHostDiagnosticUpdateSource
     {
-        private readonly VisualStudioWorkspaceImpl _workspace;
+        private readonly Lazy<VisualStudioWorkspaceImpl> _workspace;
 
         private readonly object _gate = new object();
         private readonly Dictionary<ProjectId, HashSet<object>> _diagnosticMap = new Dictionary<ProjectId, HashSet<object>>();
 
         [ImportingConstructor]
-        public HostDiagnosticUpdateSource(VisualStudioWorkspaceImpl workspace, IDiagnosticUpdateSourceRegistrationService registrationService)
+        public HostDiagnosticUpdateSource(Lazy<VisualStudioWorkspaceImpl> workspace, IDiagnosticUpdateSourceRegistrationService registrationService)
         {
             _workspace = workspace;
 
             registrationService.Register(this);
         }
 
-        public override Microsoft.CodeAnalysis.Workspace Workspace
+        public override Workspace Workspace
         {
             get
             {
-                return _workspace;
+                return _workspace.Value;
             }
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         {
             var args = DiagnosticsUpdatedArgs.DiagnosticsCreated(
                 CreateId(projectId, key),
-                _workspace,
+                Workspace,
                 solution: null,
                 projectId: projectId,
                 documentId: null,
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         {
             var args = DiagnosticsUpdatedArgs.DiagnosticsRemoved(
                 CreateId(projectId, key),
-                _workspace,
+                Workspace,
                 solution: null,
                 projectId: projectId,
                 documentId: null);

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Extensions;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Roslyn.Utilities;

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Extensions;
-using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Roslyn.Utilities;
@@ -30,11 +29,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         private readonly ExternalErrorDiagnosticUpdateSource _diagnosticProvider;
 
         public ProjectExternalErrorReporter(ProjectId projectId, string errorCodePrefix, IServiceProvider serviceProvider)
-            : this(projectId, errorCodePrefix, serviceProvider.GetMefService<VisualStudioWorkspace>(), serviceProvider.GetMefService<ExternalErrorDiagnosticUpdateSource>())
+            : this(projectId, errorCodePrefix, serviceProvider.GetMefService<VisualStudioWorkspaceImpl>())
         {
         }
 
-        public ProjectExternalErrorReporter(ProjectId projectId, string errorCodePrefix, VisualStudioWorkspace workspace, ExternalErrorDiagnosticUpdateSource diagnosticProvider)
+        public ProjectExternalErrorReporter(ProjectId projectId, string errorCodePrefix, VisualStudioWorkspaceImpl workspace)
         {
             Debug.Assert(workspace != null);
 
@@ -44,7 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             _projectId = projectId;
             _errorCodePrefix = errorCodePrefix;
             _workspace = workspace;
-            _diagnosticProvider = diagnosticProvider;
+            _diagnosticProvider = workspace.ExternalErrorDiagnosticUpdateSource;
         }
 
         private bool CanHandle(string errorId)

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -114,8 +114,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             // we need to load it as early as possible since we can have errors from
             // package from each language very early
             this.ComponentModel.GetService<TaskCenterSolutionAnalysisProgressReporter>();
-            this.ComponentModel.GetService<VisualStudioDiagnosticListTable>();
-            this.ComponentModel.GetService<VisualStudioTodoListTable>();
             this.ComponentModel.GetService<VisualStudioDiagnosticListTableCommandHandler>().Initialize(this);
 
             this.ComponentModel.GetService<VisualStudioMetadataAsSourceFileSupportService>();
@@ -138,9 +136,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             var commandHandlerServiceFactory = this.ComponentModel.GetService<ICommandHandlerServiceFactory>();
             commandHandlerServiceFactory.Initialize(ContentTypeNames.RoslynContentType);
             await LoadInteractiveMenusAsync(cancellationToken).ConfigureAwait(true);
-
-            this.ComponentModel.GetService<MiscellaneousTodoListTable>();
-            this.ComponentModel.GetService<MiscellaneousDiagnosticListTable>();
 
             // Initialize any experiments async
             var experiments = this.ComponentModel.DefaultExportProvider.GetExportedValues<IExperiment>();

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -21,7 +21,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         private readonly VisualStudioProjectFactory _projectFactory;
         private readonly VisualStudioWorkspaceImpl _workspace;
         private readonly IProjectCodeModelFactory _projectCodeModelFactory;
-        private readonly ExternalErrorDiagnosticUpdateSource _externalErrorDiagnosticUpdateSource;
 
         private static readonly ImmutableDictionary<string, string> s_projectLanguageToErrorCodePrefixMap =
             ImmutableDictionary.CreateRange(StringComparer.OrdinalIgnoreCase, new[]
@@ -36,13 +35,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         public CPSProjectFactory(
             VisualStudioProjectFactory projectFactory,
             VisualStudioWorkspaceImpl workspace,
-            IProjectCodeModelFactory projectCodeModelFactory,
-            [Import(AllowDefault = true)] /* not present in unit tests */ ExternalErrorDiagnosticUpdateSource externalErrorDiagnosticUpdateSource)
+            IProjectCodeModelFactory projectCodeModelFactory)
         {
             _projectFactory = projectFactory;
             _workspace = workspace;
             _projectCodeModelFactory = projectCodeModelFactory;
-            _externalErrorDiagnosticUpdateSource = externalErrorDiagnosticUpdateSource;
         }
 
         IWorkspaceProjectContext IWorkspaceProjectContextFactory.CreateProjectContext(
@@ -59,7 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 
             if (s_projectLanguageToErrorCodePrefixMap.TryGetKey(languageName, out var prefix))
             {
-                errorReporter = new ProjectExternalErrorReporter(visualStudioProject.Id, prefix, _workspace, _externalErrorDiagnosticUpdateSource);
+                errorReporter = new ProjectExternalErrorReporter(visualStudioProject.Id, prefix, _workspace);
             }
 
             return new CPSProject(visualStudioProject, _workspace, _projectCodeModelFactory, errorReporter, projectGuid, binOutputPath);

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -6,6 +6,8 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.GoToDefinition;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Undo;
@@ -17,8 +19,10 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser.Lists;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 
@@ -49,6 +53,17 @@ namespace Microsoft.VisualStudio.LanguageServices
                     Services.GetRequiredService<IOptionService>().RegisterDocumentOptionsProvider(optionsProvider);
                 }
             }
+
+            // this will register todo list and error list to VS
+            VisualStudioDiagnosticListTable.RegisterAsync(
+                asyncServiceProvider, this,
+                exportProvider.GetExportedValue<IDiagnosticService>(),
+                exportProvider.GetExportedValue<ITableManagerProvider>()).Forget();
+
+            VisualStudioTodoListTable.Register(
+                this,
+                exportProvider.GetExportedValue<ITodoListProvider>(),
+                exportProvider.GetExportedValue<ITableManagerProvider>());
         }
 
         internal override IInvisibleEditor OpenInvisibleEditor(DocumentId documentId)

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
@@ -29,7 +29,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub AnalyzerErrorsAreUpdated()
-            Dim hostDiagnosticUpdateSource = New HostDiagnosticUpdateSource(Nothing, New MockDiagnosticUpdateSourceRegistrationService())
+            Dim lazyWorkspace = New Lazy(Of VisualStudioWorkspaceImpl)(
+                                    Function()
+                                        Return Nothing
+                                    End Function)
+
+            Dim hostDiagnosticUpdateSource = New HostDiagnosticUpdateSource(lazyWorkspace, New MockDiagnosticUpdateSourceRegistrationService())
 
             Dim file = Path.GetTempFileName()
             Dim eventHandler = New EventHandlers(file)


### PR DESCRIPTION
we used to initialize those when packages are loaded. but with CPS, those packages are no longer automatically loaded with a solution open (perf win)

so now, it is moved to VSWorkspace ctor and it gets initialized when the workspace is created.

considered making it on demand but due to reversed dependency (error reporting happening in lower layer), required some plumbing so looked into how expensive the initialization is. and it turns out due to previous work done in these areas, initialization was quite cheap. any expensive one was already lazy or consumed by CPSProjectFactory already.

so, just moved initialization into VSWorkspace ctor and fixed MEF dependencies.

this partially handle this - https://github.com/dotnet/roslyn/issues/35514

but not FSA not running until file opened issue. that require a bit more work to move solution crawler inside of VSWorkspace ctor.