### PR TITLE
Adjust logo tests to recognize official build versions

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -6226,7 +6226,7 @@ class C
             CleanupAllGeneratedFiles(file.Path);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/35696")]
+        [Fact]
         public void NoLogo_2()
         {
             string source = @"
@@ -6244,7 +6244,7 @@ class C
             int exitCode = csc.Run(outWriter);
             Assert.Equal(0, exitCode);
 
-            var patched = Regex.Replace(outWriter.ToString().Trim(), "version \\d+\\.\\d+\\.\\d+(-[\\w\\d]+)?", "version A.B.C-d");
+            var patched = Regex.Replace(outWriter.ToString().Trim(), "version \\d+\\.\\d+\\.\\d+(-[\\w\\d]+)*", "version A.B.C-d");
             patched = ReplaceCommitHash(patched);
             Assert.Equal(@"
 Microsoft (R) Visual C# Compiler version A.B.C-d (HASH)

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -499,7 +499,7 @@ End Class
             CleanupAllGeneratedFiles(src)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35696")>
+        <Fact>
         Public Sub VbcNologo_2()
             Dim src As String = Temp.CreateFile().WriteAllText(<text>
 Class C
@@ -512,7 +512,7 @@ End Class
             Dim exitCode = cmd.Run(output, Nothing)
 
             Assert.Equal(0, exitCode)
-            Dim patched As String = Regex.Replace(output.ToString().Trim(), "version \d+\.\d+\.\d+(-[\d\w]+)?", "version A.B.C-d")
+            Dim patched As String = Regex.Replace(output.ToString().Trim(), "version \d+\.\d+\.\d+(-[\d\w]+)*", "version A.B.C-d")
             patched = ReplaceCommitHash(patched)
             Assert.Equal(<text>
 Microsoft (R) Visual Basic Compiler version A.B.C-d (HASH)
@@ -540,7 +540,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             Return Regex.Replace(s, "(\((<developer build>|[a-fA-F0-9]{8})\))", "(HASH)")
         End Function
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35696")>
+        <Fact>
         Public Sub VbcNologo_2a()
             Dim src As String = Temp.CreateFile().WriteAllText(<text>
 Class C
@@ -553,7 +553,7 @@ End Class
             Dim exitCode = cmd.Run(output, Nothing)
 
             Assert.Equal(0, exitCode)
-            Dim patched As String = Regex.Replace(output.ToString().Trim(), "version \d+\.\d+\.\d+(-[\w\d]+)?", "version A.B.C-d")
+            Dim patched As String = Regex.Replace(output.ToString().Trim(), "version \d+\.\d+\.\d+(-[\w\d]+)*", "version A.B.C-d")
             patched = ReplaceCommitHash(patched)
             Assert.Equal(<text>
 Microsoft (R) Visual Basic Compiler version A.B.C-d (HASH)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/35696

The official build uses a version that has multiple `-xyz` parts. So the compiler version output can look like this: `3.1.0-10-19264-03 (<SHA>)`. We have a couple of tests that parse this and replace the first part with `A.B.C-d` and the second part with `(HASH)`. But the regex only recognized a single optional `-xyz` part.