### PR TITLE
Extract out the AnalyzerConfigDocument related changes from #35691

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -140,7 +140,7 @@ class C
                 var newSln = workspace.CurrentSolution.AddAdditionalDocument(additionalDocId, "add.config", SourceText.From("random text"));
                 currentProject = newSln.Projects.Single();
                 var additionalDocument = currentProject.GetAdditionalDocument(additionalDocId);
-                AdditionalText additionalStream = new AdditionalTextDocument(additionalDocument.State);
+                AdditionalText additionalStream = new AdditionalTextWithState(additionalDocument.State);
                 AnalyzerOptions options = new AnalyzerOptions(ImmutableArray.Create(additionalStream));
                 var analyzer = new OptionsDiagnosticAnalyzer<SyntaxKind>(expectedOptions: options);
 

--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
@@ -860,7 +860,7 @@ class D { }
             using (var workspace = CreateWorkspace())
             {
                 var document = new TestHostDocument("public class C { }");
-                var analyzerConfigDoc = new TestHostDocument("some text");
+                var analyzerConfigDoc = new TestHostDocument("root = true");
                 var project1 = new TestHostProject(workspace, name: "project1", documents: new[] { document }, analyzerConfigDocuments: new[] { analyzerConfigDoc });
 
                 workspace.AddTestProject(project1);
@@ -876,7 +876,7 @@ class D { }
 
                 var analyzerConfigDocument = project.GetAnalyzerConfigDocument(analyzerConfigDoc.Id);
 
-                Assert.Equal("some text", (await analyzerConfigDocument.GetTextAsync()).ToString());
+                Assert.Equal("root = true", (await analyzerConfigDocument.GetTextAsync()).ToString());
             }
         }
 
@@ -919,8 +919,8 @@ class D { }
         {
             using (var workspace = CreateWorkspace())
             {
-                var startText = @"<setting value = ""goo""";
-                var newText = @"<setting value = ""goo1""";
+                var startText = @"root = true";
+                var newText = @"root = false";
                 var document = new TestHostDocument("public class C { }");
                 var analyzerConfigPath = PathUtilities.CombineAbsoluteAndRelativePaths(Temp.CreateDirectory().Path, ".editorconfig");
                 var analyzerConfigDoc = new TestHostDocument(startText, filePath: analyzerConfigPath);
@@ -989,7 +989,7 @@ class D { }
         {
             using (var workspace = CreateWorkspace())
             {
-                var startText = @"<setting value = ""goo""";
+                var startText = @"root = true";
                 var document = new TestHostDocument("public class C { }");
                 var analyzerConfigDoc = new TestHostDocument(startText);
                 var project1 = new TestHostProject(workspace, name: "project1", documents: new[] { document }, analyzerConfigDocuments: new[] { analyzerConfigDoc });
@@ -1062,7 +1062,7 @@ class D { }
         {
             using (var workspace = CreateWorkspace())
             {
-                var startText = @"<setting value = ""goo""";
+                var startText = @"root = true";
                 var document = new TestHostDocument("public class C { }");
                 var analyzerConfigDoc = new TestHostDocument(startText, "original.config");
                 var project1 = new TestHostProject(workspace, name: "project1", documents: new[] { document }, analyzerConfigDocuments: new[] { analyzerConfigDoc });
@@ -1130,7 +1130,7 @@ class D { }
         {
             using (var workspace = CreateWorkspace())
             {
-                var startText = @"<setting value = ""goo""";
+                var startText = @"root = true";
                 var document = new TestHostDocument("public class C { }");
                 var analyzerConfigDoc = new TestHostDocument(startText, "original.config");
                 var project1 = new TestHostProject(workspace, name: "project1", documents: new[] { document }, analyzerConfigDocuments: new[] { analyzerConfigDoc });
@@ -1184,7 +1184,7 @@ class D { }
                 const string docFilePath = "filePath1";
                 var document = new TestHostDocument("public class C { }", filePath: docFilePath);
                 var analyzerConfigDocFilePath = PathUtilities.CombineAbsoluteAndRelativePaths(Temp.CreateDirectory().Path, ".editorconfig");
-                var analyzerConfigDoc = new TestHostDocument(@"<setting value = ""goo""", filePath: analyzerConfigDocFilePath);
+                var analyzerConfigDoc = new TestHostDocument(@"root = true", filePath: analyzerConfigDocFilePath);
                 var project1 = new TestHostProject(workspace, name: "project1", documents: new[] { document }, analyzerConfigDocuments: new[] { analyzerConfigDoc });
                 workspace.AddTestProject(project1);
 

--- a/src/EditorFeatures/Core.Wpf/Preview/PreviewFactoryService.cs
+++ b/src/EditorFeatures/Core.Wpf/Preview/PreviewFactoryService.cs
@@ -497,6 +497,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
                 leftWorkspace, rightWorkspace, zoomLevel, cancellationToken);
         }
 
+        // NOTE: We are only sharing this code between additional documents and analyzer config documents,
+        // which are essentially plain text documents. Regular source documents need special handling
+        // and hence have a different implementation.
         private Task<object> CreateChangedAdditionalOrAnalyzerConfigDocumentPreviewViewAsync(
             TextDocument oldDocument,
             TextDocument newDocument,

--- a/src/EditorFeatures/Core.Wpf/Preview/PreviewFactoryService.cs
+++ b/src/EditorFeatures/Core.Wpf/Preview/PreviewFactoryService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -496,7 +497,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
                 leftWorkspace, rightWorkspace, zoomLevel, cancellationToken);
         }
 
-        public Task<object> CreateChangedAdditionalOrAnalyzerConfigDocumentPreviewViewAsync(
+        private Task<object> CreateChangedAdditionalOrAnalyzerConfigDocumentPreviewViewAsync(
             TextDocument oldDocument,
             TextDocument newDocument,
             double zoomLevel,
@@ -506,6 +507,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
             Action<Workspace, DocumentId> openTextDocument,
             CancellationToken cancellationToken)
         {
+            Debug.Assert(oldDocument.Kind == TextDocumentKind.AdditionalDocument || oldDocument.Kind == TextDocumentKind.AnalyzerConfigDocument);
+
             cancellationToken.ThrowIfCancellationRequested();
 
             // Note: We don't use the original buffer that is associated with oldDocument

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -214,11 +214,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
             if (projectChange.GetAddedAdditionalDocuments().Any() ||
                 projectChange.GetAddedAnalyzerReferences().Any() ||
                 projectChange.GetAddedDocuments().Any() ||
+                projectChange.GetAddedAnalyzerConfigDocuments().Any() ||
                 projectChange.GetAddedMetadataReferences().Any() ||
                 projectChange.GetAddedProjectReferences().Any() ||
                 projectChange.GetRemovedAdditionalDocuments().Any() ||
                 projectChange.GetRemovedAnalyzerReferences().Any() ||
                 projectChange.GetRemovedDocuments().Any() ||
+                projectChange.GetRemovedAnalyzerConfigDocuments().Any() ||
                 projectChange.GetRemovedMetadataReferences().Any() ||
                 projectChange.GetRemovedProjectReferences().Any())
             {
@@ -227,21 +229,32 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
 
             var changedAdditionalDocuments = projectChange.GetChangedAdditionalDocuments().ToImmutableArray();
             var changedDocuments = projectChange.GetChangedDocuments().ToImmutableArray();
+            var changedAnalyzerConfigDocuments = projectChange.GetChangedAnalyzerConfigDocuments().ToImmutableArray();
 
-            if (changedAdditionalDocuments.Length + changedDocuments.Length != 1)
+            if (changedAdditionalDocuments.Length + changedDocuments.Length + changedAnalyzerConfigDocuments.Length != 1)
             {
                 return null;
             }
 
             if (changedDocuments.Any(id => newSolution.GetDocument(id).HasInfoChanged(oldSolution.GetDocument(id))) ||
-                changedAdditionalDocuments.Any(id => newSolution.GetAdditionalDocument(id).HasInfoChanged(oldSolution.GetAdditionalDocument(id))))
+                changedAdditionalDocuments.Any(id => newSolution.GetAdditionalDocument(id).HasInfoChanged(oldSolution.GetAdditionalDocument(id))) ||
+                changedAnalyzerConfigDocuments.Any(id => newSolution.GetAnalyzerConfigDocument(id).HasInfoChanged(oldSolution.GetAnalyzerConfigDocument(id))))
             {
                 return null;
             }
 
-            return changedDocuments.Length == 1
-                ? oldSolution.GetDocument(changedDocuments[0])
-                : oldSolution.GetAdditionalDocument(changedAdditionalDocuments[0]);
+            if (changedDocuments.Length == 1)
+            {
+                return oldSolution.GetDocument(changedDocuments[0]);
+            }
+            else if (changedAdditionalDocuments.Length == 1)
+            {
+                return oldSolution.GetAdditionalDocument(changedAdditionalDocuments[0]);
+            }
+            else
+            {
+                return oldSolution.GetAnalyzerConfigDocument(changedAnalyzerConfigDocuments[0]);
+            }
         }
 
         private static void ProcessOperations(

--- a/src/EditorFeatures/Core/Implementation/SolutionChangeSummary.cs
+++ b/src/EditorFeatures/Core/Implementation/SolutionChangeSummary.cs
@@ -26,10 +26,14 @@ namespace Microsoft.CodeAnalysis.Editor
                                       p.GetRemovedDocuments().Count() +
                                       p.GetAddedAdditionalDocuments().Count() +
                                       p.GetChangedAdditionalDocuments().Count() +
-                                      p.GetRemovedAdditionalDocuments().Count();
+                                      p.GetRemovedAdditionalDocuments().Count() +
+                                      p.GetAddedAnalyzerConfigDocuments().Count() +
+                                      p.GetChangedAnalyzerConfigDocuments().Count() +
+                                      p.GetRemovedAnalyzerConfigDocuments().Count();
 
                 if (p.GetAddedDocuments().Any() || p.GetRemovedDocuments().Any() ||
                     p.GetAddedAdditionalDocuments().Any() || p.GetRemovedAdditionalDocuments().Any() ||
+                    p.GetAddedAnalyzerConfigDocuments().Any() || p.GetRemovedAnalyzerConfigDocuments().Any() ||
                     p.GetAddedMetadataReferences().Any() || p.GetRemovedMetadataReferences().Any() ||
                     p.GetAddedProjectReferences().Any() || p.GetRemovedProjectReferences().Any() ||
                     p.GetAddedAnalyzerReferences().Any() || p.GetRemovedAnalyzerReferences().Any())

--- a/src/EditorFeatures/Core/Shared/Preview/PreviewWorkspace.cs
+++ b/src/EditorFeatures/Core/Shared/Preview/PreviewWorkspace.cs
@@ -68,6 +68,14 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
             this.OnAdditionalDocumentOpened(documentId, text.Container);
         }
 
+        public override void OpenAnalyzerConfigDocument(DocumentId documentId, bool activate = true)
+        {
+            var document = this.CurrentSolution.GetAnalyzerConfigDocument(documentId);
+            var text = document.GetTextSynchronously(CancellationToken.None);
+
+            this.OnAnalyzerConfigDocumentOpened(documentId, text.Container);
+        }
+
         public override void CloseDocument(DocumentId documentId)
         {
             var document = this.CurrentSolution.GetDocument(documentId);
@@ -84,6 +92,15 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
             var version = document.GetTextVersionSynchronously(CancellationToken.None);
 
             this.OnAdditionalDocumentClosed(documentId, TextLoader.From(TextAndVersion.Create(text, version)));
+        }
+
+        public override void CloseAnalyzerConfigDocument(DocumentId documentId)
+        {
+            var document = this.CurrentSolution.GetAnalyzerConfigDocument(documentId);
+            var text = document.GetTextSynchronously(CancellationToken.None);
+            var version = document.GetTextVersionSynchronously(CancellationToken.None);
+
+            this.OnAnalyzerConfigDocumentClosed(documentId, TextLoader.From(TextAndVersion.Create(text, version)));
         }
 
         protected override void Dispose(bool finalize)

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestHostProject.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestHostProject.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         public IEnumerable<TestHostDocument> Documents;
         public IEnumerable<TestHostDocument> AdditionalDocuments;
+        public IEnumerable<TestHostDocument> AnalyzerConfigDocuments;
         public IEnumerable<ProjectReference> ProjectReferences;
 
         public string Name
@@ -166,6 +167,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             IList<MetadataReference> references,
             IList<TestHostDocument> documents,
             IList<TestHostDocument> additionalDocuments = null,
+            IList<TestHostDocument> analyzerConfigDocuments = null,
             Type hostObjectType = null,
             bool isSubmission = false,
             string filePath = null,
@@ -182,6 +184,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             _analyzerReferences = analyzerReferences ?? SpecializedCollections.EmptyEnumerable<AnalyzerReference>();
             this.Documents = documents;
             this.AdditionalDocuments = additionalDocuments ?? SpecializedCollections.EmptyEnumerable<TestHostDocument>();
+            this.AnalyzerConfigDocuments = analyzerConfigDocuments ?? SpecializedCollections.EmptyEnumerable<TestHostDocument>();
             ProjectReferences = SpecializedCollections.EmptyEnumerable<ProjectReference>();
             _isSubmission = isSubmission;
             _hostObjectType = hostObjectType;
@@ -203,7 +206,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             IEnumerable<AnalyzerReference> analyzerReferences = null,
             string assemblyName = null,
             string defaultNamespace = null)
-            : this(workspace, name, language, compilationOptions, parseOptions, SpecializedCollections.SingletonEnumerable(document), SpecializedCollections.EmptyEnumerable<TestHostDocument>(), projectReferences, metadataReferences, analyzerReferences, assemblyName, defaultNamespace)
+            : this(workspace, name, language, compilationOptions, parseOptions, SpecializedCollections.SingletonEnumerable(document), SpecializedCollections.EmptyEnumerable<TestHostDocument>(), SpecializedCollections.EmptyEnumerable<TestHostDocument>(), projectReferences, metadataReferences, analyzerReferences, assemblyName, defaultNamespace)
         {
         }
 
@@ -215,6 +218,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             ParseOptions parseOptions = null,
             IEnumerable<TestHostDocument> documents = null,
             IEnumerable<TestHostDocument> additionalDocuments = null,
+            IEnumerable<TestHostDocument> analyzerConfigDocuments = null,
             IEnumerable<TestHostProject> projectReferences = null,
             IEnumerable<MetadataReference> metadataReferences = null,
             IEnumerable<AnalyzerReference> analyzerReferences = null,
@@ -232,6 +236,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             _parseOptions = parseOptions ?? this.LanguageServiceProvider.GetService<ISyntaxTreeFactoryService>().GetDefaultParseOptions();
             this.Documents = documents ?? SpecializedCollections.EmptyEnumerable<TestHostDocument>();
             this.AdditionalDocuments = additionalDocuments ?? SpecializedCollections.EmptyEnumerable<TestHostDocument>();
+            this.AnalyzerConfigDocuments = analyzerConfigDocuments ?? SpecializedCollections.EmptyEnumerable<TestHostDocument>();
             ProjectReferences = projectReferences != null ? projectReferences.Select(p => new ProjectReference(p.Id)) : SpecializedCollections.EmptyEnumerable<ProjectReference>();
             _metadataReferences = metadataReferences ?? new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib };
             _analyzerReferences = analyzerReferences ?? SpecializedCollections.EmptyEnumerable<AnalyzerReference>();
@@ -255,6 +260,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                     doc.SetProject(this);
                 }
             }
+
+            if (analyzerConfigDocuments != null)
+            {
+                foreach (var doc in analyzerConfigDocuments)
+                {
+                    doc.SetProject(this);
+                }
+            }
         }
 
         internal void SetSolution(TestHostSolution solution)
@@ -268,6 +281,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 }
 
                 foreach (var doc in this.AdditionalDocuments)
