### PR TITLE
this addresses issue where we repeatedly trying to create different c…

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Remote/JsonConverterTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/JsonConverterTests.cs
@@ -133,9 +133,12 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         public void TestPinnedSolutionInfo()
         {
             var checksum = Checksum.Create(WellKnownSynchronizationKind.Null, ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray()));
-            VerifyJsonSerialization(new PinnedSolutionInfo(scopeId: 10, fromPrimaryBranch: false, solutionChecksum: checksum), (x, y) =>
+            VerifyJsonSerialization(new PinnedSolutionInfo(scopeId: 10, fromPrimaryBranch: false, workspaceVersion: 100, solutionChecksum: checksum), (x, y) =>
             {
-                return (x.ScopeId == y.ScopeId && x.FromPrimaryBranch == y.FromPrimaryBranch && x.SolutionChecksum == y.SolutionChecksum) ? 0 : 1;
+                return (x.ScopeId == y.ScopeId &&
+                        x.FromPrimaryBranch == y.FromPrimaryBranch &&
+                        x.WorkspaceVersion == y.WorkspaceVersion &&
+                        x.SolutionChecksum == y.SolutionChecksum) ? 0 : 1;
             });
         }
 

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -64,7 +64,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
 
                 var service = (ISolutionController)await GetSolutionServiceAsync(solution);
-                var synched = await service.GetSolutionAsync(solutionChecksum, fromPrimaryBranch: true, cancellationToken: CancellationToken.None);
+                var synched = await service.GetSolutionAsync(solutionChecksum, fromPrimaryBranch: true, solution.WorkspaceVersion, cancellationToken: CancellationToken.None);
                 Assert.Equal(solutionChecksum, await synched.State.GetChecksumAsync(CancellationToken.None));
                 Assert.True(synched.Workspace is RemoteWorkspace);
             }
@@ -360,7 +360,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
                 // update primary workspace
                 var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
-                await ((ISolutionController)service).UpdatePrimaryWorkspaceAsync(solutionChecksum, CancellationToken.None);
+                await ((ISolutionController)service).UpdatePrimaryWorkspaceAsync(solutionChecksum, solution.WorkspaceVersion, CancellationToken.None);
 
                 // get solution in remote host
                 var oopSolution = await service.GetSolutionAsync(solutionChecksum, CancellationToken.None);
@@ -382,11 +382,74 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 testAnalyzerProvider.Analyzer.Reset();
 
                 // update remote workspace
+                oopSolution = oopSolution.WithDocumentText(oopSolution.Projects.First().Documents.First().Id, SourceText.From(code + " class Test2 { }"));
                 var remoteWorkspace = (RemoteWorkspace)oopSolution.Workspace;
-                remoteWorkspace.UpdateSolution(oopSolution.WithDocumentText(oopSolution.Projects.First().Documents.First().Id, SourceText.From(code + " class Test2 { }")));
+                remoteWorkspace.UpdateSolutionIfPossible(oopSolution, solution.WorkspaceVersion + 1);
 
                 // check solution update correctly ran solution crawler
                 Assert.True(await testAnalyzerProvider.Analyzer.Called);
