### PR TITLE
Fix GetHashCode on constructed types with annotated type arguments

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedErrorType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedErrorType.vb
@@ -221,6 +221,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         Public Overrides Function GetHashCode() As Integer
+            If Me._substitution.WasConstructedForModifiers() Then
+                Return OriginalDefinition.GetHashCode()
+            End If
+
             Dim _hash As Integer = _fullInstanceType.GetHashCode()
 
             _hash = Hash.Combine(ContainingType, _hash)

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
@@ -491,6 +491,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overrides Function GetHashCode() As Integer
             Dim _hash As Integer = OriginalDefinition.GetHashCode()
+            If Me._substitution.WasConstructedForModifiers() Then
+                Return _hash
+            End If
+
             _hash = Hash.Combine(ContainingType, _hash)
 
             ' There is a circularity problem here with alpha-renamed type parameters.
@@ -978,6 +982,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Function
 
             Public Overrides Function GetHashCode() As Integer
+                If Me._substitution.WasConstructedForModifiers() Then
+                    Return OriginalDefinition.GetHashCode()
+                End If
+
                 Dim _hash As Integer = MyBase.GetHashCode()
 
                 For Each typeArgument In TypeArgumentsNoUseSiteDiagnostics
@@ -1200,7 +1208,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' No effect
                 Return Me
             End Function
-
 
         End Class
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSubstitution.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSubstitution.vb
@@ -904,5 +904,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return customModifiers
         End Function
 
+        Public Function WasConstructedForModifiers() As Boolean
+            For Each pair In _pairs
+                If Not pair.Key.Equals(pair.Value.Type.OriginalDefinition) Then
+                    Return False
+                End If
+            Next
+
+            Return If(_parent Is Nothing, True, _parent.WasConstructedForModifiers())
+        End Function
+
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -285,12 +285,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim t1IsDefinition = t1.IsDefinition
                 Dim t2IsDefinition = t2.IsDefinition
 
-                If (t1IsDefinition <> t2IsDefinition) AndAlso
-                   Not ((compareKind And TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) <> 0 AndAlso
-                            (DirectCast(t1, NamedTypeSymbol).HasTypeArgumentsCustomModifiers OrElse DirectCast(t2, NamedTypeSymbol).HasTypeArgumentsCustomModifiers)) Then
-                    Return False
-                End If
-
                 If Not (t1IsDefinition AndAlso t2IsDefinition) Then ' This is a generic instantiation case
 
                     If Not t1.OriginalDefinition.Equals(t2.OriginalDefinition) Then
@@ -303,20 +297,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                     Do
 
-                        If (compareKind And Global.Microsoft.CodeAnalysis.TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) = 0 AndAlso
-                           Not HasSameTypeArgumentCustomModifiers(container1, container2) Then
+                        If Not (container1 Is container1.ConstructedFrom AndAlso container2 Is container2.ConstructedFrom) Then
+                            ' No need to compare type arguments on those containers when they didn't add type arguments (that would cause cycles)
 
-                            Return False
-                        End If
+                            If (compareKind And Global.Microsoft.CodeAnalysis.TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) = 0 AndAlso
+                                Not HasSameTypeArgumentCustomModifiers(container1, container2) Then
 
-                        Dim args1 As ImmutableArray(Of TypeSymbol) = container1.TypeArgumentsNoUseSiteDiagnostics
-                        Dim args2 As ImmutableArray(Of TypeSymbol) = container2.TypeArgumentsNoUseSiteDiagnostics
-
-                        For i As Integer = 0 To args1.Length - 1 Step 1
-                            If Not args1(i).IsSameType(args2(i), compareKind) Then
                                 Return False
                             End If
-                        Next
+
+                            Dim args1 As ImmutableArray(Of TypeSymbol) = container1.TypeArgumentsNoUseSiteDiagnostics
+                            Dim args2 As ImmutableArray(Of TypeSymbol) = container2.TypeArgumentsNoUseSiteDiagnostics
+
+                            For i As Integer = 0 To args1.Length - 1 Step 1
+                                If Not args1(i).IsSameType(args2(i), compareKind) Then
+                                    Return False
+                                End If
+                            Next
+                        End If
 
                         container1 = container1.ContainingType
                         container2 = container2.ContainingType
@@ -326,16 +324,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                             Exit Do
                         End If
 
-                        If (container1.IsDefinition <> container2.IsDefinition) AndAlso
-                            Not ((compareKind And TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) <> 0 AndAlso
-                            (container1.HasTypeArgumentsCustomModifiers OrElse container2.HasTypeArgumentsCustomModifiers)) Then
-
-                            Return False
-                        End If
                     Loop
 
                     Return True
                 End If
+            ElseIf kind = SymbolKind.TypeParameter Then
+                If Not t1.OriginalDefinition.Equals(t2.OriginalDefinition) Then
+                    Return False ' different definition
+                End If
+
+                Return t1.ContainingType.IsSameType(t2.ContainingType, compareKind)
             End If
 
             Return t1.Equals(t2)


### PR DESCRIPTION
If you have `C<T~>` (definition) and a type `C<T!>` or `C<T?>` constructed from it, they should have the same value for `GetHashCode()`, namely the object-hash of the definition.

Fixes https://github.com/dotnet/roslyn/issues/30673

If this looks okay, then I'll extend this PR to also cover VB.

Fixes https://github.com/dotnet/roslyn/issues/30677

Tagging @AlekseyTs