+                {
+                    doc.SetProject(this);
+                }
+
+                foreach (var doc in this.AnalyzerConfigDocuments)
                 {
                     doc.SetProject(this);
                 }
@@ -296,6 +314,17 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             this.AdditionalDocuments = this.AdditionalDocuments.Where(d => d != document);
         }
 
+        internal void AddAnalyzerConfigDocument(TestHostDocument document)
+        {
+            this.AnalyzerConfigDocuments = this.AnalyzerConfigDocuments.Concat(new TestHostDocument[] { document });
+            document.SetProject(this);
+        }
+
+        internal void RemoveAnalyzerConfigDocument(TestHostDocument document)
+        {
+            this.AnalyzerConfigDocuments = this.AnalyzerConfigDocuments.Where(d => d != document);
+        }
+
         public string Language
         {
             get
@@ -322,6 +351,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 this.Language,
                 this.FilePath,
                 this.OutputFilePath,
+                outputRefFilePath: null,
+                defaultNamespace: null,
                 this.CompilationOptions,
                 this.ParseOptions,
                 this.Documents.Select(d => d.ToDocumentInfo()),
@@ -329,8 +360,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 this.MetadataReferences,
                 this.AnalyzerReferences,
                 this.AdditionalDocuments.Select(d => d.ToDocumentInfo()),
+                this.AnalyzerConfigDocuments.Select(d => d.ToDocumentInfo()),
                 this.IsSubmission,
-                this.HostObjectType)
+                this.HostObjectType,
+                hasAllInformation: true)
                 .WithDefaultNamespace(this.DefaultNamespace);
         }
 

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public IList<TestHostProject> Projects { get; }
         public IList<TestHostDocument> Documents { get; }
         public IList<TestHostDocument> AdditionalDocuments { get; }
+        public IList<TestHostDocument> AnalyzerConfigDocuments { get; }
         public IList<TestHostDocument> ProjectionDocuments { get; }
 
         private readonly BackgroundCompiler _backgroundCompiler;
@@ -52,6 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             this.Projects = new List<TestHostProject>();
             this.Documents = new List<TestHostDocument>();
             this.AdditionalDocuments = new List<TestHostDocument>();
+            this.AnalyzerConfigDocuments = new List<TestHostDocument>();
             this.ProjectionDocuments = new List<TestHostDocument>();
 
             this.CanApplyChangeDocument = true;
@@ -108,6 +110,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 document.CloseTextView();
             }
 
+            foreach (var document in AnalyzerConfigDocuments)
+            {
+                document.CloseTextView();
+            }
+
             foreach (var document in ProjectionDocuments)
             {
                 document.CloseTextView();
@@ -157,6 +164,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 {
                     this.AdditionalDocuments.Add(doc);
                 }
+
+                foreach (var doc in project.AnalyzerConfigDocuments)
+                {
+                    this.AnalyzerConfigDocuments.Add(doc);
+                }
             }
 
             this.OnProjectAdded(project.ToProjectInfo());
@@ -204,7 +216,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         public DocumentId GetDocumentId(TestHostDocument hostDocument)
         {
-            if (!Documents.Contains(hostDocument) && !AdditionalDocuments.Contains(hostDocument))
+            if (!Documents.Contains(hostDocument) &&
+                !AdditionalDocuments.Contains(hostDocument) &&
+                !AnalyzerConfigDocuments.Contains(hostDocument))
             {
                 return null;
             }
@@ -220,6 +234,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public TestHostDocument GetTestAdditionalDocument(DocumentId documentId)
         {
             return this.AdditionalDocuments.FirstOrDefault(d => d.Id == documentId);
+        }
+
+        public TestHostDocument GetTestAnalyzerConfigDocument(DocumentId documentId)
+        {
+            return this.AnalyzerConfigDocuments.FirstOrDefault(d => d.Id == documentId);
         }
 
         public TestHostProject GetTestProject(DocumentId documentId)
@@ -245,10 +264,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 case ApplyChangesKind.RemoveDocument:
                 case ApplyChangesKind.AddAdditionalDocument:
                 case ApplyChangesKind.RemoveAdditionalDocument:
+                case ApplyChangesKind.AddAnalyzerConfigDocument:
+                case ApplyChangesKind.RemoveAnalyzerConfigDocument:
                     return true;
 
                 case ApplyChangesKind.ChangeDocument:
                 case ApplyChangesKind.ChangeAdditionalDocument:
+                case ApplyChangesKind.ChangeAnalyzerConfigDocument:
                     return this.CanApplyChangeDocument;
 
                 case ApplyChangesKind.AddProjectReference:
@@ -304,6 +326,28 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var hostDocument = this.GetTestAdditionalDocument(documentId);
             hostProject.RemoveAdditionalDocument(hostDocument);
             this.OnAdditionalDocumentRemoved(documentId);
+        }
+
+        protected override void ApplyAnalyzerConfigDocumentTextChanged(DocumentId document, SourceText newText)
+        {
+            var testDocument = this.GetTestAnalyzerConfigDocument(document);
+            testDocument.Update(newText);
+        }
+
+        protected override void ApplyAnalyzerConfigDocumentAdded(DocumentInfo info, SourceText text)
+        {
+            var hostProject = this.GetTestProject(info.Id.ProjectId);
+            var hostDocument = new TestHostDocument(text.ToString(), info.Name, id: info.Id);
+            hostProject.AddAnalyzerConfigDocument(hostDocument);
+            this.OnAnalyzerConfigDocumentAdded(hostDocument.ToDocumentInfo());
+        }
+
+        protected override void ApplyAnalyzerConfigDocumentRemoved(DocumentId documentId)
+        {
+            var hostProject = this.GetTestProject(documentId.ProjectId);
+            var hostDocument = this.GetTestAnalyzerConfigDocument(documentId);
+            hostProject.RemoveAnalyzerConfigDocument(hostDocument);
+            this.OnAnalyzerConfigDocumentRemoved(documentId);
         }
 
         internal override void SetDocumentContext(DocumentId documentId)
@@ -605,6 +649,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var newSolution = this.SetCurrentSolution(oldSolution.WithAdditionalDocumentText(documentId, text));
 
             this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.AdditionalDocumentChanged, oldSolution, newSolution, documentId.ProjectId, documentId);