+            }
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
+        public async Task TestRemoteWorkspace()
+        {
+            var code = @"class Test { void Method() { } }";
+
+            // create base solution
+            using (var workspace = TestWorkspace.CreateCSharp(code))
+            {
+                // create solution service
+                var solution1 = workspace.CurrentSolution;
+                var service = await GetSolutionServiceAsync(solution1);
+
+                var oopSolution1 = await GetInitialOOPSolutionAsync(service, solution1);
+                var remoteWorkspace = (RemoteWorkspace)oopSolution1.Workspace;
+
+                await Verify(solution1, oopSolution1, expectRemoteSolutionToCurrent: true);
+                var version = solution1.WorkspaceVersion;
+
+                // update remote workspace
+                var currentSolution = oopSolution1.WithDocumentText(oopSolution1.Projects.First().Documents.First().Id, SourceText.From(code + " class Test2 { }"));
+                var oopSolution2 = remoteWorkspace.UpdateSolutionIfPossible(currentSolution, ++version);
+
+                await Verify(currentSolution, oopSolution2, expectRemoteSolutionToCurrent: true);
+
+                // move backward
+                await Verify(oopSolution1, remoteWorkspace.UpdateSolutionIfPossible(oopSolution1, solution1.WorkspaceVersion), expectRemoteSolutionToCurrent: false);
+
+                // move forward
+                currentSolution = oopSolution2.WithDocumentText(oopSolution2.Projects.First().Documents.First().Id, SourceText.From(code + " class Test3 { }"));
+                var oopSolution3 = remoteWorkspace.UpdateSolutionIfPossible(currentSolution, ++version);
+
+                await Verify(currentSolution, oopSolution3, expectRemoteSolutionToCurrent: true);
+
+                // move to new solution backward
+                var solutionInfo = await service.GetSolutionInfoAsync(await solution1.State.GetChecksumAsync(CancellationToken.None), CancellationToken.None);
+                Assert.False(remoteWorkspace.TryAddSolutionIfPossible(solutionInfo, solution1.WorkspaceVersion, out var _));
+
+                // move to new solution forward
+                Assert.True(remoteWorkspace.TryAddSolutionIfPossible(solutionInfo, ++version, out var newSolution));
+                await Verify(solution1, newSolution, expectRemoteSolutionToCurrent: true);
+            }
+
+            static async Task<Solution> GetInitialOOPSolutionAsync(SolutionService service, Solution solution)
+            {
+                // set up initial solution
+                var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
+                await ((ISolutionController)service).UpdatePrimaryWorkspaceAsync(solutionChecksum, solution.WorkspaceVersion, CancellationToken.None);
+
+                // get solution in remote host
+                return await service.GetSolutionAsync(solutionChecksum, CancellationToken.None);
+            }
+
+            static async Task Verify(Solution givenSolution, Solution remoteSolution, bool expectRemoteSolutionToCurrent)
+            {
+                // verify we got solution expected
+                Assert.Equal(await givenSolution.State.GetChecksumAsync(CancellationToken.None), await remoteSolution.State.GetChecksumAsync(CancellationToken.None));
+
+                // verify remote workspace got updated
+                Assert.True(expectRemoteSolutionToCurrent == (remoteSolution == remoteSolution.Workspace.CurrentSolution));
             }
         }
 
@@ -408,7 +471,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
 
             // update primary workspace
-            await ((ISolutionController)service).UpdatePrimaryWorkspaceAsync(solutionChecksum, CancellationToken.None);
+            await ((ISolutionController)service).UpdatePrimaryWorkspaceAsync(solutionChecksum, solution.WorkspaceVersion, CancellationToken.None);
             var first = await service.GetSolutionAsync(solutionChecksum, CancellationToken.None);
 
             Assert.IsAssignableFrom<RemoteWorkspace>(first.Workspace);
@@ -428,7 +491,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             Assert.False(object.ReferenceEquals(primaryWorkspace.PrimaryBranchId, second.BranchId));
 
             // do same once updating primary workspace
-            await ((ISolutionController)service).UpdatePrimaryWorkspaceAsync(newSolutionChecksum, CancellationToken.None);
+            await ((ISolutionController)service).UpdatePrimaryWorkspaceAsync(newSolutionChecksum, solution.WorkspaceVersion + 1, CancellationToken.None);
             var third = await service.GetSolutionAsync(newSolutionChecksum, CancellationToken.None);
 
             Assert.Equal(newSolutionChecksum, await third.State.GetChecksumAsync(CancellationToken.None));

--- a/src/Workspaces/Core/Portable/Execution/PinnedRemotableDataScope.cs
+++ b/src/Workspaces/Core/Portable/Execution/PinnedRemotableDataScope.cs
@@ -28,12 +28,20 @@ namespace Microsoft.CodeAnalysis.Execution
         /// can benefit other requests or not
         /// </summary>
         public readonly bool FromPrimaryBranch;
+
+        /// <summary>
+        /// This indicates a version of this solution. remote host engine uses this version
+        /// to decide whether caching this solution will benefit other requests or not
+        /// </summary>
+        public readonly int WorkspaceVersion;
+
         public readonly Checksum SolutionChecksum;
 
