### PR TITLE
Add ImportingConstructor attribute to fix RS0034 (Exported parts should have ImportingConstructor)

### DIFF
--- a/src/EditorFeatures/CSharp/BraceMatching/LessThanGreaterThanBraceMatcher.cs
+++ b/src/EditorFeatures/CSharp/BraceMatching/LessThanGreaterThanBraceMatcher.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
@@ -7,6 +8,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
     [ExportBraceMatcher(LanguageNames.CSharp)]
     internal class LessThanGreaterThanBraceMatcher : AbstractCSharpBraceMatcher
     {
+        [ImportingConstructor]
         public LessThanGreaterThanBraceMatcher()
             : base(SyntaxKind.LessThanToken, SyntaxKind.GreaterThanToken)
         {

--- a/src/EditorFeatures/CSharp/BraceMatching/OpenCloseBraceBraceMatcher.cs
+++ b/src/EditorFeatures/CSharp/BraceMatching/OpenCloseBraceBraceMatcher.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
@@ -7,6 +8,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
     [ExportBraceMatcher(LanguageNames.CSharp)]
     internal class OpenCloseBraceBraceMatcher : AbstractCSharpBraceMatcher
     {
+        [ImportingConstructor]
         public OpenCloseBraceBraceMatcher()
             : base(SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken)
         {

--- a/src/EditorFeatures/CSharp/BraceMatching/OpenCloseBracketBraceMatcher.cs
+++ b/src/EditorFeatures/CSharp/BraceMatching/OpenCloseBracketBraceMatcher.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
@@ -7,6 +8,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
     [ExportBraceMatcher(LanguageNames.CSharp)]
     internal class OpenCloseBracketBraceMatcher : AbstractCSharpBraceMatcher
     {
+        [ImportingConstructor]
         public OpenCloseBracketBraceMatcher()
             : base(SyntaxKind.OpenBracketToken, SyntaxKind.CloseBracketToken)
         {

--- a/src/EditorFeatures/CSharp/BraceMatching/OpenCloseParenBraceMatcher.cs
+++ b/src/EditorFeatures/CSharp/BraceMatching/OpenCloseParenBraceMatcher.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
@@ -7,6 +8,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
     [ExportBraceMatcher(LanguageNames.CSharp)]
     internal class OpenCloseParenBraceMatcher : AbstractCSharpBraceMatcher
     {
+        [ImportingConstructor]
         public OpenCloseParenBraceMatcher()
             : base(SyntaxKind.OpenParenToken, SyntaxKind.CloseParenToken)
         {

--- a/src/EditorFeatures/CSharp/EmbeddedLanguages/CSharpEmbeddedLanguageEditorFeaturesProvider.cs
+++ b/src/EditorFeatures/CSharp/EmbeddedLanguages/CSharpEmbeddedLanguageEditorFeaturesProvider.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Editor.EmbeddedLanguages
     {
         public static IEmbeddedLanguageFeaturesProvider Instance = new CSharpEmbeddedLanguageEditorFeaturesProvider();
 
+        [ImportingConstructor]
         public CSharpEmbeddedLanguageEditorFeaturesProvider() : base(CSharpEmbeddedLanguagesProvider.Info)
         {
         }

--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
         // All the characters that might potentially trigger formatting when typed
         private readonly char[] _supportedChars = ";{}#nte:)".ToCharArray();
 
+        [ImportingConstructor]
         public CSharpEditorFormattingService()
         {
         }

--- a/src/EditorFeatures/CSharp/Wrapping/CSharpWrappingCodeRefactoringProvider.cs
+++ b/src/EditorFeatures/CSharp/Wrapping/CSharpWrappingCodeRefactoringProvider.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Wrapping
                 new CSharpParameterWrapper(),
                 new CSharpBinaryExpressionWrapper());
 
+        [ImportingConstructor]
         public CSharpWrappingCodeRefactoringProvider()
             : base(s_wrappers)
         {

--- a/src/EditorFeatures/Core.Wpf/BraceMatching/ClassificationTypeFormatDefinitions.cs
+++ b/src/EditorFeatures/Core.Wpf/BraceMatching/ClassificationTypeFormatDefinitions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.BraceMatching
         [UserVisible(true)]
         private class BraceMatchingFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private BraceMatchingFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.Brace_Matching;

--- a/src/EditorFeatures/Core.Wpf/Classification/ClassificationTypeFormatDefinitions.cs
+++ b/src/EditorFeatures/Core.Wpf/Classification/ClassificationTypeFormatDefinitions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class PreprocessorTextFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private PreprocessorTextFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.Preprocessor_Text;
@@ -39,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class PunctuationFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private PunctuationFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.Punctuation;
@@ -56,6 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class StringVerbatimFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private StringVerbatimFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.String_Verbatim;
@@ -81,6 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class StringEscapeCharacterFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private StringEscapeCharacterFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.String_Escape_Character;
@@ -100,6 +104,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class ControlKeywordFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private ControlKeywordFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.Keyword_Control;
@@ -117,6 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class OperatorOverloadedFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private OperatorOverloadedFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.Operator_Overloaded;
@@ -133,6 +139,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class SymbolStaticFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private SymbolStaticFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.Symbol_Static;
@@ -171,6 +178,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserTypeClassesFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserTypeClassesFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Types_Classes;
@@ -189,6 +197,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserTypeDelegatesFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserTypeDelegatesFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Types_Delegates;
@@ -207,6 +216,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserTypeEnumsFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserTypeEnumsFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Types_Enums;
@@ -225,6 +235,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserTypeInterfacesFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserTypeInterfacesFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Types_Interfaces;
@@ -242,6 +253,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class UserTypeModulesFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserTypeModulesFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Types_Modules;
@@ -260,6 +272,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserTypeStructuresFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserTypeStructuresFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Types_Structures;
@@ -278,6 +291,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserTypeTypeParametersFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserTypeTypeParametersFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Types_Type_Parameters;
@@ -297,6 +311,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserMembersFieldNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserMembersFieldNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Members_Fields;
@@ -314,6 +329,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserMembersEnumMemberNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserMembersEnumMemberNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Members_Enum_Members;
@@ -331,6 +347,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserMembersConstantNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserMembersConstantNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Members_Constants;
@@ -348,6 +365,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserMembersLocalNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserMembersLocalNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Members_Locals;
@@ -365,6 +383,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserMembersParameterNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserMembersParameterNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Members_Parameters;
@@ -382,6 +401,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserMembersMethodNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserMembersMethodNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Members_Methods;
@@ -399,6 +419,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserMembersExtensionMethodNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserMembersExtensionMethodNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Members_Extension_Methods;
@@ -416,6 +437,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserMembersPropertyNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserMembersPropertyNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Members_Properties;
@@ -432,6 +454,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserMembersEventNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserMembersEventNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Members_Events;
@@ -448,6 +471,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserMembersNamespaceNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserMembersNamespaceNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Members_Namespaces;
@@ -465,6 +489,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class UserMembersLabelNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private UserMembersLabelNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.User_Members_Labels;
@@ -481,6 +506,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class XmlDocCommentAttributeNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlDocCommentAttributeNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.XML_Doc_Comments_Attribute_Name;
@@ -497,6 +523,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class XmlDocCommentAttributeQuotesFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlDocCommentAttributeQuotesFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.XML_Doc_Comments_Attribute_Quotes;
@@ -515,6 +542,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class XmlDocCommentAttributeValueFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlDocCommentAttributeValueFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.XML_Doc_Comments_Attribute_Value;
@@ -531,6 +559,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class XmlDocCommentCDataSectionFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlDocCommentCDataSectionFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.XML_Doc_Comments_CData_Section;
@@ -547,6 +576,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class XmlDocCommentCommentFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlDocCommentCommentFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.XML_Doc_Comments_Comment;
@@ -563,6 +593,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class XmlDocCommentDelimiterFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlDocCommentDelimiterFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.XML_Doc_Comments_Delimiter;
@@ -579,6 +610,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class XmlDocCommentEntityReferenceFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlDocCommentEntityReferenceFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.XML_Doc_Comments_Entity_Reference;
@@ -595,6 +627,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class XmlDocCommentNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlDocCommentNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.XML_Doc_Comments_Name;
@@ -611,6 +644,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class XmlDocCommentProcessingInstructionFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlDocCommentProcessingInstructionFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.XML_Doc_Comments_Processing_Instruction;
@@ -627,6 +661,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class XmlDocCommentTextFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlDocCommentTextFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.XML_Doc_Comments_Text;
@@ -665,6 +700,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class RegexCommentFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private RegexCommentFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesWpfResources.Regex_Comment;
@@ -681,6 +717,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class RegexCharacterClassFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private RegexCharacterClassFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesWpfResources.Regex_Character_Class;
@@ -697,6 +734,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class RegexAnchorFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private RegexAnchorFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesWpfResources.Regex_Anchor;
@@ -713,6 +751,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class RegexQuantifierFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private RegexQuantifierFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesWpfResources.Regex_Quantifier;
@@ -729,6 +768,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class RegexGroupingFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private RegexGroupingFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesWpfResources.Regex_Grouping;
@@ -745,6 +785,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class RegexAlternationFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private RegexAlternationFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesWpfResources.Regex_Alternation;
@@ -761,6 +802,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class RegexTextFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private RegexTextFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesWpfResources.Regex_Text;
@@ -777,6 +819,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class RegexSelfEscapedCharacterFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private RegexSelfEscapedCharacterFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesWpfResources.Regex_SelfEscapedCharacter;
@@ -797,6 +840,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [ExcludeFromCodeCoverage]
         private class RegexOtherEscapeFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private RegexOtherEscapeFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesWpfResources.Regex_OtherEscape;
@@ -813,6 +857,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class XmlLiteralAttributeNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlLiteralAttributeNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_Attribute_Name;
@@ -828,6 +873,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class XmlLiteralAttributeQuotesFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlLiteralAttributeQuotesFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_Attribute_Quotes;
@@ -843,6 +889,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class XmlLiteralAttributeValueFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlLiteralAttributeValueFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_Attribute_Value;
@@ -858,6 +905,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class XmlLiteralCDataSectionFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlLiteralCDataSectionFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_CData_Section;
@@ -873,6 +921,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class XmlLiteralCommentFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlLiteralCommentFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_Comment;
@@ -888,6 +937,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class XmlLiteralDelimiterFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlLiteralDelimiterFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_Delimiter;
@@ -903,6 +953,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class XmlLiteralEmbeddedExpressionFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlLiteralEmbeddedExpressionFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_Embedded_Expression;
@@ -919,6 +970,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class XmlLiteralEntityReferenceFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlLiteralEntityReferenceFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_Entity_Reference;
@@ -934,6 +986,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class XmlLiteralNameFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlLiteralNameFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_Name;
@@ -949,6 +1002,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class XmlLiteralProcessingInstructionFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlLiteralProcessingInstructionFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_Processing_Instruction;
@@ -964,6 +1018,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         [UserVisible(true)]
         private class XmlLiteralTextFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private XmlLiteralTextFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.VB_XML_Literals_Text;

--- a/src/EditorFeatures/Core.Wpf/ConflictTagDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/ConflictTagDefinition.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging.Tags
     [ExcludeFromCodeCoverage]
     internal class ConflictTagDefinition : MarkerFormatDefinition
     {
+        [ImportingConstructor]
         public ConflictTagDefinition()
         {
             this.Border = new Pen(Brushes.Red, thickness: 1.5);

--- a/src/EditorFeatures/Core.Wpf/Diagnostics/UnnecessaryCodeFormatDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/Diagnostics/UnnecessaryCodeFormatDefinition.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.Diagnostics
     [UserVisible(false)]
     internal sealed class UnnecessaryCodeFormatDefinition : ClassificationFormatDefinition
     {
+        [ImportingConstructor]
         private UnnecessaryCodeFormatDefinition()
         {
             this.DisplayName = EditorFeaturesResources.Unnecessary_Code;

--- a/src/EditorFeatures/Core.Wpf/EditAndContinue/ActiveStatementTagFormatDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/EditAndContinue/ActiveStatementTagFormatDefinition.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
     [ExcludeFromCodeCoverage]
     internal sealed class ActiveStatementTagFormatDefinition : MarkerFormatDefinition
     {
+        [ImportingConstructor]
         public ActiveStatementTagFormatDefinition()
         {
             // TODO (tomat): bug 777271

--- a/src/EditorFeatures/Core.Wpf/EditAndContinue/EditAndContinueErrorTypeFormatDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/EditAndContinue/EditAndContinueErrorTypeFormatDefinition.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
     [UserVisible(true)]
     internal sealed class EditAndContinueErrorTypeFormatDefinition : EditorFormatDefinition
     {
+        [ImportingConstructor]
         public EditAndContinueErrorTypeFormatDefinition()
         {
             this.ForegroundBrush = Brushes.Purple;

--- a/src/EditorFeatures/Core.Wpf/InlineRename/HighlightTags/RenameConflictTagDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/HighlightTags/RenameConflictTagDefinition.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename.HighlightTag
         public static double StrokeThickness => 1.5;
         public static double[] StrokeDashArray => new[] { 8.0, 4.0 };
 
+        [ImportingConstructor]
         public RenameConflictTagDefinition()
         {
             this.Border = new Pen(Brushes.Red, thickness: StrokeThickness) { DashStyle = new DashStyle(StrokeDashArray, 0) };

--- a/src/EditorFeatures/Core.Wpf/InlineRename/HighlightTags/RenameFieldBackgroundAndBorderTagDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/HighlightTags/RenameFieldBackgroundAndBorderTagDefinition.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename.HighlightTag
     [ExcludeFromCodeCoverage]
     internal class RenameFieldBackgroundAndBorderTagDefinition : MarkerFormatDefinition
     {
+        [ImportingConstructor]
         public RenameFieldBackgroundAndBorderTagDefinition()
         {
             // The Border color should match the BackgroundColor from the

--- a/src/EditorFeatures/Core.Wpf/InlineRename/HighlightTags/RenameFixupTagDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/HighlightTags/RenameFixupTagDefinition.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename.HighlightTag
         public static double StrokeThickness => 1.0;
         public static double[] StrokeDashArray => new[] { 4.0, 4.0 };
 
+        [ImportingConstructor]
         public RenameFixupTagDefinition()
         {
             this.Border = new Pen(Brushes.Green, thickness: StrokeThickness) { DashStyle = new DashStyle(StrokeDashArray, 0) };

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Taggers/ClassificationTypeDefinitions.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Taggers/ClassificationTypeDefinitions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         [UserVisible(true)]
         private class InlineRenameFieldFormatDefinition : ClassificationFormatDefinition
         {
+            [ImportingConstructor]
             private InlineRenameFieldFormatDefinition()
             {
                 this.DisplayName = EditorFeaturesResources.Inline_Rename_Field_Text;

--- a/src/EditorFeatures/Core.Wpf/PreviewWarningTagDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/PreviewWarningTagDefinition.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging.Tags
     [ExcludeFromCodeCoverage]
     internal class PreviewWarningTagDefinition : MarkerFormatDefinition
     {
+        [ImportingConstructor]
         public PreviewWarningTagDefinition()
         {
             this.Border = new Pen(new SolidColorBrush(Color.FromRgb(230, 117, 64)), thickness: 1.5);

--- a/src/EditorFeatures/Core.Wpf/ReferenceHighlighting/DefinitionHighlightTagDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/ReferenceHighlighting/DefinitionHighlightTagDefinition.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
     [UserVisible(true)]
     internal class DefinitionHighlightTagDefinition : MarkerFormatDefinition
     {
+        [ImportingConstructor]
         public DefinitionHighlightTagDefinition()
         {
             // NOTE: This is the same color used by the editor for reference highlighting

--- a/src/EditorFeatures/Core.Wpf/ReferenceHighlighting/WrittenReferenceHighlightTagDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/ReferenceHighlighting/WrittenReferenceHighlightTagDefinition.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
     [UserVisible(true)]
     internal class WrittenReferenceHighlightTagDefinition : MarkerFormatDefinition
     {
+        [ImportingConstructor]
         public WrittenReferenceHighlightTagDefinition()
         {
             // NOTE: This is the same color used by the editor for reference highlighting

--- a/src/EditorFeatures/Core.Wpf/RenameTracking/RenameTrackingTagDefinition.cs
+++ b/src/EditorFeatures/Core.Wpf/RenameTracking/RenameTrackingTagDefinition.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
     [ExcludeFromCodeCoverage]
     internal class RenameTrackingTagDefinition : MarkerFormatDefinition
     {
+        [ImportingConstructor]
         public RenameTrackingTagDefinition()
         {
             this.Border = new Pen(Brushes.Black, thickness: 1.0) { DashStyle = new DashStyle(new[] { 0.5, 4.0 }, 1) };

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTrackingService.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/ActiveStatementTrackingService.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
     {
         private TrackingSession _sessionOpt;
 
+        [ImportingConstructor]
         internal ActiveStatementTrackingService()
         {
         }

--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -46,6 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
         private string _rootTemporaryPathWithGuid;
         private readonly string _rootTemporaryPath;
 
+        [ImportingConstructor]
         public MetadataAsSourceFileService()
         {
             _rootTemporaryPath = Path.Combine(Path.GetTempPath(), "MetadataAsSource");

--- a/src/EditorFeatures/TestUtilities/TestWaitIndicator.cs
+++ b/src/EditorFeatures/TestUtilities/TestWaitIndicator.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
         private readonly IWaitContext _waitContext;
         private readonly Microsoft.VisualStudio.Language.Intellisense.Utilities.IWaitContext _platformWaitContext = new UncancellableWaitContext();
 
+        [ImportingConstructor]
         public TestWaitIndicator()
             : this(new UncancellableWaitContext())
         {

--- a/src/EditorFeatures/TestUtilities/Workspaces/MefTestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/MefTestWorkspace.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
     [Export(typeof(Workspace))]
     internal class MefTestWorkspace : Workspace
     {
+        [ImportingConstructor]
         public MefTestWorkspace()
             : base(Microsoft.CodeAnalysis.Host.Mef.MefHostServices.DefaultHost, "MefTest")
         {

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestFormattingRuleFactoryServiceFactory.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestFormattingRuleFactoryServiceFactory.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
     [ExportWorkspaceServiceFactory(typeof(IHostDependentFormattingRuleFactoryService), WorkspaceKind.Test), Shared]
     internal sealed class TestFormattingRuleFactoryServiceFactory : IWorkspaceServiceFactory
     {
+        [ImportingConstructor]
         public TestFormattingRuleFactoryServiceFactory()
         {
         }

--- a/src/EditorFeatures/VisualBasic/EmbeddedLanguages/VisualBasicEmbeddedLanguageEditorFeaturesProvider.vb
+++ b/src/EditorFeatures/VisualBasic/EmbeddedLanguages/VisualBasicEmbeddedLanguageEditorFeaturesProvider.vb
@@ -12,6 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Features.EmbeddedLanguages
 
         Public Shared Shadows Instance As New VisualBasicEmbeddedLanguageEditorFeaturesProvider()
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(VisualBasicEmbeddedLanguagesProvider.Info)
         End Sub

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
@@ -21,6 +21,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
 
         Private ReadOnly _specializedIndentationRule As AbstractFormattingRule
 
+        <ImportingConstructor>
         Public Sub New()
             Me.New(New SpecialFormattingRule())
         End Sub

--- a/src/EditorFeatures/VisualBasic/Wrapping/VisualBasicWrappingCodeRefactoringProvider.vb
+++ b/src/EditorFeatures/VisualBasic/Wrapping/VisualBasicWrappingCodeRefactoringProvider.vb
@@ -18,6 +18,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Wrapping
                 New VisualBasicParameterWrapper(),
                 New VisualBasicBinaryExpressionWrapper())
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(s_wrappers)
         End Sub

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -151,6 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
     {
         public override ImmutableArray<string> FixableDiagnosticIds => AddImportDiagnosticIds.FixableDiagnosticIds;
 
+        [ImportingConstructor]
         public CSharpAddImportCodeFixProvider()
         {
         }

--- a/src/Features/CSharp/Portable/AddMissingReference/CSharpAddMissingReferenceCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddMissingReference/CSharpAddMissingReferenceCodeFixProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddMissingReference
         public sealed override ImmutableArray<string> FixableDiagnosticIds { get; }
             = ImmutableArray.Create(CS0012);
 
+        [ImportingConstructor]
         public CSharpAddMissingReferenceCodeFixProvider()
         {
         }

--- a/src/Features/CSharp/Portable/AddObsoleteAttribute/CSharpAddObsoleteAttributeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddObsoleteAttribute/CSharpAddObsoleteAttributeCodeFixProvider.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddObsoleteAttribute
                 "CS1064"  // The best overloaded Add method 'MyCollection.Add(int)' for the collection initializer element is obsolete"
             );
 
+        [ImportingConstructor]
         public CSharpAddObsoleteAttributeCodeFixProvider()
             : base(CSharpSyntaxFactsService.Instance, CSharpFeaturesResources.Add_Obsolete)
         {

--- a/src/Features/CSharp/Portable/CodeFixes/FixReturnType/CSharpFixReturnTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/FixReturnType/CSharpFixReturnTypeCodeFixProvider.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.FixReturnType
         // error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("CS0127", "CS1997", "CS0201");
 
+        [ImportingConstructor]
         public CSharpFixReturnTypeCodeFixProvider()
             : base(supportsFixAll: false)
         {

--- a/src/Features/CSharp/Portable/ConflictMarkerResolution/CSharpResolveConflictMarkerCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/ConflictMarkerResolution/CSharpResolveConflictMarkerCodeFixProvider.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConflictMarkerResolution
     {
         private const string CS8300 = nameof(CS8300); // Merge conflict marker encountered
 
+        [ImportingConstructor]
         public CSharpResolveConflictMarkerCodeFixProvider()
             : base(CS8300)
         {

--- a/src/Features/CSharp/Portable/EmbeddedLanguages/CSharpEmbeddedLanguageFeaturesProvider.cs
+++ b/src/Features/CSharp/Portable/EmbeddedLanguages/CSharpEmbeddedLanguageFeaturesProvider.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Features.EmbeddedLanguages
     {
         public static IEmbeddedLanguageFeaturesProvider Instance = new CSharpEmbeddedLanguageFeaturesProvider();
 
+        [ImportingConstructor]
         public CSharpEmbeddedLanguageFeaturesProvider() : base(CSharpEmbeddedLanguagesProvider.Info)
         {
         }

--- a/src/Features/CSharp/Portable/ImplementAbstractClass/CSharpImplementAbstractClassCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementAbstractClass/CSharpImplementAbstractClassCodeFixProvider.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementAbstractClass
     {
         private const string CS0534 = nameof(CS0534); // 'Program' does not implement inherited abstract member 'Goo.bar()'
 
+        [ImportingConstructor]
         public CSharpImplementAbstractClassCodeFixProvider()
             : base(CS0534)
         {

--- a/src/Features/CSharp/Portable/OrderModifiers/CSharpOrderModifiersCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/OrderModifiers/CSharpOrderModifiersCodeFixProvider.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.OrderModifiers
     {
         private const string CS0267 = nameof(CS0267); // The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
 
+        [ImportingConstructor]
         public CSharpOrderModifiersCodeFixProvider()
             : base(CSharpSyntaxFactsService.Instance, CSharpCodeStyleOptions.PreferredModifierOrder, CSharpOrderModifiersHelper.Instance)
         {

--- a/src/Features/CSharp/Portable/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SimplifyTypeNames
     [ExtensionOrder(After = PredefinedCodeFixProviderNames.RemoveUnnecessaryCast)]
     internal partial class SimplifyTypeNamesCodeFixProvider : AbstractSimplifyTypeNamesCodeFixProvider<SyntaxKind>
     {
+        [ImportingConstructor]
         public SimplifyTypeNamesCodeFixProvider()
             : base(new CSharpSimplifyTypeNamesDiagnosticAnalyzer())
         {

--- a/src/Features/CSharp/Portable/UseCompoundAssignment/CSharpUseCompoundAssignmentCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseCompoundAssignment/CSharpUseCompoundAssignmentCodeFixProvider.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCompoundAssignment
     internal class CSharpUseCompoundAssignmentCodeFixProvider
         : AbstractUseCompoundAssignmentCodeFixProvider<SyntaxKind, AssignmentExpressionSyntax, ExpressionSyntax>
     {
+        [ImportingConstructor]
         public CSharpUseCompoundAssignmentCodeFixProvider()
             : base(Utilities.Kinds)
         {

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeFixProvider.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
 
         private static readonly ImmutableArray<UseExpressionBodyHelper> _helpers = UseExpressionBodyHelper.Helpers;
 
+        [ImportingConstructor]
         public UseExpressionBodyCodeFixProvider()
         {
             FixableDiagnosticIds = _helpers.SelectAsArray(h => h.DiagnosticId);

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
     {
         private static readonly ImmutableArray<UseExpressionBodyHelper> _helpers = UseExpressionBodyHelper.Helpers;
 
+        [ImportingConstructor]
         public UseExpressionBodyCodeRefactoringProvider()
         {
         }

--- a/src/Features/CSharp/Portable/UseExpressionBodyForLambda/UseExpressionBodyForLambdaCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBodyForLambda/UseExpressionBodyForLambdaCodeRefactoringProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
         Name = PredefinedCodeRefactoringProviderNames.UseExpressionBody), Shared]
     internal sealed class UseExpressionBodyForLambdaCodeRefactoringProvider : CodeRefactoringProvider
     {
+        [ImportingConstructor]
         public UseExpressionBodyForLambdaCodeRefactoringProvider()
         {
         }

--- a/src/Features/CSharp/Portable/UseNamedArguments/CSharpUseNamedArgumentsCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseNamedArguments/CSharpUseNamedArgumentsCodeRefactoringProvider.cs
@@ -66,6 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseNamedArguments
                 => argument.WithNameColon(SyntaxFactory.NameColon(name.ToIdentifierName()));
         }
 
+        [ImportingConstructor]
         public CSharpUseNamedArgumentsCodeRefactoringProvider()
             : base(new ArgumentAnalyzer(), new AttributeArgumentAnalyzer())
         {

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameCodeFixProvider.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     internal partial class CSharpIsAndCastCheckWithoutNameCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
+        [ImportingConstructor]
         public CSharpIsAndCastCheckWithoutNameCodeFixProvider()
             : base(supportsFixAll: false)
         {

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -39,6 +39,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
 
         private readonly IPickMembersService _pickMembersService_forTesting;
 
+        [ImportingConstructor]
         public GenerateConstructorFromMembersCodeRefactoringProvider() : this(null)
         {
         }

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
 
         private readonly IPickMembersService _pickMembersService_forTestingPurposes;
 
+        [ImportingConstructor]
         public GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider()
             : this(pickMembersService: null)
         {

--- a/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesCodeRefactoringProvider.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.GenerateOverrides
     {
         private readonly IPickMembersService _pickMembersService_forTestingPurposes;
 
+        [ImportingConstructor]
         public GenerateOverridesCodeRefactoringProvider() : this(null)
         {
         }

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportCodeFixProvider.vb
@@ -97,6 +97,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
     Friend Class VisualBasicAddImportCodeFixProvider
         Inherits AbstractAddImportCodeFixProvider
 
+        <ImportingConstructor>
         Public Sub New()
         End Sub
 

--- a/src/Features/VisualBasic/Portable/AddObsoleteAttribute/VisualBasicAddObsoleteAttributeCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddObsoleteAttribute/VisualBasicAddObsoleteAttributeCodeFixProvider.vb
@@ -16,6 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddObsoleteAttribute
                 "BC40008"  ' 'C' is obsolete.
             )
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(VisualBasicSyntaxFactsService.Instance, VBFeaturesResources.Add_Obsolete)
         End Sub

--- a/src/Features/VisualBasic/Portable/CodeFixes/AddMissingReference/VisualBasicAddMissingReferenceCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/AddMissingReference/VisualBasicAddMissingReferenceCodeFixProvider.vb
@@ -17,6 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddMissingReference
         Friend Const BC30005 As String = "BC30005" ' ERR_UnreferencedAssemblyEvent3
         Friend Const BC30652 As String = "BC30652" ' ERR_UnreferencedAssembly3
 
+        <ImportingConstructor>
         Public Sub New()
         End Sub
 

--- a/src/Features/VisualBasic/Portable/ConflictMarkerResolution/VisualBasicResolveConflictMarkerCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/ConflictMarkerResolution/VisualBasicResolveConflictMarkerCodeFixProvider.vb
@@ -11,6 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConflictMarkerResolution
 
         Private Const BC37284 As String = NameOf(BC37284)
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(BC37284)
         End Sub

--- a/src/Features/VisualBasic/Portable/EmbeddedLanguages/VisualBasicEmbeddedLanguageFeaturesProvider.vb
+++ b/src/Features/VisualBasic/Portable/EmbeddedLanguages/VisualBasicEmbeddedLanguageFeaturesProvider.vb
@@ -12,6 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Features.EmbeddedLanguages
 
         Public Shared Shadows Instance As New VisualBasicEmbeddedLanguageFeaturesProvider()
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(VisualBasicEmbeddedLanguagesProvider.Info)
         End Sub

--- a/src/Features/VisualBasic/Portable/ImplementAbstractClass/VisualBasicImplementAbstractClassCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/ImplementAbstractClass/VisualBasicImplementAbstractClassCodeFixProvider.vb
@@ -14,6 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ImplementAbstractClass
 
         Friend Const BC30610 As String = "BC30610" ' Class 'goo' must either be declared 'MustInherit' or override the following inherited 'MustOverride' member(s): 
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(BC30610)
         End Sub

--- a/src/Features/VisualBasic/Portable/OrderModifiers/VisualBasicOrderModifiersCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/OrderModifiers/VisualBasicOrderModifiersCodeFixProvider.vb
@@ -11,6 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.OrderModifiers
     Friend Class VisualBasicOrderModifiersCodeFixProvider
         Inherits AbstractOrderModifiersCodeFixProvider
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(VisualBasicSyntaxFactsService.Instance,
                        VisualBasicCodeStyleOptions.PreferredModifierOrder,

--- a/src/Features/VisualBasic/Portable/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.vb
@@ -14,6 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SimplifyTypeNames
     Partial Friend Class SimplifyTypeNamesCodeFixProvider
         Inherits AbstractSimplifyTypeNamesCodeFixProvider(Of SyntaxKind)
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(New VisualBasicSimplifyTypeNamesDiagnosticAnalyzer())
         End Sub

--- a/src/Features/VisualBasic/Portable/UseCompoundAssignment/VisualBasicUseCompoundAssignmentCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseCompoundAssignment/VisualBasicUseCompoundAssignmentCodeFixProvider.vb
@@ -11,6 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCompoundAssignment
     Friend Class VisualBasicUseCompoundAssignmentCodeFixProvider
         Inherits AbstractUseCompoundAssignmentCodeFixProvider(Of SyntaxKind, AssignmentStatementSyntax, ExpressionSyntax)
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(Kinds)
         End Sub

--- a/src/Features/VisualBasic/Portable/UseNamedArguments/VisualBasicUseNamedArgumentsCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseNamedArguments/VisualBasicUseNamedArgumentsCodeRefactoringProvider.vb
@@ -53,6 +53,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseNamedArguments
             End Function
         End Class
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(New ArgumentAnalyzer(), attributeArgumentAnalyzer:=Nothing)
         End Sub

--- a/src/VisualStudio/CSharp/Impl/ObjectBrowser/CSharpLibraryService.cs
+++ b/src/VisualStudio/CSharp/Impl/ObjectBrowser/CSharpLibraryService.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ObjectBrowser
             parameterOptions: SymbolDisplayParameterOptions.IncludeType,
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
+        [ImportingConstructor]
         public CSharpLibraryService()
             : base(Guids.CSharpLibraryId, __SymbolToolLanguage.SymbolToolLanguage_CSharp, s_typeDisplayFormat, s_memberDisplayFormat)
         {

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/DebuggeeModuleMetadataProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/DebuggeeModuleMetadataProvider.cs
@@ -56,6 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 
         private readonly DebuggeeModuleInfoCache _baselineMetadata;
 
+        [ImportingConstructor]
         public DebuggeeModuleMetadataProvider()
         {
             _baselineMetadata = new DebuggeeModuleInfoCache();

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
     [ExportWorkspaceServiceFactory(typeof(IHostDependentFormattingRuleFactoryService), ServiceLayer.Host), Shared]
     internal sealed class VisualStudioFormattingRuleFactoryServiceFactory : IWorkspaceServiceFactory
     {
+        [ImportingConstructor]
         public VisualStudioFormattingRuleFactoryServiceFactory()
         {
         }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioWorkspaceStatusServiceFactory.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
     [ExportWorkspaceServiceFactory(typeof(IWorkspaceStatusService), ServiceLayer.Host), Shared]
     internal class VisualStudioWorkspaceStatusServiceFactory : IWorkspaceServiceFactory
     {
+        [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public VisualStudioWorkspaceStatusServiceFactory()
         {

--- a/src/VisualStudio/VisualBasic/Impl/ObjectBrowser/VisualBasicLibraryService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ObjectBrowser/VisualBasicLibraryService.vb
@@ -23,6 +23,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ObjectBrowser
                 parameterOptions:=SymbolDisplayParameterOptions.IncludeType,
                 miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.UseSpecialTypes)
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(Guids.VisualBasicLibraryId, __SymbolToolLanguage.SymbolToolLanguage_VB, s_typeDisplayFormat, s_memberDisplayFormat)
         End Sub

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/VenusMargin/ProjectionSpanTagDefinition.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/VenusMargin/ProjectionSpanTagDefinition.cs
@@ -11,6 +11,7 @@ namespace Roslyn.Hosting.Diagnostics.VenusMargin
     [Name(ProjectionSpanTag.TagId)]
     internal class ProjectionSpanTagDefinition : MarkerFormatDefinition
     {
+        [ImportingConstructor]
         public ProjectionSpanTagDefinition()
         {
             this.Border = new Pen(Brushes.DarkBlue, thickness: 1.5);

--- a/src/Workspaces/CSharp/Portable/EmbeddedLanguages/LanguageServices/CSharpEmbeddedLanguagesProvider.cs
+++ b/src/Workspaces/CSharp/Portable/EmbeddedLanguages/LanguageServices/CSharpEmbeddedLanguagesProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.LanguageServices
             CSharpVirtualCharService.Instance);
         public static IEmbeddedLanguagesProvider Instance = new CSharpEmbeddedLanguagesProvider();
 
+        [ImportingConstructor]
         public CSharpEmbeddedLanguagesProvider() : base(Info)
         {
         }

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 new CSharpInferredMemberNameReducer(),
                 new CSharpDefaultExpressionReducer());
 
+        [ImportingConstructor]
         public CSharpSimplificationService() : base(s_reducers)
         {
         }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/DefaultFormattingRuleFactoryServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/DefaultFormattingRuleFactoryServiceFactory.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     [ExportWorkspaceServiceFactory(typeof(IHostDependentFormattingRuleFactoryService), ServiceLayer.Default), Shared]
     internal sealed class DefaultFormattingRuleFactoryServiceFactory : IWorkspaceServiceFactory
     {
+        [ImportingConstructor]
         public DefaultFormattingRuleFactoryServiceFactory()
         {
         }

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/IAsynchronousOperationListenerProvider.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/IAsynchronousOperationListenerProvider.cs
@@ -79,6 +79,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
             s_enableDiagnosticTokens = diagnostics;
         }
 
+        [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public AsynchronousOperationListenerProvider()
         {

--- a/src/Workspaces/Remote/Core/Diagnostics/PerformanceTrackerService.cs
+++ b/src/Workspaces/Remote/Core/Diagnostics/PerformanceTrackerService.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
         public event EventHandler SnapshotAdded;
 
+        [ImportingConstructor]
         public PerformanceTrackerService() :
             this(DefaultMinLOFValue, DefaultAverageThreshold, DefaultStddevThreshold)
         {

--- a/src/Workspaces/Remote/Core/Services/RemoteGlobalOperationNotificationService.cs
+++ b/src/Workspaces/Remote/Core/Services/RemoteGlobalOperationNotificationService.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Remote.Services
         public event EventHandler Started;
         public event EventHandler<GlobalOperationEventArgs> Stopped;
 
+        [ImportingConstructor]
         public RemoteGlobalOperationNotificationService()
         {
         }

--- a/src/Workspaces/VisualBasic/Portable/EmbeddedLanguages/LanguageServices/VisualBasicEmbeddedLanguagesProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/EmbeddedLanguages/LanguageServices/VisualBasicEmbeddedLanguagesProvider.vb
@@ -19,6 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EmbeddedLanguages.LanguageServices
 
         Public Shared Instance As New VisualBasicEmbeddedLanguagesProvider()
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(Info)
         End Sub

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.vb
@@ -28,6 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 New VisualBasicVariableDeclaratorReducer(),
                 New VisualBasicInferredMemberNameReducer())
 
+        <ImportingConstructor>
         Public Sub New()
             MyBase.New(s_reducers)
         End Sub


### PR DESCRIPTION
This is a prerequisite to updating our diagnostic analyzer package in #35439.