+        }
+
+        public void ChangeAnalyzerConfigDocument(DocumentId documentId, SourceText text)
+        {
+            var oldSolution = this.CurrentSolution;
+            var newSolution = this.SetCurrentSolution(oldSolution.WithAnalyzerConfigDocumentText(documentId, text));
+
+            this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.AnalyzerConfigDocumentChanged, oldSolution, newSolution, documentId.ProjectId, documentId);
         }
 
         public void ChangeProject(ProjectId projectId, Solution solution)

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
@@ -37,6 +37,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         private const string FeaturesAttributeName = "Features";
         private const string DocumentationModeAttributeName = "DocumentationMode";
         private const string DocumentElementName = "Document";
+        private const string AdditionalDocumentElementName = "AdditionalDocument";
+        private const string AnalyzerConfigDocumentElementName = "AnalyzerConfigDocument";
         private const string AnalyzerElementName = "Analyzer";
         private const string AssemblyNameAttributeName = "AssemblyName";
         private const string CommonReferencesAttributeName = "CommonReferences";

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
@@ -92,7 +92,7 @@ End Class
             currentProject = newSln.Projects.Single()
             Dim additionalDocument = currentProject.GetAdditionalDocument(additionalDocId)
 
-            Dim additionalStream As AdditionalText = New AdditionalTextDocument(additionalDocument.State)
+            Dim additionalStream As AdditionalText = New AdditionalTextWithState(additionalDocument.State)
             Dim options = New AnalyzerOptions(ImmutableArray.Create(additionalStream))
             Dim analyzer = New OptionsDiagnosticAnalyzer(Of SyntaxKind)(expectedOptions:=options)
 

--- a/src/VisualStudio/Core/Def/Implementation/Preview/FileChange.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/FileChange.cs
@@ -210,7 +210,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
             return _right.WithText(UpdateBufferText());
         }
 
-        public bool IsAdditionalDocumentChange => !((_left ?? _right) is Document);
+        public bool IsAdditionalDocumentChange => !((_left ?? _right) is Document) && !IsAnalyzerConfigDocumentChange;
+        public bool IsAnalyzerConfigDocumentChange => (_left ?? _right) is AnalyzerConfigDocument;
 
         internal override void GetDisplayData(VSTREEDISPLAYDATA[] pData)
         {

--- a/src/VisualStudio/Core/Def/Implementation/Preview/FileChange.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/FileChange.cs
@@ -210,8 +210,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
             return _right.WithText(UpdateBufferText());
         }
 
-        public bool IsAdditionalDocumentChange => !((_left ?? _right) is Document) && !IsAnalyzerConfigDocumentChange;
-        public bool IsAnalyzerConfigDocumentChange => (_left ?? _right) is AnalyzerConfigDocument;
+        public TextDocumentKind ChangedDocumentKind => (_left ?? _right).Kind;
 
         internal override void GetDisplayData(VSTREEDISPLAYDATA[] pData)
         {

--- a/src/VisualStudio/Core/Def/Implementation/Preview/FileChange.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/FileChange.cs
@@ -210,6 +210,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
             return _right.WithText(UpdateBufferText());
         }
 
+        // Note that either _left or _right *must* be non-null (we are either adding, removing or changing a file).
         public TextDocumentKind ChangedDocumentKind => (_left ?? _right).Kind;
 
         internal override void GetDisplayData(VSTREEDISPLAYDATA[] pData)

--- a/src/VisualStudio/Core/Def/Implementation/Preview/PreviewEngine.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/PreviewEngine.cs
@@ -133,6 +133,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
             allDocumentsWithChanges.AddRange(addedAdditionalDocuments);
             allDocumentsWithChanges.AddRange(removedAdditionalDocuments);
 
+            // AnalyzerConfig Documents
+            var changedAnalyzerConfigDocuments = projectChanges.SelectMany(p => p.GetChangedAnalyzerConfigDocuments());
+            var addedAnalyzerConfigDocuments = projectChanges.SelectMany(p => p.GetAddedAnalyzerConfigDocuments());
+            var removedAnalyzerConfigDocuments = projectChanges.SelectMany(p => p.GetRemovedAnalyzerConfigDocuments());
+
+            allDocumentsWithChanges.AddRange(changedAnalyzerConfigDocuments);
+            allDocumentsWithChanges.AddRange(addedAnalyzerConfigDocuments);
+            allDocumentsWithChanges.AddRange(removedAnalyzerConfigDocuments);
+
             AppendFileChanges(allDocumentsWithChanges, builder);
 
             // References (metadata/project/analyzer)

--- a/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
@@ -25,25 +25,37 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
 
             public void CloseDocument(TextDocument document, SourceText text)
             {
-                if (document is Document)
+                switch (document)
                 {
-                    OnDocumentClosed(document.Id, new PreviewTextLoader(text));
-                }
-                else
-                {
-                    OnAdditionalDocumentClosed(document.Id, new PreviewTextLoader(text));
+                    case Document _:
+                        OnDocumentClosed(document.Id, new PreviewTextLoader(text));
+                        break;
+
+                    case AnalyzerConfigDocument _:
+                        OnAnalyzerConfigDocumentClosed(document.Id, new PreviewTextLoader(text));
+                        break;
+
+                    default:
+                        OnAdditionalDocumentClosed(document.Id, new PreviewTextLoader(text));
+                        break;
                 }
             }
 
             public void OpenDocument(TextDocument document)
             {
-                if (document is Document)
+                switch (document)
                 {
-                    OpenDocument(document.Id);
-                }
-                else
-                {
-                    OpenAdditionalDocument(document.Id);
+                    case Document _:
+                        OpenDocument(document.Id);
+                        break;
+
+                    case AnalyzerConfigDocument _:
+                        OpenAnalyzerConfigDocument(document.Id);
+                        break;
+
+                    default:
+                        OpenAdditionalDocument(document.Id);
+                        break;
                 }
             }
 
@@ -55,6 +67,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
             protected override void ApplyAdditionalDocumentTextChanged(DocumentId id, SourceText text)
             {
                 OnAdditionalDocumentTextChanged(id, text, PreservationMode.PreserveIdentity);
+            }
+
+            protected override void ApplyAnalyzerConfigDocumentTextChanged(DocumentId id, SourceText text)
+            {
+                OnAnalyzerConfigDocumentTextChanged(id, text, PreservationMode.PreserveIdentity);
             }
 
             private class PreviewTextLoader : TextLoader

--- a/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Preview;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
 {
@@ -25,37 +26,43 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
 
             public void CloseDocument(TextDocument document, SourceText text)
             {
-                switch (document)
+                switch (document.Kind)
                 {
-                    case Document _:
+                    case TextDocumentKind.Document:
                         OnDocumentClosed(document.Id, new PreviewTextLoader(text));
                         break;
 
-                    case AnalyzerConfigDocument _:
+                    case TextDocumentKind.AnalyzerConfigDocument:
                         OnAnalyzerConfigDocumentClosed(document.Id, new PreviewTextLoader(text));
                         break;
 
-                    default:
+                    case TextDocumentKind.AdditionalDocument:
                         OnAdditionalDocumentClosed(document.Id, new PreviewTextLoader(text));
                         break;
+
+                    default:
+                        throw ExceptionUtilities.Unreachable;
                 }
             }
 
             public void OpenDocument(TextDocument document)
             {
-                switch (document)
+                switch (document.Kind)
                 {
-                    case Document _:
+                    case TextDocumentKind.Document:
                         OpenDocument(document.Id);
                         break;
 
-                    case AnalyzerConfigDocument _:
+                    case TextDocumentKind.AnalyzerConfigDocument:
                         OpenAnalyzerConfigDocument(document.Id);
                         break;
 
-                    default:
+                    case TextDocumentKind.AdditionalDocument:
                         OpenAdditionalDocument(document.Id);
                         break;
+
+                    default:
+                        throw ExceptionUtilities.Unreachable;
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.PreviewDialogWorkspace.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                         break;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(document.Kind);
                 }
             }
 
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                         break;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(document.Kind);
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Preview/TopLevelChange.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/TopLevelChange.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
@@ -82,7 +83,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
 
                 // Apply file change to document.
                 ApplyFileChangesCore(oldTextDocument, updatedTextDocument?.Id, updatedDocumentTextOpt,
-                    fileChange.CheckState, fileChange.IsAdditionalDocumentChange, fileChange.IsAnalyzerConfigDocumentChange);
+                    fileChange.CheckState, fileChange.ChangedDocumentKind);
 
                 // Now apply file change to linked documents.
                 if (oldTextDocument is Document oldDocument)
@@ -95,7 +96,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                         var newLinkedDocumentIdOpt = updatedDocumentTextOpt != null ? oldLinkedDocument.Id : null;
 
                         ApplyFileChangesCore(oldLinkedDocument, newLinkedDocumentIdOpt, updatedDocumentTextOpt,
-                            fileChange.CheckState, fileChange.IsAdditionalDocumentChange, fileChange.IsAnalyzerConfigDocumentChange);
+                            fileChange.CheckState, fileChange.ChangedDocumentKind);
                     }
                 }
                 else if (updatedTextDocument is Document updatedDocument)
@@ -103,7 +104,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                     foreach (var newLinkedDocumentId in updatedDocument.GetLinkedDocumentIds())
                     {
                         ApplyFileChangesCore(oldTextDocument, newLinkedDocumentId, updatedDocumentTextOpt,
-                            fileChange.CheckState, fileChange.IsAdditionalDocumentChange, fileChange.IsAnalyzerConfigDocumentChange);
+                            fileChange.CheckState, fileChange.ChangedDocumentKind);
                     }
                 }
             }
@@ -116,12 +117,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                 DocumentId updatedDocumentIdOpt,
                 SourceText updateDocumentTextOpt,
                 __PREVIEWCHANGESITEMCHECKSTATE checkState,
