### PR TITLE
Add support for .editorconfig files to MSBuildWorkspace

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/Constants/ItemNames.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/Constants/ItemNames.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public const string Compile = nameof(Compile);
         public const string CscCommandLineArgs = nameof(CscCommandLineArgs);
         public const string DocFileItem = nameof(DocFileItem);
+        public const string EditorConfigFiles = nameof(EditorConfigFiles);
         public const string Import = nameof(Import);
         public const string ProjectReference = nameof(ProjectReference);
         public const string Reference = nameof(Reference);

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs
@@ -361,7 +361,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
                     var documents = CreateDocumentInfos(projectFileInfo.Documents, projectId, commandLineArgs.Encoding);
                     var additionalDocuments = CreateDocumentInfos(projectFileInfo.AdditionalDocuments, projectId, commandLineArgs.Encoding);
-                    CheckForDuplicateDocuments(documents, additionalDocuments, projectPath, projectId);
+                    var analyzerConfigDocuments = CreateDocumentInfos(projectFileInfo.AnalyzerConfigDocuments, projectId, commandLineArgs.Encoding);
+                    CheckForDuplicateDocuments(documents.Concat(additionalDocuments).Concat(analyzerConfigDocuments), projectPath, projectId);
 
                     var analyzerReferences = ResolveAnalyzerReferences(commandLineArgs);
 
@@ -385,7 +386,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
                         additionalDocuments: additionalDocuments,
                         isSubmission: false,
                         hostObjectType: null)
-                        .WithDefaultNamespace(projectFileInfo.DefaultNamespace);
+                        .WithDefaultNamespace(projectFileInfo.DefaultNamespace)
+                        .WithAnalyzerConfigDocuments(analyzerConfigDocuments);
                 });
             }
 
@@ -473,10 +475,10 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 }
             }
 
-            private void CheckForDuplicateDocuments(ImmutableArray<DocumentInfo> documents, ImmutableArray<DocumentInfo> additionalDocuments, string projectFilePath, ProjectId projectId)
+            private void CheckForDuplicateDocuments(ImmutableArray<DocumentInfo> documents, string projectFilePath, ProjectId projectId)
             {
                 var paths = new HashSet<string>(PathUtilities.Comparer);
-                foreach (var doc in documents.Concat(additionalDocuments))
+                foreach (var doc in documents)
                 {
                     if (paths.Contains(doc.FilePath))
                     {

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/Extensions.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/Extensions.cs
@@ -20,6 +20,9 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public static IEnumerable<MSB.Framework.ITaskItem> GetDocuments(this MSB.Execution.ProjectInstance executedProject)
             => executedProject.GetItems(ItemNames.Compile);
 
+        public static IEnumerable<MSB.Framework.ITaskItem> GetEditorConfigFiles(this MSB.Execution.ProjectInstance executedProject)
+            => executedProject.GetItems(ItemNames.EditorConfigFiles);
+
         public static IEnumerable<MSB.Framework.ITaskItem> GetMetadataReferences(this MSB.Execution.ProjectInstance executedProject)
             => executedProject.GetItems(ItemNames.ReferencePath);
 

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFile.cs
@@ -138,7 +138,11 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 .ToImmutableArray();
 
             var additionalDocs = project.GetAdditionalFiles()
-                .Select(MakeAdditionalDocumentFileInfo)
+                .Select(MakeNonSourceFileDocumentFileInfo)
+                .ToImmutableArray();
+
+            var analyzerConfigDocs = project.GetEditorConfigFiles()
+                .Select(MakeNonSourceFileDocumentFileInfo)
                 .ToImmutableArray();
 
             return ProjectFileInfo.Create(
@@ -151,6 +155,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 commandLineArgs,
                 docs,
                 additionalDocs,
+                analyzerConfigDocs,
                 project.GetProjectReferences().ToImmutableArray(),
                 Log);
         }
@@ -187,7 +192,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             return new DocumentFileInfo(filePath, logicalPath, isLinked, isGenerated, sourceCodeKind);
         }
 
-        private DocumentFileInfo MakeAdditionalDocumentFileInfo(MSB.Framework.ITaskItem documentItem)
+        private DocumentFileInfo MakeNonSourceFileDocumentFileInfo(MSB.Framework.ITaskItem documentItem)
         {
             var filePath = GetDocumentFilePath(documentItem);
             var logicalPath = GetDocumentLogicalPath(documentItem, _projectDirectory);

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFileInfo.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFileInfo.cs
@@ -70,6 +70,11 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public ImmutableArray<DocumentFileInfo> AdditionalDocuments { get; }
 
         /// <summary>
+        /// The analyzer config documents.
+        /// </summary>
+        public ImmutableArray<DocumentFileInfo> AnalyzerConfigDocuments { get; }
+
+        /// <summary>
         /// References to other projects.
         /// </summary>
         public ImmutableArray<ProjectFileReference> ProjectReferences { get; }
@@ -96,6 +101,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             ImmutableArray<string> commandLineArgs,
             ImmutableArray<DocumentFileInfo> documents,
             ImmutableArray<DocumentFileInfo> additionalDocuments,
+            ImmutableArray<DocumentFileInfo> analyzerConfigDocuments,
             ImmutableArray<ProjectFileReference> projectReferences,
             DiagnosticLog log)
         {
@@ -111,6 +117,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             this.CommandLineArgs = commandLineArgs;
             this.Documents = documents;
             this.AdditionalDocuments = additionalDocuments;
+            this.AnalyzerConfigDocuments = analyzerConfigDocuments;
             this.ProjectReferences = projectReferences;
             this.Log = log;
         }
@@ -125,6 +132,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             ImmutableArray<string> commandLineArgs,
             ImmutableArray<DocumentFileInfo> documents,
             ImmutableArray<DocumentFileInfo> additionalDocuments,
+            ImmutableArray<DocumentFileInfo> analyzerConfigDocuments,
             ImmutableArray<ProjectFileReference> projectReferences,
             DiagnosticLog log)
             => new ProjectFileInfo(
@@ -138,6 +146,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 commandLineArgs,
                 documents,
                 additionalDocuments,
+                analyzerConfigDocuments,
                 projectReferences,
                 log);
 
