### PR TITLE
Get FullPath and deduplicate potential editorconfig files

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.EditorConfig.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.EditorConfig.targets
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
@@ -9,8 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PotentialEditorConfigFiles Include="@(Compile->GetPathsOfAllDirectoriesAbove()->Combine('.editorconfig'))" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
+    <AllDirectoriesAbove Include="@(Compile->GetPathsOfAllDirectoriesAbove())" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
+    <!-- Work around a GetPathsOfAllDirectoriesAbove() bug where it can return multiple equivalent paths when the 
+         compilation includes linked files with relative paths - https://github.com/microsoft/msbuild/issues/4392 -->
+    <PotentialEditorConfigFiles Include="@(AllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.editorconfig'))" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
     <EditorConfigFiles Include="@(PotentialEditorConfigFiles->Exists())" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.EditorConfig.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.EditorConfig.targets
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AllDirectoriesAbove Include="@(Compile->GetPathsOfAllDirectoriesAbove())" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
+    <_AllDirectoriesAbove Include="@(Compile->GetPathsOfAllDirectoriesAbove())" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
     <!-- Work around a GetPathsOfAllDirectoriesAbove() bug where it can return multiple equivalent paths when the 
          compilation includes linked files with relative paths - https://github.com/microsoft/msbuild/issues/4392 -->
-    <PotentialEditorConfigFiles Include="@(AllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.editorconfig'))" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
+    <PotentialEditorConfigFiles Include="@(_AllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.editorconfig'))" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
     <EditorConfigFiles Include="@(PotentialEditorConfigFiles->Exists())" Condition="'$(DiscoverEditorConfigFiles)' != 'false'" />
   </ItemGroup>
 


### PR DESCRIPTION
Work around https://github.com/microsoft/msbuild/issues/4392

/CC @tmeschter and @jasonmalinowski 