-                bool isAdditionalDoc,
-                bool isAnalyzerConfigDoc)
+                TextDocumentKind changedDocumentKind)
             {
                 Debug.Assert(oldDocument != null || updatedDocumentIdOpt != null);
                 Debug.Assert((updatedDocumentIdOpt != null) == (updateDocumentTextOpt != null));
-                Debug.Assert(!(isAdditionalDoc && isAnalyzerConfigDoc));
 
                 if (oldDocument == null)
                 {
@@ -129,11 +128,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                     // If unchecked, then remove this added document from new solution.
                     if (applyingChanges && checkState == __PREVIEWCHANGESITEMCHECKSTATE.PCCS_Unchecked)
                     {
-                        solution = isAdditionalDoc ?
-                            solution.RemoveAdditionalDocument(updatedDocumentIdOpt) :
-                            isAnalyzerConfigDoc ?
-                            solution.RemoveAnalyzerConfigDocument(updatedDocumentIdOpt) :
-                            solution.RemoveDocument(updatedDocumentIdOpt);
+                        switch (changedDocumentKind)
+                        {
+                            case TextDocumentKind.Document:
+                                solution = solution.RemoveDocument(updatedDocumentIdOpt);
+                                break;
+
+                            case TextDocumentKind.AnalyzerConfigDocument:
+                                solution = solution.RemoveAnalyzerConfigDocument(updatedDocumentIdOpt);
+                                break;
+
+                            case TextDocumentKind.AdditionalDocument:
+                                solution = solution.RemoveAdditionalDocument(updatedDocumentIdOpt);
+                                break;
+
+                            default:
+                                throw ExceptionUtilities.Unreachable;
+                        }
                     }
                 }
                 else if (updatedDocumentIdOpt == null)
@@ -143,11 +154,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                     if (applyingChanges && checkState == __PREVIEWCHANGESITEMCHECKSTATE.PCCS_Unchecked)
                     {
                         var oldText = oldDocument.GetTextAsync().Result.ToString();
-                        solution = isAdditionalDoc ?
-                            solution.AddAdditionalDocument(oldDocument.Id, oldDocument.Name, oldText, oldDocument.Folders, oldDocument.FilePath) :
-                            isAnalyzerConfigDoc ?
-                            solution.AddAnalyzerConfigDocument(oldDocument.Id, oldDocument.Name, SourceText.From(oldText), oldDocument.Folders, oldDocument.FilePath) :
-                            solution.AddDocument(oldDocument.Id, oldDocument.Name, oldText, oldDocument.Folders, oldDocument.FilePath);
+
+                        switch (changedDocumentKind)
+                        {
+                            case TextDocumentKind.Document:
+                                solution = solution.AddDocument(oldDocument.Id, oldDocument.Name, oldText, oldDocument.Folders, oldDocument.FilePath);
+                                break;
+
+                            case TextDocumentKind.AnalyzerConfigDocument:
+                                solution = solution.AddAnalyzerConfigDocument(oldDocument.Id, oldDocument.Name, SourceText.From(oldText), oldDocument.Folders, oldDocument.FilePath);
+                                break;
+
+                            case TextDocumentKind.AdditionalDocument:
+                                solution = solution.AddAdditionalDocument(oldDocument.Id, oldDocument.Name, oldText, oldDocument.Folders, oldDocument.FilePath);
+                                break;
+
+                            default:
+                                throw ExceptionUtilities.Unreachable;
+                        }
                     }
                 }
                 else
@@ -155,11 +179,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                     Debug.Assert(oldDocument.Id == updatedDocumentIdOpt);
 
                     // Changed document.
-                    solution = isAdditionalDoc ?
-                        solution.WithAdditionalDocumentText(updatedDocumentIdOpt, updateDocumentTextOpt) :
-                        isAnalyzerConfigDoc ?
-                        solution.WithAnalyzerConfigDocumentText(updatedDocumentIdOpt, updateDocumentTextOpt) :
-                        solution.WithDocumentText(updatedDocumentIdOpt, updateDocumentTextOpt);
+                    solution = solution.WithTextDocumentText(updatedDocumentIdOpt, updateDocumentTextOpt, mode: PreservationMode.PreserveValue);
                 }
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/Preview/TopLevelChange.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/TopLevelChange.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                                 break;
 
                             default:
-                                throw ExceptionUtilities.Unreachable;
+                                throw ExceptionUtilities.UnexpectedValue(changedDocumentKind);
                         }
                     }
                 }
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                                 break;
 
                             default:
-                                throw ExceptionUtilities.Unreachable;
+                                throw ExceptionUtilities.UnexpectedValue(changedDocumentKind);
                         }
                     }
                 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -526,6 +526,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     _workspace.ApplyChangeToWorkspace(w => w.OnAdditionalDocumentOpened(documentId, textContainer));
                 }
 
+                foreach (var (documentId, textContainer) in analyzerConfigDocumentsToOpen)
+                {
+                    _workspace.ApplyChangeToWorkspace(w => w.OnAnalyzerConfigDocumentOpened(documentId, textContainer));
+                }
+
                 // Check for those files being opened to start wire-up if necessary
                 _workspace.QueueCheckForFilesBeingOpen(documentFileNamesAdded.ToImmutable());
             }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspace.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser.Lists;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -84,11 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServices
         internal abstract Guid GetProjectGuid(ProjectId projectId);
 
         public virtual string GetFilePath(DocumentId documentId)
-        {
-            var solution = CurrentSolution;
-
-            return (solution.GetDocument(documentId) ?? solution.GetAdditionalDocument(documentId))?.FilePath;
-        }
+            => CurrentSolution.GetTextDocument(documentId)?.FilePath;
 
         /// <summary>
         /// Given a document id, opens an invisible editor for the document.

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.AddAnalyzerConfigDocumentUndoUnit.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.AddAnalyzerConfigDocumentUndoUnit.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+{
+    internal partial class VisualStudioWorkspaceImpl
+    {
+        private class AddAnalyzerConfigDocumentUndoUnit : AbstractAddDocumentUndoUnit
+        {
+            public AddAnalyzerConfigDocumentUndoUnit(
+                VisualStudioWorkspaceImpl workspace,
+                DocumentInfo docInfo,
+                SourceText text)
+                : base(workspace, docInfo, text)
+            {
+            }
+
+            protected override Project AddDocument(Project fromProject)
+                => fromProject.AddAnalyzerConfigDocument(DocumentInfo.Name, Text, DocumentInfo.Folders, DocumentInfo.FilePath).Project;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.OpenFileTracker.cs
@@ -191,10 +191,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                                     }
                                     else
                                     {
-                                        // TODO: implement the ability for analyze config documents to be opened against
-                                        // a live text editor. This is tracked by
-                                        // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/750120
                                         Debug.Assert(w.CurrentSolution.ContainsAnalyzerConfigDocument(documentId));
+                                        w.OnAnalyzerConfigDocumentOpened(documentId, textContainer, isCurrentContext);
                                     }
                                 }
                             }
@@ -366,10 +364,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                             }
                             else
                             {
-                                // TODO: implement the ability for analyze config documents to be opened against
-                                // a live text editor. This is tracked by
-                                // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/750120
                                 Debug.Assert(w.CurrentSolution.ContainsAnalyzerConfigDocument(documentId));
+                                w.OnAnalyzerConfigDocumentClosed(documentId, new FileTextLoader(moniker, defaultEncoding: null));
                             }
                         }
                     }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.RemoveAnalyzerConfigDocumentUndoUnit.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.RemoveAnalyzerConfigDocumentUndoUnit.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+{
+    internal partial class VisualStudioWorkspaceImpl
+    {
+        private class RemoveAnalyzerConfigDocumentUndoUnit : AbstractRemoveDocumentUndoUnit
+        {
+            public RemoveAnalyzerConfigDocumentUndoUnit(
+                VisualStudioWorkspaceImpl workspace,
+                DocumentId documentId)
+                : base(workspace, documentId)
+            {
+            }
+
+            protected override IReadOnlyList<DocumentId> GetDocumentIds(Project fromProject)
+                => fromProject.State.AnalyzerConfigDocumentIds.AsImmutable();
+
+            protected override TextDocument GetDocument(Solution currentSolution)
+                => currentSolution.GetAnalyzerConfigDocument(this.DocumentId);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -775,7 +775,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     break;
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(documentKind);
             }
         }
 
@@ -949,7 +949,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         break;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(documentKind);
                 }
             }
         }

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -52,7 +52,6 @@
     <Compile Include="..\..\..\ExpressionEvaluator\Core\Source\ExpressionCompiler\DkmExceptionUtilities.cs" Link="Implementation\EditAndContinue\Interop\DkmExceptionUtilities.cs" />
     <Compile Update="Implementation\MoveToNamespace\MoveToNamespaceDialog.xaml.cs">
       <DependentUpon>MoveToNamespaceDialog.xaml</DependentUpon>
-      <SubType>Code</SubType>
     </Compile>
     <Compile Update="Implementation\PickMembers\PickMembersDialog.xaml.cs">
       <DependentUpon>PickMembersDialog.xaml</DependentUpon>
@@ -78,7 +77,7 @@
     <ProjectReference Include="..\..\..\EditorFeatures\Text\Microsoft.CodeAnalysis.EditorFeatures.Text.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
     <ProjectReference Include="..\..\..\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj" />
-    <ProjectReference Include="..\..\..\Interactive\Host\Microsoft.CodeAnalysis.InteractiveHost.csproj" PrivateAssets="all" Aliases="InteractiveHost"/>
+    <ProjectReference Include="..\..\..\Interactive\Host\Microsoft.CodeAnalysis.InteractiveHost.csproj" PrivateAssets="all" Aliases="InteractiveHost" />
   </ItemGroup>
   <ItemGroup Label="File References">
     <Reference Include="System.ComponentModel.Composition" />
@@ -191,7 +190,7 @@
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" Version="$(MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.16.0.DesignTime" Version="$(MicrosoftVisualStudioTextManagerInterop160DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.VsInteractiveWindow" Version="$(MicrosoftVisualStudioVsInteractiveWindowVersion)" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.VisualStudio.VsInteractiveWindow" Version="$(MicrosoftVisualStudioVsInteractiveWindowVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.MSXML" Version="$(MicrosoftMSXMLVersion)" />

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices
                 }
             }
 
-            var document = this.CurrentSolution.GetDocument(documentId) ?? this.CurrentSolution.GetAdditionalDocument(documentId);
+            var document = this.CurrentSolution.GetTextDocument(documentId);
 
             return new InvisibleEditor(ServiceProvider.GlobalProvider, document.FilePath, GetHierarchy(documentId.ProjectId), needsSave, needsUndoDisabled);
         }

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,21 +1,34 @@
 *REMOVED*Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.DocumentId documentId, bool isSolutionClosing = false) -> void
 Microsoft.CodeAnalysis.AnalyzerConfigDocument
+Microsoft.CodeAnalysis.ApplyChangesKind.AddAnalyzerConfigDocument = 17 -> Microsoft.CodeAnalysis.ApplyChangesKind
+Microsoft.CodeAnalysis.ApplyChangesKind.ChangeAnalyzerConfigDocument = 19 -> Microsoft.CodeAnalysis.ApplyChangesKind
+Microsoft.CodeAnalysis.ApplyChangesKind.RemoveAnalyzerConfigDocument = 18 -> Microsoft.CodeAnalysis.ApplyChangesKind
+Microsoft.CodeAnalysis.Project.AddAnalyzerConfigDocument(string name, Microsoft.CodeAnalysis.Text.SourceText text, System.Collections.Generic.IEnumerable<string> folders = null, string filePath = null) -> Microsoft.CodeAnalysis.TextDocument
 Microsoft.CodeAnalysis.Project.AnalyzerConfigDocuments.get -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.AnalyzerConfigDocument>
 Microsoft.CodeAnalysis.Project.ContainsAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> bool
 Microsoft.CodeAnalysis.Project.GetAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> Microsoft.CodeAnalysis.AnalyzerConfigDocument
+Microsoft.CodeAnalysis.Project.RemoveAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> Microsoft.CodeAnalysis.Project
+Microsoft.CodeAnalysis.ProjectChanges.GetAddedAnalyzerConfigDocuments() -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.DocumentId>
+Microsoft.CodeAnalysis.ProjectChanges.GetChangedAnalyzerConfigDocuments() -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.DocumentId>
+Microsoft.CodeAnalysis.ProjectChanges.GetRemovedAnalyzerConfigDocuments() -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.DocumentId>
 Microsoft.CodeAnalysis.ProjectInfo.AnalyzerConfigDocuments.get -> System.Collections.Generic.IReadOnlyList<Microsoft.CodeAnalysis.DocumentInfo>
 Microsoft.CodeAnalysis.ProjectInfo.WithAnalyzerConfigDocuments(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.DocumentInfo> analyzerConfigDocuments) -> Microsoft.CodeAnalysis.ProjectInfo
 Microsoft.CodeAnalysis.Solution.AddAdditionalDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentInfos) -> Microsoft.CodeAnalysis.Solution
