### PR TITLE
Fix crash when using bad indexer type

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7469,7 +7469,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool argIsIndex = TypeSymbol.Equals(argType,
                 Compilation.GetWellKnownType(WellKnownType.System_Index),
                 TypeCompareKind.ConsiderEverything);
-            bool argIsRange = !argIsIndex || TypeSymbol.Equals(argType,
+            bool argIsRange = !argIsIndex && TypeSymbol.Equals(argType,
                 Compilation.GetWellKnownType(WellKnownType.System_Range),
                 TypeCompareKind.ConsiderEverything);
 


### PR DESCRIPTION
Inverted condition caused us to crash instead of giving an error message
when calling an indexer with a bad input type.

Fixes #35622