-        public PinnedSolutionInfo(int scopeId, bool fromPrimaryBranch, Checksum solutionChecksum)
+        public PinnedSolutionInfo(int scopeId, bool fromPrimaryBranch, int workspaceVersion, Checksum solutionChecksum)
         {
             ScopeId = scopeId;
             FromPrimaryBranch = fromPrimaryBranch;
+            WorkspaceVersion = workspaceVersion;
             SolutionChecksum = solutionChecksum;
         }
     }
@@ -64,6 +72,7 @@ namespace Microsoft.CodeAnalysis.Execution
             SolutionInfo = new PinnedSolutionInfo(
                 Interlocked.Increment(ref s_scopeId),
                 _storage.SolutionState.BranchId == Workspace.PrimaryBranchId,
+                _storage.SolutionState.WorkspaceVersion,
                 solutionChecksum);
 
             _storages.RegisterSnapshot(this, storage);

--- a/src/Workspaces/Core/Portable/Execution/PinnedRemotableDataScope.cs
+++ b/src/Workspaces/Core/Portable/Execution/PinnedRemotableDataScope.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Execution
         public readonly bool FromPrimaryBranch;
 
         /// <summary>
-        /// This indicates a version of this solution. remote host engine uses this version
+        /// This indicates a Solution.WorkspaceVersion of this solution. remote host engine uses this version
         /// to decide whether caching this solution will benefit other requests or not
         /// </summary>
         public readonly int WorkspaceVersion;

--- a/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
+++ b/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// Synchronize data to OOP proactively without anyone asking for it to make most of operation
         /// faster
         /// </summary>
-        Task SynchronizePrimaryWorkspaceAsync(Checksum checksum, CancellationToken cancellationToken);
+        Task SynchronizePrimaryWorkspaceAsync(Checksum checksum, int workspaceVersion, CancellationToken cancellationToken);
         Task SynchronizeTextAsync(DocumentId documentId, Checksum baseTextChecksum, IEnumerable<TextChange> textChanges, CancellationToken cancellationToken);
         Task SynchronizeGlobalAssetsAsync(Checksum[] checksums, CancellationToken cancellationToken);
     }

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
@@ -217,7 +217,9 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 await remoteHostClient.TryRunRemoteAsync(
                     WellKnownRemoteHostServices.RemoteHostService, solution,
-                    nameof(IRemoteHostService.SynchronizePrimaryWorkspaceAsync), checksum, cancellationToken).ConfigureAwait(false);
+                    nameof(IRemoteHostService.SynchronizePrimaryWorkspaceAsync),
+                    new object[] { checksum, solution.WorkspaceVersion },
+                    cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Workspaces/Remote/Core/Services/ISolutionController.cs
+++ b/src/Workspaces/Remote/Core/Services/ISolutionController.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Remote
     /// </summary>
     internal interface ISolutionController
     {
-        Task<Solution> GetSolutionAsync(Checksum solutionChecksum, bool fromPrimaryBranch, CancellationToken cancellationToken);
+        Task<Solution> GetSolutionAsync(Checksum solutionChecksum, bool fromPrimaryBranch, int workspaceVersion, CancellationToken cancellationToken);
 
-        Task UpdatePrimaryWorkspaceAsync(Checksum solutionChecksum, CancellationToken cancellationToken);
+        Task UpdatePrimaryWorkspaceAsync(Checksum solutionChecksum, int workspaceVersion, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/Core/Services/RemoteDocumentDifferenceService.cs
+++ b/src/Workspaces/Remote/Core/Services/RemoteDocumentDifferenceService.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.SolutionCrawler;
+
+namespace Microsoft.CodeAnalysis.Remote
+{
+    /// <summary>
+    /// Provide document different service specific to remote workspace's behavior.
+    /// 
+    /// default <see cref="AbstractDocumentDifferenceService"/> is optimized for typing case in editor where we have events
+    /// for each typing. but in remote workspace, we aggregate changes and update solution in bulk and we don't have concept
+    /// of active file making default implementation not suitable. functionally, default one is still correct. but it often
+    /// time makes us to do more than we need. basically, it always says this project has semantic change which can cause
+    /// a lot of re-analysis.
+    /// </summary>
+    internal class RemoteDocumentDifferenceService : IDocumentDifferenceService
+    {
+        [ExportLanguageService(typeof(IDocumentDifferenceService), LanguageNames.CSharp, layer: WorkspaceKind.Host), Shared]
+        internal class CSharpDocumentDifferenceService : RemoteDocumentDifferenceService
+        {
+        }
+
+        [ExportLanguageService(typeof(IDocumentDifferenceService), LanguageNames.VisualBasic, layer: WorkspaceKind.Host), Shared]
+        internal class VisualBasicDocumentDifferenceService : AbstractDocumentDifferenceService
+        {
+        }
+
+        public async Task<DocumentDifferenceResult> GetDifferenceAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken)
+        {
+            // in remote workspace, we don't trust any version based on VersionStamp. we only trust content based information such as
+            // checksum or tree comparision and etc.
+
+            // first check checksum
+            var oldTextChecksum = (await oldDocument.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false)).Text;
+            var newTextChecksum = (await newDocument.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false)).Text;
+            if (oldTextChecksum == newTextChecksum)
+            {
+                // null means nothing has changed.
+                return null;
+            }
+
+            var oldRoot = await oldDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var newRoot = await newDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (oldRoot.IsEquivalentTo(newRoot, topLevel: true))
+            {
+                // only method body changed
+                return new DocumentDifferenceResult(InvocationReasons.SyntaxChanged);
+            }
+
+            // semantic has changed as well.
+            return new DocumentDifferenceResult(InvocationReasons.DocumentChanged);
+        }
+    }
+}

