### PR TITLE
add value tuple dependency

### DIFF
--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -99,6 +99,7 @@
       
       <_Dependency Remove="Nerdbank.Streams"/>
       <_Dependency Remove="System.IO.Pipelines"/>
+      <_Dependency Remove="System.ValueTuple"/>
     -->
     <ItemGroup>
       <_Dependency Remove="@(_Dependency)" Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').StartsWith('Microsoft.VisualStudio.'))"/>
@@ -114,6 +115,7 @@
       <_Dependency Remove="StreamJsonRpc"/>
       <_Dependency Remove="Nerdbank.Streams"/>
       <_Dependency Remove="System.IO.Pipelines"/>
+      <_Dependency Remove="System.ValueTuple"/>
       <_Dependency Remove="System.Threading.Tasks.Dataflow"/>
       <_Dependency Remove="VSLangProj"/>
       <_Dependency Remove="VSLangProj2"/>


### PR DESCRIPTION
move ValueTuple dependency back in. 

https://github.com/dotnet/roslyn/pull/34860 (streamjsonrpc 2.0) turns out still require ValueTuple dependency