### PR TITLE
Fix #33560 Handle tokens being equal for same line

### DIFF
--- a/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
@@ -287,13 +287,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         }
 
         public static bool AreTwoTokensOnSameLine(SyntaxToken token1, SyntaxToken token2)
-        {
+        {           
             var tree = token1.SyntaxTree;
             if (tree != null && tree.TryGetText(out var text))
             {
                 return text.AreOnSameLine(token1, token2);
             }
 
+            if(token1.Equals(token2))
+            {
+                return token1.ToFullString().ContainsLineBreak();
+            }
+            
             return !CommonFormattingHelpers.GetTextBetween(token1, token2).ContainsLineBreak();
         }
 


### PR DESCRIPTION
Fixes #33560 - If tokens are equal (i.e. a single token), then directly check for line break. 