--- a/src/Workspaces/Remote/Core/Services/SolutionService.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionService.cs
@@ -48,14 +48,23 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
+        public Task<SolutionInfo> GetSolutionInfoAsync(Checksum solutionChecksum, CancellationToken cancellationToken)
+        {
+            return SolutionInfoCreator.CreateSolutionInfoAsync(_assetService, solutionChecksum, cancellationToken);
+        }
+
         public Task<Solution> GetSolutionAsync(Checksum solutionChecksum, CancellationToken cancellationToken)
         {
             // this method is called by users which means we don't know whether the solution is from primary branch or not.
             // so we will be conservative and assume it is not. meaning it won't update any internal caches but only consume cache if possible.
-            return GetSolutionInternalAsync(solutionChecksum, fromPrimaryBranch: false, cancellationToken: cancellationToken);
+            return GetSolutionInternalAsync(solutionChecksum, fromPrimaryBranch: false, workspaceVersion: -1, cancellationToken: cancellationToken);
         }
 
-        private async Task<Solution> GetSolutionInternalAsync(Checksum solutionChecksum, bool fromPrimaryBranch, CancellationToken cancellationToken)
+        private async Task<Solution> GetSolutionInternalAsync(
+            Checksum solutionChecksum,
+            bool fromPrimaryBranch,
+            int workspaceVersion,
+            CancellationToken cancellationToken)
         {
             var currentSolution = GetAvailableSolution(solutionChecksum);
             if (currentSolution != null)
@@ -72,7 +81,12 @@ namespace Microsoft.CodeAnalysis.Remote
                     return currentSolution;
                 }
 
-                var solution = await CreateSolution_NoLockAsync(solutionChecksum, fromPrimaryBranch, PrimaryWorkspace.CurrentSolution, cancellationToken).ConfigureAwait(false);
+                var solution = await CreateSolution_NoLockAsync(
+                    solutionChecksum,
+                    fromPrimaryBranch,
+                    workspaceVersion,
+                    PrimaryWorkspace.CurrentSolution,
+                    cancellationToken).ConfigureAwait(false);
                 s_lastSolution = Tuple.Create(solutionChecksum, solution);
 
                 return solution;
@@ -101,7 +115,12 @@ namespace Microsoft.CodeAnalysis.Remote
         /// these 2 are complimentary to each other. #1 makes OOP's primary solution to be ready for next call (push), #2 makes OOP's primary
         /// solution be not stale as much as possible. (pull)
         /// </summary>
