### PR TITLE
improve build + live dedup on full solution analysis on.

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -363,7 +363,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         private void RaiseDocumentDiagnosticsIfNeeded(
             Document document, StateSet stateSet, AnalysisKind kind, ImmutableArray<DiagnosticData> oldItems, ImmutableArray<DiagnosticData> newItems)
         {
-            RaiseDocumentDiagnosticsIfNeeded(document, stateSet, kind, oldItems, newItems, Owner.RaiseDiagnosticsUpdated);
+            RaiseDocumentDiagnosticsIfNeeded(document, stateSet, kind, oldItems, newItems, Owner.RaiseDiagnosticsUpdated, forceUpdate: false);
         }
 
         private void RaiseDocumentDiagnosticsIfNeeded(
@@ -371,18 +371,29 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             DiagnosticAnalysisResult oldResult, DiagnosticAnalysisResult newResult,
             Action<DiagnosticsUpdatedArgs> raiseEvents)
         {
+            // if our old result is from build and we don't have actual data, don't try micro-optimize and always refresh diagnostics.
+            // most of time, we don't actually load or hold the old data in memory from persistent storage due to perf reasons.
+            //
+            // we need this special behavior for errors from build since unlike live errors, we don't know whether errors
+            // from build is for syntax, semantic or others. due to that, we blindly mark them as semantic errors (most common type of errors from build)
+            //
+            // that can sometime cause issues. for example, if the error turns out to be syntax error (live) then we at the end fail to de-dup.
+            // but since this optimization saves us a lot of refresh between live errors analysis we want to disable this only in this condition.
+            var forceUpdate = oldResult.FromBuild && oldResult.IsAggregatedForm;
+
             var oldItems = GetResult(oldResult, kind, document.Id);
             var newItems = GetResult(newResult, kind, document.Id);
 
-            RaiseDocumentDiagnosticsIfNeeded(document, stateSet, kind, oldItems, newItems, raiseEvents);
+            RaiseDocumentDiagnosticsIfNeeded(document, stateSet, kind, oldItems, newItems, raiseEvents, forceUpdate);
         }
 
         private void RaiseDocumentDiagnosticsIfNeeded(
             Document document, StateSet stateSet, AnalysisKind kind,
             ImmutableArray<DiagnosticData> oldItems, ImmutableArray<DiagnosticData> newItems,
-            Action<DiagnosticsUpdatedArgs> raiseEvents)
+            Action<DiagnosticsUpdatedArgs> raiseEvents,
+            bool forceUpdate)
         {
-            if (oldItems.IsEmpty && newItems.IsEmpty)
+            if (!forceUpdate && oldItems.IsEmpty && newItems.IsEmpty)
             {
                 // there is nothing to update
                 return;


### PR DESCRIPTION
we found a de-dup bug with full solution analysis.

basically, when we get errors, we categorize them as either syntax, semantic or other errors. it works fine for live but errors from build, we don't know what kind of errors they are. so we mark those with most common error kind (semantic) and mark that it is from build so that we can refresh them next time we do live analysis.

with full solution analysis off, it works fine since we fix those up when a file is opened. but for closed file with FSA, we sometimes fail to de-dup correctly due to our refresh optimization.

now we always refresh errors when build error is involved.