### PR TITLE
Add optprof test

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -6,7 +6,7 @@
         {
           "container": "ManagedLangs",
           "testCases": [
-            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+            "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs"
           ]
         },
         {
@@ -60,7 +60,7 @@
         {
           "container": "ManagedLangs",
           "testCases": [
-            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+            "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs"
           ]
         },
         {
@@ -91,7 +91,7 @@
         {
           "container": "ManagedLangs",
           "testCases": [
-            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+            "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs"
           ]
         },
         {
@@ -140,7 +140,7 @@
         {
           "container": "ManagedLangs",
           "testCases": [
-            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+            "ManagedLangs.OptProfTests.DDRIT_RPS_ManagedLangs"
           ]
         },
         {

--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -4,6 +4,12 @@
       "name": "Roslyn.VisualStudio.Setup.vsix",
       "tests": [
         {
+          "container": "ManagedLangs",
+          "testCases": [
+            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+          ]
+        },
+        {
           "container": "TeamEng",
           "testCases": [
             "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble"
@@ -52,6 +58,12 @@
       "name": "Microsoft.CodeAnalysis.Compilers.vsix",
       "tests": [
         {
+          "container": "ManagedLangs",
+          "testCases": [
+            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+          ]
+        },
+        {
           "container": "TeamEng",
           "testCases": [
             "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble"
@@ -76,6 +88,12 @@
         }
       ],
       "tests": [
+        {
+          "container": "ManagedLangs",
+          "testCases": [
+            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+          ]
+        },
         {
           "container": "TeamEng",
           "testCases": [
@@ -119,6 +137,12 @@
         }
       ],
       "tests": [
+        {
+          "container": "ManagedLangs",
+          "testCases": [
+            "ManagedLangs.OptProfTest.DDRIT_RPS_ManagedLangs"
+          ]
+        },
         {
           "container": "TeamEng",
           "testCases": [


### PR DESCRIPTION
This test is now passing in master, so porting it to 16.2.

Here's PR that porting the test itself to rel/d16.2
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS/pullrequest/180800?_a=overview

**Don't merge until verified RPS results from master.**

FYI @jinujoseph @vatsalyaagrawal @dotnet/roslyn-infrastructure 