### PR TITLE
Feed the NullableContextOptions msbuild property into Nullable

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -151,9 +151,30 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         public string Nullable
         {
-            set { _store[nameof(Nullable)] = value; }
+            set
+            {
+                // We merge values into Nullable, prioritizing Nullable value over NullableContextOptions value
+                if (!string.IsNullOrEmpty(value))
+                {
+                    _store[nameof(Nullable)] = value;
+                }
+            }
             get { return (string)_store[nameof(Nullable)]; }
         }
+
+        public string NullableContextOptions
+        {
+            set
+            {
+                // We merge values into Nullable, prioritizing Nullable value over NullableContextOptions value
+                if (string.IsNullOrEmpty((string)_store[nameof(Nullable)]))
+                {
+                    _store[nameof(Nullable)] = value;
+                }
+            }
+            get { return (string)_store[nameof(Nullable)]; }
+        }
+
 
         #endregion
 

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -167,14 +167,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             set
             {
                 // We merge values into Nullable, prioritizing Nullable value over NullableContextOptions value
-                if (string.IsNullOrEmpty((string)_store[nameof(Nullable)]))
+                if (string.IsNullOrEmpty(Nullable))
                 {
-                    _store[nameof(Nullable)] = value;
+                    Nullable = value;
                 }
             }
-            get { return (string)_store[nameof(Nullable)]; }
+            get { return Nullable; }
         }
-
 
         #endregion
 

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -47,8 +47,6 @@
 
       <!-- If we are targeting winmdobj we want to specifically the pdbFile property since we do not want it to collide with the output of winmdexp-->
       <PdbFile Condition="'$(PdbFile)' == '' AND '$(OutputType)' == 'winmdobj' AND '$(_DebugSymbolsProduced)' == 'true'">$(IntermediateOutputPath)$(TargetName).compile.pdb</PdbFile>
-
-      <Nullable Condition="'$(Nullable)' == '' AND '$(NullableContextOptions)' != ''">$(NullableContextOptions)</Nullable>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -47,6 +47,8 @@
 
       <!-- If we are targeting winmdobj we want to specifically the pdbFile property since we do not want it to collide with the output of winmdexp-->
       <PdbFile Condition="'$(PdbFile)' == '' AND '$(OutputType)' == 'winmdobj' AND '$(_DebugSymbolsProduced)' == 'true'">$(IntermediateOutputPath)$(TargetName).compile.pdb</PdbFile>
+
+      <Nullable Condition="'$(Nullable)' == '' AND '$(NullableContextOptions)' != ''">$(NullableContextOptions)</Nullable>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -355,6 +355,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         [InlineData(null, "disable")]
         [InlineData("", "disable")]
         [InlineData("enable", "disable")]
+        [InlineData("other", "disable")]
         [InlineData("disable", null)]
         [InlineData("disable", "")]
         public void NullableReferenceTypes_NullableWins_Disable(string nullableContextOptions, string nullable)
@@ -364,6 +365,22 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             csc.NullableContextOptions = nullableContextOptions;
             csc.Nullable = nullable;
             Assert.Equal("/nullable:disable /out:test.exe test.cs", csc.GenerateResponseFileContents());
+        }
+
+        [Theory]
+        [InlineData(null, "enable")]
+        [InlineData("", "enable")]
+        [InlineData("disable", "enable")]
+        [InlineData("other", "enable")]
+        [InlineData("enable", null)]
+        [InlineData("enable", "")]
+        public void NullableReferenceTypes_NullableWins_Enable(string nullableContextOptions, string nullable)
+        {
+            var csc = new Csc();
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            csc.NullableContextOptions = nullableContextOptions;
+            csc.Nullable = nullable;
+            Assert.Equal("/nullable:enable /out:test.exe test.cs", csc.GenerateResponseFileContents());
         }
 
         [Fact]

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -351,6 +351,21 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.Equal("/nullable:disable /out:test.exe test.cs", csc.GenerateResponseFileContents());
         }
 
+        [Theory]
+        [InlineData(null, "disable")]
+        [InlineData("", "disable")]
+        [InlineData("enable", "disable")]
+        [InlineData("disable", null)]
+        [InlineData("disable", "")]
+        public void NullableReferenceTypes_NullableWins_Disable(string nullableContextOptions, string nullable)
+        {
+            var csc = new Csc();
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            csc.NullableContextOptions = nullableContextOptions;
+            csc.Nullable = nullable;
+            Assert.Equal("/nullable:disable /out:test.exe test.cs", csc.GenerateResponseFileContents());
+        }
+
         [Fact]
         public void NullableReferenceTypes_Safeonly()
         {


### PR DESCRIPTION
Relates to https://github.com/aspnet/AspNetCore/issues/10218

The change from `NullableContextOptions` to `Nullable` broke Razor who has a direct dependency on `Csc` task.

VSTS issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/891963