### PR TITLE
Update SuggestedAction to track successful application

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
             return currentResult;
         }
 
-        public async Task ApplyAsync(
+        public async Task<bool> ApplyAsync(
             Workspace workspace, Document fromDocument,
             ImmutableArray<CodeActionOperation> operations,
             string title, IProgressTracker progressTracker,
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
 
             if (operations.IsDefaultOrEmpty)
             {
-                return;
+                return _renameService.ActiveSession is null;
             }
 
             if (_renameService.ActiveSession != null)
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
                 workspace.Services.GetService<INotificationService>()?.SendNotification(
                     EditorFeaturesResources.Cannot_apply_operation_while_a_rename_session_is_active,
                     severity: NotificationSeverity.Error);
-                return;
+                return false;
             }
 
 #if DEBUG && false
@@ -133,6 +133,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
 
             var oldSolution = workspace.CurrentSolution;
 
+            bool applied;
+
             // Determine if we're making a simple text edit to a single file or not.
             // If we're not, then we need to make a linked global undo to wrap the 
             // application of these operations.  This way we should be able to undo 
@@ -151,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
 
                 using (workspace.Services.GetService<ISourceTextUndoService>().RegisterUndoTransaction(text, title))
                 {
-                    operations.Single().Apply(workspace, cancellationToken);
+                    applied = operations.Single().TryApply(workspace, progressTracker, cancellationToken);
                 }
             }
             else
@@ -168,7 +170,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
                         transaction.AddDocument(fromDocument.Id);
                     }
 
-                    ProcessOperations(
+                    applied = ProcessOperations(
                         workspace, operations, progressTracker,
                         cancellationToken);
 
@@ -178,6 +180,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
 
             var updatedSolution = operations.OfType<ApplyChangesOperation>().FirstOrDefault()?.ChangedSolution ?? oldSolution;
             TryNavigateToLocationOrStartRenameSession(workspace, oldSolution, updatedSolution, cancellationToken);
+            return applied;
         }
 
         private TextDocument TryGetSingleChangedText(
@@ -257,10 +260,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
             }
         }
 
-        private static void ProcessOperations(
+        /// <returns><see langword="true"/> if all expected <paramref name="operations"/> are applied successfully;
+        /// otherwise, <see langword="false"/>.</returns>
+        private static bool ProcessOperations(
             Workspace workspace, ImmutableArray<CodeActionOperation> operations,
             IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
+            var applied = true;
             var seenApplyChanges = false;
             foreach (var operation in operations)
             {
@@ -275,8 +281,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
                     seenApplyChanges = true;
                 }
 
-                operation.TryApply(workspace, progressTracker, cancellationToken);
+                applied &= operation.TryApply(workspace, progressTracker, cancellationToken);
             }
+
+            return applied;
         }
 
         private void TryNavigateToLocationOrStartRenameSession(Workspace workspace, Solution oldSolution, Solution newSolution, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/Implementation/CodeRefactorings/ICodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeRefactorings/ICodeActionEditHandlerService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor
         SolutionPreviewResult GetPreviews(
             Workspace workspace, ImmutableArray<CodeActionOperation> operations, CancellationToken cancellationToken);
 
-        Task ApplyAsync(
+        Task<bool> ApplyAsync(
             Workspace workspace, Document fromDocument,
             ImmutableArray<CodeActionOperation> operations,
             string title, IProgressTracker progressTracker,

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public string[] GetLightBulbActions()
             => _textViewWindowInProc.GetLightBulbActions();
 
-        public void ApplyLightBulbAction(string action, FixAllScope? fixAllScope, bool blockUntilComplete = true)
+        public bool ApplyLightBulbAction(string action, FixAllScope? fixAllScope, bool blockUntilComplete = true)
             => _textViewWindowInProc.ApplyLightBulbAction(action, fixAllScope, blockUntilComplete);
 
         public void InvokeCompletionList()

--- a/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
@@ -41,8 +41,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
         internal override bool TryApply(
             Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
-            workspace.TryApplyChanges(ChangedSolution, progressTracker);
-            return true;
+            return workspace.TryApplyChanges(ChangedSolution, progressTracker);
         }
     }
 }


### PR DESCRIPTION
Fixes #35909 by silently retrying to apply a code fix if the application failed due to concurrent changes in the workspace.