### PR TITLE
include exception type in CommonObjectFormatter for scripting/interactive

### DIFF
--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -1159,7 +1159,7 @@ Console.Write(Task.Run(() => { Thread.CurrentThread.Join(100); return 42; }).Con
 
             Assert.Equal("", output);
             Assert.DoesNotContain("Unexpected", error, StringComparison.OrdinalIgnoreCase);
-            Assert.True(error.StartsWith(new Exception().Message));
+            Assert.True(error.StartsWith($"{new Exception().GetType()}: {new Exception().Message}"));
         }
 
         [Fact, WorkItem(10883, "https://github.com/dotnet/roslyn/issues/10883")]
@@ -1173,7 +1173,7 @@ Console.Write(Task.Run(() => { Thread.CurrentThread.Join(100); return 42; }).Con
             var error = ReadErrorOutputToEnd();
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences("120", output);
-            AssertEx.AssertEqualToleratingWhitespaceDifferences("Bang!", error);
+            AssertEx.AssertEqualToleratingWhitespaceDifferences("System.Exception: Bang!", error);
         }
 
         [Fact]

--- a/src/Scripting/CSharpTest.Desktop/CsiTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/CsiTests.cs
@@ -148,7 +148,7 @@ throw new Exception(""Error!"");
             Assert.True(result.ContainsErrors);
             AssertEx.AssertEqualToleratingWhitespaceDifferences("OK", result.Output);
             AssertEx.AssertEqualToleratingWhitespaceDifferences($@"
-Error!
+System.Exception: Error!
    + <Initialize>.MoveNext(){string.Format(ScriptingResources.AtFileLine, $"{cwd}{Path.DirectorySeparatorChar}a.csx", "2")}
 ", result.Errors);
         }

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -248,6 +248,7 @@ div(10, 0)
 ");
             Assert.Equal(0, runner.RunInteractive());
 
+            var exception = new DivideByZeroException();
             Assert.Equal(
 $@"{LogoAndHelpPrompt}
 > int div(int a, int b) => a/b;
@@ -255,13 +256,13 @@ $@"{LogoAndHelpPrompt}
 5
 > div(10, 0)
 «Red»
-{new System.DivideByZeroException().Message}
+{exception.GetType()}: {exception.Message}
   + Submission#0.div(int, int)
 «Gray»
 > ", runner.Console.Out.ToString());
 
             Assert.Equal(
-$@"{new System.DivideByZeroException().Message}
+$@"{exception.GetType()}: {exception.Message}
   + Submission#0.div(int, int)
 ", runner.Console.Error.ToString());
         }
@@ -276,6 +277,7 @@ C<string>.div<bool>(10, 0)
 ");
             Assert.Equal(0, runner.RunInteractive());
 
+            var exception = new DivideByZeroException();
             Assert.Equal(
 $@"{LogoAndHelpPrompt}
 > static class C<T> {{ public static int div<U>(int a, int b) => a/b; }}
@@ -283,13 +285,13 @@ $@"{LogoAndHelpPrompt}
 5
 > C<string>.div<bool>(10, 0)
 «Red»
-{new System.DivideByZeroException().Message}
+{exception.GetType()}: {exception.Message}
   + Submission#0.C<T>.div<U>(int, int)
 «Gray»
 > ", runner.Console.Out.ToString());
 
             Assert.Equal(
-$@"{new System.DivideByZeroException().Message}
+$@"{exception.GetType()}: {exception.Message}
   + Submission#0.C<T>.div<U>(int, int)
 ", runner.Console.Error.ToString());
         }
@@ -889,7 +891,7 @@ $@"{LogoAndHelpPrompt}
 «Yellow»
 (1,58): warning CS0162: { CSharpResources.WRN_UnreachableCode }
 «Red»
-Bang!
+System.Exception: Bang!
 «Gray»
 > i + j + k
 120
@@ -897,7 +899,7 @@ Bang!
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(
 $@"(1,58): warning CS0162: { CSharpResources.WRN_UnreachableCode }
-Bang!",
+System.Exception: Bang!",
                 runner.Console.Error.ToString());
         }
 

--- a/src/Scripting/Core/Hosting/ObjectFormatter/CommonObjectFormatter.cs
+++ b/src/Scripting/Core/Hosting/ObjectFormatter/CommonObjectFormatter.cs
@@ -65,7 +65,10 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             var pooled = PooledStringBuilder.GetInstance();
             var builder = pooled.Builder;
 
-            builder.AppendLine(e.Message);
+            builder.Append(e.GetType());
+            builder.Append(": ");
+            builder.Append(e.Message);
+            builder.Append(Environment.NewLine);
 
             var trace = new StackTrace(e, fNeedFileInfo: true);
             foreach (var frame in trace.GetFrames())


### PR DESCRIPTION
At the moment the exception formatter swallows the exception type (doesn't show it anywhere in the formatted exception output). 

This works reasonably well for most BCL exceptions, where the exception messages are mostly quite informative. However, for some of BCL types as well as tons of custom/3rd party code exceptions, where exception messages are often not of great quality, this is not ideal. The proposed change includes the exception type in the formatted exception output.

As a result, instead of

```
> string s = null;
> "foo".IndexOf(s)
Value cannot be null.
Parameter name: value
  + string.IndexOf(string, int, int, System.StringComparison)
  + string.IndexOf(string)
```

We now get:

```
> string s = null;
> "foo".IndexOf(s)
System.ArgumentNullException: Value cannot be null.
Parameter name: value
  + string.IndexOf(string, int, int, System.StringComparison)
  + string.IndexOf(string)
```

Here is an example with a custom exception. Instead of

```
>  var processor = new ItemProcessor();
> processor.Process(item);
Error occurred
  + ProcessingEngine.ItemProcessor.Process(object)
```

We now get:

```
> var processor = new ItemProcessor();
> processor.Process(item)
ProcessingEngine.StateValidationException: Error occurred
  + ProcessingEngine.ItemProcessor.Process(object)
```