### PR TITLE
Elide an emit optimization that produces bad code near a stackalloc.

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -2104,14 +2104,21 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 return true;
             }
 
-            if (right.Kind == BoundKind.ObjectCreationExpression)
+            if (right is BoundObjectCreationExpression objCreation)
             {
+                // If we are creating a Span<T> from a stackalloc, which is a particular pattern of code
+                // produced by lowering, we must use the constructor in its standard form because the stack
+                // is required to contain nothing more than stackalloc's argument.
+                if (objCreation.Arguments.Length > 0 && objCreation.Arguments[0].Kind == BoundKind.ConvertedStackAllocExpression)
+                {
+                    return false;
+                }
+
                 // It is desirable to do in-place ctor call if possible.
                 // we could do newobj/stloc, but in-place call 
                 // produces the same or better code in current JITs 
                 if (PartialCtorResultCannotEscape(left))
                 {
-                    var objCreation = (BoundObjectCreationExpression)right;
                     var ctor = objCreation.Constructor;
 
                     // ctor can possibly see its own assignments indirectly if there are ref parameters or __arglist

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StackAlloc.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StackAlloc.cs
@@ -46,7 +46,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var locals = ArrayBuilder<LocalSymbol>.GetInstance();
                 var countTemp = CaptureExpressionInTempIfNeeded(rewrittenCount, sideEffects, locals, SynthesizedLocalKind.Spill);
                 var stackSize = RewriteStackAllocCountToSize(countTemp, elementType);
-                stackAllocNode = new BoundConvertedStackAllocExpression(stackAllocNode.Syntax, elementType, stackSize, initializerOpt, spanType);
+                stackAllocNode = new BoundConvertedStackAllocExpression(
+                    stackAllocNode.Syntax, elementType, stackSize, initializerOpt, _compilation.CreatePointerTypeSymbol(elementType));
 
                 BoundExpression constructorCall;
                 if (TryGetWellKnownTypeMember(stackAllocNode.Syntax, WellKnownMember.System_Span_T__ctor, out MethodSymbol spanConstructor))

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -630,6 +630,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return UpdateExpression(builder, node.Update(initializers));
         }
 
+        public override BoundNode VisitConvertedStackAllocExpression(BoundConvertedStackAllocExpression node)
+        {
+            BoundSpillSequenceBuilder builder = null;
+            BoundExpression count = VisitExpression(ref builder, node.Count);
+            var initializerOpt = (BoundArrayInitialization)VisitExpression(ref builder, node.InitializerOpt);
+            return UpdateExpression(builder, node.Update(node.ElementType, count, initializerOpt, node.Type));
+        }
+
         public override BoundNode VisitArrayLength(BoundArrayLength node)
         {
             BoundSpillSequenceBuilder builder = null;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStackAllocInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStackAllocInitializerTests.cs
@@ -421,6 +421,48 @@ static unsafe class C
   IL_0011:  pop
   IL_0012:  ret
 }");
+            CompileAndVerify(text,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_3),
+                options: TestOptions.UnsafeDebugExe,
+                expectedOutput: "12",
+                verify: Verification.Fails).VerifyIL("C.Main",
+@"{
+  // Code size       44 (0x2c)
+  .maxstack  4
+  .locals init (int* V_0) //p
+  IL_0000:  nop
+  IL_0001:  ldc.i4.s   16
+  IL_0003:  conv.u
+  IL_0004:  localloc
+  IL_0006:  dup
+  IL_0007:  ldc.i4.s   42
+  IL_0009:  stind.i4
+  IL_000a:  dup
+  IL_000b:  ldc.i4.4
+  IL_000c:  add
+  IL_000d:  ldc.i4.1
+  IL_000e:  call       ""byte C.Method(int)""
+  IL_0013:  stind.i4
+  IL_0014:  dup
+  IL_0015:  ldc.i4.2
+  IL_0016:  conv.i
+  IL_0017:  ldc.i4.4
+  IL_0018:  mul
+  IL_0019:  add
+  IL_001a:  ldc.i4.s   42
+  IL_001c:  stind.i4
+  IL_001d:  dup
+  IL_001e:  ldc.i4.3
+  IL_001f:  conv.i
+  IL_0020:  ldc.i4.4
+  IL_0021:  mul
+  IL_0022:  add
+  IL_0023:  ldc.i4.2
+  IL_0024:  call       ""byte C.Method(int)""
+  IL_0029:  stind.i4
+  IL_002a:  stloc.0
+  IL_002b:  ret
+}");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -16148,7 +16148,7 @@ public class Form1 {
         [Fact]
         public void CorrectOverloadOfStackAllocSpanChosen()
         {
-            var comp = CreateCompilationWithMscorlibAndSpan(@"
+            var source = @"
 using System;
 class Test
 {
@@ -16162,8 +16162,11 @@ class Test
         var span2 = condition ? new Span<int>(null, 3) : stackalloc int[4];
         Console.Write(span2.Length);
     }
-}", TestOptions.UnsafeReleaseExe);
+}";
 
