### PR TITLE
Don't check safe-to-escape of receiver arguments to readonly members

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1336,7 +1336,7 @@ moreArguments:
             // widest possible escape via writeable ref-like receiver or ref/out argument.
             uint escapeTo = scopeOfTheContainingExpression;
 
-            var isReadOnlyInvocation = symbol switch
+            var isReceiverRefReadOnly = symbol switch
             {
                 MethodSymbol m => m.IsEffectivelyReadOnly,
                 // TODO: val escape checks should be skipped for property accesses when
@@ -1350,7 +1350,7 @@ moreArguments:
 
             // collect all writeable ref-like arguments, including receiver
             var receiverType = receiverOpt?.Type;
-            if (receiverType?.IsRefLikeType == true && !isReadOnlyInvocation)
+            if (receiverType?.IsRefLikeType == true && !isReceiverRefReadOnly)
             {
                 escapeTo = GetValEscape(receiverOpt, scopeOfTheContainingExpression);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1337,6 +1337,7 @@ moreArguments:
                 // TODO: val escape checks should be skipped for property accesses when
                 // we can determine the only accessors being called are readonly.
                 // For now we are pessimistic and check escape if any accessor is non-readonly.
+                // Tracking in https://github.com/dotnet/roslyn/issues/35606
                 PropertySymbol p => p.GetMethod?.IsEffectivelyReadOnly != false && p.SetMethod?.IsEffectivelyReadOnly != false,
                 _ => throw ExceptionUtilities.UnexpectedValue(symbol)
             };

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1322,6 +1322,11 @@ moreArguments:
             uint scopeOfTheContainingExpression,
             DiagnosticBag diagnostics)
         {
+            // SPEC:
+            // In a method invocation, the following constraints apply:
+            // - If there is a ref or out argument of a ref struct type (including the receiver), with safe-to-escape E1, then
+            // - no argument (including the receiver) may have a narrower safe-to-escape than E1.
+
             if (symbol.IsStatic)
             {
                 // ignore receiver when symbol is static

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -2467,6 +2467,27 @@ class Program
         }
 
         [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        public void ReadOnlyRefStruct_Method_RefLikeStructParameter()
+        {
+            var csharp = @"
+using System;
+
+public readonly ref struct S<T>
+{
+    public void M(Span<T> x) { }
+
+    public unsafe static void N(S<byte> b)
+    {
+        Span<byte> x = stackalloc byte[5];
+        b.M(x);
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
         public void ReadOnlyMethod_RefLikeStructParameter()
         {
             var csharp = @"
@@ -2488,14 +2509,14 @@ public ref struct S<T>
         }
 
         [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
-        public void ReadOnlyStruct_Property_RefLikeStruct_01()
+        public void ReadOnlyRefStruct_RefLikeProperty()
         {
             var csharp = @"
 using System;
 
-public ref struct S<T>
+public readonly ref struct S<T>
 {
-    public Span<T> P { get => default; readonly set {} }
+    public Span<T> P { get => default; set {} }
 
     public unsafe static void N(S<byte> b)
     {
@@ -2512,7 +2533,7 @@ public ref struct S<T>
         }
 
         [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
-        public void ReadOnlyStruct_Property_RefLikeStruct_02()
+        public void ReadOnlyRefLikeProperty_01()
         {
             var csharp = @"
 using System;
@@ -2536,7 +2557,7 @@ public ref struct S<T>
         }
 
         [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
-        public void ReadOnlyProperty_RefLikeStructParameter()
+        public void ReadOnlyRefLikeProperty_02()
         {
             var csharp = @"
 using System;
@@ -2561,6 +2582,34 @@ public ref struct S<T>
 
         [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
         public void ReadOnlyIndexer_RefLikeStructParameter_01()
+        {
+            var csharp = @"
+using System;
+
+public ref struct S<T>
+{
+    public readonly Span<T> this[Span<T> span] { get => default; set {} }
+
+    public unsafe static void N(S<byte> b)
+    {
+        Span<byte> x = stackalloc byte[5];
+        _ = b[x];
+        b[x] = x;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(
+                // (11,13): error CS8347: Cannot use a result of 'S<byte>.this[Span<byte>]' in this context because it may expose variables referenced by parameter 'span' outside of their declaration scope
+                //         _ = b[x];
+                Diagnostic(ErrorCode.ERR_EscapeCall, "b[x]").WithArguments("S<byte>.this[System.Span<byte>]", "span").WithLocation(11, 13),
+                // (11,15): error CS8352: Cannot use local 'x' in this context because it may expose referenced variables outside of their declaration scope
+                //         _ = b[x];
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "x").WithArguments("x").WithLocation(11, 15));
+        }
+
+        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        public void ReadOnlyIndexer_RefLikeStructParameter_02()
         {
             var csharp = @"
 using System;
@@ -2590,34 +2639,6 @@ public ref struct S<T>
                 // (11,11): error CS8352: Cannot use local 'x' in this context because it may expose referenced variables outside of their declaration scope
                 //         b[x] = x;
                 Diagnostic(ErrorCode.ERR_EscapeLocal, "x").WithArguments("x").WithLocation(11, 11));
-        }
-
-        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
-        public void ReadOnlyIndexer_RefLikeStructParameter_02()
-        {
-            var csharp = @"
-using System;
-
-public ref struct S<T>
-{
-    public readonly Span<T> this[Span<T> span] { get => default; set {} }
-
-    public unsafe static void N(S<byte> b)
-    {
-        Span<byte> x = stackalloc byte[5];
-        _ = b[x];
-        b[x] = x;
-    }
-}
-";
-            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
-            comp.VerifyDiagnostics(
-                // (11,13): error CS8347: Cannot use a result of 'S<byte>.this[Span<byte>]' in this context because it may expose variables referenced by parameter 'span' outside of their declaration scope
-                //         _ = b[x];
-                Diagnostic(ErrorCode.ERR_EscapeCall, "b[x]").WithArguments("S<byte>.this[System.Span<byte>]", "span").WithLocation(11, 13),
-                // (11,15): error CS8352: Cannot use local 'x' in this context because it may expose referenced variables outside of their declaration scope
-                //         _ = b[x];
-                Diagnostic(ErrorCode.ERR_EscapeLocal, "x").WithArguments("x").WithLocation(11, 15));
         }
 
         [WorkItem(22197, "https://github.com/dotnet/roslyn/issues/22197")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -2466,6 +2466,160 @@ class Program
                 );
         }
 
+        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        public void ReadOnlyMethod_RefLikeStructParameter()
+        {
+            var csharp = @"
+using System;
+
+public ref struct S<T>
+{
+    public readonly void M(Span<T> x) { }
+
+    public unsafe static void N(S<byte> b)
+    {
+        Span<byte> x = stackalloc byte[5];
+        b.M(x);
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        public void ReadOnlyStruct_Property_RefLikeStruct_01()
+        {
+            var csharp = @"
+using System;
+
+public ref struct S<T>
+{
+    public Span<T> P { get => default; readonly set {} }
+
+    public unsafe static void N(S<byte> b)
+    {
+        Span<byte> x = stackalloc byte[5];
+        b.P = x;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(
+                // (11,15): error CS8352: Cannot use local 'x' in this context because it may expose referenced variables outside of their declaration scope
+                //         b.P = x;
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "x").WithArguments("x").WithLocation(11, 15));
+        }
+
+        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        public void ReadOnlyStruct_Property_RefLikeStruct_02()
+        {
+            var csharp = @"
+using System;
+
+public ref struct S<T>
+{
+    public readonly Span<T> P { get => default; set {} }
+
+    public unsafe static void N(S<byte> b)
+    {
+        Span<byte> x = stackalloc byte[5];
+        b.P = x;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(
+                // (11,15): error CS8352: Cannot use local 'x' in this context because it may expose referenced variables outside of their declaration scope
+                //         b.P = x;
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "x").WithArguments("x").WithLocation(11, 15));
+        }
+
+        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        public void ReadOnlyProperty_RefLikeStructParameter()
+        {
+            var csharp = @"
+using System;
+
+public ref struct S<T>
+{
+    public Span<T> P { get => default; readonly set {} }
+
+    public unsafe static void N(S<byte> b)
+    {
+        Span<byte> x = stackalloc byte[5];
+        b.P = x;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(
+                // (11,15): error CS8352: Cannot use local 'x' in this context because it may expose referenced variables outside of their declaration scope
+                //         b.P = x;
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "x").WithArguments("x").WithLocation(11, 15));
+        }
+
+        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        public void ReadOnlyIndexer_RefLikeStructParameter_01()
+        {
+            var csharp = @"
+using System;
+public ref struct S<T>
+{
+    public Span<T> this[Span<T> span] { get => default; readonly set {} }
+
+    public unsafe static void N(S<byte> b)
+    {
+        Span<byte> x = stackalloc byte[5];
+        _ = b[x];
+        b[x] = x;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(
+                // (10,13): error CS8350: This combination of arguments to 'S<byte>.this[Span<byte>]' is disallowed because it may expose variables referenced by parameter 'span' outside of their declaration scope
+                //         _ = b[x];
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "b[x]").WithArguments("S<byte>.this[System.Span<byte>]", "span").WithLocation(10, 13),
+                // (10,15): error CS8352: Cannot use local 'x' in this context because it may expose referenced variables outside of their declaration scope
+                //         _ = b[x];
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "x").WithArguments("x").WithLocation(10, 15),
+                // (11,9): error CS8350: This combination of arguments to 'S<byte>.this[Span<byte>]' is disallowed because it may expose variables referenced by parameter 'span' outside of their declaration scope
+                //         b[x] = x;
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "b[x]").WithArguments("S<byte>.this[System.Span<byte>]", "span").WithLocation(11, 9),
+                // (11,11): error CS8352: Cannot use local 'x' in this context because it may expose referenced variables outside of their declaration scope
+                //         b[x] = x;
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "x").WithArguments("x").WithLocation(11, 11));
+        }
+
+        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        public void ReadOnlyIndexer_RefLikeStructParameter_02()
+        {
+            var csharp = @"
+using System;
+
+public ref struct S<T>
+{
+    public readonly Span<T> this[Span<T> span] { get => default; set {} }
+
+    public unsafe static void N(S<byte> b)
+    {
+        Span<byte> x = stackalloc byte[5];
+        _ = b[x];
+        b[x] = x;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(
+                // (11,13): error CS8347: Cannot use a result of 'S<byte>.this[Span<byte>]' in this context because it may expose variables referenced by parameter 'span' outside of their declaration scope
+                //         _ = b[x];
+                Diagnostic(ErrorCode.ERR_EscapeCall, "b[x]").WithArguments("S<byte>.this[System.Span<byte>]", "span").WithLocation(11, 13),
+                // (11,15): error CS8352: Cannot use local 'x' in this context because it may expose referenced variables outside of their declaration scope
+                //         _ = b[x];
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "x").WithArguments("x").WithLocation(11, 15));
+        }
+
         [WorkItem(22197, "https://github.com/dotnet/roslyn/issues/22197")]
         [Fact()]
         public void RefTernaryMustMatchValEscapes()


### PR DESCRIPTION
Fixes #35146 but we'll need to create a new issue to track fixing escape analysis on properties where one accessor is readonly and the other is not.