### PR TITLE
Modify get contained document to accept null id as input.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -62,6 +62,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
         public static ContainedDocument TryGetContainedDocument(DocumentId id)
         {
+            if (id == null)
+            {
+                return null;
+            }
+
             ContainedDocument document;
             s_containedDocuments.TryGetValue(id, out document);
 

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -62,6 +62,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
         public static ContainedDocument TryGetContainedDocument(DocumentId id)
         {
+            // Liveshare creates their own non-VS workspace which downloads files from the host.
+            // In such a case, a null id can be passed in, so check before attempting to retrieve the document.
             if (id == null)
             {
                 return null;

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -62,8 +62,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
         public static ContainedDocument TryGetContainedDocument(DocumentId id)
         {
-            // Liveshare creates their own non-VS workspace which downloads files from the host.
-            // In such a case, a null id can be passed in, so check before attempting to retrieve the document.
             if (id == null)
             {
                 return null;

--- a/src/VisualStudio/Core/Test/Venus/ContainedDocumentTests.vb
+++ b/src/VisualStudio/Core/Test/Venus/ContainedDocumentTests.vb
@@ -1,0 +1,13 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.Venus
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Venus
+    Public Class ContainedDocumentTests
+        <Fact>
+        Public Sub ContainedDocument_AcceptsNullInput()
+            Dim documentId = ContainedDocument.TryGetContainedDocument(Nothing)
+            Assert.Null(documentId)
+        End Sub
+    End Class
+End Namespace


### PR DESCRIPTION
Liveshare is broken for 16.1 P4 or greater clients because a null check was misplaced in a refactoring.

[This method](https://github.com/dotnet/roslyn/blob/master/src/VisualStudio/Core/Def/Implementation/VisualStudioSupportsFeatureService.cs#L57) returns null because liveshare uses their own workspace type.  This causes [TryGetContainedDocument ](https://github.com/dotnet/roslyn/blob/master/src/VisualStudio/Core/Def/Implementation/VisualStudioSupportsFeatureService.cs#L87)to throw an argument exception as the id is null.

The fix implementing here is to either modify all the call sites to skip this call when null or return null when passed in null to TryGetContainedDocument.  In all reference locations I could find, a null check is performed before the result of TryGetContainedDocument was used, so this seems safe (and it's already TryGet)

Tested in a liveshare session that a > 16.1p4 client can use preview code actions.