-        private async Task<Solution> CreateSolution_NoLockAsync(Checksum solutionChecksum, bool fromPrimaryBranch, Solution baseSolution, CancellationToken cancellationToken)
+        private async Task<Solution> CreateSolution_NoLockAsync(
+            Checksum solutionChecksum,
+            bool fromPrimaryBranch,
+            int workspaceVersion,
+            Solution baseSolution,
+            CancellationToken cancellationToken)
         {
             var updater = new SolutionCreator(_assetService, baseSolution, cancellationToken);
 
@@ -114,8 +133,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 if (fromPrimaryBranch)
                 {
                     // if the solutionChecksum is for primary branch, update primary workspace cache with the solution
-                    PrimaryWorkspace.UpdateSolution(solution);
-                    return PrimaryWorkspace.CurrentSolution;
+                    return PrimaryWorkspace.UpdateSolutionIfPossible(solution, workspaceVersion);
                 }
 
                 // otherwise, just return the solution
@@ -126,28 +144,28 @@ namespace Microsoft.CodeAnalysis.Remote
             await _assetService.SynchronizeSolutionAssetsAsync(solutionChecksum, cancellationToken).ConfigureAwait(false);
 
             // get new solution info
-            var solutionInfo = await SolutionInfoCreator.CreateSolutionInfoAsync(_assetService, solutionChecksum, cancellationToken).ConfigureAwait(false);
+            var solutionInfo = await GetSolutionInfoAsync(solutionChecksum, cancellationToken).ConfigureAwait(false);
 
             if (fromPrimaryBranch)
             {
                 // if the solutionChecksum is for primary branch, update primary workspace cache with new solution
-                PrimaryWorkspace.ClearSolution();
-                PrimaryWorkspace.AddSolution(solutionInfo);
-
-                return PrimaryWorkspace.CurrentSolution;
+                if (PrimaryWorkspace.TryAddSolutionIfPossible(solutionInfo, workspaceVersion, out var solution))
+                {
+                    return solution;
+                }
             }
 
             // otherwise, just return new solution
-            var workspace = new TemporaryWorkspace(await SolutionInfoCreator.CreateSolutionInfoAsync(_assetService, solutionChecksum, cancellationToken).ConfigureAwait(false));
+            var workspace = new TemporaryWorkspace(solutionInfo);
             return workspace.CurrentSolution;
         }
 
-        Task<Solution> ISolutionController.GetSolutionAsync(Checksum solutionChecksum, bool primary, CancellationToken cancellationToken)
+        Task<Solution> ISolutionController.GetSolutionAsync(Checksum solutionChecksum, bool primary, int workspaceVersion, CancellationToken cancellationToken)
         {
-            return GetSolutionInternalAsync(solutionChecksum, primary, cancellationToken);
+            return GetSolutionInternalAsync(solutionChecksum, primary, workspaceVersion, cancellationToken);
         }
 