@@ -153,6 +162,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 commandLineArgs: ImmutableArray<string>.Empty,
                 documents: ImmutableArray<DocumentFileInfo>.Empty,
                 additionalDocuments: ImmutableArray<DocumentFileInfo>.Empty,
+                analyzerConfigDocuments: ImmutableArray<DocumentFileInfo>.Empty,
                 projectReferences: ImmutableArray<ProjectFileReference>.Empty,
                 log);
     }

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -3628,7 +3628,7 @@ class C { }";
             }
         }
 
-        [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled), AlwaysSkip = "https://github.com/dotnet/core-eng/issues/6424"), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         public async Task TestEditorConfigDiscovery()
         {
             var files = GetSimpleCSharpSolutionFiles()

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithDiscoverEditorConfigFiles.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithDiscoverEditorConfigFiles.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ProjectGuid>{9705A8E6-C854-4FD3-8CEA-EDBDD54C7FD8}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleApplication62</RootNamespace>
+    <AssemblyName>ConsoleApplication62</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <DiscoverEditorConfigFiles>true</DiscoverEditorConfigFiles>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CSharpClass.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
+++ b/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
@@ -149,6 +149,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
                 public static string ReferencesPortableProject => GetText("ProjectFiles.CSharp.ReferencesPortableProject.csproj");
                 public static string Wildcards => GetText("ProjectFiles.CSharp.Wildcards.csproj");
                 public static string WithoutCSharpTargetsImported => GetText("ProjectFiles.CSharp.WithoutCSharpTargetsImported.csproj");
+                public static string WithDiscoverEditorConfigFiles => GetText("ProjectFiles.CSharp.WithDiscoverEditorConfigFiles.csproj");
                 public static string WithPrefer32Bit => GetText("ProjectFiles.CSharp.WithPrefer32Bit.csproj");
                 public static string WithLink => GetText("ProjectFiles.CSharp.WithLink.csproj");
                 public static string WithSystemNumerics => GetText("ProjectFiles.CSharp.WithSystemNumerics.csproj");


### PR DESCRIPTION
Just threading through files discovered to the workspace; no interesting changes here.