### PR TITLE
Use "preview" language version for Miscellaneous Files

### DIFF
--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     [ExportLanguageServiceFactory(typeof(ISyntaxTreeFactoryService), LanguageNames.CSharp), Shared]
     internal partial class CSharpSyntaxTreeFactoryServiceFactory : ILanguageServiceFactory
     {
-        private static readonly CSharpParseOptions _parseOptionWithLatestLanguageVersion = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+        private static readonly CSharpParseOptions _parseOptionWithLatestLanguageVersion = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
 
         public ILanguageService CreateLanguageService(HostLanguageServices provider)
         {


### PR DESCRIPTION
Since we don't know what type of files they are, we should always use the absolute, absolute latest, which is Preview for C#.

Fixes https://github.com/dotnet/roslyn/issues/35857