### PR TITLE
Separate script arguments from the script file for InteractiveCompiler tasks

### DIFF
--- a/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
+++ b/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
@@ -263,5 +263,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 }
             }
         }
+
+        internal void AppendArgumentsIfNotNull(string arguments)
+        {
+            if (!string.IsNullOrEmpty(arguments))
+            {
+                AppendSpaceIfNotEmpty();
+                AppendTextUnquoted(arguments);
+            }
+        }
     }
 }

--- a/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
+++ b/src/Compilers/Core/MSBuildTask/CommandLineBuilderExtension.cs
@@ -264,12 +264,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
         }
 
-        internal void AppendArgumentsIfNotNull(string arguments)
+        internal void AppendArgumentIfNotNull(string argument)
         {
-            if (!string.IsNullOrEmpty(arguments))
+            if (!string.IsNullOrEmpty(argument))
             {
                 AppendSpaceIfNotEmpty();
-                AppendTextUnquoted(arguments);
+                AppendTextWithQuoting(argument);
             }
         }
     }

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 foreach (var scriptArgument in ScriptArguments)
                 {
-                    commandLine.AppendTextUnquoted(scriptArgument);
+                    commandLine.AppendArgumentsIfNotNull(scriptArgument);
                 }
             }
 

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 foreach (var scriptArgument in ScriptArguments)
                 {
-                    commandLine.AppendArgumentsIfNotNull(scriptArgument);
+                    commandLine.AppendArgumentIfNotNull(scriptArgument);
                 }
             }
 

--- a/src/Compilers/Core/MSBuildTaskTests/CsiTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CsiTests.cs
@@ -56,12 +56,21 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         }
 
         [Fact]
+        public void ScriptArgumentsNeedQuotes()
+        {
+            var csi = new Csi();
+            csi.Source = MSBuildUtil.CreateTaskItem("test.csx");
+            csi.ScriptArguments = new[] { @"C:\Some Path\Some File.ini", @"C:\Some Path\Some Other File.bak" };
+            Assert.Equal(@"/i- test.csx ""C:\Some Path\Some File.ini"" ""C:\Some Path\Some Other File.bak""", csi.GenerateResponseFileContents());
+        }
+
+        [Fact]
         public void QuotedScriptArguments()
         {
             var csi = new Csi();
             csi.Source = MSBuildUtil.CreateTaskItem("test.csx");
             csi.ScriptArguments = new[] { @"""C:\Some Path\Some File.ini""", @"""C:\Some Path\Some Other File.bak""" };
-            Assert.Equal(@"/i- test.csx ""C:\Some Path\Some File.ini"" ""C:\Some Path\Some Other File.bak""", csi.GenerateResponseFileContents());
+            Assert.Equal(@"/i- test.csx ""\""C:\Some Path\Some File.ini\"""" ""\""C:\Some Path\Some Other File.bak\""""", csi.GenerateResponseFileContents());
         }
 
         [Fact]

--- a/src/Compilers/Core/MSBuildTaskTests/CsiTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CsiTests.cs
@@ -45,5 +45,41 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 Assert.Equal("/i- test.csx", csi.GenerateResponseFileContents());
             }
         }
+
+        [Fact]
+        public void ScriptArguments()
+        {
+            var csi = new Csi();
+            csi.Source = MSBuildUtil.CreateTaskItem("test.csx");
+            csi.ScriptArguments = new[] { "-Arg1", "-Arg2" };
+            Assert.Equal("/i- test.csx -Arg1 -Arg2", csi.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        public void QuotedScriptArguments()
+        {
+            var csi = new Csi();
+            csi.Source = MSBuildUtil.CreateTaskItem("test.csx");
+            csi.ScriptArguments = new[] { @"""C:\Some Path\Some File.ini""", @"""C:\Some Path\Some Other File.bak""" };
+            Assert.Equal(@"/i- test.csx ""C:\Some Path\Some File.ini"" ""C:\Some Path\Some Other File.bak""", csi.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        public void NoScriptArguments()
+        {
+            var csi = new Csi();
+            csi.Source = MSBuildUtil.CreateTaskItem("test.csx");
+            csi.ScriptArguments = null;
+            Assert.Equal(@"/i- test.csx", csi.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        public void EmptyScriptArguments()
+        {
+            var csi = new Csi();
+            csi.Source = MSBuildUtil.CreateTaskItem("test.csx");
+            csi.ScriptArguments = new string[0];
+            Assert.Equal(@"/i- test.csx", csi.GenerateResponseFileContents());
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/17034

/CC  @tmat 