+Microsoft.CodeAnalysis.Solution.AddAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId, string name, Microsoft.CodeAnalysis.Text.SourceText text, System.Collections.Generic.IEnumerable<string> folders = null, string filePath = null) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.AddAnalyzerConfigDocuments(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentInfos) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.ContainsAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> bool
 Microsoft.CodeAnalysis.Solution.GetAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> Microsoft.CodeAnalysis.AnalyzerConfigDocument
 Microsoft.CodeAnalysis.Solution.RemoveAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.WithAnalyzerConfigDocumentText(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.Text.SourceText text, Microsoft.CodeAnalysis.PreservationMode mode = Microsoft.CodeAnalysis.PreservationMode.PreserveValue) -> Microsoft.CodeAnalysis.Solution
+Microsoft.CodeAnalysis.Solution.WithAnalyzerConfigDocumentText(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.TextAndVersion textAndVersion, Microsoft.CodeAnalysis.PreservationMode mode = Microsoft.CodeAnalysis.PreservationMode.PreserveValue) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.WithAnalyzerConfigDocumentTextLoader(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.TextLoader loader, Microsoft.CodeAnalysis.PreservationMode mode) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Workspace.CheckAnalyzerConfigDocumentIsInCurrentSolution(Microsoft.CodeAnalysis.DocumentId documentId) -> void
 Microsoft.CodeAnalysis.Workspace.CheckAnalyzerConfigDocumentIsNotInCurrentSolution(Microsoft.CodeAnalysis.DocumentId documentId) -> void
 Microsoft.CodeAnalysis.Workspace.OnAnalyzerConfigDocumentAdded(Microsoft.CodeAnalysis.DocumentInfo documentInfo) -> void
+Microsoft.CodeAnalysis.Workspace.OnAnalyzerConfigDocumentClosed(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.TextLoader reloader) -> void
+Microsoft.CodeAnalysis.Workspace.OnAnalyzerConfigDocumentOpened(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.Text.SourceTextContainer textContainer, bool isCurrentContext = true) -> void
 Microsoft.CodeAnalysis.Workspace.OnAnalyzerConfigDocumentRemoved(Microsoft.CodeAnalysis.DocumentId documentId) -> void
+Microsoft.CodeAnalysis.Workspace.OnAnalyzerConfigDocumentTextChanged(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.Text.SourceText newText, Microsoft.CodeAnalysis.PreservationMode mode) -> void
 Microsoft.CodeAnalysis.Workspace.OnAnalyzerConfigDocumentTextLoaderChanged(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.TextLoader loader) -> void
 Microsoft.CodeAnalysis.WorkspaceChangeKind.AnalyzerConfigDocumentAdded = 18 -> Microsoft.CodeAnalysis.WorkspaceChangeKind
 Microsoft.CodeAnalysis.WorkspaceChangeKind.AnalyzerConfigDocumentChanged = 21 -> Microsoft.CodeAnalysis.WorkspaceChangeKind
@@ -54,6 +67,8 @@ Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.Docume
 Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.DocumentId documentId, bool isSolutionClosing) -> void
 Microsoft.CodeAnalysis.Workspace.OnDocumentsAdded(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentInfos) -> void
 Microsoft.CodeAnalysis.Workspace.OnOutputRefFilePathChanged(Microsoft.CodeAnalysis.ProjectId projectId, string outputFilePath) -> void
+override Microsoft.CodeAnalysis.AdhocWorkspace.CloseAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> void
+override Microsoft.CodeAnalysis.AdhocWorkspace.OpenAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId, bool activate = true) -> void
 override Microsoft.CodeAnalysis.FileTextLoader.LoadTextAndVersionAsync(Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.DocumentId documentId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.TextAndVersion>
 override Microsoft.CodeAnalysis.Options.OptionKey.ToString() -> string
 static Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.AdditiveTypeNames.get -> System.Collections.Immutable.ImmutableArray<string>
@@ -63,4 +78,10 @@ static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindSourceDeclarationsWit
 static Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.FindSourceDeclarationsWithPatternAsync(Microsoft.CodeAnalysis.Solution solution, string pattern, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ISymbol>>
 static readonly Microsoft.CodeAnalysis.CodeStyle.NotificationOption.Silent -> Microsoft.CodeAnalysis.CodeStyle.NotificationOption
 virtual Microsoft.CodeAnalysis.FileTextLoader.CreateText(System.IO.Stream stream, Microsoft.CodeAnalysis.Workspace workspace) -> Microsoft.CodeAnalysis.Text.SourceText
+virtual Microsoft.CodeAnalysis.Workspace.ApplyAnalyzerConfigDocumentAdded(Microsoft.CodeAnalysis.DocumentInfo info, Microsoft.CodeAnalysis.Text.SourceText text) -> void
+virtual Microsoft.CodeAnalysis.Workspace.ApplyAnalyzerConfigDocumentRemoved(Microsoft.CodeAnalysis.DocumentId documentId) -> void
+virtual Microsoft.CodeAnalysis.Workspace.ApplyAnalyzerConfigDocumentTextChanged(Microsoft.CodeAnalysis.DocumentId id, Microsoft.CodeAnalysis.Text.SourceText text) -> void
 virtual Microsoft.CodeAnalysis.Workspace.CanApplyCompilationOptionChange(Microsoft.CodeAnalysis.CompilationOptions oldOptions, Microsoft.CodeAnalysis.CompilationOptions newOptions, Microsoft.CodeAnalysis.Project project) -> bool
+virtual Microsoft.CodeAnalysis.Workspace.CloseAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> void
+virtual Microsoft.CodeAnalysis.Workspace.GetAnalyzerConfigDocumentName(Microsoft.CodeAnalysis.DocumentId documentId) -> string
+virtual Microsoft.CodeAnalysis.Workspace.OpenAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId, bool activate = true) -> void

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 *REMOVED*Microsoft.CodeAnalysis.Workspace.ClearOpenDocument(Microsoft.CodeAnalysis.DocumentId documentId, bool isSolutionClosing = false) -> void
+Microsoft.CodeAnalysis.AdditionalDocument
 Microsoft.CodeAnalysis.AnalyzerConfigDocument
 Microsoft.CodeAnalysis.ApplyChangesKind.AddAnalyzerConfigDocument = 17 -> Microsoft.CodeAnalysis.ApplyChangesKind
 Microsoft.CodeAnalysis.ApplyChangesKind.ChangeAnalyzerConfigDocument = 19 -> Microsoft.CodeAnalysis.ApplyChangesKind

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -23,6 +23,10 @@ Microsoft.CodeAnalysis.Solution.RemoveAnalyzerConfigDocument(Microsoft.CodeAnaly
 Microsoft.CodeAnalysis.Solution.WithAnalyzerConfigDocumentText(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.Text.SourceText text, Microsoft.CodeAnalysis.PreservationMode mode = Microsoft.CodeAnalysis.PreservationMode.PreserveValue) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.WithAnalyzerConfigDocumentText(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.TextAndVersion textAndVersion, Microsoft.CodeAnalysis.PreservationMode mode = Microsoft.CodeAnalysis.PreservationMode.PreserveValue) -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.Solution.WithAnalyzerConfigDocumentTextLoader(Microsoft.CodeAnalysis.DocumentId documentId, Microsoft.CodeAnalysis.TextLoader loader, Microsoft.CodeAnalysis.PreservationMode mode) -> Microsoft.CodeAnalysis.Solution
+Microsoft.CodeAnalysis.TextDocumentKind
+Microsoft.CodeAnalysis.TextDocumentKind.AdditionalDocument = 1 -> Microsoft.CodeAnalysis.TextDocumentKind
+Microsoft.CodeAnalysis.TextDocumentKind.AnalyzerConfigDocument = 2 -> Microsoft.CodeAnalysis.TextDocumentKind
+Microsoft.CodeAnalysis.TextDocumentKind.Document = 0 -> Microsoft.CodeAnalysis.TextDocumentKind
 Microsoft.CodeAnalysis.Workspace.CheckAnalyzerConfigDocumentIsInCurrentSolution(Microsoft.CodeAnalysis.DocumentId documentId) -> void
 Microsoft.CodeAnalysis.Workspace.CheckAnalyzerConfigDocumentIsNotInCurrentSolution(Microsoft.CodeAnalysis.DocumentId documentId) -> void
 Microsoft.CodeAnalysis.Workspace.OnAnalyzerConfigDocumentAdded(Microsoft.CodeAnalysis.DocumentInfo documentInfo) -> void

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISolutionExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISolutionExtensions.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
@@ -52,19 +53,27 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return solution.GetDocument(documentId) ?? solution.GetAdditionalDocument(documentId) ?? solution.GetAnalyzerConfigDocument(documentId);
         }
 
+        public static TextDocumentKind GetDocumentKind(this Solution solution, DocumentId documentId)
+        {
+            return solution.GetTextDocument(documentId).Kind;
+        }
+
         public static Solution WithTextDocumentText(this Solution solution, DocumentId documentId, SourceText text, PreservationMode mode = PreservationMode.PreserveIdentity)
         {
-            var textDocument = solution.GetTextDocument(documentId);
-            switch (textDocument)
+            var documentKind = solution.GetDocumentKind(documentId);
+            switch (documentKind)
             {
-                case Document _:
+                case TextDocumentKind.Document:
                     return solution.WithDocumentText(documentId, text, mode);
 
-                case AnalyzerConfigDocument _:
+                case TextDocumentKind.AnalyzerConfigDocument:
                     return solution.WithAnalyzerConfigDocumentText(documentId, text, mode);
 
-                default:
+                case TextDocumentKind.AdditionalDocument:
                     return solution.WithAdditionalDocumentText(documentId, text, mode);
+
+                default:
+                    throw ExceptionUtilities.Unreachable;
             }
         }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISolutionExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISolutionExtensions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return solution.WithAdditionalDocumentText(documentId, text, mode);
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(documentKind);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/TextDocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/TextDocumentExtensions.cs
@@ -12,12 +12,17 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         /// </summary>
         public static TextDocument WithText(this TextDocument textDocument, SourceText text)
         {
-            if (textDocument is Document document)
+            switch (textDocument)
             {
-                return document.WithText(text);
-            }
+                case Document document:
+                    return document.WithText(text);
 
-            return textDocument.WithAdditionalDocumentText(text);
+                case AnalyzerConfigDocument analyzerConfigDocument:
+                    return analyzerConfigDocument.WithAnalyzerConfigDocumentText(text);
+
+                default:
+                    return textDocument.WithAdditionalDocumentText(text);
+            }
         }
 
         /// <summary>
@@ -27,6 +32,15 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             Contract.ThrowIfTrue(textDocument is Document);
             return textDocument.Project.Solution.WithAdditionalDocumentText(textDocument.Id, text, PreservationMode.PreserveIdentity).GetTextDocument(textDocument.Id);
