### PR TITLE
Set non-blocking mode per textView

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             // There could be mixed desired behavior per textView and even per same completion session.
             // The right fix would be to send this information as a result of the method. 
             // Then, the Editor would choose the right behavior for mixed cases.
-            _textView.Options.SetOptionValue(NonBlockingCompletionEditorOption, !document.Project.Solution.Workspace.Options.GetOption(CompletionOptions.BlockForCompletionItems, service.Language));
+            _textView.Options.GlobalOptions.SetOptionValue(NonBlockingCompletionEditorOption, !document.Project.Solution.Workspace.Options.GetOption(CompletionOptions.BlockForCompletionItems, service.Language));
 
             // In case of calls with multiple completion services for the same view (e.g. TypeScript and C#), those completion services must not be called simultaneously for the same session.
             // Therefore, in each completion session we use a list of commit character for a specific completion service and a specific content type.

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -96,14 +96,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return AsyncCompletionData.CompletionStartData.DoesNotParticipateInCompletion;
             }
 
-            if (!document.Project.Solution.Workspace.Options.GetOption(CompletionOptions.BlockForCompletionItems, service.Language))
-            {
-                // The Editor supports the option per textView.
-                // There could be mixed desired behavior per textView and even per same completion session.
-                // The right fix would be to send this information as a result of the method. 
-                // Then, the Editor would choose the right behavior for mixed cases.
-                _textView.Options.SetOptionValue(NonBlockingCompletionEditorOption, true);
-            }
+            // The Editor supports the option per textView.
+            // There could be mixed desired behavior per textView and even per same completion session.
+            // The right fix would be to send this information as a result of the method. 
+            // Then, the Editor would choose the right behavior for mixed cases.
+            _textView.Options.SetOptionValue(NonBlockingCompletionEditorOption, !document.Project.Solution.Workspace.Options.GetOption(CompletionOptions.BlockForCompletionItems, service.Language));
 
             // In case of calls with multiple completion services for the same view (e.g. TypeScript and C#), those completion services must not be called simultaneously for the same session.
             // Therefore, in each completion session we use a list of commit character for a specific completion service and a specific content type.

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -98,7 +98,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             if (!document.Project.Solution.Workspace.Options.GetOption(CompletionOptions.BlockForCompletionItems, service.Language))
             {
-                _textView.Options.GlobalOptions.SetOptionValue(NonBlockingCompletionEditorOption, true);
+                // The Editor supports the option per textView.
+                // There could be mixed desired behavior per textView and even per same completion session.
+                // The right fix would be to send this information as a result of the method. 
+                // Then, the Editor would choose the right behavior for mixed cases.
+                _textView.Options.SetOptionValue(NonBlockingCompletionEditorOption, true);
             }
 
             // In case of calls with multiple completion services for the same view (e.g. TypeScript and C#), those completion services must not be called simultaneously for the same session.


### PR DESCRIPTION
Since 16.1, the Editor support blocking/non-blocking mode per textView. This fixes a situation when users turned the _non-blocking_ option ON for TypeScript/F# and could never turned it OFF.

There still can happen mixed scenarios with TypeScript and C# in the same file. However, the right fix for them would be to send the value to the Editor not via the option but as a result.