-        async Task ISolutionController.UpdatePrimaryWorkspaceAsync(Checksum solutionChecksum, CancellationToken cancellationToken)
+        async Task ISolutionController.UpdatePrimaryWorkspaceAsync(Checksum solutionChecksum, int workspaceVersion, CancellationToken cancellationToken)
         {
             var currentSolution = PrimaryWorkspace.CurrentSolution;
 
@@ -160,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Remote
             using (await s_gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
                 var primary = true;
-                var solution = await CreateSolution_NoLockAsync(solutionChecksum, primary, currentSolution, cancellationToken).ConfigureAwait(false);
+                var solution = await CreateSolution_NoLockAsync(solutionChecksum, primary, workspaceVersion, currentSolution, cancellationToken).ConfigureAwait(false);
                 s_primarySolution = Tuple.Create(solutionChecksum, solution);
             }
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -282,14 +282,14 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public Task SynchronizePrimaryWorkspaceAsync(Checksum checksum, CancellationToken cancellationToken)
+        public Task SynchronizePrimaryWorkspaceAsync(Checksum checksum, int workspaceVersion, CancellationToken cancellationToken)
         {
             return RunServiceAsync(async token =>
             {
                 using (RoslynLogger.LogBlock(FunctionId.RemoteHostService_SynchronizePrimaryWorkspaceAsync, Checksum.GetChecksumLogInfo, checksum, token))
                 {
                     var solutionController = (ISolutionController)RoslynServices.SolutionService;
-                    await solutionController.UpdatePrimaryWorkspaceAsync(checksum, token).ConfigureAwait(false);
+                    await solutionController.UpdatePrimaryWorkspaceAsync(checksum, workspaceVersion, token).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }

--- a/src/Workspaces/Remote/ServiceHub/Shared/RoslynJsonConverter.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/RoslynJsonConverter.cs
@@ -191,12 +191,13 @@ namespace Microsoft.CodeAnalysis.Remote
                 // all integer is long
                 var scopeId = ReadProperty<long>(reader);
                 var fromPrimaryBranch = ReadProperty<bool>(reader);
+                var workspaceVersion = ReadProperty<long>(reader);
                 var checksum = ReadProperty<Checksum>(reader, serializer);
 
                 Contract.ThrowIfFalse(reader.Read());
                 Contract.ThrowIfFalse(reader.TokenType == JsonToken.EndObject);
 
-                return new PinnedSolutionInfo((int)scopeId, fromPrimaryBranch, checksum);
+                return new PinnedSolutionInfo((int)scopeId, fromPrimaryBranch, (int)workspaceVersion, checksum);
             }
 
             protected override void WriteValue(JsonWriter writer, PinnedSolutionInfo scope, JsonSerializer serializer)
@@ -208,6 +209,9 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 writer.WritePropertyName("primary");
                 writer.WriteValue(scope.FromPrimaryBranch);
+
+                writer.WritePropertyName("version");
+                writer.WriteValue(scope.WorkspaceVersion);
 
                 writer.WritePropertyName("checksum");
                 serializer.Serialize(writer, scope.SolutionChecksum);

--- a/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.Remote
         private static Task<Solution> GetSolutionAsync(RoslynServices roslynService, PinnedSolutionInfo solutionInfo, CancellationToken cancellationToken)
         {
             var solutionController = (ISolutionController)roslynService.SolutionService;
-            return solutionController.GetSolutionAsync(solutionInfo.SolutionChecksum, solutionInfo.FromPrimaryBranch, cancellationToken);
+            return solutionController.GetSolutionAsync(solutionInfo.SolutionChecksum, solutionInfo.FromPrimaryBranch, solutionInfo.WorkspaceVersion, cancellationToken);
         }
 
         protected async Task<T> RunServiceAsync<T>(Func<CancellationToken, Task<T>> callAsync, CancellationToken cancellationToken)


### PR DESCRIPTION
…ompilations in OOP causing a lot of allocations.

the issue was OOP solution crawler processing documents from different projects rather than per the same project. basically, void the benefit the solution crawler (processing same project one at a time so that all share the same compilation/symbols and etc)

the root cause was due to documents got removed and then readded to remote workspace solution. and that was happening because remote workspace could be moved backward.

fix is making sure that workspace can't ever move backward.

...

some background.

originally, RemoteWorkspace was added to OOP as pure cache. so that, when someone needs a solution matching one from VS, OOP doesn't need to recreate the solution from scratch.

so, it always has set RemoteWorkspace to last requested solution from VS (a snapshot of VSWorkspace.CurrentSolution)

what that means is if there are multiple requests from VS with snapshot1, snapshot2, snapshot1, snapshot3

remoteWorkspace.CurrentSolution could move from snapshot1 -> snapshot2 -> snapshot1 -> snapshot3

it was all fine as pure cache since as a cache, there is no such concept of moving forward or backward. it is just a snapshot. and RemoteWorkspace is just something we need to have due to a solution having back pointer to a workspace and I can do incremental update more efficiently. but functionally, the workspace wasn't required.

this got more complicated when solution crawler is added to OOP to support "Find all reference" and "navigate to"

strictly, solution crawler doesn't care whether solution going backward. as long as we can diff 2 solutions correctly, going backward is just another change in solution and solution crawler handle those correctly.

problem is perf. now it causes unnecessary work. causing a lot of unnecessary allocation.

what makes it worse is that we mark document removed as high priority to process them faster. and we let solution crawler process high priority document in any order rather than per project. but since we allowed remote workspace solution to go back and forth, we end up marked a lot of document high priority since documents got removed and then re-added back. and we start to process them not in group causing even more allocations.

now, we only allow remote workspace to move forward. never backward.
...

this PR also includes 1 perf improvement. previously OOP used default IDocumentDifferenceService to detect document changes in solution crawler. but the default implementation was optimized for typing that is not suitable for OOP. and we end up always did more work than what we needed since the default implementation basically see whether a document is from an opened document and otherwise, it simply says everything changed. and in OOP, all document is closed.

new OOP specific service simply gets parse tree and diff to see what got changed. this is not good for typing case, but for OOP where it bulk updates solution, better than default implementation.