+        }
+
+        /// <summary>
+        /// Creates a new instance of this analyzer config document updated to have the text specified.
+        /// </summary>
+        public static TextDocument WithAnalyzerConfigDocumentText(this TextDocument textDocument, SourceText text)
+        {
+            Contract.ThrowIfFalse(textDocument is AnalyzerConfigDocument);
+            return textDocument.Project.Solution.WithAnalyzerConfigDocumentText(textDocument.Id, text, PreservationMode.PreserveIdentity).GetTextDocument(textDocument.Id);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/TextDocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/TextDocumentExtensions.cs
@@ -20,8 +20,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 case AnalyzerConfigDocument analyzerConfigDocument:
                     return analyzerConfigDocument.WithAnalyzerConfigDocumentText(text);
 
+                case AdditionalDocument additionalDocument:
+                    return additionalDocument.WithAdditionalDocumentText(text);
+
                 default:
-                    return textDocument.WithAdditionalDocumentText(text);
+                    throw ExceptionUtilities.Unreachable;
             }
         }
 
@@ -30,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         /// </summary>
         public static TextDocument WithAdditionalDocumentText(this TextDocument textDocument, SourceText text)
         {
-            Contract.ThrowIfTrue(textDocument is Document);
+            Contract.ThrowIfFalse(textDocument is AdditionalDocument);
             return textDocument.Project.Solution.WithAdditionalDocumentText(textDocument.Id, text, PreservationMode.PreserveIdentity).GetTextDocument(textDocument.Id);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/AdhocWorkspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/AdhocWorkspace.cs
@@ -201,5 +201,33 @@ namespace Microsoft.CodeAnalysis
                 this.OnAdditionalDocumentClosed(documentId, loader);
             }
         }