+            var comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.UnsafeReleaseExe);
+            CompileAndVerify(comp, expectedOutput: "24", verify: Verification.Fails);
+            comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.UnsafeDebugExe);
             CompileAndVerify(comp, expectedOutput: "24", verify: Verification.Fails);
         }
 
@@ -16239,7 +16242,7 @@ class Test
         [Fact]
         public void StackAllocSpanLengthNotEvaluatedTwice()
         {
-            var comp = CreateCompilationWithMscorlibAndSpan(@"
+            var source = @"
 using System;
 class Test
 {
@@ -16258,8 +16261,8 @@ class Test
             Console.Write(x.Length);
         }
     }
-}", TestOptions.ReleaseExe);
-
+}";
+            var comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput: "12345", verify: Verification.Fails).VerifyIL("Test.Main", @"
 {
   // Code size       44 (0x2c)
@@ -16292,12 +16295,301 @@ class Test
   IL_0029:  blt.s      IL_0004
   IL_002b:  ret
 }");
+            comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "12345", verify: Verification.Fails).VerifyIL("Test.Main", @"
+{
+  // Code size       56 (0x38)
+  .maxstack  2
+  .locals init (int V_0, //i
+                System.Span<int> V_1, //x
+                int V_2,
+                System.Span<int> V_3,
+                bool V_4)
+  IL_0000:  nop
+  IL_0001:  ldc.i4.0
+  IL_0002:  stloc.0
+  IL_0003:  br.s       IL_002d
+  IL_0005:  nop
+  IL_0006:  call       ""int Test.GetLength()""
+  IL_000b:  stloc.2
+  IL_000c:  ldloc.2
+  IL_000d:  conv.u
+  IL_000e:  ldc.i4.4
+  IL_000f:  mul.ovf.un
+  IL_0010:  localloc
+  IL_0012:  ldloc.2
+  IL_0013:  newobj     ""System.Span<int>..ctor(void*, int)""
+  IL_0018:  stloc.3
+  IL_0019:  ldloc.3
+  IL_001a:  stloc.1
+  IL_001b:  ldloca.s   V_1
+  IL_001d:  call       ""int System.Span<int>.Length.get""
+  IL_0022:  call       ""void System.Console.Write(int)""
+  IL_0027:  nop
+  IL_0028:  nop
+  IL_0029:  ldloc.0
+  IL_002a:  ldc.i4.1
+  IL_002b:  add
+  IL_002c:  stloc.0
+  IL_002d:  ldloc.0
+  IL_002e:  ldc.i4.5
+  IL_002f:  clt
+  IL_0031:  stloc.s    V_4
+  IL_0033:  ldloc.s    V_4
+  IL_0035:  brtrue.s   IL_0005
+  IL_0037:  ret
+}");
+        }
+
+        [Fact]
+        public void NestedStackAlloc_01()
+        {
+            var source = @"
+using System;
+class Test
+{
+    public static void Main()
+    {
+        Console.WriteLine(M(2, stackalloc int[3]));
+    }
+    public static int M(int x, Span<int> y) => x * y.Length;
+}";
+            var comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: "6", verify: Verification.Fails).VerifyIL("Test.Main", @"
+{
+  // Code size       25 (0x19)
+  .maxstack  2
+  .locals init (System.Span<int> V_0)
+  IL_0000:  ldc.i4.s   12
+  IL_0002:  conv.u
+  IL_0003:  localloc
+  IL_0005:  ldc.i4.3
+  IL_0006:  newobj     ""System.Span<int>..ctor(void*, int)""
+  IL_000b:  stloc.0
+  IL_000c:  ldc.i4.2
+  IL_000d:  ldloc.0
+  IL_000e:  call       ""int Test.M(int, System.Span<int>)""
+  IL_0013:  call       ""void System.Console.WriteLine(int)""
+  IL_0018:  ret
+}");
+            comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "6", verify: Verification.Fails).VerifyIL("Test.Main", @"
+{
+  // Code size       27 (0x1b)
+  .maxstack  2
+  .locals init (System.Span<int> V_0)
+  IL_0000:  nop
+  IL_0001:  ldc.i4.s   12
+  IL_0003:  conv.u
+  IL_0004:  localloc
+  IL_0006:  ldc.i4.3
+  IL_0007:  newobj     ""System.Span<int>..ctor(void*, int)""
+  IL_000c:  stloc.0
+  IL_000d:  ldc.i4.2
+  IL_000e:  ldloc.0
+  IL_000f:  call       ""int Test.M(int, System.Span<int>)""
+  IL_0014:  call       ""void System.Console.WriteLine(int)""
+  IL_0019:  nop
+  IL_001a:  ret
+}");
+        }
+
+        [Fact]
+        public void NestedStackAlloc_02()
+        {
+            var source = @"
+using System;
+class Test
+{
+    public static void Main()
+    {
+        int z = 2;
+        Console.WriteLine(M(z, stackalloc int[3]));
+    }
+    public static int M(int x, Span<int> y) => x * y.Length;
+}";
+            var comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: "6", verify: Verification.Fails).VerifyIL("Test.Main", @"
+{
+  // Code size       27 (0x1b)
+  .maxstack  2
+  .locals init (int V_0,
+                System.Span<int> V_1)
+  IL_0000:  ldc.i4.2
+  IL_0001:  stloc.0
+  IL_0002:  ldc.i4.s   12
+  IL_0004:  conv.u
+  IL_0005:  localloc
+  IL_0007:  ldc.i4.3
+  IL_0008:  newobj     ""System.Span<int>..ctor(void*, int)""
+  IL_000d:  stloc.1
+  IL_000e:  ldloc.0
+  IL_000f:  ldloc.1
+  IL_0010:  call       ""int Test.M(int, System.Span<int>)""
+  IL_0015:  call       ""void System.Console.WriteLine(int)""
+  IL_001a:  ret
+}");
+            comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "6", verify: Verification.Fails).VerifyIL("Test.Main", @"
+{
+  // Code size       31 (0x1f)
+  .maxstack  2
+  .locals init (int V_0, //z
+                int V_1,
+                System.Span<int> V_2)
+  IL_0000:  nop
+  IL_0001:  ldc.i4.2
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  stloc.1
+  IL_0005:  ldc.i4.s   12
+  IL_0007:  conv.u
+  IL_0008:  localloc
+  IL_000a:  ldc.i4.3
+  IL_000b:  newobj     ""System.Span<int>..ctor(void*, int)""
+  IL_0010:  stloc.2
+  IL_0011:  ldloc.1
+  IL_0012:  ldloc.2
+  IL_0013:  call       ""int Test.M(int, System.Span<int>)""
+  IL_0018:  call       ""void System.Console.WriteLine(int)""
+  IL_001d:  nop
+  IL_001e:  ret
+}");
+        }
+
+        [Fact]
+        public void NestedStackAlloc_03()
+        {
+            var source = @"
+using System;
+class Test
+{
+    public static void Main()
+    {
+        int z = 2;
+        Console.WriteLine(z * stackalloc int[3] { 1, stackalloc int[2] { 4, 5 }.Length, 3 }.Length);
+    }
+    public static int M(int x, Span<int> y) => x * y.Length;
+}";
+            var comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: "6", verify: Verification.Fails).VerifyIL("Test.Main", @"
+{
+  // Code size       70 (0x46)
+  .maxstack  4
+  .locals init (int V_0,
+                System.Span<int> V_1,
+                System.Span<int> V_2)
+  IL_0000:  ldc.i4.2
+  IL_0001:  stloc.0
+  IL_0002:  ldc.i4.8
+  IL_0003:  conv.u
+  IL_0004:  localloc
+  IL_0006:  dup
+  IL_0007:  ldc.i4.4
+  IL_0008:  stind.i4
+  IL_0009:  dup
+  IL_000a:  ldc.i4.4
+  IL_000b:  add
+  IL_000c:  ldc.i4.5
+  IL_000d:  stind.i4
+  IL_000e:  ldc.i4.2
+  IL_000f:  newobj     ""System.Span<int>..ctor(void*, int)""
+  IL_0014:  stloc.1
+  IL_0015:  ldc.i4.s   12
+  IL_0017:  conv.u
+  IL_0018:  localloc
+  IL_001a:  dup
+  IL_001b:  ldc.i4.1
+  IL_001c:  stind.i4
+  IL_001d:  dup
+  IL_001e:  ldc.i4.4
+  IL_001f:  add
+  IL_0020:  ldloca.s   V_1
+  IL_0022:  call       ""int System.Span<int>.Length.get""
+  IL_0027:  stind.i4
+  IL_0028:  dup
+  IL_0029:  ldc.i4.2
+  IL_002a:  conv.i
+  IL_002b:  ldc.i4.4
+  IL_002c:  mul
+  IL_002d:  add
+  IL_002e:  ldc.i4.3
+  IL_002f:  stind.i4
+  IL_0030:  ldc.i4.3
+  IL_0031:  newobj     ""System.Span<int>..ctor(void*, int)""
+  IL_0036:  stloc.2
+  IL_0037:  ldloc.0
+  IL_0038:  ldloca.s   V_2
+  IL_003a:  call       ""int System.Span<int>.Length.get""
+  IL_003f:  mul
+  IL_0040:  call       ""void System.Console.WriteLine(int)""
+  IL_0045:  ret
+}");
+            comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "6", verify: Verification.Fails).VerifyIL("Test.Main", @"
+{
+  // Code size       74 (0x4a)
+  .maxstack  4
+  .locals init (int V_0, //z
+                int V_1,
+                System.Span<int> V_2,
+                System.Span<int> V_3)
+  IL_0000:  nop
+  IL_0001:  ldc.i4.2
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  stloc.1
+  IL_0005:  ldc.i4.8
+  IL_0006:  conv.u
+  IL_0007:  localloc
+  IL_0009:  dup
+  IL_000a:  ldc.i4.4
+  IL_000b:  stind.i4
+  IL_000c:  dup
+  IL_000d:  ldc.i4.4
+  IL_000e:  add
+  IL_000f:  ldc.i4.5
+  IL_0010:  stind.i4
+  IL_0011:  ldc.i4.2
+  IL_0012:  newobj     ""System.Span<int>..ctor(void*, int)""
+  IL_0017:  stloc.2
+  IL_0018:  ldc.i4.s   12
+  IL_001a:  conv.u
+  IL_001b:  localloc
+  IL_001d:  dup
+  IL_001e:  ldc.i4.1
+  IL_001f:  stind.i4
+  IL_0020:  dup
+  IL_0021:  ldc.i4.4
+  IL_0022:  add
+  IL_0023:  ldloca.s   V_2
+  IL_0025:  call       ""int System.Span<int>.Length.get""
+  IL_002a:  stind.i4
+  IL_002b:  dup
+  IL_002c:  ldc.i4.2
+  IL_002d:  conv.i
+  IL_002e:  ldc.i4.4
+  IL_002f:  mul
+  IL_0030:  add
+  IL_0031:  ldc.i4.3
+  IL_0032:  stind.i4
+  IL_0033:  ldc.i4.3
+  IL_0034:  newobj     ""System.Span<int>..ctor(void*, int)""
+  IL_0039:  stloc.3
+  IL_003a:  ldloc.1
+  IL_003b:  ldloca.s   V_3
+  IL_003d:  call       ""int System.Span<int>.Length.get""
+  IL_0042:  mul
+  IL_0043:  call       ""void System.Console.WriteLine(int)""
+  IL_0048:  nop
+  IL_0049:  ret
+}");
         }
 
         [Fact]
         public void ImplicitCastOperatorOnStackAllocIsLoweredCorrectly()
         {
-            var comp = CreateCompilationWithMscorlibAndSpan(@"
+            var source = @"
 using System;
 unsafe class Test
 {
@@ -16319,15 +16611,18 @@ unsafe class Test
         Console.Write(""PointerOpCalled"");
         return default(Test);
     }
-}", TestOptions.UnsafeReleaseExe);
-
-            CompileAndVerify(comp, expectedOutput: "SpanOpCalled|PointerOpCalled", verify: Verification.Fails);
+}";
+            var expectedOutput = "SpanOpCalled|PointerOpCalled";
+            var comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.UnsafeReleaseExe);
+            CompileAndVerify(comp, expectedOutput: expectedOutput, verify: Verification.Fails);
+            comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.UnsafeDebugExe);
+            CompileAndVerify(comp, expectedOutput: expectedOutput, verify: Verification.Fails);
         }
 
         [Fact]
         public void ExplicitCastOperatorOnStackAllocIsLoweredCorrectly()
         {
-            var comp = CreateCompilationWithMscorlibAndSpan(@"
+            var source = @"
 using System;
 unsafe class Test
 {
@@ -16341,8 +16636,10 @@ unsafe class Test
         Console.Write(""SpanOpCalled"");
         return default(Test);
     }
-}", TestOptions.UnsafeReleaseExe);
-
+}";
+            var comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.UnsafeReleaseExe);
+            CompileAndVerify(comp, expectedOutput: "SpanOpCalled", verify: Verification.Fails);
+            comp = CreateCompilationWithMscorlibAndSpan(source, TestOptions.UnsafeDebugExe);
             CompileAndVerify(comp, expectedOutput: "SpanOpCalled", verify: Verification.Fails);
         }
 


### PR DESCRIPTION
Fixes #35764
Also fix the type of a bound node (argument to a ctor) so it agrees with the corresponding parameter.

@jcouv @jaredpar Should this be patched on some other branch?
