### PR TITLE
Infer nested nullability for implicitly typed deconstruction variable:

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4901,6 +4901,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     else
                     {
                         var targetType = variable.Type;
+                        if (variable.Expression.ExpressionSymbol is SourceLocalSymbol local && local.IsVar)
+                        {
+                            // re-infer the left hand var type from the right hand side
+                            targetType = TypeWithAnnotations.Create(rightPart.Type);
+                            _variableTypes[local] = targetType;
+                        }
                         TypeWithState operandType;
                         TypeWithState valueType;
                         int valueSlot;
@@ -5029,7 +5035,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // For instance, Boxing conversions (see Deconstruction_ImplicitBoxingConversion_02) and
                 // ImplicitNullable conversions (see Deconstruction_ImplicitNullableConversion_02).
                 VisitRvalue(expr);
-                var fields = tupleType.TupleElements;
+                var fields = ((TupleTypeSymbol)ResultType.Type).TupleElements;
                 return fields.SelectAsArray((f, e) => (BoundExpression)new BoundFieldAccess(e.Syntax, e, f, constantValueOpt: null), expr);
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4908,7 +4908,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             if ((variable.Expression as BoundLocal)?.DeclarationKind == BoundLocalDeclarationKind.WithInferredType)
                             {
-                                // when the LHS is a var declaration, we can just visit the right part to infer it's type
+                                // when the LHS is a var declaration, we can just visit the right part to infer the type
                                 valueType = operandType = VisitRvalueWithState(rightPart);
                                 _variableTypes[variable.Expression.ExpressionSymbol] = operandType.ToTypeWithAnnotations();
                             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5031,12 +5031,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
             }
 
-            if (expr.Type is TupleTypeSymbol tuple)
+            if (expr.Type is TupleTypeSymbol tupleType)
             {
                 // https://github.com/dotnet/roslyn/issues/33011: Should include conversion.UnderlyingConversions[i].
                 // For instance, Boxing conversions (see Deconstruction_ImplicitBoxingConversion_02) and
                 // ImplicitNullable conversions (see Deconstruction_ImplicitNullableConversion_02).
-                var fields = tuple.TupleElements;
+                var fields = tupleType.TupleElements;
                 return fields.SelectAsArray((f, e) => (BoundExpression)new BoundFieldAccess(e.Syntax, e, f, constantValueOpt: null), expr);
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4901,11 +4901,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     else
                     {
                         var targetType = variable.Type;
-                        if (variable.Expression.ExpressionSymbol is SourceLocalSymbol local && local.IsVar)
+                        if (variable.Expression.ExpressionSymbol is SourceLocalSymbol local && local.IsVar && rightPart is BoundFieldAccess rightField)
                         {
                             // re-infer the left hand var type from the right hand side
-                            targetType = TypeWithAnnotations.Create(rightPart.Type);
-                            _variableTypes[local] = targetType;
+                            _variableTypes[local] = rightField.FieldSymbol.TypeWithAnnotations;
                         }
                         TypeWithState operandType;
                         TypeWithState valueType;
@@ -5029,7 +5028,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
             }
 
-            if (expr.Type is TupleTypeSymbol tupleType)
+            if (expr.Type.IsTupleType)
             {
                 // https://github.com/dotnet/roslyn/issues/33011: Should include conversion.UnderlyingConversions[i].
                 // For instance, Boxing conversions (see Deconstruction_ImplicitBoxingConversion_02) and

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -90059,12 +90059,14 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            // https://github.com/dotnet/roslyn/issues/33019: Inferred nullability of implicitly-typed
-            // deconstruction variables should be recorded in NullableWalker._variableTypes.
             comp.VerifyDiagnostics(
                 // (6,13): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         y = null; // 1
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(6, 13));
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(6, 13),
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
+                //         ay[0].ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "ay[0]").WithLocation(10, 9)
+                );
         }
 
         [Fact]


### PR DESCRIPTION
- Record the visited type of the right hand side in tuple deconstruction
- When the left hand side is 'var', re-infer the type from the visited right hand side
- Update test

Fixes https://github.com/dotnet/roslyn/issues/33019