+
+        /// <summary>
+        /// Puts the specified analyzer config document into the open state.
+        /// </summary>
+        public override void OpenAnalyzerConfigDocument(DocumentId documentId, bool activate = true)
+        {
+            var doc = this.CurrentSolution.GetAnalyzerConfigDocument(documentId);
+            if (doc != null)
+            {
+                var text = doc.GetTextSynchronously(CancellationToken.None);
+                this.OnAnalyzerConfigDocumentOpened(documentId, text.Container, activate);
+            }
+        }
+
+        /// <summary>
+        /// Puts the specified analyzer config document into the closed state
+        /// </summary>
+        public override void CloseAnalyzerConfigDocument(DocumentId documentId)
+        {
+            var doc = this.CurrentSolution.GetAnalyzerConfigDocument(documentId);
+            if (doc != null)
+            {
+                var text = doc.GetTextSynchronously(CancellationToken.None);
+                var version = doc.GetTextVersionSynchronously(CancellationToken.None);
+                var loader = TextLoader.From(TextAndVersion.Create(text, version, doc.FilePath));
+                this.OnAnalyzerConfigDocumentClosed(documentId, loader);
+            }
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/ApplyChangesKind.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ApplyChangesKind.cs
@@ -21,6 +21,9 @@ namespace Microsoft.CodeAnalysis
         ChangeAdditionalDocument = 13,
         ChangeCompilationOptions = 14,
         ChangeParseOptions = 15,
-        ChangeDocumentInfo = 16
+        ChangeDocumentInfo = 16,
+        AddAnalyzerConfigDocument = 17,
+        RemoveAnalyzerConfigDocument = 18,
+        ChangeAnalyzerConfigDocument = 19
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalDocument.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Represents an additional file passed down to analyzers.
+    /// </summary>
+    public sealed class AdditionalDocument : TextDocument
+    {
+        internal AdditionalDocument(Project project, TextDocumentState state)
+            : base(project, state, TextDocumentKind.AdditionalDocument)
+        {
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalTextWithState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalTextWithState.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     /// <summary>
-    /// Represents a non source additional text.
+    /// An implementation of <see cref="AdditionalText"/> for the compiler that wraps a <see cref="TextDocumentState"/>.
     /// </summary>
     internal sealed class AdditionalTextWithState : AdditionalText
     {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalTextWithState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalTextWithState.cs
@@ -7,31 +7,31 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     /// <summary>
-    /// Represents a non source code file.
+    /// Represents a non source additional text.
     /// </summary>
-    internal sealed class AdditionalTextDocument : AdditionalText
+    internal sealed class AdditionalTextWithState : AdditionalText
     {
-        private readonly TextDocumentState _document;
+        private readonly TextDocumentState _documentState;
 
         /// <summary>
-        /// Create a <see cref="SourceText"/> from a <see cref="TextDocumentState"/>. <paramref name="document"/> should be non-null.
+        /// Create a <see cref="SourceText"/> from a <see cref="TextDocumentState"/>. <paramref name="documentState"/> should be non-null.
         /// </summary>
-        public AdditionalTextDocument(TextDocumentState document)
+        public AdditionalTextWithState(TextDocumentState documentState)
         {
-            _document = document ?? throw new ArgumentNullException(nameof(document));
+            _documentState = documentState ?? throw new ArgumentNullException(nameof(documentState));
         }
 
         /// <summary>
         /// Resolved path of the document.
         /// </summary>
-        public override string Path => _document.FilePath ?? _document.Name;
+        public override string Path => _documentState.FilePath ?? _documentState.Name;
 
         /// <summary>
         /// Retrieves a <see cref="SourceText"/> with the contents of this file.
         /// </summary>
         public override SourceText GetText(CancellationToken cancellationToken = default)
         {
-            var text = _document.GetTextSynchronously(cancellationToken);
+            var text = _documentState.GetTextSynchronously(cancellationToken);
             return text;
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocument.cs
@@ -1,15 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Microsoft.CodeAnalysis
 {
     public sealed class AnalyzerConfigDocument : TextDocument
     {
         internal AnalyzerConfigDocument(Project project, AnalyzerConfigDocumentState state)
-            : base(project, state)
+            : base(project, state, TextDocumentKind.AnalyzerConfigDocument)
         {
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
@@ -53,6 +53,11 @@ namespace Microsoft.CodeAnalysis
             return (AnalyzerConfigDocumentState)base.UpdateText(text, mode);
         }
 
+        public new AnalyzerConfigDocumentState UpdateText(TextAndVersion newTextAndVersion, PreservationMode mode)
+        {
+            return (AnalyzerConfigDocumentState)base.UpdateText(newTextAndVersion, mode);
+        }
+
         protected override TextDocumentState UpdateText(ValueSource<TextAndVersion> newTextSource, PreservationMode mode, bool incremental)
         {
             return new AnalyzerConfigDocumentState(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis
         private Task<SyntaxTree> _syntaxTreeResultTask;
 
         internal Document(Project project, DocumentState state) :
-            base(project, state)
+            base(project, state, TextDocumentKind.Document)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -264,6 +264,11 @@ namespace Microsoft.CodeAnalysis
             return _projectState.GetAdditionalDocumentState(documentId);
         }
 
+        internal TextDocumentState GetAnalyzerConfigDocumentState(DocumentId documentId)
+        {
+            return _projectState.GetAnalyzerConfigDocumentState(documentId);
+        }
+
         internal async Task<bool> ContainsSymbolsWithNameAsync(string name, SymbolFilter filter, CancellationToken cancellationToken)
         {
             return this.SupportsCompilation &&
@@ -566,6 +571,15 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Creates a new analyzer config document in a new instance of this project.
+        /// </summary>
+        public TextDocument AddAnalyzerConfigDocument(string name, SourceText text, IEnumerable<string> folders = null, string filePath = null)
+        {
+            var id = DocumentId.CreateNewId(this.Id);
+            return this.Solution.AddAnalyzerConfigDocument(id, name, text, folders, filePath).GetAnalyzerConfigDocument(id);
+        }
+
+        /// <summary>
         /// Creates a new instance of this project updated to no longer include the specified document.
         /// </summary>
         public Project RemoveDocument(DocumentId documentId)
@@ -579,6 +593,14 @@ namespace Microsoft.CodeAnalysis
         public Project RemoveAdditionalDocument(DocumentId documentId)
         {
             return this.Solution.RemoveAdditionalDocument(documentId).GetProject(this.Id);
+        }
+
+        /// <summary>
+        /// Creates a new instance of this project updated to no longer include the specified analyzer config document.
+        /// </summary>
+        public Project RemoveAnalyzerConfigDocument(DocumentId documentId)
+        {
+            return this.Solution.RemoveAnalyzerConfigDocument(documentId).GetProject(this.Id);
         }
 
         private string GetDebuggerDisplay()

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
         private readonly Solution _solution;
         private readonly ProjectState _projectState;
         private ImmutableHashMap<DocumentId, Document> _idToDocumentMap = ImmutableHashMap<DocumentId, Document>.Empty;
-        private ImmutableHashMap<DocumentId, TextDocument> _idToAdditionalDocumentMap = ImmutableHashMap<DocumentId, TextDocument>.Empty;
+        private ImmutableHashMap<DocumentId, AdditionalDocument> _idToAdditionalDocumentMap = ImmutableHashMap<DocumentId, AdditionalDocument>.Empty;
         private ImmutableHashMap<DocumentId, AnalyzerConfigDocument> _idToAnalyzerConfigDocumentMap = ImmutableHashMap<DocumentId, AnalyzerConfigDocument>.Empty;
 
         internal Project(Solution solution, ProjectState projectState)
@@ -292,10 +292,10 @@ namespace Microsoft.CodeAnalysis
             return new Document(project, project._projectState.GetDocumentState(documentId));
         }
 
-        private static readonly Func<DocumentId, Project, TextDocument> s_createAdditionalDocumentFunction = CreateAdditionalDocument;
-        private static TextDocument CreateAdditionalDocument(DocumentId documentId, Project project)
+        private static readonly Func<DocumentId, Project, AdditionalDocument> s_createAdditionalDocumentFunction = CreateAdditionalDocument;
+        private static AdditionalDocument CreateAdditionalDocument(DocumentId documentId, Project project)
         {
-            return new TextDocument(project, project._projectState.GetAdditionalDocumentState(documentId));
+            return new AdditionalDocument(project, project._projectState.GetAdditionalDocumentState(documentId));
         }
 
         private static readonly Func<DocumentId, Project, AnalyzerConfigDocument> s_createAnalyzerConfigDocumentFunction = CreateAnalyzerConfigDocument;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis
             return _projectState.GetAdditionalDocumentState(documentId);
         }
 
-        internal TextDocumentState GetAnalyzerConfigDocumentState(DocumentId documentId)
+        internal AnalyzerConfigDocumentState GetAnalyzerConfigDocumentState(DocumentId documentId)
         {
             return _projectState.GetAnalyzerConfigDocumentState(documentId);
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectChanges.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectChanges.cs
@@ -116,6 +116,17 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        public IEnumerable<DocumentId> GetAddedAnalyzerConfigDocuments()
+        {
+            foreach (var doc in _newProject.AnalyzerConfigDocuments)
+            {
+                if (!_oldProject.ContainsAnalyzerConfigDocument(doc.Id))
+                {
+                    yield return doc.Id;
+                }
+            }
+        }
+
         /// <summary>
         /// Get Documents with any changes, including textual and non-textual changes
         /// </summary>
@@ -170,6 +181,20 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        public IEnumerable<DocumentId> GetChangedAnalyzerConfigDocuments()
+        {
+            // if the document states are different then there is a change.
+            foreach (var doc in _newProject.AnalyzerConfigDocuments)
+            {
+                var newState = _newProject.GetAnalyzerConfigDocumentState(doc.Id);
+                var oldState = _oldProject.GetAnalyzerConfigDocumentState(doc.Id);
+                if (oldState != null && newState != oldState)
+                {
+                    yield return doc.Id;
+                }
+            }
+        }
+
         public IEnumerable<DocumentId> GetRemovedDocuments()
         {
             foreach (var id in _oldProject.DocumentIds)
@@ -188,6 +213,17 @@ namespace Microsoft.CodeAnalysis
                 if (!_newProject.ContainsAdditionalDocument(id))
                 {
                     yield return id;
+                }
+            }
+        }
+
+        public IEnumerable<DocumentId> GetRemovedAnalyzerConfigDocuments()
+        {
+            foreach (var doc in _oldProject.AnalyzerConfigDocuments)
+            {
+                if (!_newProject.ContainsAnalyzerConfigDocument(doc.Id))
+                {
+                    yield return doc.Id;
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -172,6 +172,7 @@ namespace Microsoft.CodeAnalysis
             IEnumerable<MetadataReference> metadataReferences,
             IEnumerable<AnalyzerReference> analyzerReferences,
             IEnumerable<DocumentInfo> additionalDocuments,
+            IEnumerable<DocumentInfo> analyzerConfigDocuments,
             bool isSubmission,
             Type hostObjectType,
             bool hasAllInformation)
@@ -196,7 +197,7 @@ namespace Microsoft.CodeAnalysis
                 metadataReferences,
                 analyzerReferences,
                 additionalDocuments,
-                analyzerConfigDocuments: null,
+                analyzerConfigDocuments,
                 hostObjectType);
         }
 
@@ -225,7 +226,7 @@ namespace Microsoft.CodeAnalysis
             return Create(
                 id, version, name, assemblyName, language,
                 filePath, outputFilePath, outputRefFilePath: null, defaultNamespace: null, compilationOptions, parseOptions,
-                documents, projectReferences, metadataReferences, analyzerReferences, additionalDocuments,
+                documents, projectReferences, metadataReferences, analyzerReferences, additionalDocuments, analyzerConfigDocuments: null,
                 isSubmission, hostObjectType, hasAllInformation: true);
         }
 
@@ -254,7 +255,7 @@ namespace Microsoft.CodeAnalysis
             return Create(
                 id, version, name, assemblyName, language,
                 filePath, outputFilePath, outputRefFilePath, defaultNamespace: null, compilationOptions, parseOptions,
-                documents, projectReferences, metadataReferences, analyzerReferences, additionalDocuments,
+                documents, projectReferences, metadataReferences, analyzerReferences, additionalDocuments, analyzerConfigDocuments: null,
                 isSubmission, hostObjectType, hasAllInformation: true);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis
                 if (_analyzerOptionsDoNotAccessDirectly == null)
                 {
                     _analyzerOptionsDoNotAccessDirectly = new AnalyzerOptions(
-                        _additionalDocumentStates.Values.Select(d => new AdditionalTextDocument(d)).ToImmutableArray<AdditionalText>(),
+                        _additionalDocumentStates.Values.Select(d => new AdditionalTextWithState(d)).ToImmutableArray<AdditionalText>(),
                         new WorkspaceAnalyzerConfigOptionsProvider(this));
                 }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -771,19 +771,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(text));
             }
 
-            var project = _state.GetProjectState(documentId.ProjectId);
-
-            var version = VersionStamp.Create();
-            var loader = TextLoader.From(TextAndVersion.Create(text, version, name));
-
-            var info = DocumentInfo.Create(
-                documentId,
-                name: name,
-                folders: folders,
-                sourceCodeKind: GetSourceCodeKind(project),
-                loader: loader,
-                filePath: filePath);
-
+            var info = CreateDocumentInfo(documentId, name, text, folders, filePath);
             return this.AddAdditionalDocument(info);
         }
 
@@ -801,6 +789,47 @@ namespace Microsoft.CodeAnalysis
             }
 
             return new Solution(newState);
+        }
+
+        /// <summary>
+        /// Creates a new solution instance with the corresponding project updated to include a new
+        /// analyzer config document instance defined by its name and text.
+        /// </summary>
+        public Solution AddAnalyzerConfigDocument(DocumentId documentId, string name, SourceText text, IEnumerable<string> folders = null, string filePath = null)
+        {
+            if (documentId == null)
+            {
+                throw new ArgumentNullException(nameof(documentId));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (text == null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            var info = CreateDocumentInfo(documentId, name, text, folders, filePath);
+            return this.AddAnalyzerConfigDocuments(ImmutableArray.Create(info));
+        }
+
+        private DocumentInfo CreateDocumentInfo(DocumentId documentId, string name, SourceText text, IEnumerable<string> folders, string filePath)
+        {
+            var project = _state.GetProjectState(documentId.ProjectId);
+
+            var version = VersionStamp.Create();
+            var loader = TextLoader.From(TextAndVersion.Create(text, version, name));
+
+            return DocumentInfo.Create(
+                documentId,
+                name: name,
+                folders: folders,
+                sourceCodeKind: GetSourceCodeKind(project),
+                loader: loader,
+                filePath: filePath);
         }
 
         /// <summary>
@@ -929,6 +958,23 @@ namespace Microsoft.CodeAnalysis
             return new Solution(newState);
         }
 
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+        /// <summary>
+        /// Creates a new solution instance with the analyzer config document specified updated to have the text
+        /// supplied by the text loader.
+        /// </summary>
+        public Solution WithAnalyzerConfigDocumentText(DocumentId documentId, SourceText text, PreservationMode mode = PreservationMode.PreserveValue)
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        {
+            var newState = _state.WithAnalyzerConfigDocumentText(documentId, text, mode);
+            if (newState == _state)
+            {
+                return this;
+            }
+
+            return new Solution(newState);
+        }
+
         /// <summary>
         /// Creates a new solution instance with the document specified updated to have the text
         /// and version specified.
@@ -951,6 +997,23 @@ namespace Microsoft.CodeAnalysis
         public Solution WithAdditionalDocumentText(DocumentId documentId, TextAndVersion textAndVersion, PreservationMode mode = PreservationMode.PreserveValue)
         {
             var newState = _state.WithAdditionalDocumentText(documentId, textAndVersion, mode);
+            if (newState == _state)
+            {
+                return this;
+            }
+
+            return new Solution(newState);
+        }
+
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+        /// <summary>
+        /// Creates a new solution instance with the analyzer config document specified updated to have the text
+        /// and version specified.
+        /// </summary>
+        public Solution WithAnalyzerConfigDocumentText(DocumentId documentId, TextAndVersion textAndVersion, PreservationMode mode = PreservationMode.PreserveValue)
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        {
+            var newState = _state.WithAnalyzerConfigDocumentText(documentId, textAndVersion, mode);
             if (newState == _state)
             {
                 return this;
@@ -1016,21 +1079,6 @@ namespace Microsoft.CodeAnalysis
         public Solution WithAdditionalDocumentTextLoader(DocumentId documentId, TextLoader loader, PreservationMode mode)
         {
             var newState = _state.WithAdditionalDocumentTextLoader(documentId, loader, mode);
-            if (newState == _state)
-            {
-                return this;
-            }
-
-            return new Solution(newState);
-        }
-
-        /// <summary>
-        /// Creates a new solution instance with the analyzer config document specified updated to have the text
-        /// supplied by the text loader.
-        /// </summary>
-        public Solution WithAnalyzerConfigDocumentText(DocumentId documentId, SourceText text, PreservationMode mode = PreservationMode.PreserveValue)
-        {
-            var newState = _state.WithAnalyzerConfigDocumentText(documentId, text, mode);
             if (newState == _state)
             {
                 return this;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1460,6 +1460,29 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Creates a new solution instance with the analyzer config document specified updated to have the text
+        /// and version specified.
+        /// </summary>
+        public SolutionState WithAnalyzerConfigDocumentText(DocumentId documentId, TextAndVersion textAndVersion, PreservationMode mode = PreservationMode.PreserveValue)
+        {
+            if (documentId == null)
+            {
+                throw new ArgumentNullException(nameof(documentId));
+            }
+
+            if (textAndVersion == null)
+            {
+                throw new ArgumentNullException(nameof(textAndVersion));
+            }
+
+            CheckContainsAnalyzerConfigDocument(documentId);
+
+            var oldDocument = this.GetAnalyzerConfigDocumentState(documentId);
+
+            return WithAnalyzerConfigDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
+        }
+
+        /// <summary>
         /// Creates a new solution instance with the document specified updated to have a syntax tree
         /// rooted by the specified syntax node.
         /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
@@ -11,7 +11,8 @@ namespace Microsoft.CodeAnalysis
 {
     public class TextDocument
     {
-        internal readonly TextDocumentState State;
+        internal TextDocumentState State { get; }
+        internal TextDocumentKind Kind { get; }
 
         /// <summary>
         /// The project this document belongs to.
@@ -22,13 +23,14 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-        internal TextDocument(Project project, TextDocumentState state)
+        internal TextDocument(Project project, TextDocumentState state, TextDocumentKind kind)
         {
             Contract.ThrowIfNull(project);
             Contract.ThrowIfNull(state);
 
             this.Project = project;
             State = state;
+            Kind = kind;
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentKind.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentKind.cs
@@ -5,8 +5,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Indicates kind of a <see cref="TextDocument"/>
     /// </summary>
-    /// <remarks>CONSIDER: Make this type public</remarks>
-    internal enum TextDocumentKind
+    public enum TextDocumentKind
     {
         /// <summary>
         /// Indicates a regular source <see cref="CodeAnalysis.Document"/>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentKind.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentKind.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates kind of a <see cref="TextDocument"/>
+    /// </summary>
+    /// <remarks>CONSIDER: Make this type public</remarks>
+    internal enum TextDocumentKind
+    {
+        /// <summary>
+        /// Indicates a regular source <see cref="CodeAnalysis.Document"/>
+        /// </summary>
+        Document,
+
+        /// <summary>
+        /// Indicates an <see cref="CodeAnalysis.AdditionalDocument"/>
+        /// </summary>
+        AdditionalDocument,
+
+        /// <summary>
+        /// Indicates an <see cref="CodeAnalysis.AnalyzerConfigDocument"/>
+        /// </summary>
+        AnalyzerConfigDocument
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -1942,7 +1943,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected virtual string GetDocumentName(DocumentId documentId)
         {
-            var document = this.CurrentSolution.GetDocument(documentId);
+            var document = this.CurrentSolution.GetTextDocument(documentId);
             var name = document != null ? document.Name : "<Document" + documentId.Id + ">";
             return name;
         }
@@ -1951,21 +1952,13 @@ namespace Microsoft.CodeAnalysis
         /// Gets the name to use for an additional document in an error message.
         /// </summary>
         protected virtual string GetAdditionalDocumentName(DocumentId documentId)
-        {
-            var document = this.CurrentSolution.GetAdditionalDocument(documentId);
-            var name = document != null ? document.Name : "<Document" + documentId.Id + ">";
-            return name;
-        }
+            => GetDocumentName(documentId);
 
         /// <summary>
         /// Gets the name to use for an analyzer document in an error message.
         /// </summary>
         protected virtual string GetAnalyzerConfigDocumentName(DocumentId documentId)
-        {
-            var document = this.CurrentSolution.GetAnalyzerConfigDocument(documentId);
-            var name = document != null ? document.Name : "<Document" + documentId.Id + ">";
-            return name;
-        }
+            => GetDocumentName(documentId);
 
         #endregion
     }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -515,6 +515,8 @@ namespace Microsoft.CodeAnalysis
 
                 var oldSolution = this.CurrentSolution;
                 var oldDocument = oldSolution.GetTextDocument(documentId);
+                Debug.Assert(oldDocument.Kind == TextDocumentKind.AdditionalDocument || oldDocument.Kind == TextDocumentKind.AnalyzerConfigDocument);
+
                 var oldText = oldDocument.GetTextSynchronously(CancellationToken.None);
 
                 AddToOpenDocumentMap(documentId);
@@ -620,6 +622,7 @@ namespace Microsoft.CodeAnalysis
 
                 var oldSolution = this.CurrentSolution;
                 var oldDocument = oldSolution.GetTextDocument(documentId);
+                Debug.Assert(oldDocument.Kind == TextDocumentKind.AdditionalDocument || oldDocument.Kind == TextDocumentKind.AnalyzerConfigDocument);
 
                 var newSolution = withTextDocumentTextLoader(oldSolution, documentId, reloader, PreservationMode.PreserveValue);
                 newSolution = this.SetCurrentSolution(newSolution);

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -498,6 +498,9 @@ namespace Microsoft.CodeAnalysis
                 onDocumentTextChanged: (w, id, text, mode) => w.OnAnalyzerConfigDocumentTextChanged(id, text, mode));
         }
 
+        // NOTE: We are only sharing this code between additional documents and analyzer config documents,
+        // which are essentially plain text documents. Regular source documents need special handling
+        // and hence have a different implementation.
         private void OnAdditionalOrAnalyzerConfigDocumentOpened(
             DocumentId documentId,
             SourceTextContainer textContainer,
@@ -605,6 +608,9 @@ namespace Microsoft.CodeAnalysis
                 withTextDocumentTextLoader: (oldSolution, documentId, textLoader, mode) => oldSolution.WithAnalyzerConfigDocumentTextLoader(documentId, textLoader, mode));
         }
 
+        // NOTE: We are only sharing this code between additional documents and analyzer config documents,
+        // which are essentially plain text documents. Regular source documents need special handling
+        // and hence have a different implementation.
         private void OnAdditionalOrAnalyzerConfigDocumentClosed(
             DocumentId documentId,
             TextLoader reloader,

--- a/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
@@ -241,6 +241,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Adding analyzer config documents is not supported..
+        /// </summary>
+        internal static string Adding_analyzer_config_documents_is_not_supported {
+            get {
+                return ResourceManager.GetString("Adding_analyzer_config_documents_is_not_supported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Adding analyzer references is not supported..
         /// </summary>
         internal static string Adding_analyzer_references_is_not_supported {
@@ -490,6 +499,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Changing_additional_documents_is_not_supported {
             get {
                 return ResourceManager.GetString("Changing_additional_documents_is_not_supported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Changing analyzer config documents is not supported..
+        /// </summary>
+        internal static string Changing_analyzer_config_documents_is_not_supported {
+            get {
+                return ResourceManager.GetString("Changing_analyzer_config_documents_is_not_supported", resourceCulture);
             }
         }
         
@@ -3182,6 +3200,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Removing_additional_documents_is_not_supported {
             get {
                 return ResourceManager.GetString("Removing_additional_documents_is_not_supported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removing analyzer config documents is not supported..
+        /// </summary>
+        internal static string Removing_analyzer_config_documents_is_not_supported {
+            get {
+                return ResourceManager.GetString("Removing_analyzer_config_documents_is_not_supported", resourceCulture);
             }
         }
         

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -357,6 +357,9 @@
   <data name="Adding_additional_documents_is_not_supported" xml:space="preserve">
     <value>Adding additional documents is not supported.</value>
   </data>
+  <data name="Adding_analyzer_config_documents_is_not_supported" xml:space="preserve">
+    <value>Adding analyzer config documents is not supported.</value>
+  </data>
   <data name="Adding_analyzer_references_is_not_supported" xml:space="preserve">
     <value>Adding analyzer references is not supported.</value>
   </data>
@@ -372,6 +375,9 @@
   <data name="Changing_additional_documents_is_not_supported" xml:space="preserve">
     <value>Changing additional documents is not supported.</value>
   </data>
+  <data name="Changing_analyzer_config_documents_is_not_supported" xml:space="preserve">
+    <value>Changing analyzer config documents is not supported.</value>
+  </data>
   <data name="Changing_documents_is_not_supported" xml:space="preserve">
     <value>Changing documents is not supported.</value>
   </data>
@@ -380,6 +386,9 @@
   </data>
   <data name="Removing_additional_documents_is_not_supported" xml:space="preserve">
     <value>Removing additional documents is not supported.</value>
+  </data>
+  <data name="Removing_analyzer_config_documents_is_not_supported" xml:space="preserve">
+    <value>Removing analyzer config documents is not supported.</value>
   </data>
   <data name="Removing_analyzer_references_is_not_supported" xml:space="preserve">
     <value>Removing analyzer references is not supported.</value>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">Došlo k chybě při čtení zadaného konfiguračního souboru: {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Soubory C#</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">Pokud chcete nastavení souboru .editorconfig zdědit z vyšších adresářů, odeberte řádek níže.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">Beim Lesen der angegebenen Konfigurationsdatei ist ein Fehler aufgetreten: {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">C#-Dateien</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">Entfernen Sie die folgende Zeile, wenn Sie EDITORCONFIG-Einstellungen von höheren Verzeichnissen vererben möchten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">Error al leer el archivo de configuración especificado: {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Archivos de C#</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">Elimine la línea siguiente si desea heredar la configuración de .editorconfig de directorios más elevados</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">Une erreur s'est produite lors de la lecture du fichier de configuration spécifié : {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Fichiers C#</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">Supprimer la ligne ci-dessous si vous voulez hériter les paramètres .editorconfig des répertoires supérieurs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">Si è verificato un errore durante la lettura del file di configurazione specificato: {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">File C#</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">Rimuovere la riga seguente se si vogliono ereditare le impostazioni del file con estensione editorconfig da directory di livello superiore</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">指定した構成ファイルの読み取り中にエラーが発生しました: {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">C# ファイル</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">上位ディレクトリから .editorconfig 設定を継承する場合は、以下の行を削除します</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">지정한 구성 파일을 읽는 동안 오류가 발생했습니다({0}).</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">C# 파일</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">상위 디렉터리에서 .editorconfig 설정을 상속하려면 아래 행을 제거하세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">Wystąpił błąd podczas odczytywania określonego pliku konfiguracji: {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Pliki C#</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">Usuń poniższy wiersz, aby dziedziczyć ustawienia editorconfig z katalogów nadrzędnych</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">Ocorreu um erro ao ler o arquivo de configuração especificado: {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Arquivos C#</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">Remova a linha abaixo se quiser herdar as configurações do .editorconfig de diretórios superiores</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">Произошла ошибка при чтении указанного файла конфигурации: {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">Файлы C#</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">Удалите строку ниже, если вы хотите наследовать параметры .editorconfig из каталогов, расположенных выше в иерархии</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">Belirtilen yapılandırma dosyası okunurken bir hata oluştu: {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">C# dosyalarını</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">.Editorconfig ayarları daha yüksek dizinlerden devralmak isterseniz aşağıdaki satırı Kaldır</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">读取指定的配置文件时出错: {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">c# 文件</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">如果要从更高级别的目录继承 .editorconfig 设置，请删除以下行</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../WorkspacesResources.resx">
     <body>
+      <trans-unit id="Adding_analyzer_config_documents_is_not_supported">
+        <source>Adding analyzer config documents is not supported.</source>
+        <target state="new">Adding analyzer config documents is not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="An_error_occurred_while_reading_the_specified_configuration_file_colon_0">
         <source>An error occurred while reading the specified configuration file: {0}</source>
         <target state="translated">讀取指定的組態檔時發生錯誤: {0}</target>
@@ -10,6 +15,11 @@
       <trans-unit id="CSharp_files">
         <source>C# files</source>
         <target state="translated">C# 檔案</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Changing_analyzer_config_documents_is_not_supported">
+        <source>Changing analyzer config documents is not supported.</source>
+        <target state="new">Changing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Changing_document_0_is_not_supported">
@@ -1210,6 +1220,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
       <trans-unit id="Remove_the_line_below_if_you_want_to_inherit_dot_editorconfig_settings_from_higher_directories">
         <source>Remove the line below if you want to inherit .editorconfig settings from higher directories</source>
         <target state="translated">如果要從更高的目錄繼承 .editorconfig 設定，請移除以下行</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Removing_analyzer_config_documents_is_not_supported">
+        <source>Removing analyzer config documents is not supported.</source>
+        <target state="new">Removing analyzer config documents is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="Symbol_0_is_not_from_source">

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -402,7 +402,7 @@ namespace Microsoft.CodeAnalysis.Remote
                         break;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(document.Kind);
                 }
             }
 

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -387,18 +387,22 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 var sourceText = await _assetService.GetAssetAsync<SourceText>(newDocumentChecksums.Text, _cancellationToken).ConfigureAwait(false);
 
-                if (document is Document)
+                switch (document.Kind)
                 {
-                    document = document.Project.Solution.WithDocumentText(document.Id, sourceText).GetDocument(document.Id);
-                }
-                else if (document is AnalyzerConfigDocument)
-                {
-                    document = document.Project.Solution.WithAnalyzerConfigDocumentText(document.Id, sourceText).GetAnalyzerConfigDocument(document.Id);
-                }
-                else
-                {
-                    Debug.Assert(document.Project.ContainsAdditionalDocument(document.Id));
-                    document = document.Project.Solution.WithAdditionalDocumentText(document.Id, sourceText).GetAdditionalDocument(document.Id);
+                    case TextDocumentKind.Document:
+                        document = document.Project.Solution.WithDocumentText(document.Id, sourceText).GetDocument(document.Id);
+                        break;
+
+                    case TextDocumentKind.AnalyzerConfigDocument:
+                        document = document.Project.Solution.WithAnalyzerConfigDocumentText(document.Id, sourceText).GetAnalyzerConfigDocument(document.Id);
+                        break;
+
+                    case TextDocumentKind.AdditionalDocument:
+                        document = document.Project.Solution.WithAdditionalDocumentText(document.Id, sourceText).GetAdditionalDocument(document.Id);
+                        break;
+
+                    default:
+                        throw ExceptionUtilities.Unreachable;
                 }
             }
 


### PR DESCRIPTION
This PR extracts out the AnalyzerConfigDocument related changes in the Workspaces/VS layer out of https://github.com/dotnet/roslyn/pull/35691. I have cherry-picked the first 4 and last 4 commits from that PR.